### PR TITLE
M5: project-local overlays

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
@@ -15,8 +17,9 @@ import (
 
 func newApplyCmd() *cobra.Command {
 	var (
-		dryRun bool
-		scope  string
+		dryRun      bool
+		scopeFlag   string
+		projectFlag string
 	)
 	cmd := &cobra.Command{
 		Use:   "apply",
@@ -29,16 +32,29 @@ func newApplyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Discover project marker (walk-up from cwd, or explicit --project).
+			sc, projectRoot, err := resolveProjectScope(scopeFlag, projectFlag, c)
+			if err != nil {
+				return err
+			}
+
+			// When project scope active, merge overlay into canonical.
+			if sc == adapter.ScopeProject && projectRoot != "" {
+				marker, merr := project.Discover(projectRoot)
+				if merr != nil {
+					return fmt.Errorf("load project marker: %w", merr)
+				}
+				if marker != nil {
+					c = project.Merge(c, marker)
+				}
+			}
+
 			agents := []string{}
 			for name, ag := range c.Config.Agents {
 				if ag.Enabled {
 					agents = append(agents, name)
 				}
-			}
-
-			sc := adapter.ScopeUser
-			if scope == "project" {
-				sc = adapter.ScopeProject
 			}
 
 			reg := registryFactory()
@@ -51,7 +67,7 @@ func newApplyCmd() *cobra.Command {
 			}
 
 			if dryRun {
-				plan, err := render.Plan(c, reg, agents, sc, "", s)
+				plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
 				if err != nil {
 					return err
 				}
@@ -73,7 +89,7 @@ func newApplyCmd() *cobra.Command {
 			}
 
 			// Real apply: render + write
-			plan, err := render.Plan(c, reg, agents, sc, "", s)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
 			if err != nil {
 				return err
 			}
@@ -83,7 +99,7 @@ func newApplyCmd() *cobra.Command {
 
 			// Update state with post-apply hashes.
 			for name, res := range plan.PerAgent {
-				if err := render.RecordOpsState(s, name, sc, "", res.Ops); err != nil {
+				if err := render.RecordOpsState(s, name, sc, projectRoot, res.Ops); err != nil {
 					return err
 				}
 			}
@@ -102,6 +118,54 @@ func newApplyCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "compute plan without writing destinations")
-	cmd.Flags().StringVar(&scope, "scope", "user", "user | project")
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	return cmd
+}
+
+// resolveProjectScope determines the effective scope and project root.
+// Priority: --project flag > --scope flag > cwd walk-up auto-detect.
+func resolveProjectScope(scopeFlag, projectFlag string, _ source.Canonical) (adapter.Scope, string, error) {
+	// Explicit --project always implies project scope.
+	if projectFlag != "" {
+		abs, err := filepath.Abs(projectFlag)
+		if err != nil {
+			return adapter.ScopeUser, "", fmt.Errorf("resolve --project path: %w", err)
+		}
+		return adapter.ScopeProject, abs, nil
+	}
+
+	// --scope project without --project: walk up from cwd to find marker.
+	if scopeFlag == "project" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return adapter.ScopeUser, "", fmt.Errorf("getwd: %w", err)
+		}
+		marker, err := project.Discover(cwd)
+		if err != nil {
+			return adapter.ScopeUser, "", fmt.Errorf("discover project marker: %w", err)
+		}
+		if marker != nil {
+			return adapter.ScopeProject, marker.Root, nil
+		}
+		// No marker found; fall through to user scope.
+		return adapter.ScopeUser, "", nil
+	}
+
+	// Default / --scope user: auto-detect from cwd.
+	if scopeFlag == "" || scopeFlag == "user" {
+		// Auto-detect: if cwd has a marker, default to project scope.
+		if scopeFlag == "" {
+			cwd, err := os.Getwd()
+			if err == nil {
+				marker, merr := project.Discover(cwd)
+				if merr == nil && marker != nil {
+					return adapter.ScopeProject, marker.Root, nil
+				}
+			}
+		}
+		return adapter.ScopeUser, "", nil
+	}
+
+	return adapter.ScopeUser, "", fmt.Errorf("unknown --scope value %q; want user or project", scopeFlag)
 }

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -12,13 +12,18 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
 func newDiffCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		scopeFlag   string
+		projectFlag string
+	)
+	cmd := &cobra.Command{
 		Use:   "diff [<path>]",
 		Short: "print unified diff between source-rendered content and destination",
 		Args:  cobra.MaximumNArgs(1),
@@ -37,6 +42,22 @@ func newDiffCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			sc, projectRoot, err := resolveProjectScope(scopeFlag, projectFlag, c)
+			if err != nil {
+				return err
+			}
+
+			if sc == adapter.ScopeProject && projectRoot != "" {
+				marker, merr := project.Discover(projectRoot)
+				if merr != nil {
+					return fmt.Errorf("load project marker: %w", merr)
+				}
+				if marker != nil {
+					c = project.Merge(c, marker)
+				}
+			}
+
 			statePath := filepath.Join(home, ".state", "targets.json")
 			s, err := state.Load(statePath)
 			if err != nil {
@@ -49,7 +70,7 @@ func newDiffCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, adapter.ScopeUser, "", s)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
 			if err != nil {
 				return err
 			}
@@ -121,6 +142,9 @@ func newDiffCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	return cmd
 }
 
 func marshalPretty(v any) string {

--- a/internal/cli/m5_integration_test.go
+++ b/internal/cli/m5_integration_test.go
@@ -1,0 +1,209 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIntegration_M5_ProjectOverlay exercises the full M5 project-local overlay
+// pipeline end-to-end:
+//   - init + agent add claude (user scope)
+//   - .agentsync.toml with [[mcp]] in a project dir
+//   - chdir into project dir
+//   - apply (auto-detects project scope via walk-up)
+//   - verify <project>/.claude/settings.json contains proj-mcp
+func TestIntegration_M5_ProjectOverlay(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmpHome,
+	}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a .agentsync.toml with a flat [[mcp]] entry.
+	markerContent := `agents = ["claude"]
+
+[[mcp]]
+id      = "proj-mcp"
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@proj/mcp"]
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync.toml"), []byte(markerContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// chdir into project dir so auto-detect kicks in.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// apply — no --scope flag; auto-detect should find .agentsync.toml and use project scope.
+	out, err := runCLI(t, env, "apply")
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Verify project-scope settings.json was written under <projectDir>/.claude/
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	body, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read project settings.json: %v", err)
+	}
+	if !strings.Contains(string(body), "proj-mcp") {
+		t.Fatalf("project-scope MCP not landed in settings.json: %s", body)
+	}
+}
+
+// TestIntegration_M5_ExplicitProjectFlag verifies --project <path> works
+// without needing to chdir.
+func TestIntegration_M5_ExplicitProjectFlag(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmpHome,
+	}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	markerContent := `agents = ["claude"]
+
+[[mcp]]
+id      = "api-mcp"
+type    = "stdio"
+command = "node"
+args    = ["server.js"]
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync.toml"), []byte(markerContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use --project flag to avoid needing to chdir.
+	out, err := runCLI(t, env, "apply", "--project", projectDir)
+	if err != nil {
+		t.Fatalf("apply --project: %v\n%s", err, out)
+	}
+
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	body, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read project settings.json: %v", err)
+	}
+	if !strings.Contains(string(body), "api-mcp") {
+		t.Fatalf("project MCP (api-mcp) not in settings.json: %s", body)
+	}
+}
+
+// TestIntegration_M5_AgentsFilter verifies that marker agents = ["claude"]
+// filters out other agents, so only claude's project-scope files are written.
+func TestIntegration_M5_AgentsFilter(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmpHome,
+	}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Marker restricts to claude only.
+	markerContent := `agents = ["claude"]
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync.toml"), []byte(markerContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "apply", "--project", projectDir)
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Claude's project settings should exist.
+	claudeSettings := filepath.Join(projectDir, ".claude", "settings.json")
+	if _, err := os.Stat(claudeSettings); err != nil {
+		t.Logf("claude settings.json not found (may be OK if no MCP servers): %v", err)
+	}
+
+	// opencode's project config should NOT exist at <projectDir>/.opencode/
+	opencodeConfig := filepath.Join(projectDir, ".opencode")
+	if _, err := os.Stat(opencodeConfig); err == nil {
+		t.Fatalf("opencode project config unexpectedly written at %s", opencodeConfig)
+	}
+
+	// apply should mention only claude.
+	if strings.Contains(out, "opencode") {
+		t.Logf("note: opencode appeared in output; agents filter working if no MCP written: %s", out)
+	}
+}
+
+// TestIntegration_M5_MemoryImport verifies that memory.import appends content
+// to the rendered memory file.
+func TestIntegration_M5_MemoryImport(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmpHome,
+	}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an AGENTS.md in the project dir.
+	agentsMD := "# Project Rules\nAlways write tests first."
+	if err := os.WriteFile(filepath.Join(projectDir, "AGENTS.md"), []byte(agentsMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	markerContent := `agents = ["claude"]
+
+[memory]
+import = ["AGENTS.md"]
+`
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync.toml"), []byte(markerContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "apply", "--project", projectDir)
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Claude project-scope memory lands at <projectDir>/CLAUDE.md.
+	claudeMD := filepath.Join(projectDir, "CLAUDE.md")
+	body, err := os.ReadFile(claudeMD)
+	if err != nil {
+		t.Fatalf("read project CLAUDE.md: %v", err)
+	}
+	if !strings.Contains(string(body), "Project Rules") {
+		t.Fatalf("imported memory content not in CLAUDE.md: %s", body)
+	}
+}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
@@ -22,37 +23,60 @@ import (
 
 // reconcileItem describes one classified item in the reconcile pass.
 type reconcileItem struct {
-	agentName string
-	op        adapter.FileOp
-	ptr       string // non-empty for key-level items
-	cls       drift.Class
-	hsrc      string
-	happlied  string
-	hdest     string
+	agentName   string
+	op          adapter.FileOp
+	ptr         string // non-empty for key-level items
+	cls         drift.Class
+	hsrc        string
+	happlied    string
+	hdest       string
+	scope       adapter.Scope
+	projectRoot string
 }
 
 func newReconcileCmd() *cobra.Command {
-	var autoWB, autoOR, autoSafe bool
+	var (
+		autoWB, autoOR, autoSafe bool
+		scopeFlag, projectFlag   string
+	)
 	cmd := &cobra.Command{
 		Use:   "reconcile",
 		Short: "interactively resolve drift",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return reconcileRun(cmd, cmd.InOrStdin(), autoWB, autoOR, autoSafe)
+			return reconcileRun(cmd, cmd.InOrStdin(), autoWB, autoOR, autoSafe, scopeFlag, projectFlag)
 		},
 	}
 	cmd.Flags().BoolVar(&autoWB, "auto-writeback", false, "auto-resolve drift by writing dest back to source")
 	cmd.Flags().BoolVar(&autoOR, "auto-override", false, "auto-resolve drift by re-applying source to dest")
 	cmd.Flags().BoolVar(&autoSafe, "auto-safe", false, "auto-resolve only converged/pending/new (no-op)")
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	return cmd
 }
 
-func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool) error {
+func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool, scopeFlag, projectFlag string) error {
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	c, err := source.Load(afero.NewOsFs(), home)
 	if err != nil {
 		return err
 	}
+
+	sc, projectRoot, err := resolveProjectScope(scopeFlag, projectFlag, c)
+	if err != nil {
+		return err
+	}
+
+	if sc == adapter.ScopeProject && projectRoot != "" {
+		marker, merr := project.Discover(projectRoot)
+		if merr != nil {
+			return fmt.Errorf("load project marker: %w", merr)
+		}
+		if marker != nil {
+			c = project.Merge(c, marker)
+		}
+	}
+
 	statePath := filepath.Join(home, ".state", "targets.json")
 	s, err := state.Load(statePath)
 	if err != nil {
@@ -65,13 +89,13 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			agents = append(agents, name)
 		}
 	}
-	plan, err := render.Plan(c, reg, agents, adapter.ScopeUser, "", s)
+	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
 	if err != nil {
 		return err
 	}
 
 	// Collect all items in order.
-	items := collectItems(plan, reg, s)
+	items := collectItems(plan, reg, s, sc, projectRoot)
 
 	w := cmd.OutOrStdout()
 
@@ -183,7 +207,7 @@ done:
 		}
 		// Update state.
 		for name, res := range plan.PerAgent {
-			if err := render.RecordOpsState(s, name, adapter.ScopeUser, "", res.Ops); err != nil {
+			if err := render.RecordOpsState(s, name, sc, projectRoot, res.Ops); err != nil {
 				return err
 			}
 		}
@@ -197,7 +221,7 @@ done:
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.
-func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets) []reconcileItem {
+func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot string) []reconcileItem {
 	var items []reconcileItem
 	for _, name := range reg.Names() {
 		res, ok := plan.PerAgent[name]
@@ -216,17 +240,19 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				final := readJSONFile(op.Path)
 				for _, ptr := range render.CollectPointers(ours, "") {
 					hsrc := hashAnyValue(getPointerValue(ours, ptr))
-					happlied := s.Keys[fmt.Sprintf("%s:user::%s:%s", name, op.Path, ptr)].SHA256
+					happlied := s.Keys[stateKeyKey(name, sc, projectRoot, op.Path, ptr)].SHA256
 					hdest := hashAnyValue(getPointerValue(final, ptr))
 					cls := drift.Classify(hsrc, happlied, hdest)
 					items = append(items, reconcileItem{
-						agentName: name,
-						op:        op,
-						ptr:       ptr,
-						cls:       cls,
-						hsrc:      hsrc,
-						happlied:  happlied,
-						hdest:     hdest,
+						agentName:   name,
+						op:          op,
+						ptr:         ptr,
+						cls:         cls,
+						hsrc:        hsrc,
+						happlied:    happlied,
+						hdest:       hdest,
+						scope:       sc,
+						projectRoot: projectRoot,
 					})
 				}
 			} else {
@@ -235,16 +261,18 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				}
 				seen[op.Path] = true
 				hsrc := hashContent(op.Content)
-				happlied := s.Files[fmt.Sprintf("%s:user::%s", name, op.Path)].SHA256
+				happlied := s.Files[stateFileKey(name, sc, projectRoot, op.Path)].SHA256
 				hdest := hashFile(op.Path)
 				cls := drift.Classify(hsrc, happlied, hdest)
 				items = append(items, reconcileItem{
-					agentName: name,
-					op:        op,
-					cls:       cls,
-					hsrc:      hsrc,
-					happlied:  happlied,
-					hdest:     hdest,
+					agentName:   name,
+					op:          op,
+					cls:         cls,
+					hsrc:        hsrc,
+					happlied:    happlied,
+					hdest:       hdest,
+					scope:       sc,
+					projectRoot: projectRoot,
 				})
 			}
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,13 +14,18 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		scopeFlag   string
+		projectFlag string
+	)
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "report drift across registered agents",
 		Args:  cobra.NoArgs,
@@ -30,6 +35,22 @@ func newStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			sc, projectRoot, err := resolveProjectScope(scopeFlag, projectFlag, c)
+			if err != nil {
+				return err
+			}
+
+			if sc == adapter.ScopeProject && projectRoot != "" {
+				marker, merr := project.Discover(projectRoot)
+				if merr != nil {
+					return fmt.Errorf("load project marker: %w", merr)
+				}
+				if marker != nil {
+					c = project.Merge(c, marker)
+				}
+			}
+
 			statePath := filepath.Join(home, ".state", "targets.json")
 			s, err := state.Load(statePath)
 			if err != nil {
@@ -42,7 +63,7 @@ func newStatusCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, adapter.ScopeUser, "", s)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
 			if err != nil {
 				return err
 			}
@@ -65,7 +86,7 @@ func newStatusCmd() *cobra.Command {
 					}
 					seen[op.Path] = true
 					hsrc := hashContent(op.Content)
-					happlied := s.Files[fmt.Sprintf("%s:user::%s", name, op.Path)].SHA256
+					happlied := s.Files[stateFileKey(name, sc, projectRoot, op.Path)].SHA256
 					hdest := hashFile(op.Path)
 					cls := drift.Classify(hsrc, happlied, hdest)
 					fmt.Fprintf(w, "  %-20s %s\n", cls, op.Path)
@@ -80,7 +101,7 @@ func newStatusCmd() *cobra.Command {
 					final := readJSONFile(op.Path)
 					for _, ptr := range render.CollectPointers(ours, "") {
 						hsrc := hashAnyValue(getPointerValue(ours, ptr))
-						happlied := s.Keys[fmt.Sprintf("%s:user::%s:%s", name, op.Path, ptr)].SHA256
+						happlied := s.Keys[stateKeyKey(name, sc, projectRoot, op.Path, ptr)].SHA256
 						hdest := hashAnyValue(getPointerValue(final, ptr))
 						cls := drift.Classify(hsrc, happlied, hdest)
 						fmt.Fprintf(w, "  %-20s %s#%s\n", cls, op.Path, ptr)
@@ -90,6 +111,21 @@ func newStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	return cmd
+}
+
+// stateFileKey builds the state Files map key matching render.RecordOpsState.
+// Format: "agent:scope:project:path" (project is "" for user scope).
+func stateFileKey(agent string, sc adapter.Scope, projectRoot, path string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", agent, sc.String(), projectRoot, path)
+}
+
+// stateKeyKey builds the state Keys map key matching render.RecordOpsState.
+// Format: "agent:scope:project:path:ptr".
+func stateKeyKey(agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s", agent, sc.String(), projectRoot, path, ptr)
 }
 
 func hashContent(b []byte) string {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,175 @@
+// Package project handles project-scope overlays: .agentsync.toml at a repo
+// root, walk-up discovery from cwd, and merge against base canonical model.
+package project
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+const MarkerFile = ".agentsync.toml"
+
+// Marker is the parsed contents of a project's .agentsync.toml.
+type Marker struct {
+	Path    string                // absolute path of the marker file
+	Root    string                // dirname of Path
+	Agents  []string              `toml:"agents,omitempty"`
+	MCP     []ProjectMCP          `toml:"mcp,omitempty"` // [[mcp]] array-of-tables
+	Plugins ProjectPluginsSection `toml:"plugins,omitempty"`
+	Memory  ProjectMemorySection  `toml:"memory,omitempty"`
+}
+
+// ProjectMCP holds an MCP server entry from the marker file.
+// The marker uses a flat [[mcp]] array-of-tables where id, type, command,
+// args, url, headers, env and agents fields are all at the top level.
+type ProjectMCP struct {
+	ID      string            `toml:"id"`
+	Type    string            `toml:"type,omitempty"`
+	Command string            `toml:"command,omitempty"`
+	Args    []string          `toml:"args,omitempty"`
+	URL     string            `toml:"url,omitempty"`
+	Headers map[string]string `toml:"headers,omitempty"`
+	Env     map[string]string `toml:"env,omitempty"`
+	Agents  []string          `toml:"agents,omitempty"`
+	Enabled *bool             `toml:"enabled,omitempty"`
+}
+
+// toMCPServer converts a ProjectMCP to a source.MCPServer.
+func (p ProjectMCP) toMCPServer() source.MCPServer {
+	return source.MCPServer{
+		ID: p.ID,
+		Server: source.MCPServerSpec{
+			Type:    p.Type,
+			Command: p.Command,
+			Args:    p.Args,
+			URL:     p.URL,
+			Headers: p.Headers,
+			Env:     p.Env,
+			Agents:  p.Agents,
+			Enabled: p.Enabled,
+		},
+	}
+}
+
+type ProjectPluginsSection struct {
+	Disabled []string `toml:"disabled,omitempty"`
+	Enabled  []string `toml:"enabled,omitempty"`
+}
+
+type ProjectMemorySection struct {
+	Import []string `toml:"import,omitempty"` // project-relative paths
+}
+
+// Discover walks up from cwd looking for MarkerFile. Returns (nil, nil) if
+// not found. Returns error on read or parse failure.
+func Discover(cwd string) (*Marker, error) {
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, MarkerFile)
+		if data, err := os.ReadFile(candidate); err == nil {
+			var m Marker
+			if err := toml.Unmarshal(data, &m); err != nil {
+				return nil, err
+			}
+			m.Path = candidate
+			m.Root = dir
+			return &m, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, nil
+		}
+		dir = parent
+	}
+}
+
+// Merge applies the project marker on top of base. Returns a new Canonical.
+//   - Agents allowlist on Marker filters base.Config.Agents to only those
+//     listed (intersect with enabled). Empty list = use all enabled.
+//   - MCP entries on Marker are appended; collisions on .ID replace base.
+//   - Plugins.Disabled removes plugins from base by ID.
+//   - Plugins.Enabled is reserved for v1.x (currently a no-op since plugins
+//     are enabled-by-default).
+//   - Memory.Import paths are read relative to Marker.Root and appended to
+//     the base memory body (separated by a single blank line).
+func Merge(base source.Canonical, m *Marker) source.Canonical {
+	if m == nil {
+		return base
+	}
+	out := base // shallow copy is OK; we replace slices below
+
+	// Agents filter: intersect base agents with marker allowlist.
+	if len(m.Agents) > 0 {
+		allow := map[string]bool{}
+		for _, a := range m.Agents {
+			allow[a] = true
+		}
+		filtered := map[string]source.Agent{}
+		for name, ag := range base.Config.Agents {
+			if allow[name] {
+				filtered[name] = ag
+			}
+		}
+		out.Config.Agents = filtered
+	}
+
+	// MCP overlay: project entries replace base entries with same ID, or append.
+	if len(m.MCP) > 0 {
+		// Copy the base slice so we don't mutate it.
+		merged := make([]source.MCPServer, len(out.MCPServers))
+		copy(merged, out.MCPServers)
+		byID := map[string]int{}
+		for i, srv := range merged {
+			byID[srv.ID] = i
+		}
+		for _, entry := range m.MCP {
+			srv := entry.toMCPServer()
+			if idx, exists := byID[srv.ID]; exists {
+				merged[idx] = srv
+			} else {
+				byID[srv.ID] = len(merged)
+				merged = append(merged, srv)
+			}
+		}
+		out.MCPServers = merged
+	}
+
+	// Plugins.Disabled: remove plugins from base by ID.
+	if len(m.Plugins.Disabled) > 0 {
+		block := map[string]bool{}
+		for _, id := range m.Plugins.Disabled {
+			block[id] = true
+		}
+		var kept []source.Plugin
+		for _, p := range out.Plugins {
+			if !block[p.ID] {
+				kept = append(kept, p)
+			}
+		}
+		out.Plugins = kept
+	}
+
+	// Memory imports: read project-relative files and append.
+	if len(m.Memory.Import) > 0 {
+		body := out.Memory.Body
+		for _, rel := range m.Memory.Import {
+			data, err := os.ReadFile(filepath.Join(m.Root, rel))
+			if err != nil {
+				continue
+			}
+			if body != "" && !strings.HasSuffix(body, "\n") {
+				body += "\n"
+			}
+			body += "\n" + string(data)
+		}
+		out.Memory.Body = body
+	}
+	return out
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,298 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/project"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// ─── Task 1: Discover ────────────────────────────────────────────────────────
+
+func TestDiscover_FoundAtRoot(t *testing.T) {
+	tmp := t.TempDir()
+	deep := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".agentsync.toml"), []byte(`agents = ["claude"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := project.Discover(deep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil {
+		t.Fatal("expected discovery")
+	}
+	if len(m.Agents) != 1 || m.Agents[0] != "claude" {
+		t.Fatalf("agents = %v", m.Agents)
+	}
+	if m.Root != tmp {
+		t.Fatalf("root = %q, want %q", m.Root, tmp)
+	}
+}
+
+func TestDiscover_FoundInCwd(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, ".agentsync.toml"), []byte(`agents = ["codex"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := project.Discover(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil {
+		t.Fatal("expected discovery in cwd")
+	}
+	if len(m.Agents) != 1 || m.Agents[0] != "codex" {
+		t.Fatalf("agents = %v", m.Agents)
+	}
+}
+
+func TestDiscover_NotFound(t *testing.T) {
+	m, err := project.Discover(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m != nil {
+		t.Fatalf("expected nil marker, got %+v", m)
+	}
+}
+
+func TestDiscover_ParseError(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, ".agentsync.toml"), []byte(`not valid toml ][`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := project.Discover(tmp)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestDiscover_FirstMatchWins(t *testing.T) {
+	// parent has marker with agents=["claude"], child has marker with agents=["codex"]
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, ".agentsync.toml"), []byte(`agents = ["claude"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, ".agentsync.toml"), []byte(`agents = ["codex"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := project.Discover(child)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil || len(m.Agents) == 0 || m.Agents[0] != "codex" {
+		t.Fatalf("expected child marker to win; agents = %v", m.Agents)
+	}
+}
+
+// ─── Task 2: Merge ───────────────────────────────────────────────────────────
+
+func TestMerge_NilMarker(t *testing.T) {
+	base := source.Canonical{
+		Config: source.Config{
+			Agents: map[string]source.Agent{"claude": {Enabled: true}},
+		},
+	}
+	out := project.Merge(base, nil)
+	if len(out.Config.Agents) != 1 {
+		t.Fatalf("nil merge should return base unchanged; got %+v", out.Config.Agents)
+	}
+}
+
+func TestMerge_AgentsFilter(t *testing.T) {
+	base := source.Canonical{
+		Config: source.Config{
+			Agents: map[string]source.Agent{
+				"claude":  {Enabled: true},
+				"codex":   {Enabled: true},
+				"opencode": {Enabled: true},
+			},
+		},
+	}
+	m := &project.Marker{
+		Agents: []string{"claude"},
+	}
+	out := project.Merge(base, m)
+	if len(out.Config.Agents) != 1 {
+		t.Fatalf("expected 1 agent after filter, got %d: %v", len(out.Config.Agents), out.Config.Agents)
+	}
+	if _, ok := out.Config.Agents["claude"]; !ok {
+		t.Fatal("expected claude to be retained")
+	}
+}
+
+func TestMerge_AgentsFilter_EmptyAllowlist(t *testing.T) {
+	// Empty Agents allowlist = use all enabled (no filtering)
+	base := source.Canonical{
+		Config: source.Config{
+			Agents: map[string]source.Agent{
+				"claude": {Enabled: true},
+				"codex":  {Enabled: true},
+			},
+		},
+	}
+	m := &project.Marker{
+		Agents: nil,
+	}
+	out := project.Merge(base, m)
+	if len(out.Config.Agents) != 2 {
+		t.Fatalf("empty allowlist should retain all agents; got %d", len(out.Config.Agents))
+	}
+}
+
+func TestMerge_MCPOverlay_Append(t *testing.T) {
+	base := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "existing", Server: source.MCPServerSpec{Type: "stdio", Command: "echo"}},
+		},
+	}
+	m := &project.Marker{
+		MCP: []project.ProjectMCP{
+			{ID: "proj-mcp", Type: "stdio", Command: "npx", Args: []string{"-y", "@proj/mcp"}},
+		},
+	}
+	out := project.Merge(base, m)
+	if len(out.MCPServers) != 2 {
+		t.Fatalf("expected 2 MCP servers after append, got %d", len(out.MCPServers))
+	}
+	found := false
+	for _, s := range out.MCPServers {
+		if s.ID == "proj-mcp" {
+			found = true
+			if s.Server.Command != "npx" {
+				t.Fatalf("proj-mcp command = %q", s.Server.Command)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("proj-mcp not found in merged MCPServers")
+	}
+}
+
+func TestMerge_MCPOverlay_Replace(t *testing.T) {
+	base := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "existing", Server: source.MCPServerSpec{Type: "stdio", Command: "old-cmd"}},
+		},
+	}
+	m := &project.Marker{
+		MCP: []project.ProjectMCP{
+			{ID: "existing", Type: "stdio", Command: "new-cmd"},
+		},
+	}
+	out := project.Merge(base, m)
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server after replace, got %d", len(out.MCPServers))
+	}
+	if out.MCPServers[0].Server.Command != "new-cmd" {
+		t.Fatalf("expected new-cmd, got %q", out.MCPServers[0].Server.Command)
+	}
+}
+
+func TestMerge_PluginsDisabled(t *testing.T) {
+	base := source.Canonical{
+		Plugins: []source.Plugin{
+			{ID: "screenshot"},
+			{ID: "deploy"},
+			{ID: "lint"},
+		},
+	}
+	m := &project.Marker{
+		Plugins: project.ProjectPluginsSection{
+			Disabled: []string{"screenshot", "deploy"},
+		},
+	}
+	out := project.Merge(base, m)
+	if len(out.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin after disable, got %d: %v", len(out.Plugins), out.Plugins)
+	}
+	if out.Plugins[0].ID != "lint" {
+		t.Fatalf("expected lint to remain; got %q", out.Plugins[0].ID)
+	}
+}
+
+func TestMerge_MemoryImport(t *testing.T) {
+	tmp := t.TempDir()
+	agentsFile := filepath.Join(tmp, "AGENTS.md")
+	if err := os.WriteFile(agentsFile, []byte("# Project Agents\nDo stuff."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := source.Canonical{
+		Memory: source.Memory{Body: "# Base memory"},
+	}
+	m := &project.Marker{
+		Root: tmp,
+		Memory: project.ProjectMemorySection{
+			Import: []string{"AGENTS.md"},
+		},
+	}
+	out := project.Merge(base, m)
+	if out.Memory.Body == base.Memory.Body {
+		t.Fatal("memory body should have been extended")
+	}
+	if len(out.Memory.Body) <= len(base.Memory.Body) {
+		t.Fatalf("memory body not extended: %q", out.Memory.Body)
+	}
+	if !contains(out.Memory.Body, "Project Agents") {
+		t.Fatalf("imported content not in memory body: %q", out.Memory.Body)
+	}
+}
+
+func TestMerge_MemoryImport_MissingFileSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	base := source.Canonical{
+		Memory: source.Memory{Body: "# Base"},
+	}
+	m := &project.Marker{
+		Root: tmp,
+		Memory: project.ProjectMemorySection{
+			Import: []string{"nonexistent.md"},
+		},
+	}
+	out := project.Merge(base, m)
+	// Missing file is silently skipped; body unchanged.
+	if out.Memory.Body != base.Memory.Body {
+		t.Fatalf("missing import should be skipped; body = %q", out.Memory.Body)
+	}
+}
+
+func TestMerge_DoesNotMutateBase(t *testing.T) {
+	base := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "existing", Server: source.MCPServerSpec{Type: "stdio", Command: "cmd"}},
+		},
+	}
+	originalLen := len(base.MCPServers)
+	m := &project.Marker{
+		MCP: []project.ProjectMCP{
+			{ID: "new-srv", Type: "stdio", Command: "new"},
+		},
+	}
+	_ = project.Merge(base, m)
+	if len(base.MCPServers) != originalLen {
+		t.Fatalf("Merge mutated base MCPServers slice")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		})())
+}


### PR DESCRIPTION
## Summary
- `.agentsync.toml` project marker with walk-up resolution from cwd (`internal/project` package).
- Overlay merge: project MCPs land in project scope, project-disabled plugins filtered, memory imports appended, agents allowlist filters base canonical.
- `--project <path>` and `--scope` flags wired into `apply`, `status`, `diff`, `reconcile`. Auto-detect from cwd when no flag given.
- Stacked on #9 (M4).

## Test plan
- [x] `go test -race ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] M5 demo: project-local MCP (`company-api`) lands in `<project>/.claude/settings.json`
- [x] `TestIntegration_M5_ProjectOverlay` — cwd walk-up auto-detect
- [x] `TestIntegration_M5_ExplicitProjectFlag` — `--project <path>` without chdir
- [x] `TestIntegration_M5_AgentsFilter` — marker agents allowlist filters adapters
- [x] `TestIntegration_M5_MemoryImport` — memory.import appends to CLAUDE.md

Plan: docs/superpowers/plans/2026-05-04-agentsync-m5-project.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)