### PR TITLE
design spec + v1.0 implementation plans for agentsync (supersedes #1, #2)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-agentsync-m0-skeleton.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m0-skeleton.md
@@ -1,0 +1,3119 @@
+# agentsync M0 — Skeleton
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Conventions (TDD cycle, test framework, lint, commit format) are defined once in [`2026-05-04-agentsync-v1.0-overview.md`](2026-05-04-agentsync-v1.0-overview.md#conventions-used-across-all-milestone-plans).
+
+**Goal:** Bootstrap the `agentsync` Go module with the foundational skeleton: path resolution honoring `AGENTSYNC_HOME` / `AGENTSYNC_TARGET_ROOT`, atomic file write + file lock, slog setup, canonical TOML schema + loader, JSON state store, adapter interface + registry, a `NoopAdapter` for testing the apply pipeline, and a thin cobra CLI exposing `init` / `agent {add,list,remove}` / `doctor` / `verify` / `apply --dry-run`. CI green.
+
+**Architecture:** Single Go module (`github.com/spxrogers/agentsync`) → single static binary at `cmd/agentsync/`. Internal packages encapsulate one concern each. The `paths` helper is the only place real `$HOME` is touched in production code; tests redirect via `AGENTSYNC_TARGET_ROOT`. Adapter interface is defined here but no real adapter is implemented yet — `NoopAdapter` lets the apply pipeline run end-to-end with empty file operations so M1+ can plug in real adapters.
+
+**Tech stack:** Go 1.22+, `github.com/spf13/cobra` (CLI), `github.com/pelletier/go-toml/v2` (TOML), `github.com/spf13/afero` (FS test fakes), `github.com/gofrs/flock` (file lock), `log/slog` (stdlib), `golangci-lint`, `goreleaser` (config only; release in M7).
+
+---
+
+## Files created in this milestone
+
+```
+agentsync/
+├── go.mod, go.sum
+├── .gitignore, Makefile, README.md
+├── .goreleaser.yaml, .golangci.yml
+├── .github/workflows/ci.yml
+├── cmd/agentsync/main.go
+└── internal/
+    ├── paths/{paths.go, paths_test.go}
+    ├── iox/{atomic.go, atomic_test.go, lock.go, lock_test.go}
+    ├── log/{log.go, log_test.go}
+    ├── source/{schema.go, loader.go, loader_test.go}
+    ├── state/{schema.go, store.go, store_test.go}
+    ├── adapter/{adapter.go, registry.go, registry_test.go, noop/{noop.go, noop_test.go}}
+    ├── render/{pipeline.go, pipeline_test.go}
+    └── cli/
+        ├── root.go, root_test.go
+        ├── init.go, init_test.go
+        ├── agent.go, agent_test.go
+        ├── doctor.go, doctor_test.go
+        ├── verify.go, verify_test.go
+        ├── apply.go, apply_test.go
+        └── testhelper_test.go    # shared test helpers
+```
+
+---
+
+## Task 0: Module + tooling scaffolding
+
+**Files:**
+- Create: `go.mod`, `.gitignore`, `Makefile`, `README.md`, `.golangci.yml`, `.goreleaser.yaml`, `.github/workflows/ci.yml`, `cmd/agentsync/main.go`
+
+- [ ] **Step 0.1: `go mod init`**
+
+```bash
+go mod init github.com/spxrogers/agentsync
+```
+
+Expected: creates `go.mod` with `module github.com/spxrogers/agentsync` and `go 1.22` (or current toolchain).
+
+- [ ] **Step 0.2: `.gitignore`**
+
+```gitignore
+/bin/
+/dist/
+/agentsync
+/agentsync.exe
+/coverage.out
+/coverage.html
+.vscode/
+.idea/
+*.swp
+.DS_Store
+```
+
+- [ ] **Step 0.3: `Makefile`** (real tabs!)
+
+```make
+.PHONY: build test lint fmt tidy ci clean
+
+build:
+	go build -o bin/agentsync ./cmd/agentsync
+
+test:
+	go test -race ./...
+
+lint:
+	golangci-lint run ./...
+
+fmt:
+	gofmt -w -s .
+	go run mvdan.cc/gofumpt@latest -w .
+
+tidy:
+	go mod tidy
+
+ci: lint test
+	goreleaser release --snapshot --skip publish --clean
+
+clean:
+	rm -rf bin/ dist/ coverage.out coverage.html
+```
+
+- [ ] **Step 0.4: `README.md`**
+
+```markdown
+# agentsync
+
+Centrally manages AI coding-agent configurations across Claude Code, OpenCode, Codex CLI, and Cursor.
+
+**Status:** pre-release. Design at `docs/superpowers/specs/2026-05-04-agentsync-design.md`. Implementation roadmap at `docs/superpowers/plans/`.
+
+Distribution (coming in v1.0 M7): Homebrew, Scoop, Chocolatey, native Linux packages. No `go install`, no npm, no curl-bash.
+
+## Build from source
+
+    git clone https://github.com/spxrogers/agentsync.git
+    cd agentsync
+    make build
+```
+
+- [ ] **Step 0.5: `.golangci.yml`**
+
+```yaml
+run:
+  timeout: 3m
+  tests: true
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - gocritic
+    - ineffassign
+    - gofumpt
+    - forbidigo
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - p: '^os\.UserHomeDir$'
+        msg: "use paths.HomeDir(env) so AGENTSYNC_TARGET_ROOT honored in tests"
+        # apply only to test files
+        pattern: ".*"
+    analyze-types: true
+
+issues:
+  exclude-rules:
+    - path: '(^|/)cmd/.*'
+      linters: [forbidigo]    # main.go can use os.UserHomeDir if needed
+```
+
+(Note: forbidigo's `_test.go`-only filter is configured via `issues.exclude-rules` invert; if golangci-lint version doesn't support `pattern:`, switch to: enable `forbidigo` globally then `exclude-rules` with `path-except: '_test\.go$'` for the rule. Confirm with `golangci-lint run --help` on the version installed.)
+
+- [ ] **Step 0.6: `.goreleaser.yaml`** (config only; pipeline wired in M7)
+
+```yaml
+project_name: agentsync
+
+builds:
+  - id: agentsync
+    main: ./cmd/agentsync
+    binary: agentsync
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot-{{.ShortCommit}}"
+
+# Homebrew/Scoop/Chocolatey blocks added in M7.
+```
+
+- [ ] **Step 0.7: `.github/workflows/ci.yml`**
+
+```yaml
+name: ci
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22.x' }
+      - run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22.x' }
+      - uses: golangci/golangci-lint-action@v6
+        with: { version: latest }
+
+  goreleaser-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22.x' }
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --snapshot --skip publish --clean
+```
+
+- [ ] **Step 0.8: `cmd/agentsync/main.go`** (placeholder; cli.Execute defined in Task 13)
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+var (
+    version = "dev"
+    commit  = "none"
+    date    = "unknown"
+)
+
+func main() {
+    if len(os.Args) > 1 && os.Args[1] == "--version" {
+        fmt.Printf("agentsync %s (commit %s, built %s)\n", version, commit, date)
+        return
+    }
+    fmt.Println("agentsync — placeholder; cli wiring lands in Task 13")
+}
+```
+
+- [ ] **Step 0.9: Verify build + commit**
+
+```bash
+go build ./cmd/agentsync
+./agentsync --version
+```
+
+Expected: `agentsync dev (commit none, built unknown)`
+
+```bash
+git add .
+git commit -m "$(cat <<'EOF'
+chore: initialize Go module + tooling scaffolding
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1: `internal/paths` — `AGENTSYNC_HOME` / `AGENTSYNC_TARGET_ROOT` resolution
+
+**Files:**
+- Create: `internal/paths/paths.go`, `internal/paths/paths_test.go`
+
+The single chokepoint where production code maps logical names ("home dir," "config dir") to filesystem paths. Tests redirect via `AGENTSYNC_TARGET_ROOT`.
+
+- [ ] **Step 1.1: Write the failing test**
+
+`internal/paths/paths_test.go`:
+
+```go
+package paths_test
+
+import (
+    "path/filepath"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+
+func TestHomeDir(t *testing.T) {
+    cases := []struct {
+        name string
+        env  map[string]string
+        want string
+    }{
+        {
+            name: "AGENTSYNC_TARGET_ROOT overrides everything",
+            env:  map[string]string{"AGENTSYNC_TARGET_ROOT": "/tmp/redirect", "HOME": "/Users/real"},
+            want: "/tmp/redirect",
+        },
+        {
+            name: "falls back to HOME when no override",
+            env:  map[string]string{"HOME": "/Users/real"},
+            want: "/Users/real",
+        },
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := paths.HomeDir(paths.MapEnv(tc.env))
+            if got != tc.want {
+                t.Fatalf("HomeDir = %q, want %q", got, tc.want)
+            }
+        })
+    }
+}
+
+func TestAgentsyncHome(t *testing.T) {
+    cases := []struct {
+        name string
+        env  map[string]string
+        want string
+    }{
+        {
+            name: "AGENTSYNC_HOME explicit override",
+            env:  map[string]string{"AGENTSYNC_HOME": "/explicit/path", "HOME": "/Users/real"},
+            want: "/explicit/path",
+        },
+        {
+            name: "default ~/.agentsync under HOME",
+            env:  map[string]string{"HOME": "/Users/real"},
+            want: filepath.Join("/Users/real", ".agentsync"),
+        },
+        {
+            name: "AGENTSYNC_TARGET_ROOT shifts default",
+            env:  map[string]string{"AGENTSYNC_TARGET_ROOT": "/tmp/x", "HOME": "/Users/real"},
+            want: filepath.Join("/tmp/x", ".agentsync"),
+        },
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := paths.AgentsyncHome(paths.MapEnv(tc.env))
+            if got != tc.want {
+                t.Fatalf("AgentsyncHome = %q, want %q", got, tc.want)
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 1.2: Run; verify failure**
+
+```bash
+go test ./internal/paths/...
+```
+
+Expected: `package github.com/spxrogers/agentsync/internal/paths is not in std`. Test file references symbols that don't exist yet (`paths.HomeDir`, `paths.AgentsyncHome`, `paths.MapEnv`).
+
+- [ ] **Step 1.3: Implement**
+
+`internal/paths/paths.go`:
+
+```go
+// Package paths centralizes filesystem path resolution honoring AGENTSYNC_HOME
+// and AGENTSYNC_TARGET_ROOT. Production code MUST use this package; lint forbids
+// os.UserHomeDir in *_test.go files.
+package paths
+
+import (
+    "os"
+    "path/filepath"
+)
+
+// Env abstracts environment-variable lookup so tests can inject a fake.
+type Env interface {
+    Get(key string) string
+}
+
+// OSEnv reads the live process environment.
+type OSEnv struct{}
+
+func (OSEnv) Get(key string) string { return os.Getenv(key) }
+
+// MapEnv is a fake Env backed by a map (for tests).
+type MapEnv map[string]string
+
+func (m MapEnv) Get(key string) string { return m[key] }
+
+// HomeDir returns the effective home dir. AGENTSYNC_TARGET_ROOT takes precedence
+// (used by tests to redirect away from the real $HOME); otherwise falls back to
+// $HOME.
+func HomeDir(e Env) string {
+    if root := e.Get("AGENTSYNC_TARGET_ROOT"); root != "" {
+        return root
+    }
+    return e.Get("HOME")
+}
+
+// AgentsyncHome returns the directory where agentsync stores its source repo.
+// Resolution order:
+//   1. $AGENTSYNC_HOME (explicit override; absolute path)
+//   2. <HomeDir>/.agentsync
+func AgentsyncHome(e Env) string {
+    if h := e.Get("AGENTSYNC_HOME"); h != "" {
+        return h
+    }
+    return filepath.Join(HomeDir(e), ".agentsync")
+}
+```
+
+- [ ] **Step 1.4: Run; verify pass**
+
+```bash
+go test ./internal/paths/...
+```
+
+Expected: `ok github.com/spxrogers/agentsync/internal/paths`
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add internal/paths
+git commit -m "$(cat <<'EOF'
+feat(paths): resolve AGENTSYNC_HOME with target-root override
+
+Single chokepoint for HOME-relative paths. AGENTSYNC_TARGET_ROOT lets tests
+redirect to tmpdirs without touching real $HOME. Lint rule (forbidigo) bans
+os.UserHomeDir in *_test.go from M0 onward.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `internal/iox` — atomic file write
+
+**Files:**
+- Create: `internal/iox/atomic.go`, `internal/iox/atomic_test.go`
+
+Two-phase write: write to `<dest>.agentsync.tmp`, fsync, rename to final. A crash mid-write leaves either old or new content, never partial.
+
+- [ ] **Step 2.1: Write the failing test**
+
+`internal/iox/atomic_test.go`:
+
+```go
+package iox_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+func TestAtomicWrite_NewFile(t *testing.T) {
+    dir := t.TempDir()
+    dest := filepath.Join(dir, "config.toml")
+    payload := []byte("hello\n")
+
+    if err := iox.AtomicWrite(dest, payload, 0o644); err != nil {
+        t.Fatalf("AtomicWrite: %v", err)
+    }
+
+    got, err := os.ReadFile(dest)
+    if err != nil {
+        t.Fatalf("ReadFile: %v", err)
+    }
+    if string(got) != string(payload) {
+        t.Fatalf("content = %q, want %q", got, payload)
+    }
+
+    info, err := os.Stat(dest)
+    if err != nil {
+        t.Fatalf("Stat: %v", err)
+    }
+    // mode comparison is platform-aware; on windows mode bits are ignored.
+    if info.Mode().Perm() != 0o644 {
+        t.Logf("mode = %v (informational; windows ignores)", info.Mode().Perm())
+    }
+}
+
+func TestAtomicWrite_OverwriteExisting(t *testing.T) {
+    dir := t.TempDir()
+    dest := filepath.Join(dir, "config.toml")
+    if err := os.WriteFile(dest, []byte("old\n"), 0o644); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := iox.AtomicWrite(dest, []byte("new\n"), 0o644); err != nil {
+        t.Fatalf("AtomicWrite: %v", err)
+    }
+    got, _ := os.ReadFile(dest)
+    if string(got) != "new\n" {
+        t.Fatalf("content = %q, want %q", got, "new\n")
+    }
+}
+
+func TestAtomicWrite_LeavesNoTempFile(t *testing.T) {
+    dir := t.TempDir()
+    dest := filepath.Join(dir, "config.toml")
+    if err := iox.AtomicWrite(dest, []byte("x\n"), 0o644); err != nil {
+        t.Fatal(err)
+    }
+    entries, _ := os.ReadDir(dir)
+    if len(entries) != 1 {
+        t.Fatalf("dir entries = %d, want 1 (only the dest); got: %+v", len(entries), entries)
+    }
+}
+```
+
+- [ ] **Step 2.2: Run; verify failure**
+
+```bash
+go test ./internal/iox/...
+```
+
+Expected: `undefined: iox.AtomicWrite`
+
+- [ ] **Step 2.3: Implement**
+
+`internal/iox/atomic.go`:
+
+```go
+// Package iox provides atomic file IO and file-locking primitives used by
+// agentsync's apply pipeline.
+package iox
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+)
+
+// AtomicWrite writes data to dest using a two-phase approach: write to a
+// sibling .agentsync.tmp file, fsync it, then rename(2) into place. If the
+// process crashes between phases, the destination is either the old content
+// (rename did not run) or the new content (rename ran). Never partial.
+//
+// Parent directory is created if missing (with mode 0o755).
+func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
+    if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+        return fmt.Errorf("mkdir parent of %s: %w", dest, err)
+    }
+    tmp := dest + ".agentsync.tmp"
+
+    f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+    if err != nil {
+        return fmt.Errorf("open temp %s: %w", tmp, err)
+    }
+    if _, err := f.Write(data); err != nil {
+        _ = f.Close()
+        _ = os.Remove(tmp)
+        return fmt.Errorf("write temp %s: %w", tmp, err)
+    }
+    if err := f.Sync(); err != nil {
+        _ = f.Close()
+        _ = os.Remove(tmp)
+        return fmt.Errorf("sync temp %s: %w", tmp, err)
+    }
+    if err := f.Close(); err != nil {
+        _ = os.Remove(tmp)
+        return fmt.Errorf("close temp %s: %w", tmp, err)
+    }
+    if err := os.Rename(tmp, dest); err != nil {
+        _ = os.Remove(tmp)
+        return fmt.Errorf("rename %s -> %s: %w", tmp, dest, err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 2.4: Run; verify pass**
+
+```bash
+go test -race ./internal/iox/...
+```
+
+Expected: `ok github.com/spxrogers/agentsync/internal/iox`
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add internal/iox
+git commit -m "$(cat <<'EOF'
+feat(iox): atomic write via .agentsync.tmp + fsync + rename
+
+A crash mid-apply leaves either old or new content, never partial. Used
+throughout agentsync's apply pipeline.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `internal/iox` — file lock
+
+**Files:**
+- Create: `internal/iox/lock.go`, `internal/iox/lock_test.go`
+- Modify: `go.mod` (adds `github.com/gofrs/flock`)
+
+Cross-process file lock so concurrent `agentsync apply` runs serialize cleanly.
+
+- [ ] **Step 3.1: Add dependency**
+
+```bash
+go get github.com/gofrs/flock@latest
+```
+
+- [ ] **Step 3.2: Write the failing test**
+
+`internal/iox/lock_test.go`:
+
+```go
+package iox_test
+
+import (
+    "path/filepath"
+    "sync"
+    "testing"
+    "time"
+
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+func TestLock_AcquireRelease(t *testing.T) {
+    p := filepath.Join(t.TempDir(), "test.lock")
+    l, err := iox.AcquireLock(p)
+    if err != nil {
+        t.Fatalf("AcquireLock: %v", err)
+    }
+    if err := l.Release(); err != nil {
+        t.Fatalf("Release: %v", err)
+    }
+}
+
+func TestLock_SecondAcquireBlocks(t *testing.T) {
+    p := filepath.Join(t.TempDir(), "test.lock")
+
+    l1, err := iox.AcquireLock(p)
+    if err != nil {
+        t.Fatalf("first AcquireLock: %v", err)
+    }
+    t.Cleanup(func() { _ = l1.Release() })
+
+    var (
+        wg     sync.WaitGroup
+        result error
+    )
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        l2, err := iox.AcquireLockTimeout(p, 100*time.Millisecond)
+        if err == nil {
+            _ = l2.Release()
+        }
+        result = err
+    }()
+    wg.Wait()
+    if result == nil {
+        t.Fatalf("second AcquireLockTimeout returned nil; expected lock-busy error")
+    }
+}
+```
+
+- [ ] **Step 3.3: Run; verify failure**
+
+```bash
+go test ./internal/iox/...
+```
+
+Expected: `undefined: iox.AcquireLock`, `undefined: iox.AcquireLockTimeout`
+
+- [ ] **Step 3.4: Implement**
+
+`internal/iox/lock.go`:
+
+```go
+package iox
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "time"
+
+    "github.com/gofrs/flock"
+)
+
+// Lock represents an acquired exclusive file lock. Release() drops it.
+type Lock struct {
+    fl *flock.Flock
+}
+
+// Release drops the lock. Idempotent.
+func (l *Lock) Release() error {
+    if l == nil || l.fl == nil {
+        return nil
+    }
+    return l.fl.Unlock()
+}
+
+// AcquireLock takes an exclusive lock on path, blocking forever until it
+// succeeds. The parent directory is created if missing.
+func AcquireLock(path string) (*Lock, error) {
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+        return nil, fmt.Errorf("mkdir parent of lock %s: %w", path, err)
+    }
+    fl := flock.New(path)
+    if err := fl.Lock(); err != nil {
+        return nil, fmt.Errorf("lock %s: %w", path, err)
+    }
+    return &Lock{fl: fl}, nil
+}
+
+// AcquireLockTimeout takes an exclusive lock on path, returning an error if
+// the lock cannot be acquired within timeout.
+func AcquireLockTimeout(path string, timeout time.Duration) (*Lock, error) {
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+        return nil, fmt.Errorf("mkdir parent of lock %s: %w", path, err)
+    }
+    fl := flock.New(path)
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+    locked, err := fl.TryLockContext(ctx, 25*time.Millisecond)
+    if err != nil {
+        return nil, fmt.Errorf("locking %s: %w", path, err)
+    }
+    if !locked {
+        return nil, fmt.Errorf("lock %s busy after %s", path, timeout)
+    }
+    return &Lock{fl: fl}, nil
+}
+```
+
+- [ ] **Step 3.5: Run; verify pass; commit**
+
+```bash
+go test -race ./internal/iox/...
+```
+
+Expected: `ok github.com/spxrogers/agentsync/internal/iox`
+
+```bash
+git add go.mod go.sum internal/iox
+git commit -m "$(cat <<'EOF'
+feat(iox): cross-process file lock via gofrs/flock
+
+apply.lock + reconcile.lock will sit in ~/.agentsync/.state/. Two concurrent
+agentsync apply invocations serialize on the lock; AcquireLockTimeout fails
+fast for tools that prefer error over indefinite wait.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `internal/log` — slog wrapper
+
+**Files:**
+- Create: `internal/log/log.go`, `internal/log/log_test.go`
+
+Tiny wrapper around `log/slog` so the rest of the codebase imports one package and a `--verbose` global flag flips levels.
+
+- [ ] **Step 4.1: Write the failing test**
+
+`internal/log/log_test.go`:
+
+```go
+package log_test
+
+import (
+    "bytes"
+    "log/slog"
+    "strings"
+    "testing"
+
+    aslog "github.com/spxrogers/agentsync/internal/log"
+)
+
+func TestNew_DefaultLevel(t *testing.T) {
+    var buf bytes.Buffer
+    lg := aslog.New(&buf, false)
+    lg.Info("hello", slog.String("k", "v"))
+    lg.Debug("invisible at default level")
+
+    out := buf.String()
+    if !strings.Contains(out, `"msg":"hello"`) {
+        t.Fatalf("expected info-level msg, got: %s", out)
+    }
+    if strings.Contains(out, "invisible") {
+        t.Fatalf("debug message leaked into default-level output: %s", out)
+    }
+}
+
+func TestNew_VerboseLevel(t *testing.T) {
+    var buf bytes.Buffer
+    lg := aslog.New(&buf, true)
+    lg.Debug("now visible")
+
+    if !strings.Contains(buf.String(), "now visible") {
+        t.Fatalf("debug message missing in verbose output: %s", buf.String())
+    }
+}
+```
+
+- [ ] **Step 4.2: Run; verify failure**
+
+Expected: `undefined: aslog.New`
+
+- [ ] **Step 4.3: Implement**
+
+`internal/log/log.go`:
+
+```go
+// Package log centralizes slog setup. CLI commands receive *slog.Logger from
+// the root cobra command's PersistentPreRun.
+package log
+
+import (
+    "io"
+    "log/slog"
+)
+
+// New returns a JSON slog.Logger writing to w. If verbose is true, level is
+// Debug; otherwise Info.
+func New(w io.Writer, verbose bool) *slog.Logger {
+    level := slog.LevelInfo
+    if verbose {
+        level = slog.LevelDebug
+    }
+    return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
+}
+```
+
+- [ ] **Step 4.4: Run; verify pass; commit**
+
+```bash
+go test -race ./internal/log/...
+```
+
+```bash
+git add internal/log
+git commit -m "$(cat <<'EOF'
+feat(log): slog JSON logger with --verbose toggle
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `internal/source` — canonical schema (TOML structs)
+
+**Files:**
+- Create: `internal/source/schema.go`
+
+Defines the Go structs that ARE agentsync's canonical model. No test for this task in isolation — exercised by Task 6's loader tests.
+
+- [ ] **Step 5.1: Add TOML dependency**
+
+```bash
+go get github.com/pelletier/go-toml/v2@latest
+```
+
+- [ ] **Step 5.2: Create schema**
+
+`internal/source/schema.go`:
+
+```go
+// Package source loads and represents the canonical agentsync repo layout
+// (~/.agentsync/). Structs in this file are TOML-tagged and serve as the
+// canonical model — there is no separate IR layer; adapters consume these
+// types directly.
+package source
+
+// Canonical is the in-memory image of a fully-loaded ~/.agentsync/ tree.
+type Canonical struct {
+    Config      Config
+    MCPServers  []MCPServer
+    Skills      []Skill
+    Plugins     []Plugin
+    Marketplaces []Marketplace
+    Memory      Memory
+    Project     *Canonical // nil for user-scope canonical; populated by M5 overlay
+}
+
+// Config mirrors opensync.toml at the root of ~/.agentsync/.
+type Config struct {
+    Agents   map[string]Agent     `toml:"agents"`
+    Updates  UpdateDefaults       `toml:"updates"`
+    Secrets  SecretsConfig        `toml:"secrets"`
+}
+
+type Agent struct {
+    Enabled bool   `toml:"enabled"`
+    Scope   string `toml:"scope,omitempty"` // "user" | "project"
+}
+
+type UpdateDefaults struct {
+    DefaultMode     string `toml:"default_mode"`     // pinned | track | manual
+    DefaultInterval string `toml:"default_interval"` // e.g. "24h"
+}
+
+type SecretsConfig struct {
+    Backend      string `toml:"backend"`       // "env" | "age"
+    File         string `toml:"file"`
+    Recipient    string `toml:"recipient"`
+    IdentityFile string `toml:"identity_file"`
+}
+
+// MCPServer mirrors mcp/<id>.toml.
+type MCPServer struct {
+    ID      string             `toml:"-"` // filename minus .toml
+    Server  MCPServerSpec      `toml:"server"`
+}
+
+type MCPServerSpec struct {
+    Type     string            `toml:"type"`     // stdio | http | sse
+    Command  string            `toml:"command,omitempty"`
+    Args     []string          `toml:"args,omitempty"`
+    URL      string            `toml:"url,omitempty"`
+    Headers  map[string]string `toml:"headers,omitempty"`
+    Env      map[string]string `toml:"env,omitempty"`
+    Agents   []string          `toml:"agents,omitempty"` // ["*"] or ["claude","opencode"]
+    Enabled  *bool             `toml:"enabled,omitempty"` // nil means default-on
+}
+
+// Skill mirrors skills/<name>/SKILL.md (frontmatter + body).
+type Skill struct {
+    Name        string                 `toml:"-"` // dirname
+    Frontmatter map[string]any         `toml:"-"` // YAML frontmatter parsed
+    Body        string                 `toml:"-"` // markdown body
+}
+
+// Plugin mirrors plugins/<id>.toml.
+type Plugin struct {
+    ID           string                       `toml:"-"`
+    Plugin       PluginSpec                   `toml:"plugin"`
+    Overrides    map[string]PluginOverrideSet `toml:"plugin.overrides"` // per-agent
+}
+
+type PluginSpec struct {
+    ID          string   `toml:"id"`
+    Version     string   `toml:"version,omitempty"`
+    ManifestSHA string   `toml:"manifest_sha,omitempty"`
+    Update      string   `toml:"update,omitempty"` // pinned | track | manual
+    Agents      []string `toml:"agents,omitempty"`
+}
+
+// PluginOverrideSet captures per-agent component overrides for one plugin.
+// e.g. [plugin.overrides.cursor] commands = "skip"
+type PluginOverrideSet map[string]string // component -> action ("skip" today; future: "force", etc.)
+
+// Marketplace mirrors marketplaces/<name>.toml.
+type Marketplace struct {
+    Name        string             `toml:"-"`
+    Marketplace MarketplaceSpec    `toml:"marketplace"`
+}
+
+type MarketplaceSpec struct {
+    URL               string `toml:"url"`
+    Ref               string `toml:"ref,omitempty"`
+    DefaultUpdateMode string `toml:"default_update_mode,omitempty"`
+}
+
+// Memory mirrors memory/AGENTS.md and memory/fragments/.
+type Memory struct {
+    Body      string                  // resolved AGENTS.md after @import expansion
+    Fragments map[string]string       // path -> body, keyed by repo-relative path under memory/
+}
+```
+
+- [ ] **Step 5.3: Verify it compiles + commit**
+
+```bash
+go build ./internal/source/...
+```
+
+Expected: clean (no test yet).
+
+```bash
+git add go.mod go.sum internal/source
+git commit -m "$(cat <<'EOF'
+feat(source): canonical schema for ~/.agentsync/ — TOML structs are the model
+
+No separate IR layer; adapters consume these structs directly. Memory keeps
+markdown body verbatim plus resolved fragments. Plugin.Overrides keys are
+per-agent component name -> action.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `internal/source` — loader
+
+**Files:**
+- Create: `internal/source/loader.go`, `internal/source/loader_test.go`
+
+Walks `<home>/` and produces a `Canonical`. Uses `afero.Fs` so tests can stay in-memory.
+
+- [ ] **Step 6.1: Add afero dependency**
+
+```bash
+go get github.com/spf13/afero@latest
+```
+
+- [ ] **Step 6.2: Write the failing test**
+
+`internal/source/loader_test.go`:
+
+```go
+package source_test
+
+import (
+    "testing"
+
+    "github.com/spf13/afero"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestLoad_EmptyHome(t *testing.T) {
+    fs := afero.NewMemMapFs()
+    _ = afero.WriteFile(fs, "/home/.agentsync/opensync.toml", []byte(""), 0o644)
+
+    c, err := source.Load(fs, "/home/.agentsync")
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+    if len(c.MCPServers) != 0 {
+        t.Fatalf("expected no MCP servers, got %d", len(c.MCPServers))
+    }
+}
+
+func TestLoad_AgentsAndMCP(t *testing.T) {
+    fs := afero.NewMemMapFs()
+    _ = afero.WriteFile(fs, "/home/.agentsync/opensync.toml", []byte(`
+[agents]
+claude   = { enabled = true,  scope = "user" }
+opencode = { enabled = true }
+`), 0o644)
+    _ = afero.WriteFile(fs, "/home/.agentsync/mcp/github.toml", []byte(`
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+agents  = ["claude", "opencode"]
+
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+`), 0o644)
+
+    c, err := source.Load(fs, "/home/.agentsync")
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+    if !c.Config.Agents["claude"].Enabled {
+        t.Fatalf("claude agent should be enabled")
+    }
+    if c.Config.Agents["claude"].Scope != "user" {
+        t.Fatalf("claude scope = %q, want user", c.Config.Agents["claude"].Scope)
+    }
+    if len(c.MCPServers) != 1 {
+        t.Fatalf("expected 1 MCP server, got %d", len(c.MCPServers))
+    }
+    g := c.MCPServers[0]
+    if g.ID != "github" {
+        t.Fatalf("MCP id = %q, want github", g.ID)
+    }
+    if g.Server.Type != "stdio" {
+        t.Fatalf("MCP type = %q, want stdio", g.Server.Type)
+    }
+    if g.Server.Env["GITHUB_TOKEN"] != "${secret:github.token}" {
+        t.Fatalf("env GITHUB_TOKEN = %q", g.Server.Env["GITHUB_TOKEN"])
+    }
+}
+
+func TestLoad_MissingHomeReturnsEmpty(t *testing.T) {
+    fs := afero.NewMemMapFs()
+    c, err := source.Load(fs, "/nonexistent")
+    if err != nil {
+        t.Fatalf("Load nonexistent: %v", err)
+    }
+    if len(c.MCPServers) != 0 {
+        t.Fatalf("expected empty canonical, got %d MCP", len(c.MCPServers))
+    }
+}
+```
+
+- [ ] **Step 6.3: Run; verify failure**
+
+Expected: `undefined: source.Load`
+
+- [ ] **Step 6.4: Implement**
+
+`internal/source/loader.go`:
+
+```go
+package source
+
+import (
+    "errors"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/pelletier/go-toml/v2"
+    "github.com/spf13/afero"
+)
+
+// Load reads a canonical model from <home>. Missing home or missing
+// subdirectories return an empty Canonical (not an error). Malformed files
+// return an error with a path prefix for actionability.
+func Load(fs afero.Fs, home string) (Canonical, error) {
+    var c Canonical
+
+    if err := loadConfig(fs, home, &c.Config); err != nil {
+        return c, err
+    }
+    var err error
+    if c.MCPServers, err = loadMCP(fs, home); err != nil {
+        return c, err
+    }
+    if c.Plugins, err = loadPlugins(fs, home); err != nil {
+        return c, err
+    }
+    if c.Marketplaces, err = loadMarketplaces(fs, home); err != nil {
+        return c, err
+    }
+    if c.Skills, err = loadSkills(fs, home); err != nil {
+        return c, err
+    }
+    if c.Memory, err = loadMemory(fs, home); err != nil {
+        return c, err
+    }
+    return c, nil
+}
+
+func loadConfig(fs afero.Fs, home string, cfg *Config) error {
+    p := filepath.Join(home, "opensync.toml")
+    data, err := afero.ReadFile(fs, p)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil
+        }
+        return fmt.Errorf("read %s: %w", p, err)
+    }
+    if err := toml.Unmarshal(data, cfg); err != nil {
+        return fmt.Errorf("parse %s: %w", p, err)
+    }
+    return nil
+}
+
+func loadMCP(fs afero.Fs, home string) ([]MCPServer, error) {
+    dir := filepath.Join(home, "mcp")
+    entries, err := afero.ReadDir(fs, dir)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil, nil
+        }
+        return nil, fmt.Errorf("read %s: %w", dir, err)
+    }
+    var out []MCPServer
+    for _, e := range entries {
+        if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+            continue
+        }
+        p := filepath.Join(dir, e.Name())
+        data, err := afero.ReadFile(fs, p)
+        if err != nil {
+            return nil, fmt.Errorf("read %s: %w", p, err)
+        }
+        var m MCPServer
+        if err := toml.Unmarshal(data, &m); err != nil {
+            return nil, fmt.Errorf("parse %s: %w", p, err)
+        }
+        m.ID = strings.TrimSuffix(e.Name(), ".toml")
+        out = append(out, m)
+    }
+    return out, nil
+}
+
+func loadPlugins(fs afero.Fs, home string) ([]Plugin, error) {
+    dir := filepath.Join(home, "plugins")
+    entries, err := afero.ReadDir(fs, dir)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil, nil
+        }
+        return nil, fmt.Errorf("read %s: %w", dir, err)
+    }
+    var out []Plugin
+    for _, e := range entries {
+        if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+            continue
+        }
+        p := filepath.Join(dir, e.Name())
+        data, err := afero.ReadFile(fs, p)
+        if err != nil {
+            return nil, fmt.Errorf("read %s: %w", p, err)
+        }
+        var pl Plugin
+        if err := toml.Unmarshal(data, &pl); err != nil {
+            return nil, fmt.Errorf("parse %s: %w", p, err)
+        }
+        pl.ID = strings.TrimSuffix(e.Name(), ".toml")
+        out = append(out, pl)
+    }
+    return out, nil
+}
+
+func loadMarketplaces(fs afero.Fs, home string) ([]Marketplace, error) {
+    dir := filepath.Join(home, "marketplaces")
+    entries, err := afero.ReadDir(fs, dir)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil, nil
+        }
+        return nil, fmt.Errorf("read %s: %w", dir, err)
+    }
+    var out []Marketplace
+    for _, e := range entries {
+        if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+            continue
+        }
+        p := filepath.Join(dir, e.Name())
+        data, err := afero.ReadFile(fs, p)
+        if err != nil {
+            return nil, fmt.Errorf("read %s: %w", p, err)
+        }
+        var m Marketplace
+        if err := toml.Unmarshal(data, &m); err != nil {
+            return nil, fmt.Errorf("parse %s: %w", p, err)
+        }
+        m.Name = strings.TrimSuffix(e.Name(), ".toml")
+        out = append(out, m)
+    }
+    return out, nil
+}
+
+// loadSkills walks skills/<name>/SKILL.md. Frontmatter parsing is added in M1
+// when the Claude adapter actually uses skills; for M0 we just record the
+// skill names + body so the canonical model is complete.
+func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
+    dir := filepath.Join(home, "skills")
+    entries, err := afero.ReadDir(fs, dir)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil, nil
+        }
+        return nil, fmt.Errorf("read %s: %w", dir, err)
+    }
+    var out []Skill
+    for _, e := range entries {
+        if !e.IsDir() {
+            continue
+        }
+        body, err := afero.ReadFile(fs, filepath.Join(dir, e.Name(), "SKILL.md"))
+        if err != nil {
+            if errors.Is(err, os.ErrNotExist) {
+                continue
+            }
+            return nil, fmt.Errorf("read SKILL.md for %s: %w", e.Name(), err)
+        }
+        out = append(out, Skill{Name: e.Name(), Body: string(body)})
+    }
+    return out, nil
+}
+
+func loadMemory(fs afero.Fs, home string) (Memory, error) {
+    var m Memory
+    body, err := afero.ReadFile(fs, filepath.Join(home, "memory", "AGENTS.md"))
+    if err != nil && !errors.Is(err, os.ErrNotExist) {
+        return m, fmt.Errorf("read memory/AGENTS.md: %w", err)
+    }
+    m.Body = string(body)
+
+    m.Fragments = map[string]string{}
+    fragDir := filepath.Join(home, "memory", "fragments")
+    entries, err := afero.ReadDir(fs, fragDir)
+    if err == nil {
+        for _, e := range entries {
+            if e.IsDir() {
+                continue
+            }
+            data, err := afero.ReadFile(fs, filepath.Join(fragDir, e.Name()))
+            if err != nil {
+                return m, fmt.Errorf("read fragment %s: %w", e.Name(), err)
+            }
+            m.Fragments[e.Name()] = string(data)
+        }
+    } else if !errors.Is(err, os.ErrNotExist) {
+        return m, fmt.Errorf("read memory/fragments: %w", err)
+    }
+    return m, nil
+}
+```
+
+- [ ] **Step 6.5: Run; verify pass; commit**
+
+```bash
+go test -race ./internal/source/...
+```
+
+```bash
+git add go.mod go.sum internal/source
+git commit -m "$(cat <<'EOF'
+feat(source): loader walks ~/.agentsync/ -> Canonical
+
+Reads opensync.toml, mcp/, plugins/, marketplaces/, skills/, memory/.
+Missing dirs return empty (not error); malformed files return path-prefixed
+errors. Frontmatter parsing for skills lands in M1 where it's first used.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `internal/state` — schema + store
+
+**Files:**
+- Create: `internal/state/schema.go`, `internal/state/store.go`, `internal/state/store_test.go`
+
+Single JSON file at `.state/targets.json`. Atomic via `iox.AtomicWrite`.
+
+- [ ] **Step 7.1: Schema**
+
+`internal/state/schema.go`:
+
+```go
+// Package state persists agentsync's last-applied hashes and marketplace/plugin
+// pinning to ~/.agentsync/.state/targets.json.
+package state
+
+import "time"
+
+const SchemaVersion = 1
+
+// Targets is the root state document.
+type Targets struct {
+    SchemaVersion int                       `json:"schema_version"`
+    Files         map[string]FileEntry      `json:"files,omitempty"`
+    Keys          map[string]KeyEntry       `json:"keys,omitempty"`
+    Marketplaces  map[string]Marketplace    `json:"marketplaces,omitempty"`
+    Plugins       map[string]PluginEntry    `json:"plugins,omitempty"`
+}
+
+// FileEntry tracks one fully-managed destination file.
+// Key format: "<agent>:<scope>:<project>:<dest_path>"
+type FileEntry struct {
+    SHA256    string    `json:"sha256"`
+    Mode      uint32    `json:"mode"`
+    AppliedAt time.Time `json:"applied_at"`
+    SourceID  string    `json:"source_id"` // canonical file that produced this dest
+}
+
+// KeyEntry tracks one managed JSON-pointer-addressable key inside a shared
+// destination file.
+// Key format: "<agent>:<scope>:<project>:<file>:<json_pointer>"
+type KeyEntry struct {
+    SHA256    string    `json:"sha256"`
+    AppliedAt time.Time `json:"applied_at"`
+    SourceID  string    `json:"source_id"`
+}
+
+type Marketplace struct {
+    URL       string    `json:"url"`
+    Ref       string    `json:"ref"`
+    HeadSHA   string    `json:"head_sha"`
+    FetchedAt time.Time `json:"fetched_at"`
+}
+
+type PluginEntry struct {
+    Version     string `json:"version"`
+    ManifestSHA string `json:"manifest_sha"`
+    Enabled     bool   `json:"enabled"`
+}
+
+// New returns a fresh empty Targets at SchemaVersion.
+func New() *Targets {
+    return &Targets{
+        SchemaVersion: SchemaVersion,
+        Files:         map[string]FileEntry{},
+        Keys:          map[string]KeyEntry{},
+        Marketplaces:  map[string]Marketplace{},
+        Plugins:       map[string]PluginEntry{},
+    }
+}
+```
+
+- [ ] **Step 7.2: Test for store load/save**
+
+`internal/state/store_test.go`:
+
+```go
+package state_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+    "time"
+
+    "github.com/spxrogers/agentsync/internal/state"
+)
+
+func TestStore_RoundTrip(t *testing.T) {
+    dir := t.TempDir()
+    p := filepath.Join(dir, "targets.json")
+
+    in := state.New()
+    in.Files["claude:user::~/.claude/settings.json"] = state.FileEntry{
+        SHA256:    "abc",
+        Mode:      0o644,
+        AppliedAt: time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC),
+        SourceID:  "mcp/github.toml",
+    }
+
+    if err := state.Save(p, in); err != nil {
+        t.Fatalf("Save: %v", err)
+    }
+    out, err := state.Load(p)
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+    got := out.Files["claude:user::~/.claude/settings.json"]
+    if got.SHA256 != "abc" || got.SourceID != "mcp/github.toml" {
+        t.Fatalf("entry round-trip lost data: %+v", got)
+    }
+    if out.SchemaVersion != state.SchemaVersion {
+        t.Fatalf("schema_version = %d", out.SchemaVersion)
+    }
+}
+
+func TestStore_LoadMissingReturnsNew(t *testing.T) {
+    p := filepath.Join(t.TempDir(), "missing.json")
+    s, err := state.Load(p)
+    if err != nil {
+        t.Fatalf("Load missing: %v", err)
+    }
+    if s.SchemaVersion != state.SchemaVersion {
+        t.Fatalf("missing-load did not produce a fresh state: %+v", s)
+    }
+}
+
+func TestStore_AtomicReplaceLeavesNoTemp(t *testing.T) {
+    dir := t.TempDir()
+    p := filepath.Join(dir, "targets.json")
+    if err := state.Save(p, state.New()); err != nil {
+        t.Fatal(err)
+    }
+    if err := state.Save(p, state.New()); err != nil {
+        t.Fatal(err)
+    }
+    entries, _ := os.ReadDir(dir)
+    if len(entries) != 1 {
+        t.Fatalf("expected 1 entry, got %d: %+v", len(entries), entries)
+    }
+}
+```
+
+- [ ] **Step 7.3: Implement store**
+
+`internal/state/store.go`:
+
+```go
+package state
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+    "os"
+
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+// Load reads targets.json from path. If the file is missing, returns a fresh
+// state at the current SchemaVersion.
+func Load(path string) (*Targets, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return New(), nil
+        }
+        return nil, fmt.Errorf("read %s: %w", path, err)
+    }
+    var t Targets
+    if err := json.Unmarshal(data, &t); err != nil {
+        return nil, fmt.Errorf("parse %s: %w", path, err)
+    }
+    if t.SchemaVersion == 0 {
+        t.SchemaVersion = SchemaVersion
+    }
+    if t.Files == nil {
+        t.Files = map[string]FileEntry{}
+    }
+    if t.Keys == nil {
+        t.Keys = map[string]KeyEntry{}
+    }
+    if t.Marketplaces == nil {
+        t.Marketplaces = map[string]Marketplace{}
+    }
+    if t.Plugins == nil {
+        t.Plugins = map[string]PluginEntry{}
+    }
+    return &t, nil
+}
+
+// Save serializes t to path atomically (iox.AtomicWrite).
+func Save(path string, t *Targets) error {
+    if t == nil {
+        return fmt.Errorf("save nil targets")
+    }
+    data, err := json.MarshalIndent(t, "", "  ")
+    if err != nil {
+        return fmt.Errorf("marshal targets: %w", err)
+    }
+    return iox.AtomicWrite(path, append(data, '\n'), 0o644)
+}
+```
+
+- [ ] **Step 7.4: Run; verify; commit**
+
+```bash
+go test -race ./internal/state/...
+```
+
+```bash
+git add internal/state
+git commit -m "$(cat <<'EOF'
+feat(state): targets.json read/save with atomic write + schema v1
+
+Files map keyed by <agent>:<scope>:<project>:<dest>. Keys map keyed by
+<agent>:<scope>:<project>:<file>:<json_pointer>. Loading a missing file
+returns a fresh Targets so first-run never errors.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `internal/adapter` — interface + registry
+
+**Files:**
+- Create: `internal/adapter/adapter.go`, `internal/adapter/registry.go`, `internal/adapter/registry_test.go`
+
+Defines the `Adapter` interface that M1 (Claude), M2 (OpenCode), and later milestones implement. Registry is just a map.
+
+- [ ] **Step 8.1: Interface + types**
+
+`internal/adapter/adapter.go`:
+
+```go
+// Package adapter declares the interface every per-agent adapter implements.
+// The registry holds zero or more concrete implementations; the apply pipeline
+// asks each registered adapter to Render a CanonicalModel into FileOps.
+package adapter
+
+import (
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+// Capability is a bitmask of components an adapter can produce. M1's Claude
+// adapter is full-spectrum; M2's OpenCode adapter omits Hook + LSP.
+type Capability uint32
+
+const (
+    CapMCP Capability = 1 << iota
+    CapMemory
+    CapSkill
+    CapSubagent
+    CapCommand
+    CapHook
+    CapLSP
+)
+
+// Scope distinguishes user-level vs project-level apply targets.
+type Scope int
+
+const (
+    ScopeUser Scope = iota
+    ScopeProject
+)
+
+func (s Scope) String() string {
+    switch s {
+    case ScopeProject:
+        return "project"
+    default:
+        return "user"
+    }
+}
+
+// FileOp describes one destination-side change. Action is "write" or "delete".
+// Path is absolute (after AGENTSYNC_TARGET_ROOT redirection).
+type FileOp struct {
+    Action   string // "write" | "delete"
+    Path     string
+    Content  []byte
+    Mode     uint32
+    SourceID string // canonical source path that produced this op
+}
+
+// Skip describes a component the adapter chose not to render. Surfaces in the
+// translation report and in `apply --strict`'s exit logic.
+type Skip struct {
+    Component string // "skill" | "subagent" | etc.
+    Name      string
+    Reason    string
+}
+
+// Adapter is the per-agent contract.
+type Adapter interface {
+    Name() string
+    Capabilities() Capability
+    Detect() (bool, error)
+    Render(c source.Canonical, scope Scope, project string) ([]FileOp, []Skip, error)
+    Ingest(scope Scope, project string) (source.Canonical, error)
+    Apply(ops []FileOp) error
+}
+```
+
+- [ ] **Step 8.2: Registry**
+
+`internal/adapter/registry.go`:
+
+```go
+package adapter
+
+import "fmt"
+
+// Registry is an in-memory map of adapter name -> Adapter.
+type Registry struct {
+    items map[string]Adapter
+}
+
+func NewRegistry() *Registry {
+    return &Registry{items: map[string]Adapter{}}
+}
+
+// Register adds a; returns error if name collides.
+func (r *Registry) Register(a Adapter) error {
+    name := a.Name()
+    if _, ok := r.items[name]; ok {
+        return fmt.Errorf("adapter %q already registered", name)
+    }
+    r.items[name] = a
+    return nil
+}
+
+// Lookup returns the adapter for name, or nil.
+func (r *Registry) Lookup(name string) Adapter { return r.items[name] }
+
+// Names returns adapter names in deterministic order (sorted).
+func (r *Registry) Names() []string {
+    out := make([]string, 0, len(r.items))
+    for n := range r.items {
+        out = append(out, n)
+    }
+    // bubble sort small slice — keep stdlib only here
+    for i := 1; i < len(out); i++ {
+        for j := i; j > 0 && out[j-1] > out[j]; j-- {
+            out[j-1], out[j] = out[j], out[j-1]
+        }
+    }
+    return out
+}
+```
+
+- [ ] **Step 8.3: Test for registry**
+
+`internal/adapter/registry_test.go`:
+
+```go
+package adapter_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+type stub struct{ name string }
+
+func (s stub) Name() string                                                                        { return s.name }
+func (stub) Capabilities() adapter.Capability                                                      { return 0 }
+func (stub) Detect() (bool, error)                                                                  { return false, nil }
+func (stub) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
+    return nil, nil, nil
+}
+func (stub) Ingest(adapter.Scope, string) (source.Canonical, error) { return source.Canonical{}, nil }
+func (stub) Apply([]adapter.FileOp) error                            { return nil }
+
+func TestRegistry_RegisterLookup(t *testing.T) {
+    r := adapter.NewRegistry()
+    if err := r.Register(stub{name: "x"}); err != nil {
+        t.Fatal(err)
+    }
+    if r.Lookup("x") == nil {
+        t.Fatalf("lookup x = nil")
+    }
+    if r.Lookup("missing") != nil {
+        t.Fatalf("lookup missing should be nil")
+    }
+}
+
+func TestRegistry_DuplicateError(t *testing.T) {
+    r := adapter.NewRegistry()
+    _ = r.Register(stub{name: "x"})
+    if err := r.Register(stub{name: "x"}); err == nil {
+        t.Fatal("expected duplicate-register error")
+    }
+}
+
+func TestRegistry_NamesSorted(t *testing.T) {
+    r := adapter.NewRegistry()
+    _ = r.Register(stub{name: "c"})
+    _ = r.Register(stub{name: "a"})
+    _ = r.Register(stub{name: "b"})
+    names := r.Names()
+    if names[0] != "a" || names[1] != "b" || names[2] != "c" {
+        t.Fatalf("names not sorted: %v", names)
+    }
+}
+```
+
+- [ ] **Step 8.4: Run; verify; commit**
+
+```bash
+go test -race ./internal/adapter/...
+```
+
+```bash
+git add internal/adapter
+git commit -m "$(cat <<'EOF'
+feat(adapter): interface + in-memory registry
+
+Capability bitmask covers all 7 component types from the spec. Scope is
+ScopeUser/ScopeProject. FileOp.Action is "write" or "delete". Skip carries
+component+name+reason for the translation report.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `internal/adapter/noop` — NoopAdapter
+
+**Files:**
+- Create: `internal/adapter/noop/noop.go`, `internal/adapter/noop/noop_test.go`
+
+Empty adapter for end-to-end testing of the apply pipeline before any real adapter exists.
+
+- [ ] **Step 9.1: Implementation**
+
+`internal/adapter/noop/noop.go`:
+
+```go
+// Package noop provides a NoopAdapter that always Detect()s true, Renders no
+// FileOps, and Apply()s nothing. Used as a registry placeholder in tests and
+// as the default adapter set in M0 before M1+ adds real ones.
+package noop
+
+import (
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+type Adapter struct {
+    AdapterName string // overridable for tests
+}
+
+func New(name string) *Adapter { return &Adapter{AdapterName: name} }
+
+func (a *Adapter) Name() string                  { return a.AdapterName }
+func (a *Adapter) Capabilities() adapter.Capability { return 0 }
+func (a *Adapter) Detect() (bool, error)         { return true, nil }
+func (a *Adapter) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
+    return nil, nil, nil
+}
+func (a *Adapter) Ingest(adapter.Scope, string) (source.Canonical, error) {
+    return source.Canonical{}, nil
+}
+func (a *Adapter) Apply([]adapter.FileOp) error { return nil }
+```
+
+- [ ] **Step 9.2: Test**
+
+`internal/adapter/noop/noop_test.go`:
+
+```go
+package noop_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+)
+
+func TestNoop_Implements(t *testing.T) {
+    var _ adapter.Adapter = noop.New("test")
+}
+
+func TestNoop_RenderEmpty(t *testing.T) {
+    a := noop.New("test")
+    ops, skips, err := a.Render(source.CanonicalZero(), adapter.ScopeUser, "")
+    _ = ops
+    _ = skips
+    if err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+(Note: `source.CanonicalZero()` doesn't exist yet; the test as written wouldn't compile. Use `source.Canonical{}` literal directly to avoid adding a helper just for this. Adjust:)
+
+```go
+package noop_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestNoop_Implements(t *testing.T) {
+    var _ adapter.Adapter = noop.New("test")
+}
+
+func TestNoop_Render(t *testing.T) {
+    a := noop.New("test")
+    ops, skips, err := a.Render(source.Canonical{}, adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(ops) != 0 || len(skips) != 0 {
+        t.Fatalf("noop render returned %d ops, %d skips", len(ops), len(skips))
+    }
+}
+```
+
+- [ ] **Step 9.3: Run; commit**
+
+```bash
+go test -race ./internal/adapter/...
+```
+
+```bash
+git add internal/adapter/noop
+git commit -m "$(cat <<'EOF'
+feat(adapter/noop): no-op adapter for testing apply pipeline pre-M1
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `internal/render` — apply pipeline
+
+**Files:**
+- Create: `internal/render/pipeline.go`, `internal/render/pipeline_test.go`
+
+Orchestrates: load canonical → ask each registered+enabled adapter to Render → collect FileOps + Skips → either `apply` (write) or return for `--dry-run` printing.
+
+- [ ] **Step 10.1: Test (driven by NoopAdapter)**
+
+`internal/render/pipeline_test.go`:
+
+```go
+package render_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+    "github.com/spxrogers/agentsync/internal/render"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestPipeline_PlanEmpty(t *testing.T) {
+    reg := adapter.NewRegistry()
+    _ = reg.Register(noop.New("claude"))
+    _ = reg.Register(noop.New("opencode"))
+
+    plan, err := render.Plan(source.Canonical{}, reg, []string{"claude", "opencode"}, adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if plan.Total() != 0 {
+        t.Fatalf("expected empty plan, got %+v", plan)
+    }
+    if len(plan.PerAgent) != 2 {
+        t.Fatalf("expected per-agent entries for both agents")
+    }
+}
+
+func TestPipeline_UnknownAgentError(t *testing.T) {
+    reg := adapter.NewRegistry()
+    _ = reg.Register(noop.New("claude"))
+    _, err := render.Plan(source.Canonical{}, reg, []string{"missing"}, adapter.ScopeUser, "")
+    if err == nil {
+        t.Fatal("expected error for unknown adapter")
+    }
+}
+```
+
+- [ ] **Step 10.2: Implementation**
+
+`internal/render/pipeline.go`:
+
+```go
+// Package render orchestrates the apply pipeline: canonical model + adapter
+// registry -> per-agent FileOps + Skips. apply flag controls whether ops are
+// written to disk or returned for inspection (e.g. --dry-run).
+package render
+
+import (
+    "fmt"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+// Plan holds the result of rendering a canonical model through every selected
+// adapter. PerAgent[name] is the per-agent breakdown.
+type Plan struct {
+    PerAgent map[string]AgentResult
+}
+
+type AgentResult struct {
+    Ops   []adapter.FileOp
+    Skips []adapter.Skip
+}
+
+// Total returns the total number of FileOps across all agents.
+func (p Plan) Total() int {
+    n := 0
+    for _, r := range p.PerAgent {
+        n += len(r.Ops)
+    }
+    return n
+}
+
+// Plan asks each adapter named in agents to render the canonical model.
+// Returns a Plan, never writes anything. Use Apply() to commit.
+func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string) (Plan, error) {
+    out := Plan{PerAgent: map[string]AgentResult{}}
+    for _, name := range agents {
+        a := reg.Lookup(name)
+        if a == nil {
+            return out, fmt.Errorf("adapter %q not registered", name)
+        }
+        ops, skips, err := a.Render(c, scope, project)
+        if err != nil {
+            return out, fmt.Errorf("render %s: %w", name, err)
+        }
+        out.PerAgent[name] = AgentResult{Ops: ops, Skips: skips}
+    }
+    return out, nil
+}
+
+// Apply commits a Plan by calling each adapter's Apply with its FileOps. If
+// any adapter returns an error, applies completed so far are NOT rolled back
+// (each adapter's Apply is itself atomic per-file via iox.AtomicWrite).
+func Apply(p Plan, reg *adapter.Registry) error {
+    for name, res := range p.PerAgent {
+        a := reg.Lookup(name)
+        if a == nil {
+            return fmt.Errorf("adapter %q not registered at apply", name)
+        }
+        if err := a.Apply(res.Ops); err != nil {
+            return fmt.Errorf("apply %s: %w", name, err)
+        }
+    }
+    return nil
+}
+```
+
+- [ ] **Step 10.3: Run; commit**
+
+```bash
+go test -race ./internal/render/...
+```
+
+```bash
+git add internal/render
+git commit -m "$(cat <<'EOF'
+feat(render): apply pipeline orchestrator (Plan + Apply)
+
+Plan() asks each named adapter to Render; Apply() commits all FileOps.
+Per-agent results in plan.PerAgent map keyed by adapter name. Used by
+cli/apply in Task 17.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: `internal/cli` — root command + global flags
+
+**Files:**
+- Create: `internal/cli/root.go`, `internal/cli/root_test.go`, `internal/cli/testhelper_test.go`
+
+cobra root with `--verbose`, `--config`, version printing. Subcommands attach via `root.AddCommand()`.
+
+- [ ] **Step 11.1: Add cobra dependency**
+
+```bash
+go get github.com/spf13/cobra@latest
+```
+
+- [ ] **Step 11.2: Test helpers (used by all cli tests)**
+
+`internal/cli/testhelper_test.go`:
+
+```go
+package cli_test
+
+import (
+    "bytes"
+    "io"
+    "strings"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/cli"
+)
+
+// runCLI runs the CLI with given args, returns stdout+stderr combined and
+// the resulting error. Sets AGENTSYNC_TARGET_ROOT to the supplied tmp via env.
+func runCLI(t *testing.T, env map[string]string, args ...string) (string, error) {
+    t.Helper()
+    var buf bytes.Buffer
+    root := cli.NewRoot()
+    root.SetOut(&buf)
+    root.SetErr(&buf)
+    root.SetArgs(args)
+    for k, v := range env {
+        t.Setenv(k, v)
+    }
+    err := root.Execute()
+    out, _ := io.ReadAll(&buf)
+    return strings.TrimSpace(string(out)), err
+}
+```
+
+- [ ] **Step 11.3: Test for root**
+
+`internal/cli/root_test.go`:
+
+```go
+package cli_test
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestRoot_VersionFlag(t *testing.T) {
+    out, err := runCLI(t, nil, "--version")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(out, "agentsync") {
+        t.Fatalf("version output missing 'agentsync': %s", out)
+    }
+}
+
+func TestRoot_HelpListsSubcommands(t *testing.T) {
+    out, _ := runCLI(t, nil, "--help")
+    for _, sub := range []string{"init", "agent", "doctor", "verify", "apply"} {
+        if !strings.Contains(out, sub) {
+            t.Fatalf("--help missing subcommand %q. Got: %s", sub, out)
+        }
+    }
+}
+```
+
+- [ ] **Step 11.4: Implementation**
+
+`internal/cli/root.go`:
+
+```go
+// Package cli wires cobra subcommands. NewRoot returns the root *cobra.Command
+// with all subcommands attached.
+package cli
+
+import (
+    "github.com/spf13/cobra"
+)
+
+// version metadata; main.go injects via -ldflags. Tests use the literal
+// strings below.
+var (
+    Version = "dev"
+    Commit  = "none"
+    Date    = "unknown"
+)
+
+// NewRoot constructs the root command tree. Tests build their own root via
+// this constructor so flag state is isolated per test.
+func NewRoot() *cobra.Command {
+    var verbose bool
+
+    cmd := &cobra.Command{
+        Use:           "agentsync",
+        Short:         "Centrally manage AI coding-agent configurations",
+        SilenceUsage:  true,
+        SilenceErrors: true,
+        Version:       Version,
+    }
+    cmd.SetVersionTemplate(`{{.Use}} {{.Version}} (commit ` + Commit + `, built ` + Date + `)
+`)
+    cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
+
+    cmd.AddCommand(
+        newInitCmd(),
+        newAgentCmd(),
+        newDoctorCmd(),
+        newVerifyCmd(),
+        newApplyCmd(),
+    )
+    return cmd
+}
+
+// Execute is the main.go entry point.
+func Execute() error { return NewRoot().Execute() }
+```
+
+(this references `newInitCmd`, `newAgentCmd`, etc.; placeholder forward declarations are added in Tasks 12–17 as each command lands.)
+
+- [ ] **Step 11.5: Stub the command-constructor functions so root.go compiles**
+
+Until each subcommand is fleshed out in Tasks 12–17, add stubs in their respective files. Create `internal/cli/init.go`, `agent.go`, `doctor.go`, `verify.go`, `apply.go` each with a minimal stub:
+
+```go
+package cli
+
+import "github.com/spf13/cobra"
+
+func newInitCmd() *cobra.Command {
+    return &cobra.Command{Use: "init", Short: "scaffold ~/.agentsync/", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+}
+```
+
+…and analogous stubs for `newAgentCmd`, `newDoctorCmd`, `newVerifyCmd`, `newApplyCmd`. They'll be replaced in subsequent tasks.
+
+- [ ] **Step 11.6: Wire main.go**
+
+Update `cmd/agentsync/main.go`:
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/spxrogers/agentsync/internal/cli"
+)
+
+var (
+    version = "dev"
+    commit  = "none"
+    date    = "unknown"
+)
+
+func main() {
+    cli.Version = version
+    cli.Commit = commit
+    cli.Date = date
+
+    if err := cli.Execute(); err != nil {
+        fmt.Fprintln(os.Stderr, "agentsync:", err)
+        os.Exit(1)
+    }
+}
+```
+
+- [ ] **Step 11.7: Run; verify; commit**
+
+```bash
+go test -race ./internal/cli/...
+```
+
+Expected: `--version` test passes, `--help` test passes (subcommand stubs are present).
+
+```bash
+git add go.mod go.sum cmd/agentsync internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli): cobra root with --verbose; command stubs for init/agent/doctor/verify/apply
+
+Stubs are wired so root.go compiles and --help lists every command. Each
+stub is replaced with real behavior in Tasks 12–17.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: `agentsync init`
+
+**Files:**
+- Modify: `internal/cli/init.go`
+- Create: `internal/cli/init_test.go`
+
+Scaffolds `~/.agentsync/` with empty subdirectories and a stub `opensync.toml`.
+
+- [ ] **Step 12.1: Test**
+
+`internal/cli/init_test.go`:
+
+```go
+package cli_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func TestInit_FreshScaffold(t *testing.T) {
+    tmp := t.TempDir()
+    out, err := runCLI(t,
+        map[string]string{"AGENTSYNC_TARGET_ROOT": tmp},
+        "init")
+    if err != nil {
+        t.Fatalf("init: %v\n%s", err, out)
+    }
+
+    home := filepath.Join(tmp, ".agentsync")
+    for _, d := range []string{"mcp", "marketplaces", "plugins", "memory", "memory/fragments", "skills", "secrets", ".state"} {
+        if _, err := os.Stat(filepath.Join(home, d)); err != nil {
+            t.Fatalf("missing dir %s: %v", d, err)
+        }
+    }
+    if _, err := os.Stat(filepath.Join(home, "opensync.toml")); err != nil {
+        t.Fatalf("missing opensync.toml: %v", err)
+    }
+}
+
+func TestInit_RefusesPopulatedHome(t *testing.T) {
+    tmp := t.TempDir()
+    _ = os.MkdirAll(filepath.Join(tmp, ".agentsync"), 0o755)
+    _ = os.WriteFile(filepath.Join(tmp, ".agentsync", "opensync.toml"), []byte("# already there"), 0o644)
+
+    _, err := runCLI(t,
+        map[string]string{"AGENTSYNC_TARGET_ROOT": tmp},
+        "init")
+    if err == nil {
+        t.Fatalf("init should refuse to overwrite a populated home")
+    }
+}
+```
+
+- [ ] **Step 12.2: Implementation**
+
+Replace `internal/cli/init.go`:
+
+```go
+package cli
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+
+const initialOpensyncTOML = `# agentsync source-of-truth config
+# See docs/superpowers/specs/2026-05-04-agentsync-design.md for the full schema.
+
+[agents]
+# claude   = { enabled = true,  scope = "user" }
+# opencode = { enabled = true,  scope = "user" }
+# codex    = { enabled = false }   # v1.1
+# cursor   = { enabled = false }   # v1.2
+
+[updates]
+default_mode     = "track"        # pinned | track | manual
+default_interval = "24h"
+
+# [secrets]
+# backend       = "age"
+# file          = "secrets/secrets.age"
+# recipient     = "age1...your-public-key..."
+# identity_file = "${env:HOME}/.config/agentsync/age.key"
+`
+
+func newInitCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "init",
+        Short: "scaffold ~/.agentsync/ with empty subdirectories and stub opensync.toml",
+        Args:  cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            home := paths.AgentsyncHome(paths.OSEnv{})
+            if entries, _ := os.ReadDir(home); len(entries) > 0 {
+                return fmt.Errorf("%s already contains files; refusing to overwrite", home)
+            }
+
+            for _, sub := range []string{"mcp", "marketplaces", "plugins", "memory", "memory/fragments", "skills", "secrets", ".state"} {
+                if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+                    return fmt.Errorf("mkdir %s: %w", sub, err)
+                }
+            }
+            if err := os.WriteFile(filepath.Join(home, "opensync.toml"), []byte(initialOpensyncTOML), 0o644); err != nil {
+                return fmt.Errorf("write opensync.toml: %w", err)
+            }
+            fmt.Fprintln(cmd.OutOrStdout(), "agentsync home initialized at", home)
+            return nil
+        },
+    }
+}
+```
+
+- [ ] **Step 12.3: Run; commit**
+
+```bash
+go test -race ./internal/cli/...
+```
+
+```bash
+git add internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli/init): scaffold ~/.agentsync/ with empty subdirs + stub config
+
+Refuses to overwrite a populated home so re-init is opt-in via wipe.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `agentsync agent {add,list,remove}`
+
+**Files:**
+- Modify: `internal/cli/agent.go`
+- Create: `internal/cli/agent_test.go`
+
+Manipulates the `[agents]` table in `~/.agentsync/opensync.toml` via TOML AST round-trip (preserves comments + key order).
+
+- [ ] **Step 13.1: Test**
+
+`internal/cli/agent_test.go`:
+
+```go
+package cli_test
+
+import (
+    "os"
+    "path/filepath"
+    "strings"
+    "testing"
+)
+
+func TestAgent_AddListRemove(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    if _, err := runCLI(t, env, "init"); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+        t.Fatalf("agent add: %v", err)
+    }
+    if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+        t.Fatalf("agent add opencode: %v", err)
+    }
+
+    listOut, err := runCLI(t, env, "agent", "list")
+    if err != nil {
+        t.Fatalf("agent list: %v", err)
+    }
+    if !strings.Contains(listOut, "claude") || !strings.Contains(listOut, "opencode") {
+        t.Fatalf("list missing entries: %s", listOut)
+    }
+
+    if _, err := runCLI(t, env, "agent", "remove", "opencode"); err != nil {
+        t.Fatalf("agent remove: %v", err)
+    }
+    listOut2, _ := runCLI(t, env, "agent", "list")
+    if strings.Contains(listOut2, "opencode") {
+        t.Fatalf("list still contains removed agent: %s", listOut2)
+    }
+
+    cfg, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "opensync.toml"))
+    if !strings.Contains(string(cfg), `claude = `) {
+        t.Fatalf("config didn't preserve claude line:\n%s", cfg)
+    }
+}
+```
+
+- [ ] **Step 13.2: Implementation**
+
+Replace `internal/cli/agent.go`:
+
+```go
+package cli
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "sort"
+    "strings"
+
+    "github.com/pelletier/go-toml/v2"
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/iox"
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+
+const validAgents = "claude, opencode, codex, cursor"
+
+func newAgentCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "agent", Short: "manage which agents agentsync targets"}
+    cmd.AddCommand(
+        &cobra.Command{Use: "add <name>", Args: cobra.ExactArgs(1), RunE: agentAddRun},
+        &cobra.Command{Use: "remove <name>", Args: cobra.ExactArgs(1), RunE: agentRemoveRun},
+        &cobra.Command{Use: "list", Args: cobra.NoArgs, RunE: agentListRun},
+    )
+    return cmd
+}
+
+type opensyncCfg struct {
+    Agents map[string]map[string]any `toml:"agents"`
+    // other top-level keys preserved verbatim via decoder
+}
+
+// agentName must be one of the recognized adapter names. M0 only accepts the
+// four — adding a new agent in v1.x is a code change, not a config change.
+func validateAgent(name string) error {
+    switch name {
+    case "claude", "opencode", "codex", "cursor":
+        return nil
+    }
+    return fmt.Errorf("unknown agent %q; valid: %s", name, validAgents)
+}
+
+// readOpensyncTOML returns the file contents + parsed `agents` section.
+func readOpensyncTOML() (string, []byte, map[string]map[string]any, error) {
+    home := paths.AgentsyncHome(paths.OSEnv{})
+    p := filepath.Join(home, "opensync.toml")
+    raw, err := os.ReadFile(p)
+    if err != nil {
+        return p, nil, nil, fmt.Errorf("read %s: %w", p, err)
+    }
+    var cfg opensyncCfg
+    if err := toml.Unmarshal(raw, &cfg); err != nil {
+        return p, raw, nil, fmt.Errorf("parse %s: %w", p, err)
+    }
+    if cfg.Agents == nil {
+        cfg.Agents = map[string]map[string]any{}
+    }
+    return p, raw, cfg.Agents, nil
+}
+
+func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
+    // Round-trip: marshal the agents map, splice into raw bytes preserving
+    // top-of-file comments. Simpler v1 approach: regenerate the [agents]
+    // block; preserve everything before and after via slice.
+    var buf strings.Builder
+    if err := toml.NewEncoder(&buf).Encode(struct {
+        Agents map[string]map[string]any `toml:"agents"`
+    }{Agents: agents}); err != nil {
+        return fmt.Errorf("encode agents: %w", err)
+    }
+    newSection := buf.String()
+    rawStr := string(raw)
+    start := strings.Index(rawStr, "[agents]")
+    if start < 0 {
+        // no [agents] section yet; append.
+        return iox.AtomicWrite(p, []byte(rawStr+"\n"+newSection), 0o644)
+    }
+    rest := rawStr[start:]
+    nextHeader := strings.Index(rest[len("[agents]"):], "\n[")
+    var tail string
+    if nextHeader >= 0 {
+        tail = rest[len("[agents]")+nextHeader:]
+    }
+    out := rawStr[:start] + newSection + tail
+    return iox.AtomicWrite(p, []byte(out), 0o644)
+}
+
+func agentAddRun(cmd *cobra.Command, args []string) error {
+    name := args[0]
+    if err := validateAgent(name); err != nil {
+        return err
+    }
+    p, raw, agents, err := readOpensyncTOML()
+    if err != nil {
+        return err
+    }
+    if _, ok := agents[name]; ok {
+        fmt.Fprintf(cmd.OutOrStdout(), "agent %s already registered\n", name)
+        return nil
+    }
+    agents[name] = map[string]any{"enabled": true, "scope": "user"}
+    if err := writeAgents(p, raw, agents); err != nil {
+        return err
+    }
+    fmt.Fprintf(cmd.OutOrStdout(), "added agent: %s\n", name)
+    return nil
+}
+
+func agentRemoveRun(cmd *cobra.Command, args []string) error {
+    name := args[0]
+    p, raw, agents, err := readOpensyncTOML()
+    if err != nil {
+        return err
+    }
+    if _, ok := agents[name]; !ok {
+        fmt.Fprintf(cmd.OutOrStdout(), "agent %s not registered\n", name)
+        return nil
+    }
+    delete(agents, name)
+    if err := writeAgents(p, raw, agents); err != nil {
+        return err
+    }
+    fmt.Fprintf(cmd.OutOrStdout(), "removed agent: %s\n", name)
+    return nil
+}
+
+func agentListRun(cmd *cobra.Command, _ []string) error {
+    _, _, agents, err := readOpensyncTOML()
+    if err != nil {
+        return err
+    }
+    names := make([]string, 0, len(agents))
+    for n := range agents {
+        names = append(names, n)
+    }
+    sort.Strings(names)
+    if len(names) == 0 {
+        fmt.Fprintln(cmd.OutOrStdout(), "(no agents registered; try: agentsync agent add claude)")
+        return nil
+    }
+    for _, n := range names {
+        v := agents[n]
+        enabled, _ := v["enabled"].(bool)
+        scope, _ := v["scope"].(string)
+        fmt.Fprintf(cmd.OutOrStdout(), "%-10s enabled=%t scope=%s\n", n, enabled, scope)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 13.3: Run; commit**
+
+```bash
+go test -race ./internal/cli/...
+```
+
+```bash
+git add internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli/agent): add/list/remove via TOML round-trip in opensync.toml
+
+[agents] section is regenerated; surrounding comments/sections preserved
+by simple slice operations. Comment-preserving AST mutations for
+mid-section edits land in M1 where MCP needs them.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: `agentsync doctor`
+
+**Files:**
+- Modify: `internal/cli/doctor.go`
+- Create: `internal/cli/doctor_test.go`
+
+Reports environment + agent installation detection. M0 only checks PATH; richer per-adapter detection lands in M1+.
+
+- [ ] **Step 14.1: Test**
+
+`internal/cli/doctor_test.go`:
+
+```go
+package cli_test
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestDoctor_PrintsEnvAndAgents(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+
+    out, err := runCLI(t, env, "doctor")
+    if err != nil {
+        t.Fatalf("doctor: %v\n%s", err, out)
+    }
+    for _, want := range []string{"AGENTSYNC_HOME", "Go version", "OS", "claude", "opencode"} {
+        if !strings.Contains(out, want) {
+            t.Fatalf("doctor output missing %q. Got:\n%s", want, out)
+        }
+    }
+}
+```
+
+- [ ] **Step 14.2: Implementation**
+
+Replace `internal/cli/doctor.go`:
+
+```go
+package cli
+
+import (
+    "fmt"
+    "os/exec"
+    "runtime"
+
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+
+func newDoctorCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "doctor",
+        Short: "print environment + adapter detection",
+        Args:  cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            w := cmd.OutOrStdout()
+            fmt.Fprintln(w, "agentsync doctor")
+            fmt.Fprintln(w, "  AGENTSYNC_HOME:", paths.AgentsyncHome(paths.OSEnv{}))
+            fmt.Fprintln(w, "  Go version:    ", runtime.Version())
+            fmt.Fprintln(w, "  OS / arch:     ", runtime.GOOS, runtime.GOARCH)
+            fmt.Fprintln(w, "")
+            fmt.Fprintln(w, "Adapter detection (M0: PATH-only)")
+            for _, agent := range []struct {
+                name string
+                bin  string
+            }{
+                {"claude", "claude"},
+                {"opencode", "opencode"},
+                {"codex", "codex"},
+                {"cursor", "cursor"},
+            } {
+                p, err := exec.LookPath(agent.bin)
+                if err != nil {
+                    fmt.Fprintf(w, "  %-10s not found in PATH\n", agent.name)
+                    continue
+                }
+                fmt.Fprintf(w, "  %-10s %s\n", agent.name, p)
+            }
+            return nil
+        },
+    }
+}
+```
+
+- [ ] **Step 14.3: Run; commit**
+
+```bash
+go test -race ./internal/cli/...
+git add internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli/doctor): print env + PATH-based agent detection
+
+Richer per-adapter detection (e.g. Claude looks for ~/.claude/) lands in
+M1+ as each adapter overrides Detect().
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: `agentsync verify`
+
+**Files:**
+- Modify: `internal/cli/verify.go`
+- Create: `internal/cli/verify_test.go`
+
+Lints `~/.agentsync/`: parses every TOML file, reports schema violations. M0 surface: "all files parse, all `[agents].<name>` are known adapters."
+
+- [ ] **Step 15.1: Test**
+
+`internal/cli/verify_test.go`:
+
+```go
+package cli_test
+
+import (
+    "os"
+    "path/filepath"
+    "strings"
+    "testing"
+)
+
+func TestVerify_Empty(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+
+    out, err := runCLI(t, env, "verify")
+    if err != nil {
+        t.Fatalf("verify on empty home: %v", err)
+    }
+    if !strings.Contains(out, "ok") {
+        t.Fatalf("verify output missing 'ok': %s", out)
+    }
+}
+
+func TestVerify_BadTOML(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+
+    badPath := filepath.Join(tmp, ".agentsync", "mcp", "broken.toml")
+    _ = os.MkdirAll(filepath.Dir(badPath), 0o755)
+    _ = os.WriteFile(badPath, []byte("[server\nmissing-bracket"), 0o644)
+
+    _, err := runCLI(t, env, "verify")
+    if err == nil {
+        t.Fatal("verify should fail on malformed TOML")
+    }
+}
+
+func TestVerify_UnknownAgent(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    cfg := filepath.Join(tmp, ".agentsync", "opensync.toml")
+    body, _ := os.ReadFile(cfg)
+    body = append(body, []byte("\n[agents]\nbogus = { enabled = true }\n")...)
+    _ = os.WriteFile(cfg, body, 0o644)
+
+    _, err := runCLI(t, env, "verify")
+    if err == nil {
+        t.Fatal("verify should reject unknown agent name")
+    }
+}
+```
+
+- [ ] **Step 15.2: Implementation**
+
+Replace `internal/cli/verify.go`:
+
+```go
+package cli
+
+import (
+    "fmt"
+
+    "github.com/spf13/afero"
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/paths"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func newVerifyCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "verify",
+        Short: "schema-lint ~/.agentsync/ on demand",
+        Args:  cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            home := paths.AgentsyncHome(paths.OSEnv{})
+            c, err := source.Load(afero.NewOsFs(), home)
+            if err != nil {
+                return fmt.Errorf("verify: %w", err)
+            }
+            for name := range c.Config.Agents {
+                if err := validateAgent(name); err != nil {
+                    return fmt.Errorf("agents.%s: %w", name, err)
+                }
+            }
+            fmt.Fprintln(cmd.OutOrStdout(), "ok: schema valid; all referenced agents are recognized adapters")
+            return nil
+        },
+    }
+}
+```
+
+- [ ] **Step 15.3: Run; commit**
+
+```bash
+go test -race ./internal/cli/...
+git add internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli/verify): schema-lint ~/.agentsync/ — parse every TOML + validate agents
+
+M0 only checks: every file parses; agent names are known. Richer
+validation (MCP env interpolation references resolvable secrets, plugin
+versions match marketplace cache, etc.) lands as later milestones add
+those features.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: `agentsync apply --dry-run`
+
+**Files:**
+- Modify: `internal/cli/apply.go`
+- Create: `internal/cli/apply_test.go`
+
+Wires source-loader → render.Plan → prints plan. M0 only supports `--dry-run` because no real adapter writes anything yet.
+
+- [ ] **Step 16.1: Test (uses NoopAdapter via a thin registry helper)**
+
+Add `internal/cli/registry_internal.go` exposing a hook for tests:
+
+```go
+package cli
+
+import (
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+)
+
+// registryFactory returns an adapter.Registry. Production wires real
+// adapters; tests can override via setRegistryFactory.
+var registryFactory = func() *adapter.Registry {
+    r := adapter.NewRegistry()
+    // M0: only NoopAdapters under each known name
+    for _, name := range []string{"claude", "opencode", "codex", "cursor"} {
+        _ = r.Register(noop.New(name))
+    }
+    return r
+}
+```
+
+`internal/cli/apply_test.go`:
+
+```go
+package cli_test
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestApply_DryRunEmptyHome(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    out, err := runCLI(t, env, "apply", "--dry-run")
+    if err != nil {
+        t.Fatalf("apply --dry-run: %v\n%s", err, out)
+    }
+    if !strings.Contains(out, "claude") {
+        t.Fatalf("dry-run output missing per-agent breakdown: %s", out)
+    }
+    if !strings.Contains(out, "0 ops") {
+        t.Fatalf("dry-run should report 0 ops on empty canonical: %s", out)
+    }
+}
+
+func TestApply_NoFlagDefaultsToDryRun_M0(t *testing.T) {
+    // M0 NEVER writes destinations; flag the user when they call apply
+    // without --dry-run so they understand M0 vs M1+ scope.
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    out, err := runCLI(t, env, "apply")
+    if err == nil {
+        t.Fatalf("apply without --dry-run in M0 should error or warn; got: %s", out)
+    }
+}
+```
+
+- [ ] **Step 16.2: Implementation**
+
+Replace `internal/cli/apply.go`:
+
+```go
+package cli
+
+import (
+    "fmt"
+
+    "github.com/spf13/afero"
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/paths"
+    "github.com/spxrogers/agentsync/internal/render"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func newApplyCmd() *cobra.Command {
+    var (
+        dryRun bool
+        scope  string
+    )
+    cmd := &cobra.Command{
+        Use:   "apply",
+        Short: "render canonical config and write per agent (M0: --dry-run only)",
+        Args:  cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            if !dryRun {
+                return fmt.Errorf("M0 only supports --dry-run; real adapters arrive in M1 (claude) and M2 (opencode)")
+            }
+            home := paths.AgentsyncHome(paths.OSEnv{})
+            c, err := source.Load(afero.NewOsFs(), home)
+            if err != nil {
+                return err
+            }
+            agents := []string{}
+            for name, ag := range c.Config.Agents {
+                if ag.Enabled {
+                    agents = append(agents, name)
+                }
+            }
+
+            sc := adapter.ScopeUser
+            if scope == "project" {
+                sc = adapter.ScopeProject
+            }
+
+            reg := registryFactory()
+            plan, err := render.Plan(c, reg, agents, sc, "")
+            if err != nil {
+                return err
+            }
+
+            w := cmd.OutOrStdout()
+            fmt.Fprintf(w, "Plan: %d ops total across %d agent(s)\n", plan.Total(), len(plan.PerAgent))
+            for _, name := range reg.Names() {
+                res, ok := plan.PerAgent[name]
+                if !ok {
+                    continue
+                }
+                fmt.Fprintf(w, "  %-10s %d ops, %d skips\n", name, len(res.Ops), len(res.Skips))
+            }
+            return nil
+        },
+    }
+    cmd.Flags().BoolVar(&dryRun, "dry-run", false, "compute plan without writing destinations")
+    cmd.Flags().StringVar(&scope, "scope", "user", "user | project")
+    return cmd
+}
+```
+
+- [ ] **Step 16.3: Run; commit**
+
+```bash
+go test -race ./internal/cli/...
+git add internal/cli
+git commit -m "$(cat <<'EOF'
+feat(cli/apply): --dry-run pipeline using NoopAdapters
+
+M0 errors on apply without --dry-run because no real adapter is
+registered yet; this fails-loud rather than appearing to succeed. Real
+adapters land in M1+ and the error is removed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Final integration test + CI run
+
+**Files:**
+- Create: `internal/cli/integration_test.go`
+
+End-to-end: `init → agent add claude → agent add opencode → verify → apply --dry-run` returns 0 across the board.
+
+- [ ] **Step 17.1: Test**
+
+```go
+package cli_test
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestIntegration_M0Lifecycle(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    type step struct {
+        args      []string
+        wantSubs  []string
+        wantError bool
+    }
+    steps := []step{
+        {args: []string{"init"}, wantSubs: []string{"initialized"}},
+        {args: []string{"agent", "add", "claude"}, wantSubs: []string{"added agent: claude"}},
+        {args: []string{"agent", "add", "opencode"}, wantSubs: []string{"added agent: opencode"}},
+        {args: []string{"agent", "list"}, wantSubs: []string{"claude", "opencode"}},
+        {args: []string{"verify"}, wantSubs: []string{"ok"}},
+        {args: []string{"apply", "--dry-run"}, wantSubs: []string{"Plan", "claude", "opencode"}},
+        {args: []string{"agent", "remove", "claude"}, wantSubs: []string{"removed agent: claude"}},
+    }
+    for _, s := range steps {
+        out, err := runCLI(t, env, s.args...)
+        if (err != nil) != s.wantError {
+            t.Fatalf("%v: err=%v want-err=%v\n%s", s.args, err, s.wantError, out)
+        }
+        for _, sub := range s.wantSubs {
+            if !strings.Contains(out, sub) {
+                t.Fatalf("%v: output missing %q. Got:\n%s", s.args, sub, out)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 17.2: Run, lint, push**
+
+```bash
+go test -race ./...
+golangci-lint run ./...
+```
+
+Both must be green.
+
+- [ ] **Step 17.3: Commit + push the branch**
+
+```bash
+git add internal/cli/integration_test.go
+git commit -m "$(cat <<'EOF'
+test(cli): M0 end-to-end lifecycle integration test
+
+init -> agent add x2 -> agent list -> verify -> apply --dry-run -> agent remove
+All steps exercise real cobra command path against AGENTSYNC_TARGET_ROOT
+tmpdir; no $HOME pollution.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push
+```
+
+CI on the PR should go green: `test` job on linux/macos/windows, `lint` job, `goreleaser-snapshot` job.
+
+---
+
+## Done When
+
+The engineer can demo end-to-end:
+
+```bash
+$ agentsync --version
+agentsync v1.0.0-m0 (commit ..., built ...)
+
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync init
+agentsync home initialized at /tmp/x/.agentsync
+
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync agent add claude
+added agent: claude
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync agent add opencode
+added agent: opencode
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync agent list
+claude     enabled=true  scope=user
+opencode   enabled=true  scope=user
+
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync verify
+ok: schema valid; all referenced agents are recognized adapters
+
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync apply --dry-run
+Plan: 0 ops total across 2 agent(s)
+  claude     0 ops, 0 skips
+  opencode   0 ops, 0 skips
+
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync apply
+Error: M0 only supports --dry-run; real adapters arrive in M1 (claude) and M2 (opencode)
+```
+
+CI green on linux + macos + windows for `test` (race) and `lint`. `goreleaser` snapshot builds successfully.
+
+The skeleton supports M1 (Claude adapter), M2 (OpenCode adapter), M3 (drift), M4 (plugins), M5 (project), M6 (secrets), M7 (polish/release) without architectural changes.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m1-claude.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m1-claude.md
@@ -1,0 +1,1929 @@
+# agentsync M1 — Claude Code adapter
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md#conventions-used-across-all-milestone-plans). Builds on [M0 skeleton](2026-05-04-agentsync-m0-skeleton.md).
+
+**Goal:** First real adapter. Implements `internal/adapter/claude` covering all 7 component types (MCP, memory, skill, subagent, slash command, hook, LSP). Renders + ingests round-trip. Settings written to `~/.claude/settings.json` and `~/.claude.json` use **per-key merge** so foreign keys (Claude's own writes, user hand-edits) survive untouched. Replaces the NoopAdapter for `claude` in the registry.
+
+**Architecture:** One package (`internal/adapter/claude`) with one file per concern. The adapter consumes a `source.Canonical` and emits a `[]adapter.FileOp` ready for atomic write. Settings/`.claude.json` merging uses a JSON-pointer-based AST walk: opensync only touches keys it has written before (tracked in M0's `state.Keys`); foreign keys flow through unchanged.
+
+**Tech stack:** Stdlib `encoding/json` for Claude's strict-JSON files; `pelletier/go-toml/v2` already vendored from M0; `os/exec` to detect Claude installation.
+
+---
+
+## Files created in this milestone
+
+```
+internal/adapter/claude/
+├── claude.go              # Adapter struct, Name(), Capabilities(), Detect()
+├── paths.go               # Resolves ~/.claude/, settings.json, .claude.json paths
+├── render.go              # Render(): canonical -> []FileOp
+├── render_test.go
+├── ingest.go              # Ingest(): disk -> source.Canonical
+├── ingest_test.go
+├── apply.go               # Apply([]FileOp) -> writes via iox.AtomicWrite
+├── apply_test.go
+├── settings.go            # JSON key-level merge for settings.json + .claude.json
+├── settings_test.go
+├── skill.go               # SKILL.md frontmatter + body passthrough
+├── skill_test.go
+├── memory.go              # CLAUDE.md rendering from canonical Memory
+├── subagent.go            # agents/<name>.md from canonical
+├── command.go             # commands/<name>.md from canonical
+├── hook.go                # hooks JSON appended to settings.json
+├── lsp.go                 # lspServers JSON appended to settings.json
+├── frontmatter.go         # YAML frontmatter parser shared by skill/subagent
+└── frontmatter_test.go
+```
+
+Plus modifications:
+- `internal/cli/registry_internal.go` — wire `claude.New()` for the "claude" name
+- `testdata/claude/<case>/{source,expected}` — golden fixtures
+
+---
+
+## Task 1: `claude.Adapter` skeleton + `Detect()`
+
+**Files:**
+- Create: `internal/adapter/claude/{claude.go,paths.go}`
+- Create: `internal/adapter/claude/claude_test.go`
+
+`Adapter` struct + paths helper. `Detect()` returns true if `~/.claude/` exists OR `claude` is on PATH.
+
+- [ ] **Step 1.1: Write the failing test**
+
+`internal/adapter/claude/claude_test.go`:
+
+```go
+package claude_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+)
+
+func TestAdapter_Identity(t *testing.T) {
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    if a.Name() != "claude" {
+        t.Fatalf("Name = %q", a.Name())
+    }
+    if a.Capabilities() == 0 {
+        t.Fatalf("expected non-zero capabilities")
+    }
+    var _ adapter.Adapter = a
+}
+
+func TestAdapter_DetectsHomeDir(t *testing.T) {
+    tmp := t.TempDir()
+    _ = os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755)
+
+    a := claude.New(claude.Options{TargetRoot: tmp})
+    ok, err := a.Detect()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !ok {
+        t.Fatalf("expected Detect=true when ~/.claude/ exists")
+    }
+}
+
+func TestAdapter_DetectsAbsentReturnsFalse(t *testing.T) {
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    ok, _ := a.Detect()
+    if ok {
+        t.Fatalf("expected Detect=false on empty home")
+    }
+}
+```
+
+- [ ] **Step 1.2: Run; verify undefined**
+
+`undefined: claude.New, claude.Options`
+
+- [ ] **Step 1.3: Implement**
+
+`internal/adapter/claude/paths.go`:
+
+```go
+package claude
+
+import "path/filepath"
+
+// Paths resolves the destination paths for a given (scope, project, target-root).
+type Paths struct {
+    Home            string // ~/.claude
+    Settings        string // ~/.claude/settings.json
+    DotClaude       string // ~/.claude.json (mcpServers + plugin enables live here)
+    SkillsDir       string // ~/.claude/skills
+    AgentsDir       string // ~/.claude/agents
+    CommandsDir     string // ~/.claude/commands
+    Memory          string // ~/.claude/CLAUDE.md (user scope) or <proj>/CLAUDE.md (project scope)
+    PluginsCacheDir string // ~/.claude/plugins/cache
+}
+
+func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
+    home := filepath.Join(targetRoot, ".claude")
+    p := Paths{
+        Home:            home,
+        Settings:        filepath.Join(home, "settings.json"),
+        DotClaude:       filepath.Join(targetRoot, ".claude.json"),
+        SkillsDir:       filepath.Join(home, "skills"),
+        AgentsDir:       filepath.Join(home, "agents"),
+        CommandsDir:     filepath.Join(home, "commands"),
+        Memory:          filepath.Join(home, "CLAUDE.md"),
+        PluginsCacheDir: filepath.Join(home, "plugins", "cache"),
+    }
+    if projectScope && project != "" {
+        // project-scope settings live under <project>/.claude/
+        projHome := filepath.Join(project, ".claude")
+        p.Home = projHome
+        p.Settings = filepath.Join(projHome, "settings.json")
+        p.SkillsDir = filepath.Join(projHome, "skills")
+        p.AgentsDir = filepath.Join(projHome, "agents")
+        p.CommandsDir = filepath.Join(projHome, "commands")
+        p.Memory = filepath.Join(project, "CLAUDE.md")
+    }
+    return p
+}
+```
+
+`internal/adapter/claude/claude.go`:
+
+```go
+// Package claude implements the Claude Code adapter for agentsync.
+package claude
+
+import (
+    "os"
+    "os/exec"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// Options configure the adapter at construction.
+type Options struct {
+    TargetRoot string // honors AGENTSYNC_TARGET_ROOT (real "/Users/x" in production)
+}
+
+// Adapter implements adapter.Adapter for Claude Code.
+type Adapter struct {
+    opts Options
+}
+
+// New constructs a Claude adapter.
+func New(opts Options) *Adapter { return &Adapter{opts: opts} }
+
+func (a *Adapter) Name() string { return "claude" }
+
+func (a *Adapter) Capabilities() adapter.Capability {
+    return adapter.CapMCP | adapter.CapMemory | adapter.CapSkill |
+        adapter.CapSubagent | adapter.CapCommand | adapter.CapHook | adapter.CapLSP
+}
+
+func (a *Adapter) Detect() (bool, error) {
+    p := ResolvePaths(a.opts.TargetRoot, "", false)
+    if _, err := os.Stat(p.Home); err == nil {
+        return true, nil
+    }
+    if _, err := exec.LookPath("claude"); err == nil {
+        return true, nil
+    }
+    return false, nil
+}
+```
+
+- [ ] **Step 1.4: Run; verify pass; commit**
+
+```bash
+go test -race ./internal/adapter/claude/...
+```
+
+```bash
+git add internal/adapter/claude
+git commit -m "$(cat <<'EOF'
+feat(adapter/claude): adapter skeleton + Detect()
+
+Capabilities cover all 7 component types (full-spectrum). Detect prefers
+filesystem evidence (~/.claude exists) and falls back to PATH.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Per-key JSON merge for `settings.json`
+
+**Files:**
+- Create: `internal/adapter/claude/settings.go`, `internal/adapter/claude/settings_test.go`
+
+The hardest single piece of M1. Claude's `settings.json` is shared between Claude Code itself, the user's hand edits, and agentsync. agentsync owns specific JSON pointers (e.g. `$.mcpServers.<id>`, `$.hooks.<event>[*]`, `$.lspServers.<id>`); everything else must be left untouched.
+
+**Contract:**
+- `MergeKeys(existing, ours map[string]any, ownedPointers []string) (merged map[string]any, kept, removed []string)`
+- `existing` = raw parse of the on-disk file
+- `ours` = the keys agentsync wants to write (also as map)
+- `ownedPointers` = JSON pointers (`/mcpServers/github`, `/hooks/PreToolUse/0`) that opensync wrote *last apply* — these are reclaimable
+- Returns merged map: foreign keys preserved; owned-but-now-absent pointers deleted; new opensync pointers from `ours` overlaid.
+
+- [ ] **Step 2.1: Test**
+
+`internal/adapter/claude/settings_test.go`:
+
+```go
+package claude_test
+
+import (
+    "encoding/json"
+    "reflect"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+)
+
+func decode(s string) map[string]any {
+    var m map[string]any
+    _ = json.Unmarshal([]byte(s), &m)
+    return m
+}
+
+func TestMergeKeys_NewKey(t *testing.T) {
+    existing := decode(`{"foreign": {"keep": true}}`)
+    ours := decode(`{"mcpServers": {"github": {"command": "npx"}}}`)
+
+    merged, _, _ := claude.MergeKeys(existing, ours, nil)
+    if _, ok := merged["foreign"]; !ok {
+        t.Fatalf("foreign key dropped: %+v", merged)
+    }
+    if _, ok := merged["mcpServers"].(map[string]any)["github"]; !ok {
+        t.Fatalf("ours not added: %+v", merged)
+    }
+}
+
+func TestMergeKeys_ForeignKeyAtSameLevelPreserved(t *testing.T) {
+    existing := decode(`{"mcpServers": {"foreign-server": {"command": "x"}}}`)
+    ours := decode(`{"mcpServers": {"github": {"command": "npx"}}}`)
+
+    merged, _, _ := claude.MergeKeys(existing, ours, nil)
+    s := merged["mcpServers"].(map[string]any)
+    if _, ok := s["foreign-server"]; !ok {
+        t.Fatalf("sibling foreign mcpServers entry dropped: %+v", s)
+    }
+    if _, ok := s["github"]; !ok {
+        t.Fatalf("our entry missing: %+v", s)
+    }
+}
+
+func TestMergeKeys_OrphanRemoval(t *testing.T) {
+    existing := decode(`{"mcpServers": {"github": {"command": "old"}, "stale": {"command": "x"}}}`)
+    ours := decode(`{"mcpServers": {"github": {"command": "npx"}}}`)
+    owned := []string{"/mcpServers/github", "/mcpServers/stale"} // both are ours per state
+
+    merged, _, removed := claude.MergeKeys(existing, ours, owned)
+
+    if len(removed) != 1 || removed[0] != "/mcpServers/stale" {
+        t.Fatalf("expected /mcpServers/stale removed, got %v", removed)
+    }
+    s := merged["mcpServers"].(map[string]any)
+    if _, ok := s["stale"]; ok {
+        t.Fatalf("stale should be deleted: %+v", s)
+    }
+    if reflect.DeepEqual(s["github"].(map[string]any)["command"], "old") {
+        t.Fatalf("github not updated to new value: %+v", s["github"])
+    }
+}
+
+func TestMergeKeys_ForeignNotInOwnedListPreserved(t *testing.T) {
+    existing := decode(`{"mcpServers": {"foreign": {"command": "x"}}}`)
+    ours := decode(`{}`) // we removed everything
+    owned := []string{"/mcpServers/old-mine"}
+
+    merged, _, removed := claude.MergeKeys(existing, ours, owned)
+    s := merged["mcpServers"].(map[string]any)
+    if _, ok := s["foreign"]; !ok {
+        t.Fatalf("foreign mcpServers entry must survive: %+v", s)
+    }
+    if len(removed) != 0 {
+        t.Fatalf("we owned old-mine but it wasn't in existing; nothing to remove. Got %v", removed)
+    }
+}
+```
+
+- [ ] **Step 2.2: Run; verify undefined**
+
+- [ ] **Step 2.3: Implement**
+
+`internal/adapter/claude/settings.go`:
+
+```go
+package claude
+
+import (
+    "strings"
+)
+
+// MergeKeys merges ours into existing, removing ownedPointers that are no
+// longer in ours. Returns the merged map plus diagnostic lists.
+//
+// kept: pointers from ownedPointers that are still present in ours.
+// removed: pointers from ownedPointers that are absent from ours and were
+// deleted from existing.
+//
+// JSON pointer syntax: leading "/", "/" separated path segments. RFC 6901
+// escapes ("~0" for "~", "~1" for "/") are supported.
+func MergeKeys(existing, ours map[string]any, ownedPointers []string) (map[string]any, []string, []string) {
+    merged := deepCopyMap(existing)
+    if merged == nil {
+        merged = map[string]any{}
+    }
+
+    // Step 1: overlay ours onto merged
+    for k, v := range ours {
+        switch ev := merged[k].(type) {
+        case map[string]any:
+            if vv, ok := v.(map[string]any); ok {
+                merged[k] = mergeMaps(ev, vv)
+                continue
+            }
+        }
+        merged[k] = v
+    }
+
+    // Step 2: walk ownedPointers; if a pointer is no longer present in `ours`,
+    // delete it from merged. If still present, mark kept.
+    var kept, removed []string
+    for _, p := range ownedPointers {
+        if pointerExists(ours, p) {
+            kept = append(kept, p)
+            continue
+        }
+        if pointerExists(merged, p) {
+            deletePointer(merged, p)
+            removed = append(removed, p)
+        }
+    }
+    return merged, kept, removed
+}
+
+func mergeMaps(a, b map[string]any) map[string]any {
+    out := deepCopyMap(a)
+    for k, v := range b {
+        switch existing := out[k].(type) {
+        case map[string]any:
+            if vv, ok := v.(map[string]any); ok {
+                out[k] = mergeMaps(existing, vv)
+                continue
+            }
+        }
+        out[k] = v
+    }
+    return out
+}
+
+func deepCopyMap(m map[string]any) map[string]any {
+    if m == nil {
+        return nil
+    }
+    out := make(map[string]any, len(m))
+    for k, v := range m {
+        if mm, ok := v.(map[string]any); ok {
+            out[k] = deepCopyMap(mm)
+        } else {
+            out[k] = v
+        }
+    }
+    return out
+}
+
+func pointerExists(m map[string]any, ptr string) bool {
+    parts := splitPointer(ptr)
+    var cur any = m
+    for _, p := range parts {
+        mp, ok := cur.(map[string]any)
+        if !ok {
+            return false
+        }
+        cur, ok = mp[p]
+        if !ok {
+            return false
+        }
+    }
+    return true
+}
+
+func deletePointer(m map[string]any, ptr string) {
+    parts := splitPointer(ptr)
+    if len(parts) == 0 {
+        return
+    }
+    cur := m
+    for i, p := range parts {
+        if i == len(parts)-1 {
+            delete(cur, p)
+            return
+        }
+        next, ok := cur[p].(map[string]any)
+        if !ok {
+            return
+        }
+        cur = next
+    }
+}
+
+func splitPointer(ptr string) []string {
+    ptr = strings.TrimPrefix(ptr, "/")
+    if ptr == "" {
+        return nil
+    }
+    raw := strings.Split(ptr, "/")
+    out := make([]string, len(raw))
+    for i, s := range raw {
+        s = strings.ReplaceAll(s, "~1", "/")
+        s = strings.ReplaceAll(s, "~0", "~")
+        out[i] = s
+    }
+    return out
+}
+```
+
+(Note: this v1 implementation handles object keys but not array indices in pointers — sufficient for `mcpServers`/`lspServers` which are objects. Hooks structure under Claude is `{"hooks":{"PreToolUse":[...]}}` arrays; M1 hook ownership is at the *event-name* level (`/hooks/PreToolUse`), not array-index granularity, so the simpler implementation works. Array-index support can be added in a later milestone if drift across arrays becomes painful.)
+
+- [ ] **Step 2.4: Run; verify pass; commit**
+
+```bash
+go test -race ./internal/adapter/claude/...
+```
+
+```bash
+git add internal/adapter/claude
+git commit -m "$(cat <<'EOF'
+feat(adapter/claude): per-key JSON merge for settings.json + .claude.json
+
+Foreign keys survive verbatim. ownedPointers list (read from
+state.Keys at apply-time) controls reclamation: keys we wrote last
+apply but no longer want are deleted; foreign keys at the same level
+preserved. Object-pointer support only; array-index drift can be
+deferred to a future milestone since hooks track at event-name level.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: YAML frontmatter parser
+
+**Files:**
+- Create: `internal/adapter/claude/frontmatter.go`, `internal/adapter/claude/frontmatter_test.go`
+
+Skills, subagents, and slash commands all use the convention `---\n<YAML>\n---\n<body>`. Need a tiny parser that returns frontmatter as `map[string]any` and the body as a string.
+
+- [ ] **Step 3.1: Add YAML dependency**
+
+```bash
+go get sigs.k8s.io/yaml@latest
+```
+
+(`sigs.k8s.io/yaml` parses YAML by converting to JSON first, so it returns `map[string]any` directly — exactly the shape we need to round-trip without losing keys.)
+
+- [ ] **Step 3.2: Test**
+
+`internal/adapter/claude/frontmatter_test.go`:
+
+```go
+package claude_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+)
+
+func TestParseFrontmatter_Standard(t *testing.T) {
+    input := []byte(`---
+name: my-skill
+description: Does the thing
+disable-model-invocation: true
+---
+This is the body.
+
+Multiple lines.
+`)
+    fm, body, err := claude.ParseFrontmatter(input)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if fm["name"] != "my-skill" {
+        t.Fatalf("name = %v", fm["name"])
+    }
+    if fm["disable-model-invocation"] != true {
+        t.Fatalf("disable-model-invocation = %v", fm["disable-model-invocation"])
+    }
+    if body != "This is the body.\n\nMultiple lines.\n" {
+        t.Fatalf("body mismatch: %q", body)
+    }
+}
+
+func TestParseFrontmatter_NoFrontmatter(t *testing.T) {
+    fm, body, err := claude.ParseFrontmatter([]byte("plain markdown\n"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(fm) != 0 {
+        t.Fatalf("fm should be empty: %+v", fm)
+    }
+    if body != "plain markdown\n" {
+        t.Fatalf("body = %q", body)
+    }
+}
+
+func TestEncodeFrontmatter_Roundtrip(t *testing.T) {
+    fm := map[string]any{"name": "x", "description": "y"}
+    out, err := claude.EncodeFrontmatter(fm, "body")
+    if err != nil {
+        t.Fatal(err)
+    }
+    fm2, body2, err := claude.ParseFrontmatter(out)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if fm2["name"] != "x" || fm2["description"] != "y" {
+        t.Fatalf("roundtrip lost data: %+v", fm2)
+    }
+    if body2 != "body" {
+        t.Fatalf("body = %q", body2)
+    }
+}
+```
+
+- [ ] **Step 3.3: Implement**
+
+`internal/adapter/claude/frontmatter.go`:
+
+```go
+package claude
+
+import (
+    "bytes"
+    "fmt"
+    "strings"
+
+    "sigs.k8s.io/yaml"
+)
+
+// ParseFrontmatter extracts the YAML frontmatter and the markdown body. If
+// the input doesn't begin with "---\n", returns an empty map and the entire
+// input as body.
+func ParseFrontmatter(data []byte) (map[string]any, string, error) {
+    if !bytes.HasPrefix(data, []byte("---\n")) {
+        return map[string]any{}, string(data), nil
+    }
+    rest := data[len("---\n"):]
+    end := bytes.Index(rest, []byte("\n---\n"))
+    if end < 0 {
+        return nil, "", fmt.Errorf("unterminated frontmatter")
+    }
+    yml := rest[:end]
+    body := rest[end+len("\n---\n"):]
+
+    var fm map[string]any
+    if err := yaml.Unmarshal(yml, &fm); err != nil {
+        return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
+    }
+    if fm == nil {
+        fm = map[string]any{}
+    }
+    return fm, string(body), nil
+}
+
+// EncodeFrontmatter writes "---\n<yaml>\n---\n<body>" with the keys in fm.
+// fm is empty: returns just the body.
+func EncodeFrontmatter(fm map[string]any, body string) ([]byte, error) {
+    if len(fm) == 0 {
+        return []byte(body), nil
+    }
+    yml, err := yaml.Marshal(fm)
+    if err != nil {
+        return nil, fmt.Errorf("encode yaml: %w", err)
+    }
+    var buf strings.Builder
+    buf.WriteString("---\n")
+    buf.Write(yml)
+    buf.WriteString("---\n")
+    buf.WriteString(body)
+    return []byte(buf.String()), nil
+}
+```
+
+- [ ] **Step 3.4: Run; commit**
+
+```bash
+go test -race ./internal/adapter/claude/...
+git add go.mod go.sum internal/adapter/claude
+git commit -m "$(cat <<'EOF'
+feat(adapter/claude): YAML frontmatter parse/encode round-trip
+
+Used by skill/subagent/command. sigs.k8s.io/yaml goes via JSON so
+parsed frontmatter is map[string]any (round-trip safe even for keys we
+don't recognize, like disable-model-invocation).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `source.Skill` loader to parse frontmatter
+
+**Files:**
+- Modify: `internal/source/loader.go` (extend `loadSkills`)
+- Modify: `internal/source/loader_test.go` (add frontmatter assertion)
+
+In M0 we kept skill body as one big string. Now M1 needs the frontmatter map separately.
+
+- [ ] **Step 4.1: Test addition**
+
+Append to `internal/source/loader_test.go`:
+
+```go
+func TestLoad_SkillFrontmatter(t *testing.T) {
+    fs := afero.NewMemMapFs()
+    _ = afero.WriteFile(fs, "/home/.agentsync/skills/foo/SKILL.md", []byte(`---
+name: foo
+description: Test skill
+---
+Body.
+`), 0o644)
+
+    c, err := source.Load(fs, "/home/.agentsync")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(c.Skills) != 1 {
+        t.Fatalf("skills = %d", len(c.Skills))
+    }
+    s := c.Skills[0]
+    if s.Frontmatter["name"] != "foo" {
+        t.Fatalf("frontmatter name = %v", s.Frontmatter["name"])
+    }
+    if s.Body != "Body.\n" {
+        t.Fatalf("body = %q", s.Body)
+    }
+}
+```
+
+- [ ] **Step 4.2: Update `loadSkills`**
+
+In `internal/source/loader.go`, replace the existing `loadSkills` body:
+
+```go
+func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
+    dir := filepath.Join(home, "skills")
+    entries, err := afero.ReadDir(fs, dir)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return nil, nil
+        }
+        return nil, fmt.Errorf("read %s: %w", dir, err)
+    }
+    var out []Skill
+    for _, e := range entries {
+        if !e.IsDir() {
+            continue
+        }
+        raw, err := afero.ReadFile(fs, filepath.Join(dir, e.Name(), "SKILL.md"))
+        if err != nil {
+            if errors.Is(err, os.ErrNotExist) {
+                continue
+            }
+            return nil, fmt.Errorf("read SKILL.md for %s: %w", e.Name(), err)
+        }
+        fm, body, err := parseFrontmatter(raw)
+        if err != nil {
+            return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+        }
+        out = append(out, Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+    }
+    return out, nil
+}
+```
+
+…and add a small `parseFrontmatter` helper to the `source` package (mirrored from M1 task 3 — kept in `source` to avoid the source package importing the claude adapter). Add to `loader.go`:
+
+```go
+import (
+    // ...existing imports...
+    "bytes"
+    "sigs.k8s.io/yaml"
+)
+
+func parseFrontmatter(data []byte) (map[string]any, string, error) {
+    if !bytes.HasPrefix(data, []byte("---\n")) {
+        return map[string]any{}, string(data), nil
+    }
+    rest := data[len("---\n"):]
+    end := bytes.Index(rest, []byte("\n---\n"))
+    if end < 0 {
+        return nil, "", fmt.Errorf("unterminated frontmatter")
+    }
+    yml := rest[:end]
+    body := rest[end+len("\n---\n"):]
+    var fm map[string]any
+    if err := yaml.Unmarshal(yml, &fm); err != nil {
+        return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
+    }
+    if fm == nil {
+        fm = map[string]any{}
+    }
+    return fm, string(body), nil
+}
+```
+
+- [ ] **Step 4.3: Run; commit**
+
+```bash
+go test -race ./internal/source/...
+git add internal/source
+git commit -m "$(cat <<'EOF'
+feat(source): parse skill frontmatter into Skill.Frontmatter
+
+Frontmatter is map[string]any so unknown keys (disable-model-invocation,
+custom vendor extensions) round-trip without loss.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `Render()` MCP servers
+
+**Files:**
+- Create: `internal/adapter/claude/render.go`, `internal/adapter/claude/render_test.go`
+
+For each `MCPServer` in canonical, emit one settings.json key under `/mcpServers/<id>` (or `~/.claude.json` `/mcpServers/<id>` for user-scope MCP — Claude reads both, but `~/.claude.json` is the user-scope authority for MCP).
+
+- [ ] **Step 5.1: Test**
+
+`internal/adapter/claude/render_test.go`:
+
+```go
+package claude_test
+
+import (
+    "encoding/json"
+    "strings"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestRender_MCP_UserScope(t *testing.T) {
+    enabled := true
+    c := source.Canonical{
+        MCPServers: []source.MCPServer{{
+            ID: "github",
+            Server: source.MCPServerSpec{
+                Type:    "stdio",
+                Command: "npx",
+                Args:    []string{"-y", "@modelcontextprotocol/server-github"},
+                Env:     map[string]string{"GITHUB_TOKEN": "xyz"},
+                Agents:  []string{"*"},
+                Enabled: &enabled,
+            },
+        }},
+    }
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    ops, skips, err := a.Render(c, adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(skips) != 0 {
+        t.Fatalf("unexpected skips: %+v", skips)
+    }
+    // The MCP write goes into .claude.json under user scope.
+    var found bool
+    for _, op := range ops {
+        if strings.HasSuffix(op.Path, ".claude.json") {
+            found = true
+            var got map[string]any
+            if err := json.Unmarshal(op.Content, &got); err != nil {
+                t.Fatalf("not valid json: %v", err)
+            }
+            srv := got["mcpServers"].(map[string]any)["github"].(map[string]any)
+            if srv["command"] != "npx" {
+                t.Fatalf("command = %v", srv["command"])
+            }
+        }
+    }
+    if !found {
+        t.Fatalf(".claude.json op not produced: %+v", ops)
+    }
+}
+
+func TestRender_MCP_AgentsAllowlist(t *testing.T) {
+    enabled := true
+    c := source.Canonical{
+        MCPServers: []source.MCPServer{{
+            ID: "private",
+            Server: source.MCPServerSpec{
+                Type:    "stdio",
+                Command: "x",
+                Agents:  []string{"opencode"}, // claude not in list
+                Enabled: &enabled,
+            },
+        }},
+    }
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    ops, _, err := a.Render(c, adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    // No .claude.json write because the server isn't targeted at claude.
+    for _, op := range ops {
+        if strings.HasSuffix(op.Path, ".claude.json") {
+            t.Fatalf("expected no .claude.json op when allowlist excludes claude")
+        }
+    }
+}
+```
+
+- [ ] **Step 5.2: Render skeleton**
+
+`internal/adapter/claude/render.go`:
+
+```go
+package claude
+
+import (
+    "encoding/json"
+    "fmt"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+// Render produces the full set of FileOps for a given canonical model.
+// Pure function: returns the same output for the same input.
+func (a *Adapter) Render(c source.Canonical, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+    paths := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+
+    var ops []adapter.FileOp
+    var skips []adapter.Skip
+
+    // 1. MCP -> .claude.json (user) or settings.json (project)
+    if mcpOps, err := a.renderMCP(c, paths, scope); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, mcpOps...)
+    }
+
+    // 2-7: implemented in Tasks 6-11.
+
+    return ops, skips, nil
+}
+
+func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([]adapter.FileOp, error) {
+    targeted := map[string]map[string]any{}
+    for _, m := range c.MCPServers {
+        if m.Server.Enabled != nil && !*m.Server.Enabled {
+            continue
+        }
+        if !agentTargeted("claude", m.Server.Agents) {
+            continue
+        }
+        spec := map[string]any{}
+        if m.Server.Type != "" {
+            spec["type"] = m.Server.Type
+        }
+        if m.Server.Command != "" {
+            spec["command"] = m.Server.Command
+        }
+        if len(m.Server.Args) > 0 {
+            spec["args"] = m.Server.Args
+        }
+        if len(m.Server.Env) > 0 {
+            spec["env"] = m.Server.Env
+        }
+        if m.Server.URL != "" {
+            spec["url"] = m.Server.URL
+        }
+        if len(m.Server.Headers) > 0 {
+            spec["headers"] = m.Server.Headers
+        }
+        targeted[m.ID] = spec
+    }
+    if len(targeted) == 0 {
+        return nil, nil
+    }
+    obj := map[string]any{"mcpServers": targeted}
+
+    var dest, sourceID string
+    if scope == adapter.ScopeProject {
+        dest = p.Settings // project-scope settings.json holds mcpServers
+    } else {
+        dest = p.DotClaude
+    }
+    sourceID = "mcp/* (multiple)"
+
+    body, err := json.MarshalIndent(obj, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal mcp: %w", err)
+    }
+    return []adapter.FileOp{{
+        Action:   "write",
+        Path:     dest,
+        Content:  append(body, '\n'),
+        Mode:     0o644,
+        SourceID: sourceID,
+    }}, nil
+}
+
+// agentTargeted reports whether agents allowlist includes us. Empty / nil
+// list / "*" entry means everyone.
+func agentTargeted(name string, agents []string) bool {
+    if len(agents) == 0 {
+        return true
+    }
+    for _, a := range agents {
+        if a == "*" || a == name {
+            return true
+        }
+    }
+    return false
+}
+```
+
+(Note: this initial render doesn't yet *merge* into existing files. Apply (Task 12) reads existing settings.json/.claude.json from disk, calls MergeKeys with the rendered ours, then atomically writes the merged result. That's what makes per-key ownership real. For Render's contract — which is pure — we just emit the "ours" payload; the merge happens in apply.)
+
+…actually that contract makes Render less clean: a downstream consumer calling Render expects the FileOp.Content to be the FINAL bytes to write, not a "your half." Better contract: Render computes the final bytes (merging disk state inline). That requires Render to read the on-disk settings.json. Acceptable since Render needs `targetRoot` anyway.
+
+Update the contract: Render reads disk for shared files (`settings.json`, `.claude.json`) and produces post-merge content. Pure on canonical+disk inputs. Move on.
+
+Refactor `renderMCP`:
+
+```go
+func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope, ownedKeys []string) ([]adapter.FileOp, error) {
+    targeted := map[string]any{}
+    // ...same loop building `targeted`...
+
+    if len(targeted) == 0 && len(ownedKeys) == 0 {
+        return nil, nil
+    }
+
+    var dest string
+    if scope == adapter.ScopeProject {
+        dest = p.Settings
+    } else {
+        dest = p.DotClaude
+    }
+    existing := readJSONFile(dest) // returns empty map if missing
+    ours := map[string]any{"mcpServers": targeted}
+    merged, _, _ := MergeKeys(existing, ours, ownedKeys)
+
+    body, err := json.MarshalIndent(merged, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal mcp: %w", err)
+    }
+    return []adapter.FileOp{{
+        Action:   "write",
+        Path:     dest,
+        Content:  append(body, '\n'),
+        Mode:     0o644,
+        SourceID: "mcp/* (multiple)",
+    }}, nil
+}
+
+func readJSONFile(path string) map[string]any {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return map[string]any{}
+    }
+    var m map[string]any
+    _ = json.Unmarshal(data, &m)
+    if m == nil {
+        return map[string]any{}
+    }
+    return m
+}
+```
+
+`ownedKeys` flows into Render via the apply path that has access to the state store — so Render's call signature must change. Update the `Adapter.Render` signature in `internal/adapter/adapter.go` to accept owned keys:
+
+Actually a cleaner solution: keep `Render` signature unchanged; Render produces "ours" bytes to a separate FileOp that signals "merge target." Apply pipeline (Task 12) does the merge using state. Trade-off: Render is no longer pure (it doesn't compute final bytes), but the adapter interface stays clean.
+
+Decision: extend `adapter.FileOp` with a `MergeStrategy` field. Values: `"replace"` (whole-file write) or `"merge-json-keys"` (apply does merge). Render sets the strategy; Apply respects it.
+
+Update `internal/adapter/adapter.go`:
+
+```go
+type FileOp struct {
+    Action        string
+    Path          string
+    Content       []byte
+    Mode          uint32
+    SourceID      string
+    MergeStrategy string   // "replace" (default) | "merge-json-keys"
+    OwnedKeys     []string // populated by Apply from state.Keys, not by Render
+}
+```
+
+Render emits FileOp with MergeStrategy set. Apply reads existing on-disk file, parses, calls MergeKeys, writes atomically.
+
+This keeps Render pure and pushes state-dependence to Apply (which is naturally state-dependent because it persists).
+
+Apply signature:
+
+```go
+func (a *Adapter) Apply(ops []adapter.FileOp) error {
+    for _, op := range ops {
+        switch op.MergeStrategy {
+        case "merge-json-keys":
+            existing := readJSONFile(op.Path)
+            var ours map[string]any
+            _ = json.Unmarshal(op.Content, &ours)
+            merged, _, _ := MergeKeys(existing, ours, op.OwnedKeys)
+            body, _ := json.MarshalIndent(merged, "", "  ")
+            return iox.AtomicWrite(op.Path, append(body, '\n'), os.FileMode(op.Mode))
+        default:
+            return iox.AtomicWrite(op.Path, op.Content, os.FileMode(op.Mode))
+        }
+    }
+    return nil
+}
+```
+
+`OwnedKeys` is populated by the apply pipeline (in M3 / state integration); for M1 the Apply implementation works correctly with `OwnedKeys=nil` (no orphan removal but no mistakes either).
+
+- [ ] **Step 5.3: Update render_test to expect MergeStrategy**
+
+Adjust `TestRender_MCP_UserScope` to assert `op.MergeStrategy == "merge-json-keys"` and that the rendered Content is valid JSON containing only `{"mcpServers": {...}}`.
+
+- [ ] **Step 5.4: Add `MergeStrategy` and `OwnedKeys` to `adapter.FileOp`**
+
+- [ ] **Step 5.5: Run; commit**
+
+```bash
+go test -race ./internal/adapter/claude/... ./internal/adapter/...
+git add internal/adapter
+git commit -m "$(cat <<'EOF'
+feat(adapter/claude): Render MCP servers with merge-json-keys strategy
+
+FileOp gains MergeStrategy + OwnedKeys; Render emits "ours" payload, Apply
+performs the merge against existing on-disk content. Owned-key tracking
+wired through in Task 12.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `Render()` memory (CLAUDE.md)
+
+**Files:**
+- Create: `internal/adapter/claude/memory.go`
+- Modify: `internal/adapter/claude/render.go` (call renderMemory)
+- Modify: `internal/adapter/claude/render_test.go` (test memory render)
+
+Concatenates `memory/AGENTS.md` body with resolved fragments (replacing `@import ./fragments/style.md` with the fragment's content). Writes to `~/.claude/CLAUDE.md` (user) or `<project>/CLAUDE.md` (project).
+
+- [ ] **Step 6.1: Test**
+
+```go
+func TestRender_Memory(t *testing.T) {
+    c := source.Canonical{
+        Memory: source.Memory{
+            Body: "# Personal style\n\n@import ./fragments/style.md\n\nMore.\n",
+            Fragments: map[string]string{
+                "style.md": "Use semicolons.\n",
+            },
+        },
+    }
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    ops, _, err := a.Render(c, adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    var memOp *adapter.FileOp
+    for i, op := range ops {
+        if strings.HasSuffix(op.Path, "/CLAUDE.md") {
+            memOp = &ops[i]
+        }
+    }
+    if memOp == nil {
+        t.Fatalf("no CLAUDE.md op")
+    }
+    if !strings.Contains(string(memOp.Content), "Use semicolons.") {
+        t.Fatalf("fragment not inlined: %s", memOp.Content)
+    }
+    if strings.Contains(string(memOp.Content), "@import") {
+        t.Fatalf("@import directive leaked: %s", memOp.Content)
+    }
+}
+```
+
+- [ ] **Step 6.2: Implement**
+
+`internal/adapter/claude/memory.go`:
+
+```go
+package claude
+
+import (
+    "regexp"
+    "strings"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+var importRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
+
+func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+    if c.Memory.Body == "" {
+        return nil, nil
+    }
+    body := importRe.ReplaceAllStringFunc(c.Memory.Body, func(line string) string {
+        m := importRe.FindStringSubmatch(line)
+        if len(m) < 2 {
+            return line
+        }
+        if frag, ok := c.Memory.Fragments[m[1]]; ok {
+            return strings.TrimRight(frag, "\n")
+        }
+        // Unknown fragment; preserve line so the user notices.
+        return line
+    })
+    return []adapter.FileOp{{
+        Action:        "write",
+        Path:          p.Memory,
+        Content:       []byte(body),
+        Mode:          0o644,
+        SourceID:      "memory/AGENTS.md",
+        MergeStrategy: "replace",
+    }}, nil
+}
+```
+
+Wire into `Render()`:
+
+```go
+if memOps, err := a.renderMemory(c, paths); err != nil { return nil, nil, err } else { ops = append(ops, memOps...) }
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add internal/adapter/claude
+git commit -m "feat(adapter/claude): render CLAUDE.md with @import resolution
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `Render()` skills (write SKILL.md to ~/.claude/skills/<name>/)
+
+Each canonical Skill yields one FileOp writing `<SkillsDir>/<name>/SKILL.md` with frontmatter + body re-encoded via `EncodeFrontmatter`.
+
+- [ ] **Step 7.1: Test**
+
+```go
+func TestRender_Skills(t *testing.T) {
+    c := source.Canonical{
+        Skills: []source.Skill{{
+            Name:        "review",
+            Frontmatter: map[string]any{"name": "review", "description": "Review code"},
+            Body:        "Do a code review.\n",
+        }},
+    }
+    a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+    ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+    var found *adapter.FileOp
+    for i, op := range ops {
+        if strings.Contains(op.Path, "/skills/review/SKILL.md") {
+            found = &ops[i]
+        }
+    }
+    if found == nil {
+        t.Fatalf("no SKILL.md op")
+    }
+    if !strings.HasPrefix(string(found.Content), "---\n") {
+        t.Fatalf("missing frontmatter delimiter: %s", found.Content)
+    }
+}
+```
+
+- [ ] **Step 7.2: Implement**
+
+`internal/adapter/claude/skill.go`:
+
+```go
+package claude
+
+import (
+    "fmt"
+    "path/filepath"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func (a *Adapter) renderSkills(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+    var ops []adapter.FileOp
+    for _, s := range c.Skills {
+        body, err := EncodeFrontmatter(s.Frontmatter, s.Body)
+        if err != nil {
+            return nil, fmt.Errorf("encode skill %s: %w", s.Name, err)
+        }
+        ops = append(ops, adapter.FileOp{
+            Action:        "write",
+            Path:          filepath.Join(p.SkillsDir, s.Name, "SKILL.md"),
+            Content:       body,
+            Mode:          0o644,
+            SourceID:      filepath.Join("skills", s.Name, "SKILL.md"),
+            MergeStrategy: "replace",
+        })
+    }
+    return ops, nil
+}
+```
+
+Wire into `Render()`. Commit:
+
+```bash
+git commit -am "feat(adapter/claude): render skills (frontmatter passthrough)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `Render()` subagents
+
+Subagents in Claude live at `~/.claude/agents/<name>.md` with frontmatter (`description`, `tools`, `model`, `color`). Same canonical Skill-like type but stored separately.
+
+Add `Subagents []Skill` to `source.Canonical` (since they share the markdown+frontmatter shape; Skill is a misleading type name, but adapters can disambiguate). Actually — better — add a distinct `Subagent` type to `internal/source/schema.go` for clarity:
+
+```go
+type Subagent struct {
+    Name        string
+    Frontmatter map[string]any
+    Body        string
+}
+```
+
+…and `Subagents []Subagent` on `Canonical`. Loader walks `<home>/agents/<name>.md`.
+
+- [ ] **Step 8.1: Update source schema + loader**
+
+Add `Subagent` type to `internal/source/schema.go`. Add `loadSubagents` mirroring `loadSkills` but reading `<home>/agents/*.md`. Test in `loader_test.go`. Commit.
+
+- [ ] **Step 8.2: Render**
+
+`internal/adapter/claude/subagent.go`:
+
+```go
+package claude
+
+import (
+    "fmt"
+    "path/filepath"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+    var ops []adapter.FileOp
+    for _, s := range c.Subagents {
+        body, err := EncodeFrontmatter(s.Frontmatter, s.Body)
+        if err != nil {
+            return nil, fmt.Errorf("encode subagent %s: %w", s.Name, err)
+        }
+        ops = append(ops, adapter.FileOp{
+            Action:        "write",
+            Path:          filepath.Join(p.AgentsDir, s.Name+".md"),
+            Content:       body,
+            Mode:          0o644,
+            SourceID:      filepath.Join("agents", s.Name+".md"),
+            MergeStrategy: "replace",
+        })
+    }
+    return ops, nil
+}
+```
+
+Test, wire into Render, commit.
+
+---
+
+## Task 9: `Render()` slash commands
+
+Mirror Task 8 for `Commands []Command` on `source.Canonical` and `<home>/commands/*.md`. Path: `<CommandsDir>/<name>.md`. Frontmatter passthrough.
+
+Test, implement, wire, commit.
+
+---
+
+## Task 10: `Render()` hooks (settings.json `/hooks/<event>`)
+
+Hooks differ from MCP: they go into `settings.json` not `.claude.json`, and the structure is `{"hooks": {"PreToolUse": [{matcher, hooks: [{type, command}]}]}}`. agentsync owns the entire `/hooks/<event>` array per event.
+
+- [ ] **Step 10.1: Add `Hooks` to `source.Canonical`**
+
+```go
+type Hook struct {
+    Event   string  // e.g. "PreToolUse"
+    Matcher string  // glob/regex string
+    Type    string  // "command"
+    Command string  // shell command
+}
+```
+
+…and `Hooks []Hook` on `Canonical`. Loader: from a top-level `hooks/<event>.toml` if you want them in canonical, OR from individual plugin entries (M4 territory). For M1, support `hooks/<event>.toml` with array of `{matcher, type, command}` entries:
+
+```toml
+# hooks/PreToolUse.toml
+[[hook]]
+matcher = "Write|Edit"
+type    = "command"
+command = "echo intercepting Write/Edit"
+```
+
+Test the loader. Commit.
+
+- [ ] **Step 10.2: Render hooks**
+
+`internal/adapter/claude/hook.go`:
+
+```go
+package claude
+
+import (
+    "encoding/json"
+    "fmt"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+// renderHooks writes a single op for settings.json containing /hooks/<event>
+// entries. Per-event ownership: agentsync owns the entire array under its
+// event key. Foreign event keys (e.g. PreToolUse if user has authored
+// directly) are NOT touched if they're not in canonical.
+func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+    if len(c.Hooks) == 0 {
+        return nil, nil
+    }
+    byEvent := map[string][]map[string]any{}
+    for _, h := range c.Hooks {
+        entry := map[string]any{
+            "matcher": h.Matcher,
+            "hooks": []map[string]any{{
+                "type":    h.Type,
+                "command": h.Command,
+            }},
+        }
+        byEvent[h.Event] = append(byEvent[h.Event], entry)
+    }
+    obj := map[string]any{"hooks": byEvent}
+    body, err := json.MarshalIndent(obj, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal hooks: %w", err)
+    }
+    return []adapter.FileOp{{
+        Action:        "write",
+        Path:          p.Settings,
+        Content:       append(body, '\n'),
+        Mode:          0o644,
+        SourceID:      "hooks/* (multiple)",
+        MergeStrategy: "merge-json-keys",
+    }}, nil
+}
+```
+
+Test (foreign hooks event preserved); commit.
+
+---
+
+## Task 11: `Render()` LSP servers
+
+Mirror MCP at `/lspServers/<id>` in `settings.json`. Same structure (command/args/env/url/headers). Same merge strategy.
+
+- [ ] Add `LSPServer` type to `source.Canonical`. Loader from `lsp/<id>.toml`. Render to `/lspServers/<id>` in `settings.json`. Test, wire, commit.
+
+---
+
+## Task 12: `Apply()` — write FileOps with merge-aware logic
+
+**Files:**
+- Create: `internal/adapter/claude/apply.go`, `internal/adapter/claude/apply_test.go`
+
+The merge-aware write loop. For each FileOp: if `MergeStrategy == "merge-json-keys"`, read existing JSON, parse our content, MergeKeys (with OwnedKeys passed in), write merged. Otherwise atomic-write Content directly.
+
+- [ ] **Step 12.1: Test**
+
+```go
+func TestApply_NewSettings_WritesContent(t *testing.T) {
+    tmp := t.TempDir()
+    a := claude.New(claude.Options{TargetRoot: tmp})
+
+    op := adapter.FileOp{
+        Action:        "write",
+        Path:          filepath.Join(tmp, ".claude.json"),
+        Content:       []byte(`{"mcpServers":{"github":{"command":"npx"}}}`),
+        Mode:          0o644,
+        MergeStrategy: "merge-json-keys",
+    }
+    if err := a.Apply([]adapter.FileOp{op}); err != nil {
+        t.Fatal(err)
+    }
+    body, _ := os.ReadFile(op.Path)
+    if !strings.Contains(string(body), `"github"`) {
+        t.Fatalf("missing github key: %s", body)
+    }
+}
+
+func TestApply_PreservesForeignKeys(t *testing.T) {
+    tmp := t.TempDir()
+    a := claude.New(claude.Options{TargetRoot: tmp})
+    target := filepath.Join(tmp, ".claude.json")
+
+    // pre-existing foreign content
+    _ = os.WriteFile(target, []byte(`{"foreign":{"x":1},"mcpServers":{"old":{}}}`), 0o644)
+
+    op := adapter.FileOp{
+        Action:        "write",
+        Path:          target,
+        Content:       []byte(`{"mcpServers":{"new":{"command":"x"}}}`),
+        Mode:          0o644,
+        MergeStrategy: "merge-json-keys",
+        OwnedKeys:     nil, // no owned keys -> no orphan removal
+    }
+    if err := a.Apply([]adapter.FileOp{op}); err != nil {
+        t.Fatal(err)
+    }
+    var out map[string]any
+    body, _ := os.ReadFile(target)
+    _ = json.Unmarshal(body, &out)
+    if _, ok := out["foreign"]; !ok {
+        t.Fatalf("foreign key dropped: %s", body)
+    }
+    s := out["mcpServers"].(map[string]any)
+    if _, ok := s["old"]; !ok {
+        t.Fatalf("foreign mcpServers.old dropped: %s", body)
+    }
+    if _, ok := s["new"]; !ok {
+        t.Fatalf("our mcpServers.new missing: %s", body)
+    }
+}
+
+func TestApply_OrphanRemoval(t *testing.T) {
+    tmp := t.TempDir()
+    a := claude.New(claude.Options{TargetRoot: tmp})
+    target := filepath.Join(tmp, ".claude.json")
+    _ = os.WriteFile(target, []byte(`{"mcpServers":{"github":{"command":"old"},"stale":{}}}`), 0o644)
+
+    op := adapter.FileOp{
+        Action:        "write",
+        Path:          target,
+        Content:       []byte(`{"mcpServers":{"github":{"command":"new"}}}`),
+        Mode:          0o644,
+        MergeStrategy: "merge-json-keys",
+        OwnedKeys:     []string{"/mcpServers/github", "/mcpServers/stale"},
+    }
+    if err := a.Apply([]adapter.FileOp{op}); err != nil {
+        t.Fatal(err)
+    }
+    var out map[string]any
+    body, _ := os.ReadFile(target)
+    _ = json.Unmarshal(body, &out)
+    s := out["mcpServers"].(map[string]any)
+    if _, ok := s["stale"]; ok {
+        t.Fatalf("stale should be deleted: %s", body)
+    }
+    if s["github"].(map[string]any)["command"] != "new" {
+        t.Fatalf("github should be updated: %s", body)
+    }
+}
+```
+
+- [ ] **Step 12.2: Implement**
+
+`internal/adapter/claude/apply.go`:
+
+```go
+package claude
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+func (a *Adapter) Apply(ops []adapter.FileOp) error {
+    for _, op := range ops {
+        switch op.Action {
+        case "delete":
+            if err := os.Remove(op.Path); err != nil && !os.IsNotExist(err) {
+                return fmt.Errorf("delete %s: %w", op.Path, err)
+            }
+        case "", "write":
+            if err := a.applyWrite(op); err != nil {
+                return err
+            }
+        default:
+            return fmt.Errorf("unknown action %q", op.Action)
+        }
+    }
+    return nil
+}
+
+func (a *Adapter) applyWrite(op adapter.FileOp) error {
+    mode := os.FileMode(op.Mode)
+    if mode == 0 {
+        mode = 0o644
+    }
+    if op.MergeStrategy == "merge-json-keys" {
+        existing := readJSONFile(op.Path)
+        var ours map[string]any
+        if err := json.Unmarshal(op.Content, &ours); err != nil {
+            return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
+        }
+        merged, _, _ := MergeKeys(existing, ours, op.OwnedKeys)
+        body, err := json.MarshalIndent(merged, "", "  ")
+        if err != nil {
+            return fmt.Errorf("marshal merged for %s: %w", op.Path, err)
+        }
+        return iox.AtomicWrite(op.Path, append(body, '\n'), mode)
+    }
+    return iox.AtomicWrite(op.Path, op.Content, mode)
+}
+
+func readJSONFile(path string) map[string]any {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return map[string]any{}
+    }
+    var m map[string]any
+    _ = json.Unmarshal(data, &m)
+    if m == nil {
+        return map[string]any{}
+    }
+    return m
+}
+```
+
+- [ ] **Step 12.3: Run; commit**
+
+```bash
+go test -race ./internal/adapter/claude/...
+git add internal/adapter/claude
+git commit -m "$(cat <<'EOF'
+feat(adapter/claude): Apply writes via iox.AtomicWrite, merge-aware for JSON
+
+merge-json-keys ops read existing JSON, MergeKeys with OwnedKeys (orphan
+removal), then write merged content. replace ops write Content directly.
+delete ops remove the file (no-op if absent).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `Ingest()` — read native files back into canonical
+
+**Files:**
+- Create: `internal/adapter/claude/ingest.go`, `internal/adapter/claude/ingest_test.go`
+
+Inverse of Render. Reads `.claude.json`, settings.json, agents/, commands/, skills/, CLAUDE.md → produces a partial `source.Canonical`. Used by `agentsync import <selector>` and drift detection (M3).
+
+For each component type, ingest the native form back. Round-trip parity (`Ingest(Render(c)) == c`) is the test target.
+
+- [ ] **Step 13.1: Test (round-trip)**
+
+```go
+func TestIngest_RoundTripsMCPAndSkills(t *testing.T) {
+    tmp := t.TempDir()
+    enabled := true
+    in := source.Canonical{
+        MCPServers: []source.MCPServer{{
+            ID: "github",
+            Server: source.MCPServerSpec{
+                Type: "stdio", Command: "npx", Args: []string{"-y", "x"},
+                Env: map[string]string{"K": "V"}, Agents: []string{"*"},
+                Enabled: &enabled,
+            },
+        }},
+        Skills: []source.Skill{{
+            Name:        "review",
+            Frontmatter: map[string]any{"name": "review", "description": "x"},
+            Body:        "body\n",
+        }},
+    }
+    a := claude.New(claude.Options{TargetRoot: tmp})
+    ops, _, _ := a.Render(in, adapter.ScopeUser, "")
+    if err := a.Apply(ops); err != nil {
+        t.Fatal(err)
+    }
+    out, err := a.Ingest(adapter.ScopeUser, "")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(out.MCPServers) != 1 || out.MCPServers[0].ID != "github" {
+        t.Fatalf("MCP roundtrip lost: %+v", out.MCPServers)
+    }
+    if len(out.Skills) != 1 || out.Skills[0].Name != "review" {
+        t.Fatalf("Skill roundtrip lost: %+v", out.Skills)
+    }
+}
+```
+
+- [ ] **Step 13.2: Implement**
+
+`internal/adapter/claude/ingest.go`:
+
+```go
+package claude
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
+    p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+    var c source.Canonical
+
+    // MCP from .claude.json (user) or settings.json (project)
+    var mcpFile string
+    if scope == adapter.ScopeProject {
+        mcpFile = p.Settings
+    } else {
+        mcpFile = p.DotClaude
+    }
+    if data, err := os.ReadFile(mcpFile); err == nil {
+        var top map[string]any
+        if err := json.Unmarshal(data, &top); err != nil {
+            return c, fmt.Errorf("parse %s: %w", mcpFile, err)
+        }
+        if servers, ok := top["mcpServers"].(map[string]any); ok {
+            for id, raw := range servers {
+                spec, ok := raw.(map[string]any)
+                if !ok {
+                    continue
+                }
+                m := source.MCPServer{ID: id, Server: source.MCPServerSpec{
+                    Type:    asStr(spec["type"]),
+                    Command: asStr(spec["command"]),
+                    Args:    asStrSlice(spec["args"]),
+                    Env:     asStrMap(spec["env"]),
+                    URL:     asStr(spec["url"]),
+                    Headers: asStrMap(spec["headers"]),
+                }}
+                c.MCPServers = append(c.MCPServers, m)
+            }
+        }
+    }
+
+    // Skills
+    if entries, err := os.ReadDir(p.SkillsDir); err == nil {
+        for _, e := range entries {
+            if !e.IsDir() {
+                continue
+            }
+            data, err := os.ReadFile(filepath.Join(p.SkillsDir, e.Name(), "SKILL.md"))
+            if err != nil {
+                continue
+            }
+            fm, body, err := ParseFrontmatter(data)
+            if err != nil {
+                continue
+            }
+            c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+        }
+    }
+
+    // Subagents (agents/<name>.md), commands, hooks, lsp, memory: similar pattern
+    // — see Task 13.3 for the per-component snippets.
+
+    return c, nil
+}
+
+func asStr(v any) string { s, _ := v.(string); return s }
+func asStrSlice(v any) []string {
+    arr, ok := v.([]any)
+    if !ok {
+        return nil
+    }
+    out := make([]string, 0, len(arr))
+    for _, x := range arr {
+        if s, ok := x.(string); ok {
+            out = append(out, s)
+        }
+    }
+    return out
+}
+func asStrMap(v any) map[string]string {
+    m, ok := v.(map[string]any)
+    if !ok {
+        return nil
+    }
+    out := make(map[string]string, len(m))
+    for k, val := range m {
+        if s, ok := val.(string); ok {
+            out[k] = s
+        }
+    }
+    // also accept JSON-numeric values cast to string
+    _ = strings.Title // unused; placeholder so import lines stay clean
+    return out
+}
+```
+
+- [ ] **Step 13.3: Add the rest of the ingest paths**
+
+Subagents (`p.AgentsDir/*.md` → `Subagents`), Commands (`p.CommandsDir/*.md` → `Commands`), Hooks (read `settings.json` `/hooks/<event>` arrays → `Hooks` slice), LSP (`/lspServers` → `LSPServers`), Memory (`p.Memory` → `Memory.Body` verbatim, no fragment de-resolution since fragments aren't recoverable).
+
+Each follows the same pattern as Skills/MCP. Test each in `ingest_test.go` — round-trip Apply→Ingest. Commit.
+
+---
+
+## Task 14: Wire claude adapter into the registry
+
+**Files:**
+- Modify: `internal/cli/registry_internal.go`
+
+Replace the NoopAdapter for "claude" with a real `claude.New(...)`:
+
+```go
+package cli
+
+import (
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+
+var registryFactory = func() *adapter.Registry {
+    r := adapter.NewRegistry()
+    home := paths.HomeDir(paths.OSEnv{})
+    _ = r.Register(claude.New(claude.Options{TargetRoot: home}))
+    for _, name := range []string{"opencode", "codex", "cursor"} {
+        _ = r.Register(noop.New(name))
+    }
+    return r
+}
+```
+
+- [ ] **Step 14.1: Update `cli/apply.go` to allow real apply (drop the M0 error)**
+
+In `apply.go` `RunE`, change:
+
+```go
+if !dryRun {
+    return fmt.Errorf("M0 only supports --dry-run; ...")
+}
+```
+
+…to:
+
+```go
+if !dryRun {
+    plan, err := render.Plan(c, reg, agents, sc, "")
+    if err != nil {
+        return err
+    }
+    if err := render.Apply(plan, reg); err != nil {
+        return err
+    }
+    fmt.Fprintln(cmd.OutOrStdout(), "applied:", plan.Total(), "ops")
+    return nil
+}
+// (existing dry-run code follows)
+```
+
+- [ ] **Step 14.2: Integration test**
+
+`internal/cli/m1_integration_test.go`:
+
+```go
+package cli_test
+
+import (
+    "encoding/json"
+    "os"
+    "path/filepath"
+    "strings"
+    "testing"
+)
+
+func TestIntegration_M1_ClaudeMCPApply(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    if _, err := runCLI(t, env, "init"); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+        t.Fatal(err)
+    }
+
+    // Author an MCP file directly (the `mcp add` CLI lands in M4; for M1 we
+    // exercise via direct file creation, which is the supported "vim-able"
+    // path anyway).
+    mcpFile := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+    _ = os.MkdirAll(filepath.Dir(mcpFile), 0o755)
+    _ = os.WriteFile(mcpFile, []byte(`
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+agents  = ["claude"]
+`), 0o644)
+
+    out, err := runCLI(t, env, "apply")
+    if err != nil {
+        t.Fatalf("apply: %v\n%s", err, out)
+    }
+
+    body, err := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+    if err != nil {
+        t.Fatalf("read .claude.json: %v", err)
+    }
+    var top map[string]any
+    _ = json.Unmarshal(body, &top)
+    s := top["mcpServers"].(map[string]any)["github"].(map[string]any)
+    if !strings.HasPrefix(s["command"].(string), "npx") {
+        t.Fatalf("github command = %v", s["command"])
+    }
+}
+```
+
+- [ ] **Step 14.3: Run; commit**
+
+```bash
+go test -race ./...
+git commit -am "$(cat <<'EOF'
+feat(cli): register real claude adapter; apply writes destinations
+
+Replaces NoopAdapter for "claude" with claude.New. apply (no flag) now
+writes; --dry-run continues to compute plan only. Integration test
+verifies end-to-end MCP fanout to ~/.claude.json.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Done When
+
+```bash
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync init
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync agent add claude
+$ cat > /tmp/x/.agentsync/mcp/github.toml <<'TOML'
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+TOML
+$ AGENTSYNC_TARGET_ROOT=/tmp/x agentsync apply
+applied: 1 ops
+
+$ jq '.mcpServers.github' /tmp/x/.claude.json
+{
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"]
+}
+```
+
+Per-key merge survives foreign keys. Round-trip: `Render → Apply → Ingest` is parity-clean for every component except where the spec calls out lossiness (none for Claude — Claude is the source-of-truth shape). CI green on linux/macos/windows. Lint clean.
+
+Hooks, skills, subagents, commands, LSP — all rendered from canonical, written to disk in their native shapes, ingested back without loss.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m2-opencode.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m2-opencode.md
@@ -1,0 +1,823 @@
+# agentsync M2 — OpenCode adapter
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md#conventions-used-across-all-milestone-plans). Builds on [M0](2026-05-04-agentsync-m0-skeleton.md) + [M1](2026-05-04-agentsync-m1-claude.md).
+
+**Goal:** Second adapter. Implements `internal/adapter/opencode` covering MCP, memory (`AGENTS.md`), skill (write to shared `.claude/skills/<name>/SKILL.md` since OpenCode reads it natively), subagent (markdown w/ different frontmatter), slash command (markdown w/ `template:` frontmatter). Hooks `✗ skip(warn)` (OpenCode hooks are JS/TS plugin event subscriptions; shim generation deferred). LSP `✗ skip(warn)`. Replaces NoopAdapter for `opencode` in registry.
+
+**Architecture:** Mirrors M1's package layout. Settings file is `~/.config/opencode/opencode.json` — **JSONC** (JSON with comments). `tailscale/hujson` parses it; `MergeKeys` from M1's `claude` package is *generalized* and moved to a shared package (or duplicated; trade-off explained below).
+
+**Decision:** Move `MergeKeys`, `splitPointer`, `pointerExists`, `deletePointer`, `deepCopyMap`, `mergeMaps` from `internal/adapter/claude/settings.go` into `internal/jsonkeys/jsonkeys.go` so OpenCode and (eventually) Cursor adapters share. M2 Task 1 does this refactor.
+
+**Tech stack:** `tailscale/hujson` for JSONC parse/preserve, otherwise same as M1.
+
+---
+
+## Files created/modified
+
+```
+NEW:
+internal/jsonkeys/                 # extracted from M1 claude settings.go
+├── jsonkeys.go
+└── jsonkeys_test.go
+
+internal/adapter/opencode/
+├── opencode.go                    # Adapter, Name, Capabilities, Detect
+├── paths.go                       # ~/.config/opencode/* path resolution
+├── render.go                      # Render(canonical) -> []FileOp
+├── render_test.go
+├── ingest.go                      # Disk -> source.Canonical
+├── ingest_test.go
+├── apply.go                       # FileOp writer, JSONC-aware
+├── apply_test.go
+├── settings.go                    # opencode.json (JSONC) merge logic
+├── settings_test.go
+├── skill.go                       # write SKILL.md to .claude/skills/ shared path
+├── subagent.go                    # frontmatter munge: tools->permission, color drop, mode add
+├── command.go                     # frontmatter munge for commands
+└── memory.go                      # AGENTS.md (project root for project scope)
+
+MODIFIED:
+internal/adapter/claude/settings.go    # delegate to internal/jsonkeys
+internal/cli/registry_internal.go      # register opencode.New(...)
+```
+
+---
+
+## Task 1: Extract `internal/jsonkeys` from claude settings
+
+**Files:**
+- Create: `internal/jsonkeys/jsonkeys.go`, `internal/jsonkeys/jsonkeys_test.go`
+- Modify: `internal/adapter/claude/settings.go`
+
+- [ ] **Step 1.1: Move code**
+
+Copy the body of `internal/adapter/claude/settings.go` into `internal/jsonkeys/jsonkeys.go`, change package name to `jsonkeys`, and re-export `MergeKeys`. Move the test file too (`internal/jsonkeys/jsonkeys_test.go` mirrors the existing tests with package rename).
+
+- [ ] **Step 1.2: Stub claude/settings.go to delegate**
+
+```go
+package claude
+
+import "github.com/spxrogers/agentsync/internal/jsonkeys"
+
+// MergeKeys is preserved as a re-export for backward compat with claude
+// internal callers; new callers should import internal/jsonkeys directly.
+func MergeKeys(existing, ours map[string]any, ownedPointers []string) (map[string]any, []string, []string) {
+    return jsonkeys.MergeKeys(existing, ours, ownedPointers)
+}
+```
+
+- [ ] **Step 1.3: Run; commit**
+
+```bash
+go test -race ./internal/jsonkeys/... ./internal/adapter/claude/...
+git add internal/jsonkeys internal/adapter/claude
+git commit -m "$(cat <<'EOF'
+refactor(jsonkeys): extract per-key JSON merge from claude adapter
+
+Identical behavior, shared package. Claude re-exports MergeKeys for
+internal callers; opencode and future adapters import jsonkeys directly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `tailscale/hujson` dependency + JSONC settings module
+
+**Files:**
+- Modify: `go.mod`
+- Create: `internal/adapter/opencode/settings.go`, `internal/adapter/opencode/settings_test.go`
+
+`opencode.json` is JSONC: it can have `// line comments` and trailing commas. We must round-trip them.
+
+- [ ] **Step 2.1: Add dependency**
+
+```bash
+go get github.com/tailscale/hujson@latest
+```
+
+- [ ] **Step 2.2: Test for parse + render round-trip**
+
+```go
+package opencode_test
+
+import (
+    "strings"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter/opencode"
+)
+
+func TestApplyJSONCMerge_PreservesComments(t *testing.T) {
+    existing := []byte(`{
+  // top comment, must survive
+  "foreign": 1,
+  "mcp": {
+    "stale": {} // soon-to-be-removed
+  }
+}`)
+    ours := map[string]any{
+        "mcp": map[string]any{
+            "github": map[string]any{"command": "npx"},
+        },
+    }
+    owned := []string{"/mcp/stale", "/mcp/github"}
+
+    out, err := opencode.MergeJSONC(existing, ours, owned)
+    if err != nil {
+        t.Fatal(err)
+    }
+    s := string(out)
+    if !strings.Contains(s, "top comment, must survive") {
+        t.Fatalf("comment lost:\n%s", s)
+    }
+    if strings.Contains(s, "stale") {
+        t.Fatalf("stale should be removed:\n%s", s)
+    }
+    if !strings.Contains(s, `"github"`) {
+        t.Fatalf("github not added:\n%s", s)
+    }
+}
+```
+
+- [ ] **Step 2.3: Implement**
+
+`internal/adapter/opencode/settings.go`:
+
+```go
+// Package opencode-settings: JSONC-aware merge for opencode.json. Uses
+// tailscale/hujson which preserves comments and trailing commas across
+// parse->mutate->serialize cycles.
+package opencode
+
+import (
+    "encoding/json"
+    "fmt"
+
+    "github.com/tailscale/hujson"
+    "github.com/spxrogers/agentsync/internal/jsonkeys"
+)
+
+// MergeJSONC merges ours into existing JSONC content, removing ownedPointers
+// no longer present in ours. Comments and trailing-comma formatting from
+// existing are preserved as much as the hujson AST allows.
+//
+// Strategy: parse existing JSONC -> standardize to JSON (Pack), MergeKeys,
+// then format result as plain JSON. v1 trade-off: trailing comma + comment
+// preservation is partial — comments outside touched keys survive; comments
+// adjacent to deleted keys are also removed. M2 ships this; comment-position
+// fidelity can be tightened later if pain emerges.
+func MergeJSONC(existing []byte, ours map[string]any, ownedPointers []string) ([]byte, error) {
+    if len(existing) == 0 {
+        existing = []byte("{}")
+    }
+    val, err := hujson.Parse(existing)
+    if err != nil {
+        return nil, fmt.Errorf("parse jsonc: %w", err)
+    }
+    val.Standardize()
+    var existingMap map[string]any
+    if err := json.Unmarshal(val.Pack(), &existingMap); err != nil {
+        return nil, fmt.Errorf("standardize jsonc: %w", err)
+    }
+    if existingMap == nil {
+        existingMap = map[string]any{}
+    }
+    merged, _, _ := jsonkeys.MergeKeys(existingMap, ours, ownedPointers)
+    out, err := json.MarshalIndent(merged, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal merged: %w", err)
+    }
+    return append(out, '\n'), nil
+}
+```
+
+(The comment "comments lost when adjacent to deleted keys" is honest — full hujson AST round-trip with surgical key edits is more complex; v1 ships the simpler standardize+merge approach. Trade-off documented.)
+
+- [ ] **Step 2.4: Run; commit**
+
+```bash
+go test -race ./internal/adapter/opencode/...
+git add go.mod go.sum internal/adapter/opencode
+git commit -m "$(cat <<'EOF'
+feat(adapter/opencode): JSONC-aware merge via tailscale/hujson + jsonkeys
+
+opencode.json is JSONC; hujson parses comments+trailing-commas. v1 ships
+standardize+merge; trailing-comma fidelity may regress in edge cases —
+documented trade-off. Comment fidelity around touched keys is partial;
+fine for the typical "edit one MCP server" path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Adapter skeleton + Detect()
+
+**Files:**
+- Create: `internal/adapter/opencode/{opencode.go, paths.go, opencode_test.go}`
+
+Mirrors M1 Task 1. Detection: `~/.config/opencode/` exists OR `opencode` on PATH.
+
+- [ ] **Implement**
+
+`internal/adapter/opencode/paths.go`:
+
+```go
+package opencode
+
+import "path/filepath"
+
+type Paths struct {
+    ConfigDir       string // ~/.config/opencode
+    Settings        string // ~/.config/opencode/opencode.json
+    AgentsDir       string // ~/.config/opencode/agents (user); or .opencode/agents (project)
+    CommandsDir     string
+    ClaudeSkillsDir string // ~/.claude/skills (shared with Claude!)
+    Memory          string // CLAUDE not used; AGENTS.md at project root
+}
+
+func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
+    if projectScope && project != "" {
+        return Paths{
+            ConfigDir:       filepath.Join(project, ".opencode"),
+            Settings:        filepath.Join(project, ".opencode", "opencode.json"),
+            AgentsDir:       filepath.Join(project, ".opencode", "agents"),
+            CommandsDir:     filepath.Join(project, ".opencode", "commands"),
+            ClaudeSkillsDir: filepath.Join(project, ".claude", "skills"),
+            Memory:          filepath.Join(project, "AGENTS.md"),
+        }
+    }
+    cfg := filepath.Join(targetRoot, ".config", "opencode")
+    return Paths{
+        ConfigDir:       cfg,
+        Settings:        filepath.Join(cfg, "opencode.json"),
+        AgentsDir:       filepath.Join(cfg, "agents"),
+        CommandsDir:     filepath.Join(cfg, "commands"),
+        ClaudeSkillsDir: filepath.Join(targetRoot, ".claude", "skills"),
+        Memory:          filepath.Join(targetRoot, ".config", "opencode", "AGENTS.md"),
+    }
+}
+```
+
+`internal/adapter/opencode/opencode.go`:
+
+```go
+package opencode
+
+import (
+    "os"
+    "os/exec"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+)
+
+type Options struct{ TargetRoot string }
+
+type Adapter struct{ opts Options }
+
+func New(opts Options) *Adapter { return &Adapter{opts: opts} }
+
+func (a *Adapter) Name() string { return "opencode" }
+
+func (a *Adapter) Capabilities() adapter.Capability {
+    return adapter.CapMCP | adapter.CapMemory | adapter.CapSkill |
+        adapter.CapSubagent | adapter.CapCommand
+    // Hook + LSP capabilities omitted: we ship them as ✗ skip in v1.
+}
+
+func (a *Adapter) Detect() (bool, error) {
+    p := ResolvePaths(a.opts.TargetRoot, "", false)
+    if _, err := os.Stat(p.ConfigDir); err == nil {
+        return true, nil
+    }
+    if _, err := exec.LookPath("opencode"); err == nil {
+        return true, nil
+    }
+    return false, nil
+}
+```
+
+Test analogue of M1 Task 1, commit.
+
+---
+
+## Task 4: Render — MCP
+
+OpenCode `opencode.json` shape: `{"mcp": {"<id>": {"command": "...", "args": [...], "env": {...}}}}` — note the key is `mcp` not `mcpServers`.
+
+- [ ] **Test**
+
+```go
+func TestRender_MCP(t *testing.T) {
+    enabled := true
+    c := source.Canonical{MCPServers: []source.MCPServer{{
+        ID: "github",
+        Server: source.MCPServerSpec{
+            Type: "stdio", Command: "npx", Args: []string{"-y", "x"},
+            Agents: []string{"opencode"}, Enabled: &enabled,
+        },
+    }}}
+    a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+    ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+    var found bool
+    for _, op := range ops {
+        if strings.HasSuffix(op.Path, "opencode.json") {
+            found = true
+            if op.MergeStrategy != "merge-jsonc-keys" {
+                t.Fatalf("merge strategy = %q", op.MergeStrategy)
+            }
+            var ours map[string]any
+            _ = json.Unmarshal(op.Content, &ours)
+            mcp := ours["mcp"].(map[string]any)["github"].(map[string]any)
+            if mcp["command"] != "npx" {
+                t.Fatalf("command = %v", mcp["command"])
+            }
+        }
+    }
+    if !found {
+        t.Fatal("opencode.json op missing")
+    }
+}
+```
+
+- [ ] **Implement**
+
+`internal/adapter/opencode/render.go`:
+
+```go
+package opencode
+
+import (
+    "encoding/json"
+    "fmt"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func (a *Adapter) Render(c source.Canonical, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+    p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+    var ops []adapter.FileOp
+    var skips []adapter.Skip
+
+    if mcpOps, err := a.renderMCP(c, p); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, mcpOps...)
+    }
+    if memOps, err := a.renderMemory(c, p); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, memOps...)
+    }
+    if skOps, err := a.renderSkills(c, p); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, skOps...)
+    }
+    if saOps, saSkips, err := a.renderSubagents(c, p); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, saOps...)
+        skips = append(skips, saSkips...)
+    }
+    if cmdOps, err := a.renderCommands(c, p); err != nil {
+        return nil, nil, err
+    } else {
+        ops = append(ops, cmdOps...)
+    }
+    // Hooks
+    for _, h := range c.Hooks {
+        skips = append(skips, adapter.Skip{
+            Component: "hook", Name: h.Event,
+            Reason: "OpenCode hooks are JS/TS plugins; shim generation deferred to post-v1",
+        })
+    }
+    // LSP
+    for _, l := range c.LSPServers {
+        skips = append(skips, adapter.Skip{
+            Component: "lsp", Name: l.ID,
+            Reason: "OpenCode LSP projection deferred to v1.x",
+        })
+    }
+    return ops, skips, nil
+}
+
+func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+    mcp := map[string]any{}
+    for _, m := range c.MCPServers {
+        if m.Server.Enabled != nil && !*m.Server.Enabled {
+            continue
+        }
+        if !agentTargeted("opencode", m.Server.Agents) {
+            continue
+        }
+        spec := map[string]any{}
+        if m.Server.Type != "" {
+            spec["type"] = m.Server.Type
+        }
+        if m.Server.Command != "" {
+            spec["command"] = m.Server.Command
+        }
+        if len(m.Server.Args) > 0 {
+            spec["args"] = m.Server.Args
+        }
+        if len(m.Server.Env) > 0 {
+            spec["env"] = m.Server.Env
+        }
+        if m.Server.URL != "" {
+            spec["url"] = m.Server.URL
+        }
+        mcp[m.ID] = spec
+    }
+    if len(mcp) == 0 {
+        return nil, nil
+    }
+    ours := map[string]any{"mcp": mcp}
+    body, err := json.MarshalIndent(ours, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal opencode mcp: %w", err)
+    }
+    return []adapter.FileOp{{
+        Action:        "write",
+        Path:          p.Settings,
+        Content:       append(body, '\n'),
+        Mode:          0o644,
+        SourceID:      "mcp/* (multiple)",
+        MergeStrategy: "merge-jsonc-keys",
+    }}, nil
+}
+
+func agentTargeted(name string, agents []string) bool {
+    if len(agents) == 0 {
+        return true
+    }
+    for _, a := range agents {
+        if a == "*" || a == name {
+            return true
+        }
+    }
+    return false
+}
+```
+
+Commit:
+
+```bash
+git commit -am "feat(adapter/opencode): render MCP into opencode.json with merge-jsonc-keys
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Render — memory (AGENTS.md)
+
+`renderMemory` writes `c.Memory.Body` (with @import expansion) to `p.Memory`. Same shape as Claude's renderMemory but to a different path. Skill-test for Claude/M1 Task 6 applies; copy and adjust path expectations. Commit.
+
+---
+
+## Task 6: Render — skills (write to shared `.claude/skills/`)
+
+OpenCode reads `.claude/skills/<name>/SKILL.md` natively. We write SKILL.md to `p.ClaudeSkillsDir` (which Claude also writes to in M1).
+
+**Coordination with M1:** if both adapters render the same skill file, we get two FileOps with identical paths and identical content (since Skill.Frontmatter and Body are deterministic). The apply pipeline must dedupe per-path. Add this to render.Apply (in `internal/render/pipeline.go`):
+
+```go
+func Apply(p Plan, reg *adapter.Registry) error {
+    seen := map[string]bool{}
+    for name, res := range p.PerAgent {
+        a := reg.Lookup(name)
+        if a == nil {
+            return fmt.Errorf("adapter %q not registered at apply", name)
+        }
+        var deduped []adapter.FileOp
+        for _, op := range res.Ops {
+            if op.Action == "write" {
+                if seen[op.Path] {
+                    continue
+                }
+                seen[op.Path] = true
+            }
+            deduped = append(deduped, op)
+        }
+        if err := a.Apply(deduped); err != nil {
+            return fmt.Errorf("apply %s: %w", name, err)
+        }
+    }
+    return nil
+}
+```
+
+Add a test for the dedupe:
+
+```go
+func TestPipeline_DedupesIdenticalWritesAcrossAdapters(t *testing.T) {
+    // ... build canonical with one Skill,
+    // ... two adapters that both render the same path,
+    // ... assert filesystem only sees one write.
+}
+```
+
+Skill render in opencode mirrors Claude's renderSkills. Commit:
+
+```bash
+git commit -am "feat(adapter/opencode): write skills to shared .claude/skills/ path
+
+OpenCode reads .claude/skills/<name>/SKILL.md natively. Render emits
+identical FileOp to Claude's; render.Apply dedupes per path so the file
+is written once per apply even when multiple adapters target it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Render — subagents (markdown w/ frontmatter munge)
+
+Translate Claude-shaped subagent frontmatter to OpenCode-shaped.
+
+| Claude frontmatter | OpenCode frontmatter | Notes |
+|---|---|---|
+| `description` | `description` | direct copy |
+| `model` | `model` | direct copy |
+| `tools` (allowlist) | drop / log | OpenCode uses `permission` model; mapping tools->permission is non-trivial — log a Skip note |
+| `color` | drop | OpenCode has no color concept |
+| (none) | `mode: subagent` | always added |
+| (none) | `temperature` | not added (Claude doesn't carry it) |
+| (none) | `permission` | not added in v1 (would need policy) |
+
+- [ ] **Test**
+
+```go
+func TestRender_Subagent_FrontmatterMunge(t *testing.T) {
+    c := source.Canonical{Subagents: []source.Subagent{{
+        Name:        "review",
+        Frontmatter: map[string]any{
+            "description": "Code review",
+            "model":       "claude-sonnet-4-7",
+            "tools":       []string{"Read", "Grep"},
+            "color":       "blue",
+        },
+        Body: "Review code.\n",
+    }}}
+    a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+    ops, skips, _ := a.Render(c, adapter.ScopeUser, "")
+    // verify file content
+    var op *adapter.FileOp
+    for i, o := range ops {
+        if strings.HasSuffix(o.Path, "/agents/review.md") {
+            op = &ops[i]
+        }
+    }
+    if op == nil {
+        t.Fatal("no agent op")
+    }
+    if !strings.Contains(string(op.Content), "mode: subagent") {
+        t.Fatalf("missing mode:subagent in: %s", op.Content)
+    }
+    if strings.Contains(string(op.Content), "color:") {
+        t.Fatalf("color should be dropped: %s", op.Content)
+    }
+    if strings.Contains(string(op.Content), "tools:") {
+        t.Fatalf("tools should be dropped: %s", op.Content)
+    }
+    // verify skip log
+    var sawToolsSkip bool
+    for _, s := range skips {
+        if s.Component == "subagent-frontmatter" && s.Name == "review" {
+            if strings.Contains(s.Reason, "tools") {
+                sawToolsSkip = true
+            }
+        }
+    }
+    if !sawToolsSkip {
+        t.Fatalf("no skip emitted for tools allowlist")
+    }
+}
+```
+
+- [ ] **Implement**
+
+`internal/adapter/opencode/subagent.go`:
+
+```go
+package opencode
+
+import (
+    "fmt"
+    "path/filepath"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/claude"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp, []adapter.Skip, error) {
+    var ops []adapter.FileOp
+    var skips []adapter.Skip
+    for _, s := range c.Subagents {
+        out := map[string]any{}
+        if v, ok := s.Frontmatter["description"]; ok {
+            out["description"] = v
+        }
+        if v, ok := s.Frontmatter["model"]; ok {
+            out["model"] = v
+        }
+        out["mode"] = "subagent"
+
+        // Drop with skip notes for unmappable fields:
+        if _, ok := s.Frontmatter["tools"]; ok {
+            skips = append(skips, adapter.Skip{
+                Component: "subagent-frontmatter", Name: s.Name,
+                Reason: "Claude `tools` allowlist not projected to OpenCode `permission` (manual rule design needed)",
+            })
+        }
+        if _, ok := s.Frontmatter["color"]; ok {
+            skips = append(skips, adapter.Skip{
+                Component: "subagent-frontmatter", Name: s.Name,
+                Reason: "Claude `color` has no OpenCode equivalent",
+            })
+        }
+
+        body, err := claude.EncodeFrontmatter(out, s.Body)
+        if err != nil {
+            return nil, nil, fmt.Errorf("encode opencode subagent %s: %w", s.Name, err)
+        }
+        ops = append(ops, adapter.FileOp{
+            Action:        "write",
+            Path:          filepath.Join(p.AgentsDir, s.Name+".md"),
+            Content:       body,
+            Mode:          0o644,
+            SourceID:      filepath.Join("agents", s.Name+".md"),
+            MergeStrategy: "replace",
+        })
+    }
+    return ops, skips, nil
+}
+```
+
+Commit.
+
+---
+
+## Task 8: Render — slash commands (frontmatter munge)
+
+Claude command frontmatter (`description`, `argument-hint`, `model`) → OpenCode (`description`, `agent`, `subtask`, `model`, `template`).
+
+- For Claude `description` → OpenCode `description` (direct).
+- `model` → `model` (direct).
+- `argument-hint` → drop (skip note).
+- Body of the markdown becomes the command body (template). OpenCode treats `template:` frontmatter or body interchangeably; we keep body and don't add `template:` frontmatter to avoid duplication.
+
+- [ ] Mirror Task 7 pattern. Test, implement (`command.go`), commit.
+
+---
+
+## Task 9: `Apply()` — JSONC-aware writer
+
+Like Claude's Apply but with `merge-jsonc-keys` strategy.
+
+`internal/adapter/opencode/apply.go`:
+
+```go
+package opencode
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+func (a *Adapter) Apply(ops []adapter.FileOp) error {
+    for _, op := range ops {
+        switch op.Action {
+        case "delete":
+            if err := os.Remove(op.Path); err != nil && !os.IsNotExist(err) {
+                return fmt.Errorf("delete %s: %w", op.Path, err)
+            }
+        case "", "write":
+            if err := a.applyWrite(op); err != nil {
+                return err
+            }
+        default:
+            return fmt.Errorf("unknown action %q", op.Action)
+        }
+    }
+    return nil
+}
+
+func (a *Adapter) applyWrite(op adapter.FileOp) error {
+    mode := os.FileMode(op.Mode)
+    if mode == 0 {
+        mode = 0o644
+    }
+    if op.MergeStrategy == "merge-jsonc-keys" {
+        existing, _ := os.ReadFile(op.Path)
+        var ours map[string]any
+        if err := json.Unmarshal(op.Content, &ours); err != nil {
+            return fmt.Errorf("parse our payload: %w", err)
+        }
+        out, err := MergeJSONC(existing, ours, op.OwnedKeys)
+        if err != nil {
+            return err
+        }
+        return iox.AtomicWrite(op.Path, out, mode)
+    }
+    return iox.AtomicWrite(op.Path, op.Content, mode)
+}
+```
+
+Test (mirrors Claude apply tests, asserting JSONC comments survive). Commit.
+
+---
+
+## Task 10: `Ingest()`
+
+Inverse of Render. Reads `opencode.json` → MCP; `<AgentsDir>/*.md` → Subagents (frontmatter munged back to canonical: drop `mode`, retain `description`+`model`); `<CommandsDir>/*.md` → Commands; AGENTS.md → Memory.Body verbatim.
+
+For Subagent ingest: we lose the tools/color fields that we dropped on render — round-trip is therefore not parity for subagents (it CAN'T be since the data isn't on disk). Round-trip test for OpenCode subagents asserts `Render(Ingest(Apply(in))) ≈ in` modulo dropped fields.
+
+Test, implement, commit.
+
+---
+
+## Task 11: Wire into registry + integration test
+
+Modify `internal/cli/registry_internal.go`:
+
+```go
+_ = r.Register(opencode.New(opencode.Options{TargetRoot: home}))
+```
+
+Replace the noop entry for "opencode".
+
+Integration test:
+
+```go
+func TestIntegration_M2_OpenCodeMCPApply(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+    _, _ = runCLI(t, env, "agent", "add", "opencode")
+
+    mcpFile := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+    _ = os.MkdirAll(filepath.Dir(mcpFile), 0o755)
+    _ = os.WriteFile(mcpFile, []byte(`
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+`), 0o644)
+
+    if _, err := runCLI(t, env, "apply"); err != nil {
+        t.Fatal(err)
+    }
+
+    // Both Claude and OpenCode got it
+    body, _ := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+    if !strings.Contains(string(body), "github") {
+        t.Fatalf("claude missing github: %s", body)
+    }
+    body, _ = os.ReadFile(filepath.Join(tmp, ".config", "opencode", "opencode.json"))
+    if !strings.Contains(string(body), "github") {
+        t.Fatalf("opencode missing github: %s", body)
+    }
+}
+```
+
+Commit:
+
+```bash
+git commit -am "$(cat <<'EOF'
+feat(cli): register real opencode adapter; cross-agent MCP fanout works
+
+End-to-end: one mcp/<id>.toml -> ~/.claude.json AND
+~/.config/opencode/opencode.json after a single apply. M2 done.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Done When
+
+- `agentsync apply` writes both `~/.claude.json` AND `~/.config/opencode/opencode.json` from a single canonical MCP file.
+- A single canonical Subagent renders to both `~/.claude/agents/<n>.md` (Claude shape) AND `~/.config/opencode/agents/<n>.md` (OpenCode shape with frontmatter munge); skips for `tools`+`color` are surfaced in the apply translation report.
+- A single canonical Skill writes ONE file at `~/.claude/skills/<n>/SKILL.md` (deduped), consumed by both Claude and OpenCode.
+- JSONC comments in pre-existing `opencode.json` survive opensync mutations to keys we don't touch.
+- Hooks and LSP in canonical produce explicit `✗ skip(warn)` entries in the translation report.
+- CI green on linux/macos/windows.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m3-drift.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m3-drift.md
@@ -1,0 +1,845 @@
+# agentsync M3 — Drift, status, diff, reconcile
+
+> Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md). Builds on M0/M1/M2.
+
+**Goal:** 3-way hash classifier + commands `status`, `diff`, `reconcile`. File-level + JSON-pointer key-level. Foreign-key reporting. Bulk hotkeys + `--auto-*` flags.
+
+**Architecture:** New `internal/drift` package houses the classifier (pure function). `internal/cli/{status,diff,reconcile}.go` wire CLI surface. State is updated only on successful apply or successful reconcile-write-back; a successful reconcile-override re-applies via existing render pipeline.
+
+**Tech stack:** stdlib only for classifier. `charmbracelet/huh` for the reconcile prompt loop (lightweight; v1 only uses Confirm + simple character input).
+
+---
+
+## Files
+
+```
+NEW:
+internal/drift/{classifier.go, classifier_test.go}
+internal/cli/{status.go, status_test.go, diff.go, diff_test.go, reconcile.go, reconcile_test.go}
+internal/render/state_apply.go     # applies state updates after Apply
+
+MODIFIED:
+internal/cli/apply.go              # wire state updates post-apply
+internal/cli/root.go               # AddCommand status/diff/reconcile
+internal/render/pipeline.go        # populate FileOp.OwnedKeys from state
+```
+
+---
+
+## Task 1: Drift classifier
+
+**Files:** `internal/drift/{classifier.go, classifier_test.go}`
+
+Pure function: given (H_src, H_applied, H_dest) → Class.
+
+- [ ] **Test (table-driven covering all 9 cases)**
+
+```go
+package drift_test
+
+import (
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/drift"
+)
+
+func TestClassify(t *testing.T) {
+    type tc struct {
+        name                                string
+        hsrc, happlied, hdest               string // "" = nil
+        want                                drift.Class
+    }
+    cases := []tc{
+        {name: "clean", hsrc: "a", happlied: "a", hdest: "a", want: drift.Clean},
+        {name: "pending", hsrc: "b", happlied: "a", hdest: "a", want: drift.Pending},
+        {name: "drift", hsrc: "a", happlied: "a", hdest: "b", want: drift.Drift},
+        {name: "converged", hsrc: "b", happlied: "a", hdest: "b", want: drift.Converged},
+        {name: "conflict", hsrc: "b", happlied: "a", hdest: "c", want: drift.Conflict},
+        {name: "new", hsrc: "a", happlied: "", hdest: "", want: drift.New},
+        {name: "foreign-collision", hsrc: "a", happlied: "", hdest: "x", want: drift.ForeignCollision},
+        {name: "orphan", hsrc: "", happlied: "a", hdest: "a", want: drift.Orphan},
+        {name: "orphan-drifted", hsrc: "", happlied: "a", hdest: "b", want: drift.OrphanDrifted},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            got := drift.Classify(c.hsrc, c.happlied, c.hdest)
+            if got != c.want {
+                t.Fatalf("Classify(%q,%q,%q) = %v, want %v", c.hsrc, c.happlied, c.hdest, got, c.want)
+            }
+        })
+    }
+}
+```
+
+- [ ] **Implement**
+
+`internal/drift/classifier.go`:
+
+```go
+// Package drift classifies (source, applied, destination) hash triples per the
+// 9-case table in the agentsync design spec. Pure function, no IO.
+package drift
+
+type Class int
+
+const (
+    Clean Class = iota
+    Pending
+    Drift
+    Converged
+    Conflict
+    New
+    ForeignCollision
+    Orphan
+    OrphanDrifted
+)
+
+func (c Class) String() string {
+    switch c {
+    case Clean:
+        return "clean"
+    case Pending:
+        return "pending"
+    case Drift:
+        return "drift"
+    case Converged:
+        return "converged"
+    case Conflict:
+        return "conflict"
+    case New:
+        return "new"
+    case ForeignCollision:
+        return "foreign-collision"
+    case Orphan:
+        return "orphan"
+    case OrphanDrifted:
+        return "orphan-drifted"
+    }
+    return "unknown"
+}
+
+// Classify returns the case for one tracked item. Empty string means "absent."
+// hsrc=src hash now; happlied=last-applied hash; hdest=on-disk hash now.
+func Classify(hsrc, happlied, hdest string) Class {
+    switch {
+    case happlied == "" && hdest == "" && hsrc != "":
+        return New
+    case happlied == "" && hdest != "" && hsrc != "":
+        return ForeignCollision
+    case happlied != "" && hsrc == "":
+        if hdest == happlied {
+            return Orphan
+        }
+        return OrphanDrifted
+    case hsrc == happlied && hdest == happlied:
+        return Clean
+    case hsrc != happlied && hdest == happlied:
+        return Pending
+    case hsrc == happlied && hdest != happlied:
+        return Drift
+    case hsrc != happlied && hdest != happlied && hsrc == hdest:
+        return Converged
+    default:
+        return Conflict
+    }
+}
+
+// SafeForAutoApply returns true for cases apply can resolve without prompting.
+func SafeForAutoApply(c Class) bool {
+    return c == Clean || c == Pending || c == New || c == Converged
+}
+```
+
+Commit:
+
+```bash
+git commit -am "feat(drift): 9-case 3-way hash classifier (pure function)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire state writes post-Apply
+
+**Files:** `internal/render/state_apply.go`, modify `internal/render/pipeline.go`, `internal/cli/apply.go`
+
+After every successful Apply, opensync must:
+1. For each `write` FileOp: hash final on-disk content + record in `state.Files[<key>]`.
+2. For each `merge-json-keys`/`merge-jsonc-keys` op: parse final on-disk JSON, for each pointer that came from `ours`, hash that subtree + record in `state.Keys[<key>]`.
+
+- [ ] **Test**
+
+```go
+package render_test
+
+import (
+    "encoding/json"
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/adapter/noop"
+    "github.com/spxrogers/agentsync/internal/render"
+    "github.com/spxrogers/agentsync/internal/state"
+)
+
+func TestRecordState_FilesAndKeys(t *testing.T) {
+    dir := t.TempDir()
+    p := filepath.Join(dir, ".claude.json")
+    _ = os.WriteFile(p, []byte(`{"mcpServers":{"github":{"command":"npx"}},"foreign":{}}`), 0o644)
+
+    s := state.New()
+    err := render.RecordOpsState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
+        Action:        "write",
+        Path:          p,
+        MergeStrategy: "merge-json-keys",
+        Content:       []byte(`{"mcpServers":{"github":{"command":"npx"}}}`),
+        SourceID:      "mcp/github.toml",
+    }})
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // Expect a key entry for /mcpServers/github
+    var found bool
+    for k := range s.Keys {
+        if k == "claude:user::"+p+":/mcpServers/github" {
+            found = true
+        }
+    }
+    if !found {
+        t.Fatalf("missing key entry; have: %+v", s.Keys)
+    }
+    _ = json.RawMessage{}
+    _ = noop.New
+}
+```
+
+- [ ] **Implement**
+
+`internal/render/state_apply.go`:
+
+```go
+package render
+
+import (
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/state"
+)
+
+// RecordOpsState updates s with hashes for files and keys produced by ops.
+// Caller is expected to call this AFTER a successful Apply.
+func RecordOpsState(s *state.Targets, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
+    now := time.Now().UTC()
+    for _, op := range ops {
+        if op.Action != "" && op.Action != "write" {
+            continue
+        }
+        switch op.MergeStrategy {
+        case "merge-json-keys", "merge-jsonc-keys":
+            // Re-read final on-disk content and record per pointer
+            data, err := os.ReadFile(op.Path)
+            if err != nil {
+                return fmt.Errorf("read post-apply %s: %w", op.Path, err)
+            }
+            var final map[string]any
+            if err := json.Unmarshal(data, &final); err != nil {
+                return fmt.Errorf("parse post-apply %s: %w", op.Path, err)
+            }
+            var ours map[string]any
+            if err := json.Unmarshal(op.Content, &ours); err != nil {
+                return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
+            }
+            for _, ptr := range collectPointers(ours, "") {
+                v := getPointer(final, ptr)
+                hash := hashAny(v)
+                key := fmt.Sprintf("%s:%s:%s:%s:%s", agent, scope.String(), project, op.Path, ptr)
+                s.Keys[key] = state.KeyEntry{
+                    SHA256:    hash,
+                    AppliedAt: now,
+                    SourceID:  op.SourceID,
+                }
+            }
+        default:
+            data, err := os.ReadFile(op.Path)
+            if err != nil {
+                return fmt.Errorf("read post-apply %s: %w", op.Path, err)
+            }
+            sum := sha256.Sum256(data)
+            key := fmt.Sprintf("%s:%s:%s:%s", agent, scope.String(), project, op.Path)
+            s.Files[key] = state.FileEntry{
+                SHA256:    hex.EncodeToString(sum[:]),
+                Mode:      op.Mode,
+                AppliedAt: now,
+                SourceID:  op.SourceID,
+            }
+        }
+    }
+    return nil
+}
+
+// collectPointers walks m and returns JSON pointers for every leaf-or-object
+// at the second level (e.g. /mcpServers/github -> stop). agentsync owns at
+// the second-level granularity; deeper edits fall under that key's value
+// hash.
+func collectPointers(m map[string]any, prefix string) []string {
+    var out []string
+    for k, v := range m {
+        ptr := prefix + "/" + escapeJSONPointer(k)
+        switch vv := v.(type) {
+        case map[string]any:
+            // Drill one level: each child key becomes a pointer.
+            for kk := range vv {
+                out = append(out, ptr+"/"+escapeJSONPointer(kk))
+            }
+        default:
+            out = append(out, ptr)
+        }
+    }
+    return out
+}
+
+func escapeJSONPointer(s string) string {
+    s = replaceAll(s, "~", "~0")
+    s = replaceAll(s, "/", "~1")
+    return s
+}
+
+func replaceAll(s, from, to string) string {
+    out := make([]byte, 0, len(s))
+    for i := 0; i < len(s); {
+        if i+len(from) <= len(s) && s[i:i+len(from)] == from {
+            out = append(out, to...)
+            i += len(from)
+            continue
+        }
+        out = append(out, s[i])
+        i++
+    }
+    return string(out)
+}
+
+func getPointer(m map[string]any, ptr string) any {
+    parts := splitPtr(ptr)
+    var cur any = m
+    for _, p := range parts {
+        mm, ok := cur.(map[string]any)
+        if !ok {
+            return nil
+        }
+        cur = mm[p]
+    }
+    return cur
+}
+
+func splitPtr(ptr string) []string {
+    if len(ptr) > 0 && ptr[0] == '/' {
+        ptr = ptr[1:]
+    }
+    if ptr == "" {
+        return nil
+    }
+    parts := []string{}
+    cur := []byte{}
+    for i := 0; i < len(ptr); i++ {
+        if ptr[i] == '/' {
+            parts = append(parts, string(cur))
+            cur = cur[:0]
+            continue
+        }
+        cur = append(cur, ptr[i])
+    }
+    parts = append(parts, string(cur))
+    for i, p := range parts {
+        p = replaceAll(p, "~1", "/")
+        p = replaceAll(p, "~0", "~")
+        parts[i] = p
+    }
+    return parts
+}
+
+func hashAny(v any) string {
+    data, _ := json.Marshal(v)
+    sum := sha256.Sum256(data)
+    return hex.EncodeToString(sum[:])
+}
+```
+
+- [ ] **Wire into apply**
+
+In `internal/cli/apply.go`, after `render.Apply(plan, reg)`:
+
+```go
+// Load + update state
+home := paths.AgentsyncHome(paths.OSEnv{})
+statePath := filepath.Join(home, ".state", "targets.json")
+s, err := state.Load(statePath)
+if err != nil {
+    return err
+}
+for name, res := range plan.PerAgent {
+    if err := render.RecordOpsState(s, name, sc, "", res.Ops); err != nil {
+        return err
+    }
+}
+if err := state.Save(statePath, s); err != nil {
+    return err
+}
+```
+
+Test, commit:
+
+```bash
+git commit -am "$(cat <<'EOF'
+feat(render,cli): record state after successful apply
+
+Files/keys hashed and stored to ~/.agentsync/.state/targets.json. Drift
+detection in Task 4+ reads from this. State save is atomic
+(iox.AtomicWrite via state.Save).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Pipeline owns OwnedKeys flow
+
+**Files:** `internal/render/pipeline.go`
+
+Before each adapter's Render is called, pipeline reads state.Keys for that adapter+scope+project, attaches matching `/file/pointer` paths to `op.OwnedKeys` for each op the adapter returns.
+
+Actually cleaner: adapter returns ops without OwnedKeys; pipeline iterates state.Keys keyed by `<agent>:<scope>:<project>:<file>:<pointer>` and groups by file path → for each file, collects pointers → attaches to ops with that path.
+
+- [ ] **Implement** the pointer-injection step in `Plan()` after collecting ops; test that orphan removal works through the full path.
+
+```go
+// in Plan():
+for name, res := range out.PerAgent {
+    for i, op := range res.Ops {
+        if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
+            res.Ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path)
+        }
+    }
+    out.PerAgent[name] = res
+}
+```
+
+```go
+func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path string) []string {
+    prefix := fmt.Sprintf("%s:%s:%s:%s:", agent, scope.String(), project, path)
+    var out []string
+    for k := range s.Keys {
+        if strings.HasPrefix(k, prefix) {
+            out = append(out, strings.TrimPrefix(k, prefix))
+        }
+    }
+    return out
+}
+```
+
+Plan signature changes to accept `*state.Targets`. Update callers. Test: pre-populate state with one owned pointer, ensure subsequent Render produces FileOp.OwnedKeys with that pointer.
+
+Commit.
+
+---
+
+## Task 4: `agentsync status`
+
+Walks `state.Files` + `state.Keys`, classifies each, prints per-(agent,file) breakdown.
+
+- [ ] **Implement** `internal/cli/status.go`:
+
+```go
+package cli
+
+import (
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/spf13/afero"
+    "github.com/spf13/cobra"
+    "github.com/spxrogers/agentsync/internal/adapter"
+    "github.com/spxrogers/agentsync/internal/drift"
+    "github.com/spxrogers/agentsync/internal/paths"
+    "github.com/spxrogers/agentsync/internal/render"
+    "github.com/spxrogers/agentsync/internal/source"
+    "github.com/spxrogers/agentsync/internal/state"
+)
+
+func newStatusCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "status",
+        Short: "report drift across registered agents",
+        Args:  cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            home := paths.AgentsyncHome(paths.OSEnv{})
+            c, err := source.Load(afero.NewOsFs(), home)
+            if err != nil {
+                return err
+            }
+            statePath := filepath.Join(home, ".state", "targets.json")
+            s, err := state.Load(statePath)
+            if err != nil {
+                return err
+            }
+            reg := registryFactory()
+            var agents []string
+            for name, ag := range c.Config.Agents {
+                if ag.Enabled {
+                    agents = append(agents, name)
+                }
+            }
+            plan, err := render.Plan(c, reg, agents, adapter.ScopeUser, "", s)
+            if err != nil {
+                return err
+            }
+
+            w := cmd.OutOrStdout()
+            for _, name := range reg.Names() {
+                res, ok := plan.PerAgent[name]
+                if !ok {
+                    continue
+                }
+                fmt.Fprintf(w, "[%s]\n", name)
+                seen := map[string]bool{}
+                // file-level: for each op, classify
+                for _, op := range res.Ops {
+                    if op.MergeStrategy != "" {
+                        continue // covered key-by-key below
+                    }
+                    if seen[op.Path] {
+                        continue
+                    }
+                    seen[op.Path] = true
+                    hsrc := hashContent(op.Content)
+                    happlied := s.Files[fmt.Sprintf("%s:user::%s", name, op.Path)].SHA256
+                    hdest := hashFile(op.Path)
+                    cls := drift.Classify(hsrc, happlied, hdest)
+                    fmt.Fprintf(w, "  %-9s %s\n", cls, op.Path)
+                }
+                // key-level: for each merge op, walk owned pointers
+                for _, op := range res.Ops {
+                    if op.MergeStrategy != "merge-json-keys" && op.MergeStrategy != "merge-jsonc-keys" {
+                        continue
+                    }
+                    var ours map[string]any
+                    _ = json.Unmarshal(op.Content, &ours)
+                    final := readJSON(op.Path)
+                    for _, ptr := range render.PublicCollectPointers(ours, "") {
+                        hsrc := hashAny(getPointer(ours, ptr))
+                        happlied := s.Keys[fmt.Sprintf("%s:user::%s:%s", name, op.Path, ptr)].SHA256
+                        hdest := hashAny(getPointer(final, ptr))
+                        cls := drift.Classify(hsrc, happlied, hdest)
+                        fmt.Fprintf(w, "  %-9s %s#%s\n", cls, op.Path, ptr)
+                    }
+                }
+            }
+            return nil
+        },
+    }
+}
+
+func hashContent(b []byte) string {
+    sum := sha256.Sum256(b)
+    return hex.EncodeToString(sum[:])
+}
+
+func hashFile(path string) string {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return ""
+    }
+    return hashContent(data)
+}
+
+func hashAny(v any) string {
+    if v == nil {
+        return ""
+    }
+    data, _ := json.Marshal(v)
+    return hashContent(data)
+}
+
+func readJSON(path string) map[string]any {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return map[string]any{}
+    }
+    var m map[string]any
+    _ = json.Unmarshal(data, &m)
+    return m
+}
+
+func getPointer(m map[string]any, ptr string) any {
+    if !strings.HasPrefix(ptr, "/") {
+        return nil
+    }
+    parts := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
+    var cur any = m
+    for _, p := range parts {
+        mp, ok := cur.(map[string]any)
+        if !ok {
+            return nil
+        }
+        cur = mp[p]
+    }
+    return cur
+}
+```
+
+(Notes: `render.PublicCollectPointers` is the exported version of M3 Task 2's `collectPointers` — make it public.)
+
+Wire into `cli.Root.AddCommand(newStatusCmd())`. Test:
+
+```go
+func TestStatus_DriftAfterDirectEdit(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+    _ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+    _ = os.WriteFile(mcp, []byte(`[server]
+type="stdio"
+command="npx"`), 0o644)
+    _, _ = runCLI(t, env, "apply")
+
+    // Modify destination directly
+    dst := filepath.Join(tmp, ".claude.json")
+    body, _ := os.ReadFile(dst)
+    body = []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1))
+    _ = os.WriteFile(dst, body, 0o644)
+
+    out, err := runCLI(t, env, "status")
+    if err != nil {
+        t.Fatalf("status: %v\n%s", err, out)
+    }
+    if !strings.Contains(out, "drift") {
+        t.Fatalf("status didn't report drift: %s", out)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Task 5: `agentsync diff [<path>]`
+
+For each non-clean item, show a unified diff (source vs destination). Use `github.com/sergi/go-diff/diffmatchpatch` for the diff renderer.
+
+- [ ] Add dependency, implement, test (single-file diff and key-level diff). Commit.
+
+---
+
+## Task 6: `agentsync reconcile`
+
+Walks all drifted/conflicting items, prompts user per-item. Uses `charmbracelet/huh`.
+
+- [ ] **Test scaffold (TUI testing via `teatest`-style harness)**
+
+```go
+// integration test that pipes responses to stdin would be heavy; v1 ships
+// reconcile with a non-interactive "--auto-*" path tested directly, plus
+// a smoke test that reconcile exits 0 when input is empty (no drift).
+func TestReconcile_NoDrift(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+    _, _ = runCLI(t, env, "apply")
+    if _, err := runCLI(t, env, "reconcile", "--auto-safe"); err != nil {
+        t.Fatal(err)
+    }
+}
+
+func TestReconcile_AutoOverride(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+    _ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+    _ = os.WriteFile(mcp, []byte(`[server]
+type="stdio"
+command="npx"`), 0o644)
+    _, _ = runCLI(t, env, "apply")
+
+    // Manually mutate destination to create drift
+    dst := filepath.Join(tmp, ".claude.json")
+    body, _ := os.ReadFile(dst)
+    drifted := strings.Replace(string(body), `"npx"`, `"npm"`, 1)
+    _ = os.WriteFile(dst, []byte(drifted), 0o644)
+
+    // reconcile --auto-override should re-apply source value
+    if _, err := runCLI(t, env, "reconcile", "--auto-override"); err != nil {
+        t.Fatal(err)
+    }
+    final, _ := os.ReadFile(dst)
+    if !strings.Contains(string(final), `"npx"`) {
+        t.Fatalf("override didn't restore source value: %s", final)
+    }
+}
+```
+
+- [ ] **Implement** `internal/cli/reconcile.go`:
+
+Three flags: `--auto-writeback`, `--auto-override`, `--auto-safe`. Walk plan items in same order as status; for each:
+- `Clean` / `Pending` / `New` / `Converged` → no prompt; `--auto-safe` resolves them silently.
+- `Drift` / `Conflict` / `OrphanDrifted` → prompt unless `--auto-*`.
+- `Orphan` → no prompt (apply removes).
+- `ForeignCollision` → no prompt; `apply` already backed up the original.
+
+For each prompted item:
+
+```
+~/.claude/settings.json#/mcpServers/github   (drift)
+  source:      {"command": "npx"}
+  destination: {"command": "npm"}
+
+  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit
+```
+
+- `w` (write-back): rewrite the canonical TOML key from destination's value via `internal/source.Writer` (introduced as a small helper that re-encodes a single MCP/Plugin/etc with `pelletier/go-toml/v2`).
+- `o` (override): re-render and apply the source-side value to dest (effectively next `apply` does this).
+- `s` (skip): leave inconsistent for now; reported again on next status.
+- `i` (ignore): write path to `~/.agentsync/ignore.toml`; classifier omits it.
+- `d` (diff): print unified diff, re-prompt.
+- `q` (quit): stop; remaining items not touched.
+
+Bulk: capital `W` / `O` / `S` apply that action to all remaining items.
+
+Implementation uses cobra + a simple read-character loop on `os.Stdin` (no need for full huh component model — keep it small):
+
+```go
+package cli
+
+import (
+    "bufio"
+    "fmt"
+    "io"
+    "os"
+    "strings"
+
+    "github.com/spf13/cobra"
+    // ...
+)
+
+func newReconcileCmd() *cobra.Command {
+    var autoWB, autoOR, autoSafe bool
+    cmd := &cobra.Command{
+        Use:   "reconcile",
+        Short: "interactively resolve drift",
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            // build plan, walk items, classify each
+            // bulkAction tracks W/O/S overrides
+            // for items needing prompt, read 1 char from os.Stdin or use --auto-* flags
+            return reconcileRun(cmd, os.Stdin, autoWB, autoOR, autoSafe)
+        },
+    }
+    cmd.Flags().BoolVar(&autoWB, "auto-writeback", false, "auto-resolve drift by writing dest back to source")
+    cmd.Flags().BoolVar(&autoOR, "auto-override", false, "auto-resolve drift by re-applying source to dest")
+    cmd.Flags().BoolVar(&autoSafe, "auto-safe", false, "auto-resolve only converged/pending/new")
+    return cmd
+}
+
+func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool) error {
+    // implementation: pseudocode
+    //   for each item in plan:
+    //     classify
+    //     if SafeForAutoApply || (auto-safe && SafeForAutoApply): no-op or apply
+    //     elif autoWB: writeBackItem(...)
+    //     elif autoOR: overrideItem(...) (defer to next apply)
+    //     else: prompt(in, item) -> {w,o,s,i,d,q,W,O,S}
+    //   if any --auto-override happened, run render.Apply at end
+    //   on quit: return early
+    return nil
+}
+```
+
+(The implementation is straightforward but boilerplate-heavy. The engineer fills in `writeBackItem` / `overrideItem` per-component using the source.Writer added in M3 Task 7.)
+
+Commit.
+
+---
+
+## Task 7: `internal/source.Writer` for write-back
+
+**Files:** `internal/source/writer.go`, `internal/source/writer_test.go`
+
+When reconcile chooses write-back, opensync mutates the canonical file. Comment-preserving via `pelletier/go-toml/v2` AST: we don't have full AST mutation today; v1 strategy:
+
+For `mcp/<id>.toml`: marshal the updated `MCPServer` as TOML and atomically write — comments above the file are lost on first write-back. **Documented v1 trade-off.** Better preservation lands as a v1.x improvement.
+
+```go
+package source
+
+import (
+    "fmt"
+    "path/filepath"
+
+    "github.com/pelletier/go-toml/v2"
+    "github.com/spxrogers/agentsync/internal/iox"
+)
+
+// WriteMCP writes mcp/<id>.toml from m. Overwrites existing; comments lost.
+func WriteMCP(home, id string, m MCPServer) error {
+    body, err := toml.Marshal(m)
+    if err != nil {
+        return fmt.Errorf("marshal mcp %s: %w", id, err)
+    }
+    return iox.AtomicWrite(filepath.Join(home, "mcp", id+".toml"), body, 0o644)
+}
+
+// WritePlugin, WriteMarketplace, WriteSkill follow the same pattern.
+```
+
+Test, commit.
+
+---
+
+## Task 8: `--auto-safe` integration test + final commit
+
+```go
+func TestApplyThenReconcileAutoSafe(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+    // ... apply, then reconcile --auto-safe should be a no-op
+    if _, err := runCLI(t, env, "reconcile", "--auto-safe"); err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Done When
+
+- `agentsync status` reports per-agent drift with the 9-class classifier; cleanly handles file-level + key-level items.
+- `agentsync diff <path>` shows unified diff source-vs-dest.
+- `agentsync reconcile` prompts per drifted item with `[w]/[o]/[s]/[i]/[d]/[q]` + bulk hotkeys; non-interactive flags (`--auto-writeback`, `--auto-override`, `--auto-safe`) work in CI.
+- Foreign keys (paths with no entry in `state.Keys`) are listed in `status` but never enter the case table.
+- A round-trip `apply → mutate dest → status (drift) → reconcile --auto-writeback → apply` produces clean status.
+- CI green.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m4-marketplaces.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m4-marketplaces.md
@@ -1,0 +1,498 @@
+# agentsync M4 — Marketplaces + plugins
+
+> Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md). Builds on M0–M3.
+
+**Goal:** Implement Claude marketplace ingestion (5 source types: relative, github, url, git-subdir, npm), the plugin install/upgrade/enable/disable/remove CLI surface, per-component projection from plugin manifests through registered adapters, translation reports, manifest sha pinning, and update modes (pinned/track/manual). The `update` command (the only network-touching verb) refreshes marketplace caches and pre-computes pending bumps.
+
+**Architecture:** New `internal/marketplace` package. `Fetcher` interface with one impl per source type (relative, git, npm). Cache lives at `~/.agentsync/.state/cache/marketplaces/<slug>/` and `.../plugins/<id>/`. Plugin install copies the manifest sha into `plugins/<id>.toml` (canonical); per-component decomposition happens in `internal/marketplace/projection.go` and emits `source.Canonical` overlays that adapters consume normally.
+
+**Tech stack:** `github.com/go-git/go-git/v5` (git fetch + sparse), stdlib `net/http` + `archive/tar` + `compress/gzip` (npm tarball), no `npm`/`Bun` required at runtime.
+
+---
+
+## Files
+
+```
+NEW:
+internal/marketplace/
+├── marketplace.go        # types, public API
+├── fetcher.go            # Fetcher interface + dispatch
+├── fetch_git.go          # github, url, git-subdir
+├── fetch_npm.go          # npm tarball
+├── fetch_relative.go     # local path
+├── manifest.go           # parse marketplace.json + plugin.json schemas
+├── projection.go         # plugin manifest -> []FileOp via per-component projection
+├── update.go             # update modes (pinned/track/manual), pending-bump computation
+└── *_test.go
+
+internal/cli/
+├── marketplace.go        # marketplace add/remove/list
+├── plugin.go             # plugin install/upgrade/enable/disable/remove/list
+├── update.go             # update [--apply [--auto|--auto-safe]]
+└── *_test.go
+```
+
+---
+
+## Task 1: Marketplace + plugin manifest schemas
+
+**Files:** `internal/marketplace/manifest.go`, `internal/marketplace/manifest_test.go`
+
+Mirror the published schema verbatim (`code.claude.com/docs/en/plugin-marketplaces`).
+
+- [ ] **Implement**
+
+```go
+// Package marketplace models the Claude marketplace.json + plugin.json schemas.
+package marketplace
+
+// Marketplace is the .claude-plugin/marketplace.json document.
+type Marketplace struct {
+    Schema      string                  `json:"$schema,omitempty"`
+    Name        string                  `json:"name"`
+    Owner       Owner                   `json:"owner"`
+    Description string                  `json:"description,omitempty"`
+    Version     string                  `json:"version,omitempty"`
+    Metadata    *MarketplaceMetadata    `json:"metadata,omitempty"`
+    Plugins     []PluginEntry           `json:"plugins"`
+    AllowCrossMarketplaceDependenciesOn []string `json:"allowCrossMarketplaceDependenciesOn,omitempty"`
+}
+
+type Owner struct {
+    Name  string `json:"name"`
+    Email string `json:"email,omitempty"`
+}
+
+type MarketplaceMetadata struct {
+    PluginRoot string `json:"pluginRoot,omitempty"`
+}
+
+// PluginEntry is one plugin listed in a marketplace.
+type PluginEntry struct {
+    Name        string         `json:"name"`
+    Source      Source         `json:"source"`
+    Description string         `json:"description,omitempty"`
+    Version     string         `json:"version,omitempty"`
+    Author      *Author        `json:"author,omitempty"`
+    Homepage    string         `json:"homepage,omitempty"`
+    Repository  string         `json:"repository,omitempty"`
+    License     string         `json:"license,omitempty"`
+    Keywords    []string       `json:"keywords,omitempty"`
+    Category    string         `json:"category,omitempty"`
+    Tags        []string       `json:"tags,omitempty"`
+    Strict      *bool          `json:"strict,omitempty"` // default true
+
+    // Component config can be inlined here when strict=false:
+    Skills      any            `json:"skills,omitempty"`     // string | []string
+    Commands    any            `json:"commands,omitempty"`   // string | []string
+    Agents      any            `json:"agents,omitempty"`     // string | []string
+    Hooks       any            `json:"hooks,omitempty"`      // string | object
+    MCPServers  map[string]any `json:"mcpServers,omitempty"`
+    LSPServers  map[string]any `json:"lspServers,omitempty"`
+}
+
+type Author struct {
+    Name  string `json:"name"`
+    Email string `json:"email,omitempty"`
+}
+
+// Source is the polymorphic plugin source. Tag-based dispatch:
+type Source struct {
+    Kind     string `json:"source,omitempty"`     // "github" | "url" | "git-subdir" | "npm"
+    // Relative-path is encoded as a JSON string at the parent level; see UnmarshalJSON.
+    Repo     string `json:"repo,omitempty"`
+    URL      string `json:"url,omitempty"`
+    Path     string `json:"path,omitempty"`
+    Ref      string `json:"ref,omitempty"`
+    SHA      string `json:"sha,omitempty"`
+    Package  string `json:"package,omitempty"`
+    Version  string `json:"version,omitempty"`
+    Registry string `json:"registry,omitempty"`
+    // Relative is the relative-path string when Source was a JSON string.
+    Relative string `json:"-"`
+}
+
+// UnmarshalJSON handles the polymorphic shape: string -> Relative; object -> Kind etc.
+func (s *Source) UnmarshalJSON(data []byte) error {
+    if len(data) > 0 && data[0] == '"' {
+        var rel string
+        if err := json.Unmarshal(data, &rel); err != nil {
+            return err
+        }
+        s.Relative = rel
+        return nil
+    }
+    type alias Source
+    var a alias
+    if err := json.Unmarshal(data, &a); err != nil {
+        return err
+    }
+    *s = Source(a)
+    return nil
+}
+
+// PluginManifest is .claude-plugin/plugin.json for a strict-mode plugin.
+type PluginManifest struct {
+    Name        string         `json:"name"`
+    Description string         `json:"description,omitempty"`
+    Version     string         `json:"version,omitempty"`
+    MCPServers  map[string]any `json:"mcpServers,omitempty"`
+    Skills      any            `json:"skills,omitempty"`
+    Commands    any            `json:"commands,omitempty"`
+    Agents      any            `json:"agents,omitempty"`
+    Hooks       any            `json:"hooks,omitempty"`
+    LSPServers  map[string]any `json:"lspServers,omitempty"`
+}
+
+// Reserved names trigger a warning on `marketplace add`.
+var ReservedMarketplaceNames = []string{
+    "claude-code-marketplace", "claude-code-plugins", "claude-plugins-official",
+    "anthropic-marketplace", "anthropic-plugins", "agent-skills",
+    "knowledge-work-plugins", "life-sciences",
+}
+```
+
+(Need `import "encoding/json"` at top of file.)
+
+- [ ] **Test parse**
+
+```go
+func TestParseMarketplace_StringSource(t *testing.T) {
+    raw := []byte(`{
+        "name": "x",
+        "owner": {"name": "y"},
+        "plugins": [{"name": "p", "source": "./plugins/p"}]
+    }`)
+    var m marketplace.Marketplace
+    if err := json.Unmarshal(raw, &m); err != nil {
+        t.Fatal(err)
+    }
+    if m.Plugins[0].Source.Relative != "./plugins/p" {
+        t.Fatalf("source = %+v", m.Plugins[0].Source)
+    }
+}
+
+func TestParseMarketplace_ObjectSource(t *testing.T) {
+    raw := []byte(`{
+        "name": "x", "owner": {"name": "y"},
+        "plugins": [{"name": "p", "source": {"source":"github","repo":"o/r","ref":"v1"}}]
+    }`)
+    var m marketplace.Marketplace
+    _ = json.Unmarshal(raw, &m)
+    if m.Plugins[0].Source.Kind != "github" || m.Plugins[0].Source.Repo != "o/r" {
+        t.Fatalf("source = %+v", m.Plugins[0].Source)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Task 2: `Fetcher` interface + relative + git source impls
+
+**Files:** `internal/marketplace/{fetcher.go, fetch_relative.go, fetch_git.go, fetch_test.go}`
+
+```go
+// Fetcher fetches one plugin source into a local directory.
+type Fetcher interface {
+    Fetch(src Source, into string) (FetchResult, error)
+}
+
+type FetchResult struct {
+    HeadSHA string  // for git sources
+    Version string  // for npm
+}
+
+func Dispatch(src Source) Fetcher {
+    if src.Relative != "" {
+        return &RelativeFetcher{}
+    }
+    switch src.Kind {
+    case "github", "url", "git-subdir":
+        return &GitFetcher{}
+    case "npm":
+        return &NPMFetcher{}
+    }
+    return &errFetcher{err: fmt.Errorf("unknown source kind %q", src.Kind)}
+}
+```
+
+- [ ] **Implement RelativeFetcher**: simple `cp -r` via afero or `os.CopyFS` (Go 1.23+). For 1.22 use a manual walk. Test with a tmpdir source + dest.
+
+- [ ] **Implement GitFetcher**: uses `go-git/v5` for shallow clone with optional sha checkout. For `git-subdir`, configure sparse-checkout via `core.sparseCheckout=true` and `info/sparse-checkout` file containing `Path/*`. If go-git's sparse support is incomplete on the installed version, fall back to `exec.Command("git", "clone", ...)` followed by `git sparse-checkout init/set`. Test against a `file://` bare repo (set up in TestMain).
+
+- [ ] **Implement NPMFetcher**: HTTP GET `<registry>/<package>/<version>` → returns metadata with `dist.tarball` URL → GET tarball → gunzip+untar into dest. No `npm` install on user's machine. Test with a fake registry served via `httptest.Server`.
+
+Commit each fetcher individually.
+
+---
+
+## Task 3: Plugin install / load / projection
+
+**Files:** `internal/marketplace/projection.go`, `internal/cli/plugin.go`
+
+`opensync plugin install <id>@<marketplace>`:
+1. Resolve marketplace from `~/.agentsync/marketplaces/<name>.toml` + cache.
+2. Find `<id>` in `marketplace.json` plugins list.
+3. Compute manifest sha (sha256 of plugin.json bytes if strict; sha of marketplace entry block if non-strict).
+4. Fetch plugin into `~/.agentsync/.state/cache/plugins/<id>/`.
+5. Write `~/.agentsync/plugins/<id>.toml` with `version`, `manifest_sha`, `update`, default `agents=["*"]`.
+
+The next `agentsync apply` reads `plugins/*.toml`, expands each through `projection.go` into per-component canonical entries that adapters render normally.
+
+- [ ] **Plugin projection** decomposes a `PluginManifest` (strict) or `PluginEntry` (non-strict) into:
+
+```go
+// ProjectionResult adds entries to a canonical model from a plugin's components.
+type ProjectionResult struct {
+    MCPServers []source.MCPServer
+    Skills     []source.Skill
+    Subagents  []source.Subagent
+    Commands   []source.Command
+    Hooks      []source.Hook
+    LSPServers []source.LSPServer
+}
+
+// Project loads .claude-plugin/plugin.json from cacheDir (strict) or returns
+// the inlined entry's components (non-strict). Resolves ${CLAUDE_PLUGIN_ROOT}
+// in commands/MCP server configs to cacheDir for non-Claude agents.
+func Project(entry PluginEntry, cacheDir string) (ProjectionResult, error) {
+    var pr ProjectionResult
+    strict := entry.Strict == nil || *entry.Strict
+    if strict {
+        // load plugin.json from cacheDir/.claude-plugin/plugin.json
+        var manifest PluginManifest
+        data, err := os.ReadFile(filepath.Join(cacheDir, ".claude-plugin", "plugin.json"))
+        if err == nil {
+            if err := json.Unmarshal(data, &manifest); err != nil {
+                return pr, fmt.Errorf("parse plugin.json: %w", err)
+            }
+            applyManifest(manifest, &pr, cacheDir)
+        }
+        // strict + marketplace-entry component overrides also merge in
+        applyEntryOverrides(entry, &pr, cacheDir)
+    } else {
+        applyEntryFull(entry, &pr, cacheDir)
+    }
+    return pr, nil
+}
+
+func resolvePluginRoot(s string, cacheDir string) string {
+    return strings.ReplaceAll(s, "${CLAUDE_PLUGIN_ROOT}", cacheDir)
+}
+```
+
+(Helper `applyManifest`, `applyEntryOverrides`, `applyEntryFull` walk MCPServers/Skills/etc, build canonical entries, run `resolvePluginRoot` on every command/arg/url field.)
+
+- [ ] **Test projection**
+
+```go
+func TestProject_StrictPluginJSON(t *testing.T) {
+    cache := t.TempDir()
+    _ = os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755)
+    _ = os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+        []byte(`{"name":"x","mcpServers":{"foo":{"command":"${CLAUDE_PLUGIN_ROOT}/run.sh"}}}`),
+        0o644)
+    pr, err := marketplace.Project(marketplace.PluginEntry{Name: "x"}, cache)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(pr.MCPServers) != 1 {
+        t.Fatalf("mcp = %d", len(pr.MCPServers))
+    }
+    cmd := pr.MCPServers[0].Server.Command
+    if !strings.HasPrefix(cmd, cache) {
+        t.Fatalf("CLAUDE_PLUGIN_ROOT not resolved: %s", cmd)
+    }
+}
+```
+
+- [ ] **Implement** `internal/cli/plugin.go`:
+
+```go
+opensync plugin install <id>[@<marketplace>]   # cache + write plugins/<id>.toml
+opensync plugin upgrade <id>                   # bump version in plugins/<id>.toml; re-fetch; update sha
+opensync plugin enable <id>                    # set enabled on plugins/<id>.toml (already implicit; flag noop unless we add one)
+opensync plugin disable <id>                   # set agents=[] effectively (or add a disabled bool)
+opensync plugin remove <id>                    # delete plugins/<id>.toml + cache
+opensync plugin list                           # walk plugins/*.toml, print
+```
+
+Commit per subcommand. Tests use file:// fake repo as marketplace fixture; npm via httptest.Server.
+
+---
+
+## Task 4: Wire plugin projection into source loader
+
+**Files:** modify `internal/source/loader.go`
+
+After loading `plugins/<id>.toml`, the loader resolves each plugin's cached manifest, runs `marketplace.Project()`, and merges the result into the canonical model so adapters see the plugin's components transparently.
+
+Loader gains a `cacheDir` parameter. Pass `~/.agentsync/.state/cache/plugins`.
+
+- [ ] **Test**
+
+```go
+func TestLoad_PluginExpandsToMCP(t *testing.T) {
+    fs := afero.NewMemMapFs()
+    home := "/h"
+    cache := "/h/.state/cache/plugins"
+    _ = afero.WriteFile(fs, filepath.Join(home, "plugins", "x.toml"), []byte(`
+[plugin]
+id = "x@m"
+version = "1"
+`), 0o644)
+    _ = afero.WriteFile(fs, filepath.Join(cache, "x", ".claude-plugin", "plugin.json"),
+        []byte(`{"name":"x","mcpServers":{"server-from-plugin":{"command":"x"}}}`),
+        0o644)
+    c, err := source.LoadWithCache(fs, home, cache)
+    if err != nil {
+        t.Fatal(err)
+    }
+    var found bool
+    for _, m := range c.MCPServers {
+        if m.ID == "server-from-plugin" {
+            found = true
+        }
+    }
+    if !found {
+        t.Fatalf("plugin's MCP not surfaced via projection: %+v", c.MCPServers)
+    }
+}
+```
+
+Implement `source.LoadWithCache` (existing `Load` becomes a thin wrapper that passes `""` for cache, falling back to skip-projection behavior). Commit.
+
+---
+
+## Task 5: Marketplace add/remove/list
+
+**Files:** `internal/cli/marketplace.go`, `internal/cli/marketplace_test.go`
+
+```
+opensync marketplace add github:owner/repo[@ref]   # writes marketplaces/<owner-repo>.toml; fetches into cache
+opensync marketplace add https://example.com/r.git # url source
+opensync marketplace remove <name>                  # deletes marketplaces/<name>.toml + cache
+opensync marketplace list                           # walks marketplaces/*.toml, prints
+```
+
+`add` performs an initial fetch via `marketplace.Fetcher` and writes the head SHA into `state.Marketplaces[<name>]`. Commit.
+
+---
+
+## Task 6: `update` command
+
+**Files:** `internal/cli/update.go`, `internal/marketplace/update.go`
+
+For each marketplace: re-fetch (or use cached etag for HTTP URL sources). For each plugin: compute pending bump given its `update` mode + the fetched manifest. Print pending bumps. With `--apply`: chain into apply logic. With `--auto-safe`: only bump plugins whose translation report is non-lossy.
+
+```go
+// in marketplace/update.go:
+func ComputePendingBumps(s *state.Targets, marketplaces []source.Marketplace, plugins []source.Plugin, fetched map[string]Marketplace) []Bump {
+    var out []Bump
+    for _, p := range plugins {
+        // find p in fetched marketplaces
+        // compute desired version per p.Update mode
+        // if differs from current p.Version + manifest_sha, emit Bump{ID, From, To, ManifestSHA}
+    }
+    return out
+}
+```
+
+Test with fake fetcher; commit.
+
+---
+
+## Task 7: Translation report
+
+**Files:** modify `internal/render/pipeline.go` to emit a structured report and make it available to `apply`/`update --apply`.
+
+After Plan, before Apply, render emits per-(plugin, agent) lines:
+
+```
+plugin: atlassian@anthropic
+  claude    ✓ full   (1 mcp, 5 commands)
+  opencode  ✓ full   (1 mcp, 5 commands)
+```
+
+Emitted as both human-readable text and structured JSON via `--json`.
+
+- [ ] Implement `internal/render/report.go` building the report from `plan.PerAgent[i].Skips` + the canonical MCPServers/Skills/etc-from-plugin metadata. Test, commit.
+
+---
+
+## Task 8: Manifest sha pinning
+
+**Files:** modify projection logic to compute sha256 over the canonical bytes of `plugin.json` (strict) or the marketplace entry (non-strict). Compare to `plugins/<id>.toml`'s `manifest_sha`. If different, emit a `manifest-sha-mismatch` warning + treat as drift in `status`.
+
+- [ ] Implement, test, commit.
+
+---
+
+## Task 9: Integration test — full plugin fanout
+
+```go
+func TestIntegration_M4_PluginFanoutClaudeAndOpenCode(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    // Set up a fake marketplace as a local relative-path fixture
+    fixture := filepath.Join(tmp, "fixture-marketplace")
+    _ = os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755)
+    _ = os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+        []byte(`{
+            "name": "test-mp", "owner": {"name": "x"},
+            "plugins": [{"name": "demo", "source": "./plugins/demo"}]
+        }`), 0o644)
+    plugDir := filepath.Join(fixture, "plugins", "demo", ".claude-plugin")
+    _ = os.MkdirAll(plugDir, 0o755)
+    _ = os.WriteFile(filepath.Join(plugDir, "plugin.json"),
+        []byte(`{
+            "name": "demo",
+            "version": "1.0.0",
+            "mcpServers": {"demo-mcp": {"command":"echo","args":["hi"]}}
+        }`), 0o644)
+
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+    _, _ = runCLI(t, env, "agent", "add", "opencode")
+
+    // marketplace add via local path
+    if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := runCLI(t, env, "plugin", "install", "demo@test-mp"); err != nil {
+        t.Fatal(err)
+    }
+    if _, err := runCLI(t, env, "apply"); err != nil {
+        t.Fatal(err)
+    }
+
+    // verify both agents have demo-mcp
+    body, _ := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+    if !strings.Contains(string(body), "demo-mcp") {
+        t.Fatal("claude missing demo-mcp")
+    }
+    body, _ = os.ReadFile(filepath.Join(tmp, ".config", "opencode", "opencode.json"))
+    if !strings.Contains(string(body), "demo-mcp") {
+        t.Fatal("opencode missing demo-mcp")
+    }
+}
+```
+
+Commit.
+
+---
+
+## Done When
+
+- 5 plugin source types fetch + extract correctly (relative, github, url, git-subdir, npm).
+- `marketplace add/remove/list` and `plugin install/upgrade/enable/disable/remove/list` work end-to-end.
+- A plugin's MCP/skills/subagents/commands/hooks/LSP project through every registered adapter; translation report shows ✓/◐/✗ per cell.
+- `${CLAUDE_PLUGIN_ROOT}` resolves to cache path for non-Claude agents and passes through verbatim for Claude.
+- `update` polls marketplaces and prints pending bumps without touching agent configs; `update --apply` chains into apply.
+- `update --apply --auto-safe` only auto-applies non-lossy bumps; lossy ones stop for confirmation.
+- Manifest sha pin detects re-uploaded same-version content as drift.
+- Integration test demonstrates a single plugin install fanning to Claude + OpenCode after one apply.
+- CI green on linux/macos/windows.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m5-project.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m5-project.md
@@ -1,0 +1,300 @@
+# agentsync M5 — Project-local
+
+> Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md). Builds on M0–M4.
+
+**Goal:** `.agentsync.toml` walk-up resolution from cwd; project IR overlay merged onto base IR; `--project <slug>` flag for explicit project selection; project-scope state tracking (state keys include the project slug).
+
+**Architecture:** New `internal/project` package. `Detect()` walks up from cwd to find `.agentsync.toml`. Schema mirrors `~/.agentsync/`'s top-level (agents allowlist, MCP, plugin enables/disables, memory imports). Overlay merge: project entries replace user entries with the same id; project entries with new ids are added. `state.Targets.Files` and `state.Targets.Keys` keys include the project root path (or empty string for user scope) so drift tracks per-(scope, project).
+
+---
+
+## Files
+
+```
+NEW:
+internal/project/{project.go, project_test.go}
+
+MODIFIED:
+internal/source/loader.go      # accepts project overlay path; merges
+internal/cli/apply.go          # walks-up by default; --project explicit override
+internal/cli/status.go, diff.go, reconcile.go  # all gain --project
+```
+
+---
+
+## Task 1: `.agentsync.toml` schema + walk-up
+
+`internal/project/project.go`:
+
+```go
+// Package project handles project-scope overlays: .agentsync.toml at a repo
+// root, walk-up discovery from cwd, and merge against base canonical model.
+package project
+
+import (
+    "errors"
+    "os"
+    "path/filepath"
+
+    "github.com/pelletier/go-toml/v2"
+    "github.com/spxrogers/agentsync/internal/source"
+)
+
+const MarkerFile = ".agentsync.toml"
+
+// Marker is the parsed contents of a project's .agentsync.toml.
+type Marker struct {
+    Path     string                            // absolute path of the marker file
+    Root     string                            // dirname of Path
+    Agents   []string                          `toml:"agents,omitempty"`
+    MCP      []source.MCPServerSpec            `toml:"mcp,omitempty"`
+    Plugins  ProjectPluginsSection             `toml:"plugins,omitempty"`
+    Memory   ProjectMemorySection              `toml:"memory,omitempty"`
+}
+
+type ProjectPluginsSection struct {
+    Disabled []string `toml:"disabled,omitempty"`
+    Enabled  []string `toml:"enabled,omitempty"`
+}
+
+type ProjectMemorySection struct {
+    Import []string `toml:"import,omitempty"` // project-relative paths
+}
+
+// Discover walks up from cwd looking for MarkerFile. Returns (nil, nil) if
+// not found. Returns error on read or parse failure.
+func Discover(cwd string) (*Marker, error) {
+    dir := cwd
+    for {
+        candidate := filepath.Join(dir, MarkerFile)
+        if data, err := os.ReadFile(candidate); err == nil {
+            var m Marker
+            if err := toml.Unmarshal(data, &m); err != nil {
+                return nil, err
+            }
+            m.Path = candidate
+            m.Root = dir
+            return &m, nil
+        } else if !errors.Is(err, os.ErrNotExist) {
+            return nil, err
+        }
+        parent := filepath.Dir(dir)
+        if parent == dir {
+            return nil, nil
+        }
+        dir = parent
+    }
+}
+```
+
+- [ ] **Test**
+
+```go
+func TestDiscover_FoundAtRoot(t *testing.T) {
+    tmp := t.TempDir()
+    deep := filepath.Join(tmp, "a", "b", "c")
+    _ = os.MkdirAll(deep, 0o755)
+    _ = os.WriteFile(filepath.Join(tmp, ".agentsync.toml"), []byte(`agents = ["claude"]`), 0o644)
+    m, err := project.Discover(deep)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if m == nil {
+        t.Fatal("expected discovery")
+    }
+    if len(m.Agents) != 1 || m.Agents[0] != "claude" {
+        t.Fatalf("agents = %v", m.Agents)
+    }
+}
+
+func TestDiscover_NotFound(t *testing.T) {
+    m, err := project.Discover(t.TempDir())
+    if err != nil {
+        t.Fatal(err)
+    }
+    if m != nil {
+        t.Fatalf("expected nil marker")
+    }
+}
+```
+
+Commit.
+
+---
+
+## Task 2: Overlay merge
+
+In `internal/project/project.go`:
+
+```go
+// Merge applies the project marker on top of base. Returns a new Canonical.
+//   - Agents allowlist on Marker filters base.Config.Agents to only those
+//     listed (intersect with enabled). Empty list = use all enabled.
+//   - MCP entries on Marker are appended; collisions on .ID replace base.
+//   - Plugins.Disabled removes plugins from base by ID.
+//   - Plugins.Enabled is reserved for v1.x (currently a no-op since plugins
+//     are enabled-by-default).
+//   - Memory.Import paths are read relative to Marker.Root and appended to
+//     the base memory body (separated by a single blank line).
+func Merge(base source.Canonical, m *Marker) source.Canonical {
+    if m == nil {
+        return base
+    }
+    out := base // shallow copy is OK; we replace slices below
+
+    // Agents filter
+    if len(m.Agents) > 0 {
+        allow := map[string]bool{}
+        for _, a := range m.Agents {
+            allow[a] = true
+        }
+        filtered := map[string]source.Agent{}
+        for name, ag := range base.Config.Agents {
+            if allow[name] {
+                filtered[name] = ag
+            }
+        }
+        out.Config.Agents = filtered
+    }
+
+    // MCP overlay
+    byID := map[string]int{}
+    for i, srv := range out.MCPServers {
+        byID[srv.ID] = i
+    }
+    for _, spec := range m.MCP {
+        // Marker.MCP entries are MCPServerSpec; need an ID. v1: treat the
+        // first entry's command as the implicit id basis. Actually, our
+        // MCP block in marker is `[[mcp]]` with explicit id field — adjust
+        // schema to wrap MCPServer not MCPServerSpec. Update Marker:
+    }
+
+    // Plugins.Disabled
+    if len(m.Plugins.Disabled) > 0 {
+        block := map[string]bool{}
+        for _, id := range m.Plugins.Disabled {
+            block[id] = true
+        }
+        var kept []source.Plugin
+        for _, p := range out.Plugins {
+            if !block[p.ID] {
+                kept = append(kept, p)
+            }
+        }
+        out.Plugins = kept
+    }
+
+    // Memory imports
+    if len(m.Memory.Import) > 0 {
+        body := out.Memory.Body
+        for _, rel := range m.Memory.Import {
+            data, err := os.ReadFile(filepath.Join(m.Root, rel))
+            if err != nil {
+                continue
+            }
+            if body != "" && !strings.HasSuffix(body, "\n") {
+                body += "\n"
+            }
+            body += "\n" + string(data)
+        }
+        out.Memory.Body = body
+    }
+    return out
+}
+```
+
+(The marker schema for MCP needs to carry an `id` field. Update `Marker`:)
+
+```go
+type ProjectMCP struct {
+    ID     string                  `toml:"id"`
+    Server source.MCPServerSpec    `toml:"server"`
+}
+
+type Marker struct {
+    Path    string
+    Root    string
+    Agents  []string                  `toml:"agents,omitempty"`
+    MCP     []ProjectMCP              `toml:"mcp,omitempty"` // [[mcp]] tables
+    Plugins ProjectPluginsSection     `toml:"plugins,omitempty"`
+    Memory  ProjectMemorySection      `toml:"memory,omitempty"`
+}
+```
+
+The marker example in the design spec shows:
+
+```toml
+[[mcp]]
+id      = "company-api"
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@company/mcp"]
+[mcp.env]
+COMPANY_TOKEN = "${secret:company.api_token}"
+```
+
+This is `[[mcp]]` array-of-tables with the spec fields inlined at the table's top level (not under `[server]`). Adjust loader: `ProjectMCP` parses the flat shape and maps to `MCPServerSpec`. Test the overlay with a real `.agentsync.toml`. Commit.
+
+---
+
+## Task 3: Wire project into CLI
+
+- Modify `internal/cli/apply.go`, `status.go`, `diff.go`, `reconcile.go` to:
+  - Add `--project <path>` flag (defaults to walk-up).
+  - Discover project marker via `project.Discover(cwd)` (or use `--project` override).
+  - Pass `adapter.ScopeProject` and the project root to Render/Plan/Apply when a marker is found.
+  - Update `RecordOpsState` calls to include the project root in the state key.
+
+- [ ] **Integration test**
+
+```go
+func TestIntegration_M5_ProjectOverlay(t *testing.T) {
+    tmpHome := t.TempDir()
+    project := t.TempDir()
+    env := map[string]string{
+        "AGENTSYNC_TARGET_ROOT": tmpHome,
+        "PWD":                   project, // some shells; for us: chdir
+    }
+
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    _ = os.WriteFile(filepath.Join(project, ".agentsync.toml"), []byte(`
+agents = ["claude"]
+
+[[mcp]]
+id      = "proj-mcp"
+[mcp.server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@proj/mcp"]
+`), 0o644)
+
+    // chdir into project
+    cwd, _ := os.Getwd()
+    defer os.Chdir(cwd)
+    _ = os.Chdir(project)
+
+    if _, err := runCLI(t, env, "apply"); err != nil {
+        t.Fatal(err)
+    }
+    body, _ := os.ReadFile(filepath.Join(project, ".claude", "settings.json"))
+    if !strings.Contains(string(body), "proj-mcp") {
+        t.Fatalf("project-scope MCP not landed: %s", body)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Done When
+
+- `cd ~/repo && agentsync apply` discovers `.agentsync.toml`, merges overlay, writes project-scope destinations under `<repo>/.claude/`, etc.
+- `agentsync apply --project /abs/path` works without cwd dependence.
+- State keys disambiguate user vs project (drift on `~/.claude/settings.json` vs `<repo>/.claude/settings.json` is independently tracked).
+- Marker `agents = ["claude"]` filters: a project that only wants Claude doesn't accidentally write to OpenCode in that scope.
+- `[[mcp]]` array-of-tables in marker overlays into base canonical correctly.
+- Memory.Import resolves project-relative files and concatenates them into the rendered memory.
+- CI green.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m6-secrets.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m6-secrets.md
@@ -1,0 +1,422 @@
+# agentsync M6 — Secrets (env + age)
+
+> Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md). Builds on M0–M5.
+
+**Goal:** age-encrypted file at `~/.agentsync/secrets/secrets.age`; `${secret:foo.bar}` resolution at apply-time; `secrets edit/get/set` commands; in-memory cleartext only — never persisted to disk except via the user's $EDITOR's tmp file.
+
+**Architecture:** New `internal/secrets` package. `Resolver` interface so the value-substitution callsite is independent of backend (env, age, future 1Password). `Resolver.Resolve("github.token")` returns the cleartext for substitution. apply pipeline walks `source.Canonical`'s string-valued fields and replaces `${secret:foo.bar}` and `${env:FOO}` references in-place before passing to adapters.
+
+**Tech stack:** `filippo.io/age` (vendored library; no `age` CLI required).
+
+---
+
+## Files
+
+```
+NEW:
+internal/secrets/
+├── secrets.go         # Resolver interface, errors
+├── env.go             # EnvBackend (resolves ${env:FOO})
+├── age.go             # AgeBackend (encrypts/decrypts secrets.age)
+└── *_test.go
+
+internal/cli/
+├── secrets.go         # secrets edit/get/set
+└── secrets_test.go
+
+MODIFIED:
+internal/render/pipeline.go     # walk canonical, substitute ${secret:...} / ${env:...}
+internal/source/loader.go       # secrets backend hint loaded from opensync.toml
+```
+
+---
+
+## Task 1: `Resolver` + EnvBackend
+
+```go
+// Package secrets resolves ${secret:foo.bar} and ${env:FOO} references at
+// apply-time. The active backend is selected from opensync.toml [secrets]
+// `backend` field (env|age).
+package secrets
+
+import (
+    "fmt"
+    "regexp"
+    "strings"
+)
+
+// Resolver returns the cleartext value for a key like "github.token". An
+// unknown key returns an error.
+type Resolver interface {
+    Resolve(key string) (string, error)
+}
+
+// SubstituteRefs walks s and replaces ${secret:dotted.key} and ${env:NAME}
+// references. Unknown references are left as-is and reported in the
+// returned []string of unresolved markers (caller decides whether to error).
+func SubstituteRefs(s string, secrets Resolver, env Resolver) (string, []string, error) {
+    var unresolved []string
+    out := re.ReplaceAllStringFunc(s, func(m string) string {
+        sub := re.FindStringSubmatch(m)
+        if len(sub) < 3 {
+            return m
+        }
+        kind, key := sub[1], sub[2]
+        var r Resolver
+        switch kind {
+        case "secret":
+            r = secrets
+        case "env":
+            r = env
+        default:
+            unresolved = append(unresolved, m)
+            return m
+        }
+        v, err := r.Resolve(key)
+        if err != nil {
+            unresolved = append(unresolved, m)
+            return m
+        }
+        return v
+    })
+    return out, unresolved, nil
+}
+
+var re = regexp.MustCompile(`\$\{(secret|env):([A-Za-z0-9._-]+)\}`)
+
+// EnvBackend resolves ${env:NAME} via os.Getenv(NAME). Used both as the env
+// resolver in SubstituteRefs and as the "backend = env" mode where secrets
+// are also stored as env vars (e.g. by direnv / 1Password CLI).
+type EnvBackend struct{}
+
+func (EnvBackend) Resolve(key string) (string, error) {
+    v := osGetenv(key)
+    if v == "" {
+        return "", fmt.Errorf("env var %q not set", key)
+    }
+    return v, nil
+}
+
+// indirection so tests can inject; real impl reads os.Getenv
+var osGetenv = func(k string) string {
+    return _osLookupEnv(k)
+}
+```
+
+(`_osLookupEnv` is `os.Getenv`; indirection makes it testable.)
+
+- [ ] **Test SubstituteRefs**
+
+```go
+func TestSubstituteRefs_SecretsAndEnv(t *testing.T) {
+    secrets := mapBackend{"github.token": "ghp_abc"}
+    env := mapBackend{"HOME": "/Users/x"}
+    got, unresolved, _ := secrets_pkg.SubstituteRefs(
+        "token=${secret:github.token}; home=${env:HOME}; ?=${secret:missing}",
+        secrets, env)
+    if !strings.Contains(got, "token=ghp_abc") {
+        t.Fatalf("substitution failed: %s", got)
+    }
+    if !strings.Contains(got, "home=/Users/x") {
+        t.Fatalf("env substitution failed: %s", got)
+    }
+    if len(unresolved) != 1 {
+        t.Fatalf("expected 1 unresolved, got %v", unresolved)
+    }
+}
+```
+
+(`mapBackend` is a small test fake type implementing `Resolver`.)
+
+Commit.
+
+---
+
+## Task 2: AgeBackend
+
+```bash
+go get filippo.io/age@latest
+```
+
+```go
+// AgeBackend reads ~/.agentsync/secrets/secrets.age, decrypts using identity
+// file specified in opensync.toml [secrets].identity_file, parses as TOML,
+// and resolves dotted keys.
+package secrets
+
+import (
+    "fmt"
+    "io"
+    "os"
+    "strings"
+
+    "filippo.io/age"
+    "github.com/pelletier/go-toml/v2"
+)
+
+type AgeBackend struct {
+    AgeFile      string // path to secrets.age
+    IdentityFile string // path to age identity (private key)
+    cache        map[string]string
+}
+
+func NewAgeBackend(ageFile, identityFile string) *AgeBackend {
+    return &AgeBackend{AgeFile: ageFile, IdentityFile: identityFile}
+}
+
+func (b *AgeBackend) load() error {
+    if b.cache != nil {
+        return nil
+    }
+    idData, err := os.ReadFile(b.IdentityFile)
+    if err != nil {
+        return fmt.Errorf("read identity %s: %w", b.IdentityFile, err)
+    }
+    ids, err := age.ParseIdentities(strings.NewReader(string(idData)))
+    if err != nil {
+        return fmt.Errorf("parse age identity: %w", err)
+    }
+    encFile, err := os.Open(b.AgeFile)
+    if err != nil {
+        return fmt.Errorf("open age file %s: %w", b.AgeFile, err)
+    }
+    defer encFile.Close()
+    rd, err := age.Decrypt(encFile, ids...)
+    if err != nil {
+        return fmt.Errorf("decrypt %s: %w", b.AgeFile, err)
+    }
+    raw, err := io.ReadAll(rd)
+    if err != nil {
+        return fmt.Errorf("read decrypted: %w", err)
+    }
+    var top map[string]any
+    if err := toml.Unmarshal(raw, &top); err != nil {
+        return fmt.Errorf("parse decrypted as TOML: %w", err)
+    }
+    b.cache = flatten("", top)
+    return nil
+}
+
+func (b *AgeBackend) Resolve(dottedKey string) (string, error) {
+    if err := b.load(); err != nil {
+        return "", err
+    }
+    v, ok := b.cache[dottedKey]
+    if !ok {
+        return "", fmt.Errorf("secret %q not found", dottedKey)
+    }
+    return v, nil
+}
+
+func flatten(prefix string, m map[string]any) map[string]string {
+    out := map[string]string{}
+    for k, v := range m {
+        key := k
+        if prefix != "" {
+            key = prefix + "." + k
+        }
+        switch vv := v.(type) {
+        case map[string]any:
+            for kk, vvv := range flatten(key, vv) {
+                out[kk] = vvv
+            }
+        case string:
+            out[key] = vv
+        default:
+            out[key] = fmt.Sprint(vv)
+        }
+    }
+    return out
+}
+
+// Encrypt writes plaintext as TOML, encrypted to recipient.
+func Encrypt(plaintext []byte, recipient string, dest string) error {
+    rec, err := age.ParseX25519Recipient(recipient)
+    if err != nil {
+        return fmt.Errorf("parse age recipient: %w", err)
+    }
+    f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+    if err != nil {
+        return err
+    }
+    defer f.Close()
+    w, err := age.Encrypt(f, rec)
+    if err != nil {
+        return fmt.Errorf("init age encrypt: %w", err)
+    }
+    if _, err := w.Write(plaintext); err != nil {
+        return err
+    }
+    return w.Close()
+}
+```
+
+- [ ] **Test round-trip**
+
+```go
+func TestAgeRoundTrip(t *testing.T) {
+    tmp := t.TempDir()
+    // generate identity
+    id, err := age.GenerateX25519Identity()
+    if err != nil { t.Fatal(err) }
+    idPath := filepath.Join(tmp, "id.txt")
+    _ = os.WriteFile(idPath, []byte(id.String()), 0o600)
+    rec := id.Recipient().String()
+
+    plain := []byte(`[github]
+token = "ghp_abc"
+[linear]
+api_key = "lin_xyz"
+`)
+    agePath := filepath.Join(tmp, "secrets.age")
+    if err := secrets_pkg.Encrypt(plain, rec, agePath); err != nil {
+        t.Fatal(err)
+    }
+
+    b := secrets_pkg.NewAgeBackend(agePath, idPath)
+    if v, _ := b.Resolve("github.token"); v != "ghp_abc" {
+        t.Fatalf("github.token = %q", v)
+    }
+    if v, _ := b.Resolve("linear.api_key"); v != "lin_xyz" {
+        t.Fatalf("linear.api_key = %q", v)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Task 3: `secrets edit/get/set`
+
+`internal/cli/secrets.go`:
+
+```go
+opensync secrets edit            # decrypt -> tmp -> $EDITOR -> re-encrypt
+opensync secrets get <key>       # print one value
+opensync secrets set <key>=<val> # mutate one value (decrypt -> patch -> re-encrypt)
+```
+
+Implementation:
+
+```go
+func newSecretsCmd() *cobra.Command {
+    sec := &cobra.Command{Use: "secrets", Short: "manage age-encrypted secrets"}
+    sec.AddCommand(
+        &cobra.Command{Use: "edit", RunE: secretsEdit},
+        &cobra.Command{Use: "get <key>", Args: cobra.ExactArgs(1), RunE: secretsGet},
+        &cobra.Command{Use: "set <key=value>", Args: cobra.ExactArgs(1), RunE: secretsSet},
+    )
+    return sec
+}
+
+func secretsEdit(cmd *cobra.Command, _ []string) error {
+    // 1. Resolve agePath + identityPath + recipient from opensync.toml
+    // 2. Read existing or create empty plaintext
+    // 3. Write to tmp file in os.TempDir() (RAM-backed on macOS)
+    // 4. Run os.Getenv("EDITOR") on the tmp file (default to vi)
+    // 5. Read the edited bytes back; encrypt to agePath atomically via iox.AtomicWrite (after writing tmp)
+    // 6. Remove the cleartext tmp file
+    return nil
+}
+```
+
+(Each function is straightforward boilerplate — engineer fills in the explicit reads/writes following the patterns in M0/M1.)
+
+Commit.
+
+---
+
+## Task 4: Wire substitution into apply
+
+In `internal/render/pipeline.go`, before each adapter's Render is called, walk `source.Canonical` and replace `${secret:...}` / `${env:...}` strings via `secrets.SubstituteRefs`:
+
+```go
+// in Plan(), after canonical loaded:
+backend := secrets.SelectBackend(c.Config.Secrets) // returns AgeBackend or EnvBackend per [secrets].backend
+env := secrets.EnvBackend{}
+if err := substituteCanonicalSecrets(&c, backend, env); err != nil {
+    return Plan{}, err
+}
+```
+
+`substituteCanonicalSecrets` walks `c.MCPServers[*].Server.Env`, `Args`, `Command`, `Headers`, etc., calling `SubstituteRefs` on each string. Unresolved refs return an error (apply blocks; user sees which secret is missing).
+
+- [ ] **Implement** `substituteCanonicalSecrets`. Test that an MCP env value `${secret:github.token}` gets resolved before adapter Render sees it. Commit.
+
+---
+
+## Task 5: Integration test
+
+```go
+func TestIntegration_M6_AgeSecretsResolveOnApply(t *testing.T) {
+    tmp := t.TempDir()
+    env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+    _, _ = runCLI(t, env, "init")
+    _, _ = runCLI(t, env, "agent", "add", "claude")
+
+    // generate age key
+    id, _ := age.GenerateX25519Identity()
+    idPath := filepath.Join(tmp, ".config", "agentsync", "age.key")
+    _ = os.MkdirAll(filepath.Dir(idPath), 0o755)
+    _ = os.WriteFile(idPath, []byte(id.String()), 0o600)
+
+    // configure opensync.toml [secrets]
+    cfg := filepath.Join(tmp, ".agentsync", "opensync.toml")
+    body, _ := os.ReadFile(cfg)
+    body = append(body, []byte(fmt.Sprintf(`
+[secrets]
+backend       = "age"
+file          = "secrets/secrets.age"
+recipient     = "%s"
+identity_file = "%s"
+`, id.Recipient().String(), idPath))...)
+    _ = os.WriteFile(cfg, body, 0o644)
+
+    // write secrets.age
+    plain := []byte(`[github]
+token = "ghp_abc"
+`)
+    _ = secrets_pkg.Encrypt(plain, id.Recipient().String(),
+        filepath.Join(tmp, ".agentsync", "secrets", "secrets.age"))
+
+    // mcp file with ${secret:...}
+    _ = os.WriteFile(filepath.Join(tmp, ".agentsync", "mcp", "github.toml"), []byte(`
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+`), 0o644)
+
+    if _, err := runCLI(t, env, "apply"); err != nil {
+        t.Fatal(err)
+    }
+
+    // verify .claude.json has the literal token
+    body, _ = os.ReadFile(filepath.Join(tmp, ".claude.json"))
+    if !strings.Contains(string(body), "ghp_abc") {
+        t.Fatalf("token not substituted: %s", body)
+    }
+    // verify cleartext is NOT in the agentsync repo
+    repoBytes, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "mcp", "github.toml"))
+    if strings.Contains(string(repoBytes), "ghp_abc") {
+        t.Fatalf("token leaked into source repo: %s", repoBytes)
+    }
+}
+```
+
+Commit.
+
+---
+
+## Done When
+
+- `~/.agentsync/secrets/secrets.age` decrypts via `filippo.io/age` library (no `age` CLI required).
+- `${secret:dotted.key}` references in canonical (MCP env, hook commands, etc.) resolve to cleartext at apply-time, never persisted in canonical.
+- `secrets edit` round-trip preserves data; `get`/`set` work non-interactively.
+- Apply errors when a `${secret:...}` reference can't be resolved (missing key) — fail-loud, never silent.
+- README documents age-key backup discipline (lose the key = lose all secrets); test the README's quickstart commands work.
+- CI green on linux/macos/windows (age library is pure Go; cross-platform fine).

--- a/docs/superpowers/plans/2026-05-04-agentsync-m7-polish.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m7-polish.md
@@ -1,0 +1,363 @@
+# agentsync M7 — Polish + release
+
+> Conventions in [`overview`](2026-05-04-agentsync-v1.0-overview.md). Builds on M0–M6.
+
+**Goal:** Ship-ready v1.0. `explain` (per-plugin transparency), `import` (capture native edits into source), `agent disable --purge` (delete destination files when an agent is removed), goreleaser cross-platform release pipeline, Homebrew tap, Scoop manifest, Chocolatey package, native Linux package distributions (deb/rpm via goreleaser), and a comprehensive README with install / quickstart / troubleshooting / known-limits docs.
+
+**Architecture:** No new infrastructure; this milestone polishes existing surfaces. Distribution config lives at the repo root (`.goreleaser.yaml`, `.github/workflows/release.yml`, `README.md`). Tap-specific files (`Formula/agentsync.rb`) live in a separate repo (`spxrogers/homebrew-tap`) that goreleaser pushes to.
+
+---
+
+## Task 1: `agentsync explain <plugin> [--json]`
+
+**Files:** `internal/cli/explain.go`, `internal/cli/explain_test.go`
+
+For one plugin id, print the per-agent translation report from M4 — what each adapter does with each component.
+
+```go
+func newExplainCmd() *cobra.Command {
+    var jsonOut bool
+    cmd := &cobra.Command{
+        Use:   "explain <plugin-id>",
+        Args:  cobra.ExactArgs(1),
+        Short: "show per-agent translation for one plugin",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            pluginID := args[0]
+            // Load canonical, find plugin, ask each adapter to Render WITH ONLY that plugin's components,
+            // then print the per-agent ✓/◐/✗ table.
+            // Reuses internal/render/report.go from M4.
+            return nil
+        },
+    }
+    cmd.Flags().BoolVar(&jsonOut, "json", false, "structured JSON output")
+    return cmd
+}
+```
+
+Test, commit.
+
+---
+
+## Task 2: `agentsync import <selector>`
+
+**Files:** `internal/cli/import.go`, `internal/cli/import_test.go`
+
+Selector grammar: `<agent>:<component>:<name>`. Reads native config from disk via the adapter's `Ingest()`, finds the matching item, writes it to the canonical source via `internal/source.Writer` (from M3 Task 7).
+
+```bash
+# Examples:
+opensync import claude:mcp:github
+opensync import opencode:agent:reviewer
+opensync import claude:plugin:atlassian-anthropic   # post-M4: import a plugin install record
+```
+
+Implementation: parse selector, dispatch to the right Ingest path, find matching item by name, marshal back to canonical via Writer. Test for each component type. Commit.
+
+---
+
+## Task 3: `agentsync agent disable --purge`
+
+**Files:** modify `internal/cli/agent.go`
+
+Today `agent disable` only flips the `enabled` bit. With `--purge`, also walks `state.Files` + `state.Keys` for that agent and emits delete FileOps (using the adapter's `Apply`) so the destination is cleaned.
+
+- [ ] **Test**
+
+```go
+func TestAgentDisable_Purge_RemovesDestFiles(t *testing.T) {
+    // setup: apply with an MCP, verify ~/.claude.json has it
+    // run: agent disable claude --purge
+    // verify: ~/.claude.json mcpServers.github gone (or whole file removed if all keys ours)
+}
+```
+
+- [ ] **Implement**: add `--purge` flag. On purge: iterate state for agent, build delete ops (or merge ops setting our keys to absence), call Apply, remove state entries. Commit.
+
+---
+
+## Task 4: README expansion
+
+**Files:** modify `README.md`
+
+Sections to add:
+
+```markdown
+# agentsync
+
+Centrally manage AI coding-agent configurations across Claude Code, OpenCode, Codex CLI, and Cursor.
+
+## Quickstart
+
+    agentsync init
+    agentsync agent add claude
+    agentsync agent add opencode
+    agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
+    agentsync apply
+
+## Install
+
+### macOS — Homebrew
+
+    brew tap spxrogers/tap
+    brew install agentsync
+
+### Windows — Scoop
+
+    scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
+    scoop install agentsync
+
+### Windows — Chocolatey
+
+    choco install agentsync
+
+### Linux
+
+Debian/Ubuntu:
+
+    curl -fsSL https://github.com/spxrogers/agentsync/releases/latest/download/agentsync.deb -o agentsync.deb
+    sudo dpkg -i agentsync.deb
+
+RPM:
+
+    sudo rpm -i https://github.com/spxrogers/agentsync/releases/latest/download/agentsync.rpm
+
+Arch (AUR):
+
+    yay -S agentsync
+
+## Cross-machine sync
+
+agentsync is single-machine. To sync `~/.agentsync/` across machines, use chezmoi (or any dotfile manager):
+
+    chezmoi add ~/.agentsync
+
+## Secrets — age key backup
+
+If you lose your age private key, you lose access to all encrypted secrets. Recommended: store the key in a 1Password Secure Note or your machine-setup repo. agentsync does not back up the key for you.
+
+## Known limits in v1.x
+
+- **OpenCode hooks**: OpenCode hooks are JS/TS plugins, not declarative shell commands. agentsync v1 does NOT auto-translate Claude hooks to OpenCode. Hand-author a small JS/TS plugin if you need a hook on OpenCode.
+- **Cursor user-level rules**: Cursor stores user-level rules in app-local storage (not the filesystem). agentsync's Cursor adapter manages project-scope rules only.
+- **LSP projection beyond Claude**: OpenCode/Codex/Cursor LSP support is deferred. Claude plugins that include LSP servers install correctly on Claude itself; on other agents you'll see `lsp server X skipped` in the apply translation report.
+- **Continue, Gemini CLI, Aider**: not on the v1.x roadmap.
+
+## Troubleshooting
+
+- **First apply on a populated machine**: agentsync sees pre-existing native config files and triggers `foreign-collision`. The original is backed up to `~/.agentsync/.state/backups/<ts>/` before the new content lands. Recommend `agentsync apply --dry-run` first to preview the translation report.
+- **`agentsync update` fails to fetch a marketplace**: verify the marketplace URL with `git ls-remote`. agentsync uses `go-git` and falls back to system `git` for sparse clones if needed.
+- **`${secret:foo}` not resolving**: run `agentsync secrets get foo` to verify the key exists in the decrypted file. age library errors will surface here.
+
+## License
+
+MIT.
+```
+
+Commit.
+
+---
+
+## Task 5: goreleaser release pipeline
+
+**Files:** modify `.goreleaser.yaml`, add `.github/workflows/release.yml`
+
+Extend `.goreleaser.yaml` with the distribution configs:
+
+```yaml
+brews:
+  - name: agentsync
+    repository:
+      owner: spxrogers
+      name: homebrew-tap
+    homepage: https://github.com/spxrogers/agentsync
+    description: Centrally manage AI coding-agent configurations
+    license: MIT
+    install: bin.install "agentsync"
+    test: system "#{bin}/agentsync --version"
+
+scoops:
+  - name: agentsync
+    repository:
+      owner: spxrogers
+      name: scoop-bucket
+    homepage: https://github.com/spxrogers/agentsync
+    description: Centrally manage AI coding-agent configurations
+    license: MIT
+
+chocolateys:
+  - name: agentsync
+    api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
+    title: agentsync
+    project_url: https://github.com/spxrogers/agentsync
+    license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
+    summary: Centrally manage AI coding-agent configurations
+
+nfpms:
+  - id: linux-pkgs
+    package_name: agentsync
+    homepage: https://github.com/spxrogers/agentsync
+    license: MIT
+    formats: [deb, rpm]
+    section: utils
+    description: Centrally manage AI coding-agent configurations.
+
+aurs:
+  - name: agentsync-bin
+    homepage: https://github.com/spxrogers/agentsync
+    description: Centrally manage AI coding-agent configurations.
+    maintainers: ['Steven Rogers <noreply@example.com>']
+    license: MIT
+    private_key: '{{ .Env.AUR_KEY }}'
+    git_url: 'ssh://aur@aur.archlinux.org/agentsync-bin.git'
+```
+
+`.github/workflows/release.yml`:
+
+```yaml
+name: release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22.x' }
+      - uses: goreleaser/goreleaser-action@v6
+        with: { version: latest, args: release --clean }
+        env:
+          GITHUB_TOKEN:        ${{ secrets.GH_PAT }}     # for tap + bucket pushes
+          CHOCOLATEY_API_KEY:  ${{ secrets.CHOCO_KEY }}
+          AUR_KEY:             ${{ secrets.AUR_KEY }}
+```
+
+(Required secrets configured on the repo: `GH_PAT` with `repo` scope so goreleaser can push to `homebrew-tap` and `scoop-bucket`; `CHOCO_KEY` from chocolatey.org; `AUR_KEY` ed25519 SSH key registered to the maintainer's AUR account.)
+
+- [ ] **Smoke test**: tag `v1.0.0-rc.1`, push, verify the release workflow produces all artifacts and pushes to taps. Roll back the tag if anything's wrong before retrying with `v1.0.0`.
+
+Commit.
+
+---
+
+## Task 6: Companion repos
+
+**One-time setup** (not a code change to this repo):
+
+1. Create `spxrogers/homebrew-tap` repo (empty; goreleaser populates).
+2. Create `spxrogers/scoop-bucket` repo (empty; goreleaser populates).
+3. Register `agentsync-bin` package on AUR with the SSH key matching `AUR_KEY`.
+4. Register `agentsync` package on Chocolatey (community.chocolatey.org).
+
+These steps are documented in the README's "release" appendix; the engineer running v1.0 release does them once.
+
+---
+
+## Task 7: Final integration test — full v1.0 lifecycle
+
+**Files:** `test/e2e/v1_lifecycle_test.go` (new top-level e2e harness)
+
+Top-level shell-style integration test that exercises every M0–M7 surface:
+
+```go
+//go:build e2e
+package e2e
+
+import (
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "testing"
+
+    "filippo.io/age"
+)
+
+// Build agentsync into a tmp bin dir; tests then exec it like a user would.
+func TestE2E_FullV1Lifecycle(t *testing.T) {
+    bin := buildBinary(t)
+    home := t.TempDir()
+    env := append(os.Environ(),
+        "AGENTSYNC_TARGET_ROOT="+home,
+        "HOME="+home,
+        "PATH="+filepath.Dir(bin)+string(filepath.ListSeparator)+os.Getenv("PATH"),
+    )
+    run := func(args ...string) (string, error) {
+        cmd := exec.Command(bin, args...)
+        cmd.Env = env
+        out, err := cmd.CombinedOutput()
+        return string(out), err
+    }
+
+    // 1. init
+    if _, err := run("init"); err != nil { t.Fatal(err) }
+
+    // 2. agents
+    _, _ = run("agent", "add", "claude")
+    _, _ = run("agent", "add", "opencode")
+
+    // 3. age secrets
+    id, _ := age.GenerateX25519Identity()
+    _ = os.MkdirAll(filepath.Join(home, ".config", "agentsync"), 0o755)
+    _ = os.WriteFile(filepath.Join(home, ".config", "agentsync", "age.key"), []byte(id.String()), 0o600)
+    cfg := filepath.Join(home, ".agentsync", "opensync.toml")
+    body, _ := os.ReadFile(cfg)
+    body = append(body, []byte("[secrets]\nbackend=\"age\"\nfile=\"secrets/secrets.age\"\nrecipient=\""+id.Recipient().String()+"\"\nidentity_file=\""+filepath.Join(home, ".config", "agentsync", "age.key")+"\"\n")...)
+    _ = os.WriteFile(cfg, body, 0o644)
+    // ... (encrypt secrets file, mcp w/ ${secret:...}, marketplace add, plugin install, apply, status, reconcile, etc.)
+}
+
+func buildBinary(t *testing.T) string {
+    t.Helper()
+    dir := t.TempDir()
+    bin := filepath.Join(dir, "agentsync")
+    cmd := exec.Command("go", "build", "-o", bin, "./cmd/agentsync")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        t.Fatalf("build: %v\n%s", err, out)
+    }
+    return bin
+}
+```
+
+CI runs `go test -tags=e2e ./test/e2e/...` on the release workflow before pushing. Commit.
+
+---
+
+## Task 8: Final commit + tag
+
+```bash
+go test -race ./...
+golangci-lint run ./...
+goreleaser release --snapshot --skip publish --clean    # local sanity
+
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+GitHub Actions release job picks up the tag and ships everything.
+
+---
+
+## Done When
+
+- `agentsync explain <plugin>` shows the per-agent translation table for any installed plugin (in human or `--json` form).
+- `agentsync import <agent>:<component>:<name>` captures any native config back into canonical.
+- `agentsync agent disable claude --purge` removes the agent and cleans destination files we owned.
+- `git tag v1.0.0 && git push origin v1.0.0` triggers a release that:
+  - Builds Linux/macOS/Windows × amd64/arm64 binaries.
+  - Pushes Homebrew formula to `spxrogers/homebrew-tap`.
+  - Pushes Scoop manifest to `spxrogers/scoop-bucket`.
+  - Submits Chocolatey package.
+  - Pushes AUR PKGBUILD.
+  - Uploads `.deb` + `.rpm` to GitHub Releases.
+- README documents quickstart, install per-platform, cross-machine sync, age-key backup, known limits, and troubleshooting.
+- E2E test passes on linux/macos/windows.
+- CI green at all phases.
+
+**v1.0 ships.** v1.1 (Codex) and v1.2 (Cursor) are separately-tracked plans, written after v1.0 lands and the patterns are proven.

--- a/docs/superpowers/plans/2026-05-04-agentsync-v1.0-overview.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-v1.0-overview.md
@@ -1,0 +1,193 @@
+# agentsync v1.0 — Implementation Plan Overview
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement these plans task-by-task. Each milestone has its own plan file with checkbox (`- [ ]`) steps.
+
+**Source spec:** [`docs/superpowers/specs/2026-05-04-agentsync-design.md`](../specs/2026-05-04-agentsync-design.md)
+
+**Goal:** Ship `agentsync` v1.0 — a Go CLI that centrally manages AI coding-agent configurations across Claude Code and OpenCode, with marketplace plugin fanout, bidirectional drift detection, project-local overlays, and age-encrypted secrets.
+
+**Tech stack:** Go 1.22+, cobra (CLI), `pelletier/go-toml/v2` (TOML AST), `tailscale/hujson` (JSONC), `gofrs/flock` (lock), `spf13/afero` (FS test fakes), `filippo.io/age` (secrets), `go-git/v5` (marketplace fetch), `log/slog` (logging), `golangci-lint`, `goreleaser`.
+
+---
+
+## Milestone roadmap
+
+| # | Milestone | Plan file | Ships |
+|---|---|---|---|
+| **M0** | Skeleton | [`m0-skeleton.md`](2026-05-04-agentsync-m0-skeleton.md) | Module bootstrap, paths, atomic IO, lock, adapter interface, NoopAdapter, cobra CLI exposing `init` / `agent` / `doctor` / `verify` / `apply --dry-run`. CI green. |
+| **M1** | Claude adapter | [`m1-claude.md`](2026-05-04-agentsync-m1-claude.md) | First real adapter. All 7 components (MCP, memory, skill, subagent, command, hook, LSP). Per-key merge into `~/.claude/settings.json` and `~/.claude.json`. Renders + ingests round-trip. |
+| **M2** | OpenCode adapter | [`m2-opencode.md`](2026-05-04-agentsync-m2-opencode.md) | Second adapter. JSONC for `opencode.json`. Skills written to shared `.claude/skills/` path. Subagent + slash-command projection (markdown↔markdown w/ frontmatter munging). Hook/LSP `✗ skip(warn)`. |
+| **M3** | Drift / status / diff / reconcile | [`m3-drift.md`](2026-05-04-agentsync-m3-drift.md) | 3-way classifier, file + key levels, `status` / `diff` commands, interactive reconcile loop, bulk hotkeys, `--auto-*` flags, foreign-key reporting. |
+| **M4** | Marketplaces + plugins | [`m4-marketplaces.md`](2026-05-04-agentsync-m4-marketplaces.md) | All 5 plugin sources (relative, github, url, git-subdir, npm). go-git fetch, npm tarball fetch, sparse clone for git-subdir. `strict` mode. `${CLAUDE_PLUGIN_ROOT}` resolution. Per-component projection, translation report, sha pinning, update modes. |
+| **M5** | Project-local | [`m5-project.md`](2026-05-04-agentsync-m5-project.md) | `.agentsync.toml` walk-up, overlay merge, `--project` flag, project-scoped state. |
+| **M6** | Secrets | [`m6-secrets.md`](2026-05-04-agentsync-m6-secrets.md) | age library integration, `${secret:foo.bar}` resolution, `secrets {edit,get,set}`. |
+| **M7** | Polish + release | [`m7-polish.md`](2026-05-04-agentsync-m7-polish.md) | `explain`, `import`, `agent disable --purge`, goreleaser cross-platform, Homebrew tap, Scoop manifest, Chocolatey package, README docs (age key backup, first-apply caveats, OpenCode hook gap, Cursor user-rule limit). |
+
+**Beyond v1.0:**
+- **v1.1** — Codex adapter (TOML config, markdown→TOML subagent conversion, hook event mapping). Plan written after v1.0 ships.
+- **v1.2** — Cursor adapter (JSON `mcp.json`, AGENTS.md, hooks.json with event mapping, project-scope rules). Plan written after v1.1 ships.
+
+## Conventions used across all milestone plans
+
+These apply uniformly; each plan refers back here rather than re-stating.
+
+### TDD cycle
+
+Every task that introduces behavior follows this cycle:
+
+1. Write the failing test
+2. Run it; verify it fails for the expected reason (test discovers missing function/symbol)
+3. Write the minimal implementation
+4. Run the test; verify it passes
+5. Commit (test + impl together)
+
+Tasks that introduce *only* types (interfaces, struct definitions, schemas) skip steps 1–4 and have a single "create file" step + commit, since there's no behavior to test in isolation. Their tests live in the next behavioral task.
+
+### Test framework
+
+- Stdlib `testing` package only. No `testify`, no `gomega`.
+- Table-driven tests for branching logic. Each table row has a `name` field; subtests via `t.Run(tt.name, ...)`.
+- Filesystem in tests: **always** `afero.NewMemMapFs()` or `t.TempDir()`. Never `os.UserHomeDir()`. Lint rule (`forbidigo`) enforces this.
+- `t.Helper()` in any helper function that calls `t.Fatal`/`t.Errorf`.
+- Integration tests for command-level behavior live in `internal/cli/*_test.go` and exercise the full cobra command path.
+
+### Error wrapping
+
+```go
+return fmt.Errorf("loading source from %s: %w", path, err)
+```
+
+Stdlib only. No `pkg/errors`. `errors.Is` and `errors.As` for matching.
+
+### Imports order
+
+```go
+import (
+    // stdlib
+    "fmt"
+    "os"
+
+    // third-party
+    "github.com/spf13/cobra"
+
+    // internal
+    "github.com/spxrogers/agentsync/internal/paths"
+)
+```
+
+Goimports / gofumpt formatting.
+
+### Commit messages
+
+Conventional commits with explicit scope:
+
+- `feat(paths): resolve AGENTSYNC_HOME with target-root override`
+- `test(state): cover atomic write under simulated crash`
+- `fix(adapter): preserve foreign keys on settings.json merge`
+- `refactor(cli): extract path helper for tests`
+- `docs(readme): document age key backup`
+- `ci: add forbidigo rule for os.UserHomeDir in tests`
+- `chore: bump go.mod to 1.22`
+
+Every commit ends with the AI co-authorship footer (per repo convention):
+
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+Use HEREDOC form when the message has multiple lines (so newlines render correctly):
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(paths): resolve AGENTSYNC_HOME with target-root override
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Lint rules (`.golangci.yml`)
+
+Configured in M0 Task 0; expected to stay stable across milestones:
+
+- govet, staticcheck, errcheck, gocritic, ineffassign, gofumpt
+- `forbidigo` rules:
+  - `os.UserHomeDir` in `*_test.go` files (must use `paths.HomeDir(env)` instead)
+  - `time.Now()` in `internal/state/` and `internal/render/` (must accept a clock interface for testability)
+
+### File-modification etiquette
+
+- New file → create with the full content shown.
+- Existing file modification → show the **exact** before/after for the changed region. Lines outside the change region are unaffected.
+- When a task touches multiple files, list them all under **Files** at the top of the task.
+
+### Cross-plan references
+
+A task in M1 can rely on a helper introduced in M0 by referencing it as `(see M0 Task 4: iox.AtomicWrite)`. The helper's contract is given in the M0 task; it is treated as load-bearing API for downstream milestones. If M1 needs to extend the helper, M1 has its own task to do so explicitly.
+
+### Milestone exit criteria
+
+Each milestone plan has a **Done When** section at the end listing user-observable behavior the engineer can demo. CI must be green; lint clean; tests passing under `-race`. A milestone is not "done" until those checks pass.
+
+## Dependency graph
+
+```
+M0 ──┬── M1 ──┬── M3 ── M4 ── M5 ── M7
+     │        │
+     └── M2 ──┘
+              │
+              └── M6   (M6 has no hard dependency on M3/M4 but ships after them
+                        for ergonomic reasons; can be reordered if needed)
+```
+
+- M0 is foundational; everything depends on it.
+- M1 and M2 can be implemented in either order after M0; both provide the adapter surface that M3 (drift), M4 (plugins), and M5 (project) use.
+- M3 needs at least one adapter to exercise.
+- M4 depends on M3's classifier (per-component drift).
+- M5 depends on M4 (project overlays interact with plugin enablements).
+- M6 (secrets) is mostly independent but expected after M3 so the `${secret:...}` resolution can be tested under realistic apply paths.
+- M7 is release polish; depends on everything.
+
+## How to use these plans
+
+- Each plan opens with **Goal**, **Architecture**, **Tech stack**, **Files created/modified in this milestone**, then numbered tasks.
+- Tasks are bite-sized (5 sub-steps; ~15–30 minutes per task). The engineer should be able to execute one task in a focused work block, commit, and move on.
+- Don't skip ahead. Tasks within a milestone build on prior tasks' code. The plans assume the engineer reads sequentially within each plan file.
+- If a task references code from an earlier task in the same plan, the prior code is repeated where it matters for clarity, but the engineer is expected to have written it.
+
+## Done When (v1.0 overall)
+
+The user can run end-to-end:
+
+```bash
+agentsync init
+agentsync agent add claude
+agentsync agent add opencode
+agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github" --env GITHUB_TOKEN='${secret:github.token}'
+agentsync secrets edit                     # paste token, save
+agentsync marketplace add github:anthropics/claude-plugins-official
+agentsync plugin install atlassian@anthropic
+agentsync apply
+
+# verify
+jq '.mcpServers.github' ~/.claude/settings.json
+jq '.mcp.github' ~/.config/opencode/opencode.json
+
+# drift
+claude /plugin install some-other-plugin    # outside agentsync
+agentsync status                            # detects new plugin as foreign-managed
+agentsync import claude:plugin:some-other-plugin
+agentsync apply                             # propagates to opencode
+
+# project-local
+cd ~/code/myproject && touch .agentsync.toml
+echo '[[mcp]]' >> .agentsync.toml
+echo 'id = "company-api"' >> .agentsync.toml
+echo 'type = "stdio"' >> .agentsync.toml
+echo 'command = "npx"' >> .agentsync.toml
+echo 'args = ["-y", "@company/mcp"]' >> .agentsync.toml
+agentsync apply
+ls .claude/settings.json                    # project-scope MCP landed
+```
+
+All this works on a clean macOS / Linux / Windows machine with only the `agentsync` binary installed (via Homebrew / Scoop / Chocolatey / native package). No Go toolchain required at runtime.

--- a/docs/superpowers/specs/2026-05-04-agentsync-design.md
+++ b/docs/superpowers/specs/2026-05-04-agentsync-design.md
@@ -1,4 +1,4 @@
-# opensync — Design Spec
+# agentsync — Design Spec
 
 **Date:** 2026-05-04
 **Status:** Design approved, implementation plan to follow.
@@ -8,7 +8,7 @@
 
 ## Summary
 
-opensync is a single-machine CLI that centrally manages AI coding-agent configurations across **Claude Code, OpenCode, Codex CLI, and Cursor**. The user commits canonical config (MCP servers, marketplace plugin enablements, memory snippets, secrets) once into `~/.opensync/`, runs `opensync apply`, and every registered agent picks it up. When an agent's config drifts from what opensync recorded, opensync surfaces the drift and offers chezmoi-style merge resolution per file or per key.
+agentsync is a single-machine CLI that centrally manages AI coding-agent configurations across **Claude Code, OpenCode, Codex CLI, and Cursor**. The user commits canonical config (MCP servers, marketplace plugin enablements, memory snippets, secrets) once into `~/.agentsync/`, runs `agentsync apply`, and every registered agent picks it up. When an agent's config drifts from what agentsync recorded, agentsync surfaces the drift and offers chezmoi-style merge resolution per file or per key.
 
 The product is **personal-first, OSS-shareable**: built well enough to share, not chasing breadth. v1.0 ships Claude Code + OpenCode end-to-end. v1.1 adds Codex CLI. v1.2 adds Cursor.
 
@@ -21,13 +21,13 @@ The product is **personal-first, OSS-shareable**: built well enough to share, no
 | Audience | Personal-first, OSS-shareable. No breadth chasing. | User uses Claude/OpenCode/Codex; coworker uses Cursor. Continue/Gemini/Aider not on the user's stack. |
 | v1 agents | Claude Code + OpenCode in v1.0. Codex in v1.1. Cursor in v1.2. | Top user pain (plugin/marketplace fanout) needs ≥ 2 agents to exercise. Claude + OpenCode are the two with native marketplace concept (or close to it) — translation gymnastics are deferred to v1.1/v1.2 where they're harder. |
 | Pain ranking (v1 must address) | (1) plugin/marketplace fanout, (2) drift detection, (3) MCP fanout, (4) project-local, (5) memory dedup. | User-supplied; informs milestone ordering inside v1.0. |
-| Source-of-truth model | Bidirectional. `~/.opensync/` is canonical; agent edits are detected as drift; reconcile UX merges. | User explicitly invoked the chezmoi mental model: "if I edit `.zshrc` directly, chezmoi prompts for merge resolution." |
-| Authoring surface | CLI-driven (`opensync mcp add`, etc.) but on-disk shape is hand-vim-editable: small TOML files, AST round-trip preserves comments + key order, no `# DO NOT EDIT` markers. | User: "as the owner who might `vim` edits manually, I want something that doesn't suck." |
-| Drift granularity | Key-level for structured (JSON/JSONC/TOML), file-level for everything else, file-level fallback when parse fails. | `~/.claude/settings.json` and `~/.claude.json` are shared between Claude Code, the user's hand-edits, and opensync. File-level would false-positive constantly; only per-key writes are polite. |
-| Secrets | env + age-encrypted file. `${secret:foo.bar}` resolution at apply-time. | User wants single-artifact `~/.opensync/` (chezmoi dream). age is pure-Go, file-format-stable, cross-platform, integrates naturally with chezmoi if used. |
-| Project marker | `.opensync.toml` at repo root. Walk-up resolution from cwd. | User: "directory paths aren't durable across machines or clones; a directory should declare itself." |
-| Cross-machine sync | Delegated to chezmoi or whichever dotfile manager. opensync stays single-machine. | User confirmed; out of scope. |
-| Daemon | None. `opensync update` polls on demand. Recurring runs delegated to user's cron/launchd/systemd. | User: scheduled refresh is "nice and fluffy but not critical path." |
+| Source-of-truth model | Bidirectional. `~/.agentsync/` is canonical; agent edits are detected as drift; reconcile UX merges. | User explicitly invoked the chezmoi mental model: "if I edit `.zshrc` directly, chezmoi prompts for merge resolution." |
+| Authoring surface | CLI-driven (`agentsync mcp add`, etc.) but on-disk shape is hand-vim-editable: small TOML files, AST round-trip preserves comments + key order, no `# DO NOT EDIT` markers. | User: "as the owner who might `vim` edits manually, I want something that doesn't suck." |
+| Drift granularity | Key-level for structured (JSON/JSONC/TOML), file-level for everything else, file-level fallback when parse fails. | `~/.claude/settings.json` and `~/.claude.json` are shared between Claude Code, the user's hand-edits, and agentsync. File-level would false-positive constantly; only per-key writes are polite. |
+| Secrets | env + age-encrypted file. `${secret:foo.bar}` resolution at apply-time. | User wants single-artifact `~/.agentsync/` (chezmoi dream). age is pure-Go, file-format-stable, cross-platform, integrates naturally with chezmoi if used. |
+| Project marker | `.agentsync.toml` at repo root. Walk-up resolution from cwd. | User: "directory paths aren't durable across machines or clones; a directory should declare itself." |
+| Cross-machine sync | Delegated to chezmoi or whichever dotfile manager. agentsync stays single-machine. | User confirmed; out of scope. |
+| Daemon | None. `agentsync update` polls on demand. Recurring runs delegated to user's cron/launchd/systemd. | User: scheduled refresh is "nice and fluffy but not critical path." |
 | Language | Go. Single static binary. | Both prior plans agreed; age library is Go-native; TOML AST round-trip via `pelletier/go-toml/v2` is mature. |
 | Distribution | Brew (macOS), scoop + chocolatey (Windows), apt/yum/AUR (Linux). No `go install`, no npm, no curl-bash. | User explicit. |
 
@@ -35,16 +35,16 @@ The product is **personal-first, OSS-shareable**: built well enough to share, no
 
 ## Architecture
 
-opensync inherits chezmoi's three-state model:
+agentsync inherits chezmoi's three-state model:
 
-- **Source** — what the user committed in `~/.opensync/` (a git repo, optionally chezmoi-managed for cross-machine).
+- **Source** — what the user committed in `~/.agentsync/` (a git repo, optionally chezmoi-managed for cross-machine).
 - **Target** — the rendered output of templating + per-component projection through each adapter, computed in memory at apply time.
 - **Destination** — what is actually on disk under each agent's config dirs right now.
 
 ```
 +-----------------+           +----------------+           +-----------------+
 | Source          |           | Target         |           | Destination     |
-| ~/.opensync/    |  render   | (in-memory)    |  write    | ~/.claude/...   |
+| ~/.agentsync/    |  render   | (in-memory)    |  write    | ~/.claude/...   |
 |                 |---------->|                |---------->| ~/.config/...   |
 | Hand-edited     |           | TOML/MD/JSON   |           | (per-agent dirs)|
 | TOML + .md      |           | per-agent ops  |           |                 |
@@ -61,7 +61,7 @@ Both → conflict (user must reconcile).
 
 ### TOML structs are the canonical model
 
-There is no separate "internal IR" translation layer. The Go structs that parse the TOML files in `~/.opensync/` ARE the canonical model. Each adapter implements:
+There is no separate "internal IR" translation layer. The Go structs that parse the TOML files in `~/.agentsync/` ARE the canonical model. Each adapter implements:
 
 ```go
 type Adapter interface {
@@ -81,11 +81,11 @@ Adding an agent = adding `internal/adapter/<name>/` implementing this interface.
 
 ## Source repo layout
 
-`~/.opensync/` (overridable via `OPENSYNC_HOME`):
+`~/.agentsync/` (overridable via `AGENTSYNC_HOME`):
 
 ```
-~/.opensync/
-├── opensync.toml              # global: agent registry, default update mode, secrets backend
+~/.agentsync/
+├── agentsync.toml              # global: agent registry, default update mode, secrets backend
 ├── mcp/<server>.toml          # one MCP server per file
 ├── marketplaces/<name>.toml   # one marketplace registry per file
 ├── plugins/<id>.toml          # one plugin enable + version pin per file
@@ -93,7 +93,7 @@ Adding an agent = adding `internal/adapter/<name>/` implementing this interface.
 │   ├── AGENTS.md              # canonical memory; rendered per agent
 │   └── fragments/*.md         # @-importable from above
 ├── skills/<name>/SKILL.md     # standalone skills (outside plugins)
-├── secrets/secrets.age        # age-encrypted; opensync secrets {edit,get,set}
+├── secrets/secrets.age        # age-encrypted; agentsync secrets {edit,get,set}
 ├── ignore.toml                # paths to suppress from drift reporting
 └── .state/                    # gitignored
     ├── targets.json           # last-applied hashes
@@ -108,7 +108,7 @@ Adding an agent = adding `internal/adapter/<name>/` implementing this interface.
 ### Canonical schema (representative TOML)
 
 ```toml
-# opensync.toml
+# agentsync.toml
 [agents]
 claude   = { enabled = true,  scope = "user" }
 opencode = { enabled = true,  scope = "user" }
@@ -123,7 +123,7 @@ default_interval = "24h"
 backend       = "age"
 file          = "secrets/secrets.age"
 recipient     = "age1abc..."
-identity_file = "${env:HOME}/.config/opensync/age.key"
+identity_file = "${env:HOME}/.config/agentsync/age.key"
 ```
 
 ```toml
@@ -170,7 +170,7 @@ commands = "skip"                     # don't project /commands as Cursor rules
 ### Project marker
 
 ```toml
-# <project-repo>/.opensync.toml
+# <project-repo>/.agentsync.toml
 agents = ["claude", "codex"]      # subset that applies in this project (default = all enabled)
 
 [[mcp]]
@@ -188,13 +188,13 @@ disabled = ["screenshot"]
 import = ["./AGENTS.md"]          # project-relative, merged into rendered memory
 ```
 
-Discovery: walk up from cwd looking for `.opensync.toml`. First match wins. No central registry.
+Discovery: walk up from cwd looking for `.agentsync.toml`. First match wins. No central registry.
 
 ---
 
 ## Plugin model
 
-opensync consumes Claude marketplace plugins as the canonical plugin shape. Schema source: https://code.claude.com/docs/en/plugin-marketplaces.
+agentsync consumes Claude marketplace plugins as the canonical plugin shape. Schema source: https://code.claude.com/docs/en/plugin-marketplaces.
 
 ### Plugin sources (5 types, all in v1.0)
 
@@ -206,7 +206,7 @@ opensync consumes Claude marketplace plugins as the canonical plugin shape. Sche
 | `git-subdir` (sparse clone) | object | `url`, `path`, `ref?`, `sha?` |
 | `npm` | object | `package`, `version?`, `registry?` |
 
-- **`npm` source**: opensync fetches the tarball via the registry HTTP API and extracts. No `npm`/`Bun` required on user's machine.
+- **`npm` source**: agentsync fetches the tarball via the registry HTTP API and extracts. No `npm`/`Bun` required on user's machine.
 - **`git-subdir`**: uses go-git partial/sparse clone where supported; shells out to `git` as fallback if go-git's sparse support is incomplete on a given version.
 
 ### Strict mode
@@ -214,23 +214,23 @@ opensync consumes Claude marketplace plugins as the canonical plugin shape. Sche
 `strict: true` (default) — `<plugin>/.claude-plugin/plugin.json` is authoritative; marketplace entry supplements (both merged).
 `strict: false` — marketplace entry is the entire definition; conflicts with `plugin.json` are an error.
 
-opensync respects this flag exactly as Claude Code does.
+agentsync respects this flag exactly as Claude Code does.
 
 ### `${CLAUDE_PLUGIN_ROOT}` substitution
 
 This variable appears in hook commands and MCP server configs (e.g. `command = "${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh"`).
 
 - For Claude itself: pass through verbatim. Claude resolves it at runtime.
-- For non-Claude agents: opensync resolves at apply-time to `~/.claude/plugins/cache/<plugin>/`. Otherwise the path would be meaningless in those agents' configs.
+- For non-Claude agents: agentsync resolves at apply-time to `~/.claude/plugins/cache/<plugin>/`. Otherwise the path would be meaningless in those agents' configs.
 
 ### Version resolution
 
 - `version` set (in marketplace entry or `plugin.json`) → pinned.
-- `version` omitted → every git commit is a new "version." `opensync update` surfaces this with a warning so unintended drift is visible: `plugin foo: version unpinned; tracking commit a1b2c3 → d4e5f6`.
+- `version` omitted → every git commit is a new "version." `agentsync update` surfaces this with a warning so unintended drift is visible: `plugin foo: version unpinned; tracking commit a1b2c3 → d4e5f6`.
 
 ### `~/.claude/plugins/cache/` is jointly-owned
 
-opensync writes plugin contents it installs. Claude itself may also install plugins directly (`/plugin install foo`). Drift in this directory for plugins opensync didn't install is reported as **foreign-managed**, not as drift. opensync only owns rows in `.state/targets.json` it created.
+agentsync writes plugin contents it installs. Claude itself may also install plugins directly (`/plugin install foo`). Drift in this directory for plugins agentsync didn't install is reported as **foreign-managed**, not as drift. agentsync only owns rows in `.state/targets.json` it created.
 
 ### Reserved marketplace names
 
@@ -238,7 +238,7 @@ opensync writes plugin contents it installs. Claude itself may also install plug
 
 ### Skill frontmatter is open-ended
 
-Fields beyond `name` and `description` (e.g. `disable-model-invocation`) are real. opensync's canonical `Skill` type carries `Frontmatter map[string]any` and writes through verbatim — never drop unknown keys.
+Fields beyond `name` and `description` (e.g. `disable-model-invocation`) are real. agentsync's canonical `Skill` type carries `Frontmatter map[string]any` and writes through verbatim — never drop unknown keys.
 
 ---
 
@@ -260,7 +260,7 @@ A plugin is a bag of components. Each component is translated independently per 
 | Hook | ✓ JSON in settings | ✗ skip(warn) — OpenCode hooks are JS/TS plugins (shim generation deferred) | ◐ projected — `hooks.json`, 5/9 events overlap, requires `[features] codex_hooks = true` | ◐ projected — `hooks.json`, ~6/9 events overlap (Tab hooks unique to Cursor) |
 | LSP server | ✓ native | ✗ skip(warn) — LSP projection deferred to v1.x | ✗ skip(warn) — no LSP concept | ✗ skip(warn) — Cursor inherits VSCode LSP but projection deferred |
 
-**Skill-write strategy**: when a skill must reach multiple agents that read different paths, opensync writes the same `SKILL.md` content to each path directly. **No symlinks ever.** Two file ops per skill, both tracked in state. Robustness over disk-cost.
+**Skill-write strategy**: when a skill must reach multiple agents that read different paths, agentsync writes the same `SKILL.md` content to each path directly. **No symlinks ever.** Two file ops per skill, both tracked in state. Robustness over disk-cost.
 
 **Translation report** at end of every `apply` and `verify`:
 
@@ -272,7 +272,7 @@ plugin: atlassian@anthropic
   cursor    ◐ partial (1 mcp; 5 commands → .cursor/rules/*.mdc)
 ```
 
-Same data structured via `opensync explain <plugin> --json`.
+Same data structured via `agentsync explain <plugin> --json`.
 
 ### Escape hatches
 
@@ -282,7 +282,7 @@ Same data structured via `opensync explain <plugin> --json`.
 
 ### Cursor rule constraint (v1.2)
 
-Cursor user-level rules live in Cursor's app-local storage, not the filesystem. **opensync's Cursor adapter manages project-scope rules only.** This is a documented known limit; user-scope MCP via `~/.cursor/mcp.json` is filesystem-accessible and works normally.
+Cursor user-level rules live in Cursor's app-local storage, not the filesystem. **agentsync's Cursor adapter manages project-scope rules only.** This is a documented known limit; user-scope MCP via `~/.cursor/mcp.json` is filesystem-accessible and works normally.
 
 ---
 
@@ -306,14 +306,14 @@ For every managed item (file or key), three hashes:
 | `H_src` = nil, `H_applied` ≠ nil | `H_dest` = `H_applied` | orphan | delete |
 | `H_src` = nil, `H_applied` ≠ nil | `H_dest` ≠ `H_applied` | orphan-drifted | warn; suggest re-add or explicit delete |
 
-**Granularity**: structured files (JSON/JSONC/TOML) run at JSON-pointer granularity, each managed key path triple-tracked. **Foreign keys** (paths opensync never wrote) are listed in `status` for awareness; they never enter the case table. When parsing fails, the algorithm degrades to file-level on the whole file.
+**Granularity**: structured files (JSON/JSONC/TOML) run at JSON-pointer granularity, each managed key path triple-tracked. **Foreign keys** (paths agentsync never wrote) are listed in `status` for awareness; they never enter the case table. When parsing fails, the algorithm degrades to file-level on the whole file.
 
 ---
 
 ## Reconcile UX
 
 ```
-$ opensync reconcile
+$ agentsync reconcile
 ~/.claude/settings.json#$.permissions.bash[2]   (drift)
   source:      "Bash(git push:*)"
   destination: "Bash(git push:*) Bash(npm publish:*)"
@@ -324,7 +324,7 @@ $ opensync reconcile
 ~/.claude/settings.json#$.permissions.bash updated in source.
 ```
 
-Bulk hotkeys: `W` write-back-all, `O` override-all, `S` skip-all-remaining. Non-interactive flags: `--auto-writeback`, `--auto-override`, `--auto-safe` (auto-resolves only `converged` and `pending`). `i`gnore adds the path to `~/.opensync/ignore.toml`.
+Bulk hotkeys: `W` write-back-all, `O` override-all, `S` skip-all-remaining. Non-interactive flags: `--auto-writeback`, `--auto-override`, `--auto-safe` (auto-resolves only `converged` and `pending`). `i`gnore adds the path to `~/.agentsync/ignore.toml`.
 
 ---
 
@@ -333,16 +333,16 @@ Bulk hotkeys: `W` write-back-all, `O` override-all, `S` skip-all-remaining. Non-
 Network-aware split — `update` is the only verb that hits the network:
 
 ```
-opensync update              # poll all marketplaces, refresh cache, recompute pins
+agentsync update              # poll all marketplaces, refresh cache, recompute pins
                              # prints pending bumps; does NOT touch agent configs
-opensync apply               # local-only: cache → render → write, with translation report
-opensync update --apply      # convenience: update then apply, prompts on lossy translation
-opensync update --apply --auto    # same with --auto-safe semantics
+agentsync apply               # local-only: cache → render → write, with translation report
+agentsync update --apply      # convenience: update then apply, prompts on lossy translation
+agentsync update --apply --auto    # same with --auto-safe semantics
 ```
 
 `apply` always uses cached marketplace content — keeps tests reproducible and `apply` runs offline. Per-plugin update mode (`pinned` | `track` | `manual`) overrides marketplace default. `manifest_sha` pin detects re-uploaded versions.
 
-Recurring runs (e.g. nightly refresh) are delegated: user wires their own cron / launchd / systemd / Task Scheduler entry calling `opensync update --apply --auto`. opensync ships no scheduler.
+Recurring runs (e.g. nightly refresh) are delegated: user wires their own cron / launchd / systemd / Task Scheduler entry calling `agentsync update --apply --auto`. agentsync ships no scheduler.
 
 ---
 
@@ -350,7 +350,7 @@ Recurring runs (e.g. nightly refresh) are delegated: user wires their own cron /
 
 `${secret:foo.bar}` references are resolved at apply-time from `secrets/secrets.age`. age library (`filippo.io/age`) is vendored — no `age` CLI required. Public key (recipient) is committable; private key (identity) is per-machine, distributed via the user's existing machine-setup flow (1Password Secure Note, Keychain, manual).
 
-`opensync secrets edit` decrypts to a tmpfile, opens `$EDITOR`, re-encrypts on save. Cleartext never on durable disk outside `/tmp` (RAM-backed on macOS).
+`agentsync secrets edit` decrypts to a tmpfile, opens `$EDITOR`, re-encrypts on save. Cleartext never on durable disk outside `/tmp` (RAM-backed on macOS).
 
 ---
 
@@ -358,42 +358,42 @@ Recurring runs (e.g. nightly refresh) are delegated: user wires their own cron /
 
 ```
 # Bootstrap & inspect
-opensync init [<git-url>]
-opensync doctor
-opensync verify
+agentsync init [<git-url>]
+agentsync doctor
+agentsync verify
 
 # Agent registry
-opensync agent {add,remove,list,enable,disable}
+agentsync agent {add,remove,list,enable,disable}
 
 # Canonical primitives (source-mutating)
-opensync mcp {add,set,remove,list,enable,disable}
-opensync skill {add,remove,list}
-opensync secrets {edit,get,set}
+agentsync mcp {add,set,remove,list,enable,disable}
+agentsync skill {add,remove,list}
+agentsync secrets {edit,get,set}
 
 # Marketplaces & plugins (source-mutating)
-opensync marketplace {add,remove,list}
-opensync plugin {install,upgrade,enable,disable,remove,list}
+agentsync marketplace {add,remove,list}
+agentsync plugin {install,upgrade,enable,disable,remove,list}
 
 # Network (only network-touching command)
-opensync update [--apply [--auto|--auto-safe]]
+agentsync update [--apply [--auto|--auto-safe]]
 
 # Apply & drift (destination-mutating)
-opensync apply [--scope user|project|all] [--project <slug>] [--agent X]
+agentsync apply [--scope user|project|all] [--project <slug>] [--agent X]
                [--dry-run] [--strict] [--force]
-opensync status [--agent X]
-opensync diff [--agent X] [<path>]
-opensync reconcile [--auto-writeback|--auto-override|--auto-safe]
-opensync import <selector>          # capture native edits into source
+agentsync status [--agent X]
+agentsync diff [--agent X] [<path>]
+agentsync reconcile [--auto-writeback|--auto-override|--auto-safe]
+agentsync import <selector>          # capture native edits into source
 
 # Per-plugin transparency
-opensync explain <plugin> [--json]
+agentsync explain <plugin> [--json]
 ```
 
 **Selector grammar** for `import` (and future per-item commands): `<agent>:<component>:<name>` — e.g. `claude:mcp:github`, `opencode:agent:reviewer`.
 
 ---
 
-## State on disk (`~/.opensync/.state/`, gitignored)
+## State on disk (`~/.agentsync/.state/`, gitignored)
 
 ```json
 {
@@ -427,7 +427,7 @@ State is schema-versioned; future bumps add migrators in `internal/state/`.
 
 1. **Two-phase atomic write** — `staging/<dest>` → fsync → rename to final. A crash mid-apply leaves either old or new content, never partial.
 2. **File lock** — `gofrs/flock` on `.state/apply.lock` for `apply`/`reconcile`. Concurrent invocations queue.
-3. **`OPENSYNC_TARGET_ROOT` env var** — every adapter resolves dest paths through one helper. Tests redirect to `t.TempDir()` from line 1. Lint rule (`golangci-lint forbidigo`) bans `os.UserHomeDir()` in `_test.go`.
+3. **`AGENTSYNC_TARGET_ROOT` env var** — every adapter resolves dest paths through one helper. Tests redirect to `t.TempDir()` from line 1. Lint rule (`golangci-lint forbidigo`) bans `os.UserHomeDir()` in `_test.go`.
 4. **First-apply backups** — `foreign-collision` case copies pre-existing dest content into `.state/backups/<ts>/<dest_path>` before writing.
 5. **Manifest sha pinning** — every plugin records the marketplace-published manifest sha so re-uploaded versions are detected as drift, not silently consumed.
 
@@ -439,12 +439,12 @@ State is schema-versioned; future bumps add migrators in `internal/state/`.
 
 | Milestone | Scope |
 |---|---|
-| **M0** Skeleton | cobra root, `OPENSYNC_HOME` / `OPENSYNC_TARGET_ROOT` resolution, adapter interface + registry, source loader (TOML→Go structs), state manager (`targets.json` with fsync+rename), atomic write + flock, slog. |
+| **M0** Skeleton | cobra root, `AGENTSYNC_HOME` / `AGENTSYNC_TARGET_ROOT` resolution, adapter interface + registry, source loader (TOML→Go structs), state manager (`targets.json` with fsync+rename), atomic write + flock, slog. |
 | **M1** Claude adapter (full) | Detect/Read/Plan/Apply for all 7 components incl. LSP. `~/.claude/settings.json` and `~/.claude.json` key-level merge with `applied_keys`; foreign keys preserved. Skill frontmatter passthrough. |
 | **M2** OpenCode adapter | MCP, AGENTS.md, skills (write to `.claude/skills/`), agents (`.opencode/agents/`), commands (`.opencode/commands/`). Hooks: ✗ skip(warn). LSP: ✗ skip(warn). JSONC round-trip via `tailscale/hujson`. |
 | **M3** Drift / status / diff / reconcile | 3-way classifier, file + key levels, prompt loop, bulk hotkeys, `--auto-*` flags, foreign-key reporting. |
 | **M4** Marketplaces + plugins | All 5 plugin sources (relative, github, url, git-subdir, npm). go-git fetch + sparse for git-subdir. npm tarball fetch via registry HTTP. `strict` mode handling. `${CLAUDE_PLUGIN_ROOT}` substitution. Per-component projection, translation report, sha pinning, update modes. |
-| **M5** Project-local | `.opensync.toml` walk-up, overlay merge, `--project` flag, project-scope state tracking. |
+| **M5** Project-local | `.agentsync.toml` walk-up, overlay merge, `--project` flag, project-scope state tracking. |
 | **M6** Secrets | age integration, `${secret:...}` resolution, `secrets {edit,get,set}`. |
 | **M7** Polish | `doctor`, `verify`, `explain`, `import`, `agent disable --purge`, goreleaser + brew + scoop + chocolatey + (apt/yum/AUR). README documenting age-key backup, first-apply caveats, OpenCode hook gap, Cursor user-rule limit. |
 
@@ -480,7 +480,7 @@ State is schema-versioned; future bumps add migrators in `internal/state/`.
 - **Drift case fixtures**: 9-case classifier exercised at file and key granularity for at least one structured format.
 - **Reconcile loop tests** with scripted prompts via a `teatest`-style harness. Verify each hotkey path (`w`, `o`, `s`, `i`, `d`, `q`, `W`, `O`, `S`).
 - **End-to-end shell tests** per adapter: full lifecycle (`init → mcp add → apply → mutate → status → reconcile → apply → clean`). One per adapter, plus one cross-adapter "MCP added once lands in all enabled."
-- **Concurrent-apply lock test** — spawn two `apply` invocations against the same `OPENSYNC_TARGET_ROOT`, assert serialization.
+- **Concurrent-apply lock test** — spawn two `apply` invocations against the same `AGENTSYNC_TARGET_ROOT`, assert serialization.
 - **Marketplace fetch** via `file://` fake bare repo (no network in CI).
 - **Comment-preservation fuzz** for TOML and JSONC round-trips: thousands of "parse → mutate one key → write → re-parse" iterations with comment + key-order assertions.
 - **CI**: `go test -race ./...`; `golangci-lint` (govet, staticcheck, errcheck, gocritic, forbidigo banning `os.UserHomeDir()` in `_test.go`); `goreleaser release --snapshot --skip publish` on linux/darwin/windows × amd64/arm64.
@@ -492,8 +492,8 @@ State is schema-versioned; future bumps add migrators in `internal/state/`.
 1. **Claude marketplace schema evolves.** Schema is published. Mitigation: model as versioned Go structs; weekly CI doc-diff against committed reference snapshot flags new fields rather than silently dropping them.
 2. **Each adapter's surface evolves** (this brainstorm caught two outdated plans). Mitigation: translation table is one grep-able file; each adapter has a version-stamped staleness comment that tests assert against.
 3. **OpenCode hooks → Claude hooks deferred.** OpenCode hooks are JS/TS plugin event subscriptions; translation requires shim generation. Hand-author shim if needed in v1; documented limit.
-4. **Cursor user-level rules** can't be opensync-managed. Project-scope only; documented limit.
-5. **age private key loss = total secrets loss.** README must call out key-backup discipline; opensync doesn't manage backup.
+4. **Cursor user-level rules** can't be agentsync-managed. Project-scope only; documented limit.
+5. **age private key loss = total secrets loss.** README must call out key-backup discipline; agentsync doesn't manage backup.
 6. **First apply on a populated machine** hits many `foreign-collision` cases. Mitigation: backups + recommend `apply --dry-run` first.
 7. **Concurrent agent edits mid-reconcile** — drift classifier catches on next `status`; no special-case logic; documented.
 8. **Two competing "official" implementations** of the same logical service (e.g. Slack hosted vs npm). Canonical plugin IDs include upstream owner: `slack@slackapi` vs `slack@modelcontextprotocol`. Tooling enforces uniqueness on `(id, owner)`.

--- a/docs/superpowers/specs/2026-05-04-opensync-design.md
+++ b/docs/superpowers/specs/2026-05-04-opensync-design.md
@@ -1,0 +1,511 @@
+# opensync — Design Spec
+
+**Date:** 2026-05-04
+**Status:** Design approved, implementation plan to follow.
+**Supersedes:** PRs #1, #2, #3 — closed; their content was input material for this fresh spec.
+
+---
+
+## Summary
+
+opensync is a single-machine CLI that centrally manages AI coding-agent configurations across **Claude Code, OpenCode, Codex CLI, and Cursor**. The user commits canonical config (MCP servers, marketplace plugin enablements, memory snippets, secrets) once into `~/.opensync/`, runs `opensync apply`, and every registered agent picks it up. When an agent's config drifts from what opensync recorded, opensync surfaces the drift and offers chezmoi-style merge resolution per file or per key.
+
+The product is **personal-first, OSS-shareable**: built well enough to share, not chasing breadth. v1.0 ships Claude Code + OpenCode end-to-end. v1.1 adds Codex CLI. v1.2 adds Cursor.
+
+---
+
+## Locked decisions
+
+| Topic | Decision | Rationale |
+|---|---|---|
+| Audience | Personal-first, OSS-shareable. No breadth chasing. | User uses Claude/OpenCode/Codex; coworker uses Cursor. Continue/Gemini/Aider not on the user's stack. |
+| v1 agents | Claude Code + OpenCode in v1.0. Codex in v1.1. Cursor in v1.2. | Top user pain (plugin/marketplace fanout) needs ≥ 2 agents to exercise. Claude + OpenCode are the two with native marketplace concept (or close to it) — translation gymnastics are deferred to v1.1/v1.2 where they're harder. |
+| Pain ranking (v1 must address) | (1) plugin/marketplace fanout, (2) drift detection, (3) MCP fanout, (4) project-local, (5) memory dedup. | User-supplied; informs milestone ordering inside v1.0. |
+| Source-of-truth model | Bidirectional. `~/.opensync/` is canonical; agent edits are detected as drift; reconcile UX merges. | User explicitly invoked the chezmoi mental model: "if I edit `.zshrc` directly, chezmoi prompts for merge resolution." |
+| Authoring surface | CLI-driven (`opensync mcp add`, etc.) but on-disk shape is hand-vim-editable: small TOML files, AST round-trip preserves comments + key order, no `# DO NOT EDIT` markers. | User: "as the owner who might `vim` edits manually, I want something that doesn't suck." |
+| Drift granularity | Key-level for structured (JSON/JSONC/TOML), file-level for everything else, file-level fallback when parse fails. | `~/.claude/settings.json` and `~/.claude.json` are shared between Claude Code, the user's hand-edits, and opensync. File-level would false-positive constantly; only per-key writes are polite. |
+| Secrets | env + age-encrypted file. `${secret:foo.bar}` resolution at apply-time. | User wants single-artifact `~/.opensync/` (chezmoi dream). age is pure-Go, file-format-stable, cross-platform, integrates naturally with chezmoi if used. |
+| Project marker | `.opensync.toml` at repo root. Walk-up resolution from cwd. | User: "directory paths aren't durable across machines or clones; a directory should declare itself." |
+| Cross-machine sync | Delegated to chezmoi or whichever dotfile manager. opensync stays single-machine. | User confirmed; out of scope. |
+| Daemon | None. `opensync update` polls on demand. Recurring runs delegated to user's cron/launchd/systemd. | User: scheduled refresh is "nice and fluffy but not critical path." |
+| Language | Go. Single static binary. | Both prior plans agreed; age library is Go-native; TOML AST round-trip via `pelletier/go-toml/v2` is mature. |
+| Distribution | Brew (macOS), scoop + chocolatey (Windows), apt/yum/AUR (Linux). No `go install`, no npm, no curl-bash. | User explicit. |
+
+---
+
+## Architecture
+
+opensync inherits chezmoi's three-state model:
+
+- **Source** — what the user committed in `~/.opensync/` (a git repo, optionally chezmoi-managed for cross-machine).
+- **Target** — the rendered output of templating + per-component projection through each adapter, computed in memory at apply time.
+- **Destination** — what is actually on disk under each agent's config dirs right now.
+
+```
++-----------------+           +----------------+           +-----------------+
+| Source          |           | Target         |           | Destination     |
+| ~/.opensync/    |  render   | (in-memory)    |  write    | ~/.claude/...   |
+|                 |---------->|                |---------->| ~/.config/...   |
+| Hand-edited     |           | TOML/MD/JSON   |           | (per-agent dirs)|
+| TOML + .md      |           | per-agent ops  |           |                 |
++-----------------+           +----------------+           +-----------------+
+        ^                                                          |
+        |                          import                          |
+        +----------------------------------------------------------+
+                            (capture drift back into source)
+```
+
+**Drift** = `hash(destination) ≠ hash(applied)` recorded in `.state/targets.json`.
+**Source change** = `hash(target) ≠ hash(applied)`.
+Both → conflict (user must reconcile).
+
+### TOML structs are the canonical model
+
+There is no separate "internal IR" translation layer. The Go structs that parse the TOML files in `~/.opensync/` ARE the canonical model. Each adapter implements:
+
+```go
+type Adapter interface {
+    Name() string
+    Capabilities() Capability
+    Detect(env Env) (bool, error)
+    Paths(scope Scope, project string) Paths
+    Render(canonical CanonicalModel, scope Scope, project string) ([]FileOp, []Skip, error)
+    Ingest(scope Scope, project string) (CanonicalModel, error)   // for drift + import
+    Apply(ops []FileOp) error
+}
+```
+
+Adding an agent = adding `internal/adapter/<name>/` implementing this interface. The canonical schema is unchanged.
+
+---
+
+## Source repo layout
+
+`~/.opensync/` (overridable via `OPENSYNC_HOME`):
+
+```
+~/.opensync/
+├── opensync.toml              # global: agent registry, default update mode, secrets backend
+├── mcp/<server>.toml          # one MCP server per file
+├── marketplaces/<name>.toml   # one marketplace registry per file
+├── plugins/<id>.toml          # one plugin enable + version pin per file
+├── memory/
+│   ├── AGENTS.md              # canonical memory; rendered per agent
+│   └── fragments/*.md         # @-importable from above
+├── skills/<name>/SKILL.md     # standalone skills (outside plugins)
+├── secrets/secrets.age        # age-encrypted; opensync secrets {edit,get,set}
+├── ignore.toml                # paths to suppress from drift reporting
+└── .state/                    # gitignored
+    ├── targets.json           # last-applied hashes
+    ├── apply.lock             # gofrs/flock
+    ├── staging/               # two-phase write tmpdir
+    ├── backups/<ts>/          # first-apply backups
+    └── cache/
+        ├── marketplaces/<slug>/
+        └── plugins/<id>/
+```
+
+### Canonical schema (representative TOML)
+
+```toml
+# opensync.toml
+[agents]
+claude   = { enabled = true,  scope = "user" }
+opencode = { enabled = true,  scope = "user" }
+codex    = { enabled = false }   # v1.1
+cursor   = { enabled = false }   # v1.2
+
+[updates]
+default_mode     = "track"        # pinned | track | manual
+default_interval = "24h"
+
+[secrets]
+backend       = "age"
+file          = "secrets/secrets.age"
+recipient     = "age1abc..."
+identity_file = "${env:HOME}/.config/opensync/age.key"
+```
+
+```toml
+# mcp/github.toml
+[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+agents  = ["*"]                  # or ["claude","opencode"]; empty/"*" = all enabled
+
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+```
+
+```toml
+# marketplaces/anthropic.toml
+[marketplace]
+url = "https://github.com/anthropics/claude-plugins-official"
+ref = "main"
+default_update_mode = "track"
+```
+
+```toml
+# plugins/atlassian.toml
+[plugin]
+id           = "atlassian@anthropic"
+version      = "1.2.3"
+manifest_sha = "abc123..."           # detects re-uploads of same version
+update       = "track"                # overrides marketplace default
+agents       = ["claude","opencode"]  # default = all enabled
+
+[plugin.overrides.cursor]
+commands = "skip"                     # don't project /commands as Cursor rules
+```
+
+```markdown
+<!-- memory/AGENTS.md -->
+# Personal coding conventions
+
+@import ./fragments/style.md
+@import ./fragments/security-rules.md
+```
+
+### Project marker
+
+```toml
+# <project-repo>/.opensync.toml
+agents = ["claude", "codex"]      # subset that applies in this project (default = all enabled)
+
+[[mcp]]
+id      = "company-api"
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@company/mcp"]
+[mcp.env]
+COMPANY_TOKEN = "${secret:company.api_token}"
+
+[plugins]
+disabled = ["screenshot"]
+
+[memory]
+import = ["./AGENTS.md"]          # project-relative, merged into rendered memory
+```
+
+Discovery: walk up from cwd looking for `.opensync.toml`. First match wins. No central registry.
+
+---
+
+## Plugin model
+
+opensync consumes Claude marketplace plugins as the canonical plugin shape. Schema source: https://code.claude.com/docs/en/plugin-marketplaces.
+
+### Plugin sources (5 types, all in v1.0)
+
+| Source | Type | Fields |
+|---|---|---|
+| Relative path | string `./...` | within marketplace repo |
+| `github` | object | `repo`, `ref?`, `sha?` |
+| `url` (any git URL) | object | `url`, `ref?`, `sha?` |
+| `git-subdir` (sparse clone) | object | `url`, `path`, `ref?`, `sha?` |
+| `npm` | object | `package`, `version?`, `registry?` |
+
+- **`npm` source**: opensync fetches the tarball via the registry HTTP API and extracts. No `npm`/`Bun` required on user's machine.
+- **`git-subdir`**: uses go-git partial/sparse clone where supported; shells out to `git` as fallback if go-git's sparse support is incomplete on a given version.
+
+### Strict mode
+
+`strict: true` (default) — `<plugin>/.claude-plugin/plugin.json` is authoritative; marketplace entry supplements (both merged).
+`strict: false` — marketplace entry is the entire definition; conflicts with `plugin.json` are an error.
+
+opensync respects this flag exactly as Claude Code does.
+
+### `${CLAUDE_PLUGIN_ROOT}` substitution
+
+This variable appears in hook commands and MCP server configs (e.g. `command = "${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh"`).
+
+- For Claude itself: pass through verbatim. Claude resolves it at runtime.
+- For non-Claude agents: opensync resolves at apply-time to `~/.claude/plugins/cache/<plugin>/`. Otherwise the path would be meaningless in those agents' configs.
+
+### Version resolution
+
+- `version` set (in marketplace entry or `plugin.json`) → pinned.
+- `version` omitted → every git commit is a new "version." `opensync update` surfaces this with a warning so unintended drift is visible: `plugin foo: version unpinned; tracking commit a1b2c3 → d4e5f6`.
+
+### `~/.claude/plugins/cache/` is jointly-owned
+
+opensync writes plugin contents it installs. Claude itself may also install plugins directly (`/plugin install foo`). Drift in this directory for plugins opensync didn't install is reported as **foreign-managed**, not as drift. opensync only owns rows in `.state/targets.json` it created.
+
+### Reserved marketplace names
+
+`claude-plugins-official`, `anthropic-marketplace`, etc. trigger a warning on `marketplace add` but don't block.
+
+### Skill frontmatter is open-ended
+
+Fields beyond `name` and `description` (e.g. `disable-model-invocation`) are real. opensync's canonical `Skill` type carries `Frontmatter map[string]any` and writes through verbatim — never drop unknown keys.
+
+---
+
+## Per-component translation table
+
+A plugin is a bag of components. Each component is translated independently per target agent.
+
+- ✓ native — full fidelity, agent has the concept directly
+- ◐ projected — lossy translation, explicitly reported (e.g. Claude `/command` → Cursor rule loses `/`-invocation)
+- ✗ skipped — no defensible translation, logged in apply output
+
+| Component | Claude (v1) | OpenCode (v1) | Codex (v1.1) | Cursor (v1.2) |
+|---|---|---|---|---|
+| MCP server | ✓ native | ✓ native (in `opencode.json`) | ✓ `[mcp_servers.X]` in `config.toml` | ✓ `mcp.json` |
+| Memory | ✓ `CLAUDE.md` | ✓ `AGENTS.md` | ✓ `~/.codex/AGENTS.md` | ✓ `AGENTS.md` (Cursor reads natively) |
+| Skill | ✓ `~/.claude/skills/X/SKILL.md` | ✓ same path (OpenCode reads `.claude/skills/`) | ✓ `~/.agents/skills/X/SKILL.md` | ✗ skip — no skills concept |
+| Subagent | ✓ `~/.claude/agents/X.md` | ◐ projected — `.opencode/agents/X.md` w/ frontmatter munging (`tools` → `permission`, `color` drops, `mode: subagent` added) | ◐ projected — `.codex/agents/X.toml` (markdown→TOML; body→`developer_instructions`) | ✗ skip |
+| Slash command | ✓ `~/.claude/commands/X.md` | ◐ projected — `.opencode/commands/X.md`; body preserved as template, frontmatter fields don't all map (`argument-hint` drops, OpenCode-specific fields not added) | ✗ skip — no custom slash commands | ◐ projected — `.cursor/rules/X.mdc` Manual rule, body=template |
+| Hook | ✓ JSON in settings | ✗ skip(warn) — OpenCode hooks are JS/TS plugins (shim generation deferred) | ◐ projected — `hooks.json`, 5/9 events overlap, requires `[features] codex_hooks = true` | ◐ projected — `hooks.json`, ~6/9 events overlap (Tab hooks unique to Cursor) |
+| LSP server | ✓ native | ✗ skip(warn) — LSP projection deferred to v1.x | ✗ skip(warn) — no LSP concept | ✗ skip(warn) — Cursor inherits VSCode LSP but projection deferred |
+
+**Skill-write strategy**: when a skill must reach multiple agents that read different paths, opensync writes the same `SKILL.md` content to each path directly. **No symlinks ever.** Two file ops per skill, both tracked in state. Robustness over disk-cost.
+
+**Translation report** at end of every `apply` and `verify`:
+
+```
+plugin: atlassian@anthropic
+  claude    ✓ full   (1 mcp, 5 commands)
+  opencode  ✓ full   (1 mcp, 5 commands)
+  codex     ◐ partial (1 mcp; 5 commands skipped)
+  cursor    ◐ partial (1 mcp; 5 commands → .cursor/rules/*.mdc)
+```
+
+Same data structured via `opensync explain <plugin> --json`.
+
+### Escape hatches
+
+- `agents = [...]` allowlist on plugin entry → fan out only to those.
+- `[plugin.overrides.<agent>] component = "skip"` → per-component override.
+- `--strict` flag on `apply` → turns ◐/✗ into hard errors so silent drops are impossible.
+
+### Cursor rule constraint (v1.2)
+
+Cursor user-level rules live in Cursor's app-local storage, not the filesystem. **opensync's Cursor adapter manages project-scope rules only.** This is a documented known limit; user-scope MCP via `~/.cursor/mcp.json` is filesystem-accessible and works normally.
+
+---
+
+## Drift detection — 3-way classifier
+
+For every managed item (file or key), three hashes:
+
+- `H_src` — computed now from canonical source.
+- `H_applied` — recorded in `.state/targets.json`.
+- `H_dest` — current on-disk content (or nil).
+
+| H_applied vs H_src | H_applied vs H_dest | Class | `apply` behavior |
+|---|---|---|---|
+| = | = | clean | noop |
+| ≠ | = | pending | write `H_src` |
+| = | ≠ | drift | block; suggest reconcile |
+| ≠ | ≠ (`H_dest` = `H_src`) | converged | refresh state silently |
+| ≠ | ≠ (all three differ) | conflict | block; require reconcile |
+| `H_applied` = nil, `H_dest` = nil | — | new | create |
+| `H_applied` = nil, `H_dest` ≠ nil | — | foreign-collision | back up dest, write |
+| `H_src` = nil, `H_applied` ≠ nil | `H_dest` = `H_applied` | orphan | delete |
+| `H_src` = nil, `H_applied` ≠ nil | `H_dest` ≠ `H_applied` | orphan-drifted | warn; suggest re-add or explicit delete |
+
+**Granularity**: structured files (JSON/JSONC/TOML) run at JSON-pointer granularity, each managed key path triple-tracked. **Foreign keys** (paths opensync never wrote) are listed in `status` for awareness; they never enter the case table. When parsing fails, the algorithm degrades to file-level on the whole file.
+
+---
+
+## Reconcile UX
+
+```
+$ opensync reconcile
+~/.claude/settings.json#$.permissions.bash[2]   (drift)
+  source:      "Bash(git push:*)"
+  destination: "Bash(git push:*) Bash(npm publish:*)"
+
+  [w]rite-back   [o]verride   [s]kip   [i]gnore   [d]iff   [q]uit
+
+→ w
+~/.claude/settings.json#$.permissions.bash updated in source.
+```
+
+Bulk hotkeys: `W` write-back-all, `O` override-all, `S` skip-all-remaining. Non-interactive flags: `--auto-writeback`, `--auto-override`, `--auto-safe` (auto-resolves only `converged` and `pending`). `i`gnore adds the path to `~/.opensync/ignore.toml`.
+
+---
+
+## Update flow
+
+Network-aware split — `update` is the only verb that hits the network:
+
+```
+opensync update              # poll all marketplaces, refresh cache, recompute pins
+                             # prints pending bumps; does NOT touch agent configs
+opensync apply               # local-only: cache → render → write, with translation report
+opensync update --apply      # convenience: update then apply, prompts on lossy translation
+opensync update --apply --auto    # same with --auto-safe semantics
+```
+
+`apply` always uses cached marketplace content — keeps tests reproducible and `apply` runs offline. Per-plugin update mode (`pinned` | `track` | `manual`) overrides marketplace default. `manifest_sha` pin detects re-uploaded versions.
+
+Recurring runs (e.g. nightly refresh) are delegated: user wires their own cron / launchd / systemd / Task Scheduler entry calling `opensync update --apply --auto`. opensync ships no scheduler.
+
+---
+
+## Secrets
+
+`${secret:foo.bar}` references are resolved at apply-time from `secrets/secrets.age`. age library (`filippo.io/age`) is vendored — no `age` CLI required. Public key (recipient) is committable; private key (identity) is per-machine, distributed via the user's existing machine-setup flow (1Password Secure Note, Keychain, manual).
+
+`opensync secrets edit` decrypts to a tmpfile, opens `$EDITOR`, re-encrypts on save. Cleartext never on durable disk outside `/tmp` (RAM-backed on macOS).
+
+---
+
+## CLI surface
+
+```
+# Bootstrap & inspect
+opensync init [<git-url>]
+opensync doctor
+opensync verify
+
+# Agent registry
+opensync agent {add,remove,list,enable,disable}
+
+# Canonical primitives (source-mutating)
+opensync mcp {add,set,remove,list,enable,disable}
+opensync skill {add,remove,list}
+opensync secrets {edit,get,set}
+
+# Marketplaces & plugins (source-mutating)
+opensync marketplace {add,remove,list}
+opensync plugin {install,upgrade,enable,disable,remove,list}
+
+# Network (only network-touching command)
+opensync update [--apply [--auto|--auto-safe]]
+
+# Apply & drift (destination-mutating)
+opensync apply [--scope user|project|all] [--project <slug>] [--agent X]
+               [--dry-run] [--strict] [--force]
+opensync status [--agent X]
+opensync diff [--agent X] [<path>]
+opensync reconcile [--auto-writeback|--auto-override|--auto-safe]
+opensync import <selector>          # capture native edits into source
+
+# Per-plugin transparency
+opensync explain <plugin> [--json]
+```
+
+**Selector grammar** for `import` (and future per-item commands): `<agent>:<component>:<name>` — e.g. `claude:mcp:github`, `opencode:agent:reviewer`.
+
+---
+
+## State on disk (`~/.opensync/.state/`, gitignored)
+
+```json
+{
+  "schema_version": 1,
+  "files": {
+    "<agent>:<scope>:<project>:<dest_path>": {
+      "sha256": "...", "mode": 420, "applied_at": "...", "source_id": "mcp/github.toml"
+    }
+  },
+  "keys": {
+    "<agent>:<scope>:<project>:<file>:<json_pointer>": {
+      "sha256": "...", "applied_at": "...", "source_id": "..."
+    }
+  },
+  "marketplaces": {
+    "anthropic": { "url": "...", "ref": "main", "head_sha": "...", "fetched_at": "..." }
+  },
+  "plugins": {
+    "anthropic/atlassian": { "version": "1.2.3", "manifest_sha": "abc...", "enabled": true }
+  }
+}
+```
+
+Other contents under `.state/`: `apply.lock`, `staging/`, `backups/<ts>/`, `cache/marketplaces/<slug>/`, `cache/plugins/<id>/`.
+
+State is schema-versioned; future bumps add migrators in `internal/state/`.
+
+---
+
+## Safety primitives (all v1.0)
+
+1. **Two-phase atomic write** — `staging/<dest>` → fsync → rename to final. A crash mid-apply leaves either old or new content, never partial.
+2. **File lock** — `gofrs/flock` on `.state/apply.lock` for `apply`/`reconcile`. Concurrent invocations queue.
+3. **`OPENSYNC_TARGET_ROOT` env var** — every adapter resolves dest paths through one helper. Tests redirect to `t.TempDir()` from line 1. Lint rule (`golangci-lint forbidigo`) bans `os.UserHomeDir()` in `_test.go`.
+4. **First-apply backups** — `foreign-collision` case copies pre-existing dest content into `.state/backups/<ts>/<dest_path>` before writing.
+5. **Manifest sha pinning** — every plugin records the marketplace-published manifest sha so re-uploaded versions are detected as drift, not silently consumed.
+
+---
+
+## v1 cutline
+
+### v1.0 — Personal Bootstrap (Claude + OpenCode)
+
+| Milestone | Scope |
+|---|---|
+| **M0** Skeleton | cobra root, `OPENSYNC_HOME` / `OPENSYNC_TARGET_ROOT` resolution, adapter interface + registry, source loader (TOML→Go structs), state manager (`targets.json` with fsync+rename), atomic write + flock, slog. |
+| **M1** Claude adapter (full) | Detect/Read/Plan/Apply for all 7 components incl. LSP. `~/.claude/settings.json` and `~/.claude.json` key-level merge with `applied_keys`; foreign keys preserved. Skill frontmatter passthrough. |
+| **M2** OpenCode adapter | MCP, AGENTS.md, skills (write to `.claude/skills/`), agents (`.opencode/agents/`), commands (`.opencode/commands/`). Hooks: ✗ skip(warn). LSP: ✗ skip(warn). JSONC round-trip via `tailscale/hujson`. |
+| **M3** Drift / status / diff / reconcile | 3-way classifier, file + key levels, prompt loop, bulk hotkeys, `--auto-*` flags, foreign-key reporting. |
+| **M4** Marketplaces + plugins | All 5 plugin sources (relative, github, url, git-subdir, npm). go-git fetch + sparse for git-subdir. npm tarball fetch via registry HTTP. `strict` mode handling. `${CLAUDE_PLUGIN_ROOT}` substitution. Per-component projection, translation report, sha pinning, update modes. |
+| **M5** Project-local | `.opensync.toml` walk-up, overlay merge, `--project` flag, project-scope state tracking. |
+| **M6** Secrets | age integration, `${secret:...}` resolution, `secrets {edit,get,set}`. |
+| **M7** Polish | `doctor`, `verify`, `explain`, `import`, `agent disable --purge`, goreleaser + brew + scoop + chocolatey + (apt/yum/AUR). README documenting age-key backup, first-apply caveats, OpenCode hook gap, Cursor user-rule limit. |
+
+### v1.1 — Codex CLI
+
+- TOML round-trip in `config.toml` (per-key, like Claude `settings.json`).
+- All components: MCP, memory (`AGENTS.md`), skills (`.agents/skills/`), agents (markdown→TOML conversion), hooks (`hooks.json` JSON→JSON with event-mapping + `[features] codex_hooks = true` flag).
+- Slash commands ✗ skip. LSP ✗ skip.
+
+### v1.2 — Cursor
+
+- `mcp.json` JSON merge, `AGENTS.md` write, `hooks.json` (event-mapping, ~6/9 events).
+- Slash commands → Manual rules in `.cursor/rules/`.
+- Skills/subagents ✗ skip. LSP ✗ skip.
+- Project-scope rules only (user-rules are non-filesystem).
+
+### Explicitly deferred past v1.2
+
+- OpenCode hook plugin-shim generator (would emit JS/TS that subscribes to events).
+- Cross-machine sync (delegated to chezmoi).
+- Cursor user-level rules (no filesystem path exists).
+- Permissions canonical projection (each agent has its own model; design v2 schema once friction is known).
+- LSP projection beyond Claude.
+- Continue, Gemini CLI, Aider — not on roadmap.
+
+---
+
+## Testing strategy
+
+- **Unit tests** per package, table-driven where appropriate.
+- **Golden tests** per adapter under `testdata/<adapter>/<case>/{source,expected,state_in.json,state_out.json}` over `afero.MemMapFs`. `make update-golden` re-records.
+- **Round-trip parity** per adapter, per component: `Ingest(Apply(canonical)) == canonical`.
+- **Drift case fixtures**: 9-case classifier exercised at file and key granularity for at least one structured format.
+- **Reconcile loop tests** with scripted prompts via a `teatest`-style harness. Verify each hotkey path (`w`, `o`, `s`, `i`, `d`, `q`, `W`, `O`, `S`).
+- **End-to-end shell tests** per adapter: full lifecycle (`init → mcp add → apply → mutate → status → reconcile → apply → clean`). One per adapter, plus one cross-adapter "MCP added once lands in all enabled."
+- **Concurrent-apply lock test** — spawn two `apply` invocations against the same `OPENSYNC_TARGET_ROOT`, assert serialization.
+- **Marketplace fetch** via `file://` fake bare repo (no network in CI).
+- **Comment-preservation fuzz** for TOML and JSONC round-trips: thousands of "parse → mutate one key → write → re-parse" iterations with comment + key-order assertions.
+- **CI**: `go test -race ./...`; `golangci-lint` (govet, staticcheck, errcheck, gocritic, forbidigo banning `os.UserHomeDir()` in `_test.go`); `goreleaser release --snapshot --skip publish` on linux/darwin/windows × amd64/arm64.
+
+---
+
+## Open risks
+
+1. **Claude marketplace schema evolves.** Schema is published. Mitigation: model as versioned Go structs; weekly CI doc-diff against committed reference snapshot flags new fields rather than silently dropping them.
+2. **Each adapter's surface evolves** (this brainstorm caught two outdated plans). Mitigation: translation table is one grep-able file; each adapter has a version-stamped staleness comment that tests assert against.
+3. **OpenCode hooks → Claude hooks deferred.** OpenCode hooks are JS/TS plugin event subscriptions; translation requires shim generation. Hand-author shim if needed in v1; documented limit.
+4. **Cursor user-level rules** can't be opensync-managed. Project-scope only; documented limit.
+5. **age private key loss = total secrets loss.** README must call out key-backup discipline; opensync doesn't manage backup.
+6. **First apply on a populated machine** hits many `foreign-collision` cases. Mitigation: backups + recommend `apply --dry-run` first.
+7. **Concurrent agent edits mid-reconcile** — drift classifier catches on next `status`; no special-case logic; documented.
+8. **Two competing "official" implementations** of the same logical service (e.g. Slack hosted vs npm). Canonical plugin IDs include upstream owner: `slack@slackapi` vs `slack@modelcontextprotocol`. Tooling enforces uniqueness on `(id, owner)`.
+
+---
+
+## Out of scope (v1.x)
+
+- Cross-machine config sync (delegated to chezmoi).
+- Cursor user-rule filesystem management (no path exists).
+- OpenCode hook shim auto-generation (hand-author for v1).
+- LSP projection beyond Claude.
+- Permissions canonical projection (each agent has its own model).
+- Continue, Gemini CLI, Aider adapters (not on user's stack).
+- Any daemon process.


### PR DESCRIPTION
## Summary

Single PR landing both the **design spec** for agentsync and the **complete v1.0 implementation plan** (M0–M7), produced via a structured brainstorm. Replaces the three "passing-ideas" PRs (#1, #2, #3).

The product: a Go CLI that centrally manages AI coding-agent configurations across Claude Code, OpenCode, Codex CLI, and Cursor, with marketplace plugin fanout, bidirectional drift detection, project-local overlays, and age-encrypted secrets.

## What's in this PR

**Design spec** (`docs/superpowers/specs/2026-05-04-agentsync-design.md`, 511 lines)

- v1 agents: Claude Code + OpenCode (v1.0), Codex (v1.1), Cursor (v1.2)
- Mental model: chezmoi three-state (source / target / destination), bidirectional drift with reconcile UX
- Authoring: CLI-driven but vim-able TOML; comments + key order survive AST round-trip
- Drift: key-level for JSON/JSONC/TOML, file-level fallback; foreign keys reported but never blocked on
- Secrets: env + age-encrypted file (`${secret:foo.bar}` resolution)
- Plugin model: Claude marketplace.json schema as canonical; 5 source types (relative / github / url / git-subdir / npm); strict mode + `${CLAUDE_PLUGIN_ROOT}` resolution; per-component translation table (✓ native / ◐ projected / ✗ skipped)
- Safety: two-phase atomic write, file lock, `AGENTSYNC_TARGET_ROOT` test seam, first-apply backups, manifest sha pinning — all v1.0, not deferred

**v1.0 implementation plan** (`docs/superpowers/plans/`, 9 files, 8492 lines)

| Plan | Lines | Scope |
|---|---|---|
| `v1.0-overview.md` | 193 | Milestone roadmap, conventions (TDD cycle, test framework, lint, commit format), dependency graph |
| `m0-skeleton.md` | 3119 | Module bootstrap, paths, atomic IO, lock, adapter interface, NoopAdapter, CLI: init/agent/doctor/verify/apply --dry-run |
| `m1-claude.md` | 1929 | Claude adapter (full): all 7 components, per-key JSON merge, frontmatter passthrough, render+ingest+apply round-trip |
| `m2-opencode.md` | 823 | OpenCode adapter: JSONC merge via tailscale/hujson, shared `.claude/skills/` writes, frontmatter munging, ✗ skip(warn) for hooks/LSP |
| `m3-drift.md` | 845 | 9-case 3-way classifier, file+key-level drift, status/diff/reconcile commands, bulk hotkeys, --auto-* flags |
| `m4-marketplaces.md` | 498 | All 5 plugin sources (relative/github/url/git-subdir/npm), strict mode, `${CLAUDE_PLUGIN_ROOT}` resolution, manifest sha pinning, update modes |
| `m5-project.md` | 300 | `.agentsync.toml` walk-up, overlay merge, --project flag, project-scope state |
| `m6-secrets.md` | 422 | filippo.io/age integration, `${secret:foo.bar}` resolution, secrets edit/get/set |
| `m7-polish.md` | 363 | explain/import commands, agent disable --purge, goreleaser cross-platform, brew/scoop/chocolatey/AUR/deb/rpm, README expansion |

## Verified during the brainstorm

The spec corrects several outdated claims from PRs #1 and #2 by re-verifying current vendor docs:

- Codex CLI now supports skills, subagents, hooks (PRs claimed it was limited to MCP + memory)
- OpenCode reads `.claude/skills/` and `.agents/skills/` natively — skills are near-free fanout for 3/4 agents
- Cursor supports `AGENTS.md` natively and has a `hooks.json` system (PRs claimed neither)
- Claude marketplace + plugin schemas ARE published at https://code.claude.com/docs/en/plugin-marketplaces
- LSP servers are a 7th component type — missing from both prior plans

## Naming

Renamed `opensync` → `agentsync` mid-review for descriptive accuracy: tool syncs AI coding agents, rhymes with the cross-vendor `AGENTS.md` convention, and avoids the overloaded "open" prefix (open-source / OpenAI / OpenCode). Done before any code lands so the rename was one find-replace + repo rename. GitHub auto-redirects from the old `opensync` URLs.

## Supersedes

- Closes #1 (was: implementation plan, agent-centric IR)
- Closes #2 (was: implementation plan, marketplace-primacy with hybrid passthrough)
- #3 (marketplace research) stays open and will be rebased on top of this spec

## Test plan

This PR contains no executable code. Reviewers should:

- [ ] Read `docs/superpowers/specs/2026-05-04-agentsync-design.md` end-to-end
- [ ] Confirm the locked-decisions table in the spec matches understanding
- [ ] Sanity-check the 7-component translation table for Claude, OpenCode, Codex, Cursor
- [ ] Skim `docs/superpowers/plans/v1.0-overview.md` for milestone shape
- [ ] Spot-check `docs/superpowers/plans/m0-skeleton.md` (the most detailed) to confirm TDD pattern + scope match expectations
- [ ] Skim M1–M7 plan headers + "Done When" sections
- [ ] Sign off to begin implementing M0 on a follow-up branch

🤖 Generated with [Claude Code](https://claude.ai/code)