### PR TITLE
feat(marketplace): real plugin component projection (skills/subagents/commands)

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -128,25 +128,29 @@ artifact distributed publicly.
 Carried over from [issue #13 §4](https://github.com/spxrogers/agentsync/issues/13#issuecomment-4375725634)
 because the M0–M7 + PR #14 stack does not address it.
 
-- [ ] **Plugin component projection stub** —
-      `internal/marketplace/projection.go:93–103` records
-      `Skills` / `Commands` / `Subagents` from a plugin's manifest as **stub
-      entries with only `Name` populated** (the path), no frontmatter or body.
-      The Claude render path expects fully-loaded components. The M4
-      integration test and the BDD `06_marketplace_plugins.feature` use
-      synthetic fixtures that may not exercise this path.
+- [x] **Plugin component projection stub** — FIXED in PR #16
+      (`claude/plugin-projection-fix`).
 
-      **Verify before public:** install a real Claude marketplace plugin
-      (e.g. `atlassian@anthropic`) end-to-end and inspect the rendered output
-      at `~/.claude/skills/<name>/SKILL.md`,
-      `~/.claude/agents/<name>.md`, `~/.claude/commands/<name>.md`. If the
-      destination files are empty or missing body, the projector needs to
-      actually load the markdown content (parse frontmatter + read body) for
-      these three component types.
+      `internal/marketplace/projection.go` previously recorded
+      `Skills` / `Commands` / `Subagents` from a plugin's manifest as stub
+      entries with only the raw path in `Name`. The projection layer now fully
+      loads each component: resolves the path, reads the markdown file via the
+      injected `readFile` function, calls `source.ParseFrontmatter`, and
+      populates `Name` (from frontmatter `name:` key or basename fallback),
+      `Frontmatter`, and `Body`. Missing files are skipped with a warning;
+      malformed frontmatter is a hard error.
 
-      This is the only item below "deliberate v1.0 cut" that could meaningfully
-      surprise a public user — worth either fixing or pinning a "known limit"
-      banner on `agentsync plugin install` for these component types.
+      The fix applies to both `applyManifest` (strict plugin.json path) and
+      `applyEntryOverrides` / `applyEntryFull` (non-strict PluginEntry path).
+
+      - Unit tests in `internal/marketplace/projection_test.go` cover happy
+        path (directory-based skills, inline frontmatter name, filename
+        fallback), missing-file skip, malformed-frontmatter error, and I/O
+        error propagation.
+      - Live integration test in `projection_live_test.go` (build tag `live`,
+        opt-in via `AGENTSYNC_LIVE_PLUGIN_TEST=1`) fetches `obra/superpowers`
+        via `GitFetcher` and asserts at least 5 skills land with non-empty
+        Body and frontmatter.
 
 ## §6 — Comment preservation (documented v1.x deferral)
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 ## Testing
 
 Every `just test*` recipe runs **inside a hermetic container** (podman first,
-docker fallback). The repo is mounted read-only, the network is off, and
-every test's `HOME` is a fresh tmpdir — the suite cannot touch your real
-`~/.claude.json`, `~/.config/opencode/`, or `~/.agentsync/`.
+docker fallback) — except the two explicit on-host opt-ins (`test-fast` and
+`test-live`) called out below. The repo is mounted read-only, the network
+is off, and every test's `HOME` is a fresh tmpdir — the suite cannot touch
+your real `~/.claude.json`, `~/.config/opencode/`, or `~/.agentsync/`.
 
 | Layer                                       | Question it answers                          | Command             |
 | ------------------------------------------- | -------------------------------------------- | ------------------- |
@@ -84,6 +85,12 @@ For fast in-place iteration without spinning up the container, `just test-fast`
 runs the unit/integration layer directly on the host. The existing tests
 already redirect `HOME` via `AGENTSYNC_TARGET_ROOT`, so they are still safe;
 the container is the release gate.
+
+`just test-live` runs the **live cohort** (build tag `live`) — currently the
+`obra/superpowers` projection check, which clones the real upstream plugin
+to verify agentsync's projector keeps working as the upstream evolves. It
+runs on host because it needs network access; it is opt-in and **NOT** part
+of `test-release`, so the release gate stays hermetic and offline.
 
 ## License
 

--- a/internal/marketplace/main_live_test.go
+++ b/internal/marketplace/main_live_test.go
@@ -1,0 +1,15 @@
+//go:build live
+
+package marketplace_test
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain for the live build tag. Live tests make real network calls and
+// are intended to run on the host (not in the hermetic container). They are
+// opt-in via AGENTSYNC_LIVE_PLUGIN_TEST=1 and the -tags=live build flag.
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/internal/marketplace/main_test.go
+++ b/internal/marketplace/main_test.go
@@ -1,3 +1,5 @@
+//go:build !live
+
 package marketplace_test
 
 import (
@@ -11,6 +13,9 @@ import (
 // touches the filesystem (tmp dirs, AGENTSYNC_TARGET_ROOT redirection,
 // state files, etc.), so we refuse to run on the host. Use `just test`
 // or `just test-release` to invoke through the hermetic container.
+//
+// The `//go:build !live` constraint means this TestMain is excluded when
+// running with -tags=live. The live test has its own main_live_test.go.
 func TestMain(m *testing.M) {
 	testenv.MustRunInContainer()
 	os.Exit(m.Run())

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -1,8 +1,15 @@
+// Package marketplace models the Claude marketplace plugin format and provides
+// the projection layer that decomposes plugin manifests into canonical source
+// model entries. Skills, commands, and subagents are fully loaded from their
+// on-disk markdown files (frontmatter + body + clean Name) via the injected
+// readFile function so that adapters downstream receive complete, render-ready
+// entries.
 package marketplace
 
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +44,8 @@ func Project(entry PluginEntry, cacheDir string) (ProjectionResult, error) {
 }
 
 // ProjectWithReader is like Project but uses a caller-supplied readFile function
-// for loading plugin.json. This enables in-memory filesystem use in tests.
+// for loading plugin.json and component markdown files. This enables in-memory
+// filesystem use in tests.
 func ProjectWithReader(entry PluginEntry, cacheDir string, readFile func(string) ([]byte, error)) (ProjectionResult, error) {
 	var pr ProjectionResult
 	strict := entry.Strict == nil || *entry.Strict
@@ -53,12 +61,18 @@ func ProjectWithReader(entry PluginEntry, cacheDir string, readFile func(string)
 			if err := json.Unmarshal(data, &manifest); err != nil {
 				return pr, fmt.Errorf("parse plugin.json: %w", err)
 			}
-			applyManifest(manifest, &pr, cacheDir)
+			if err := applyManifest(manifest, &pr, cacheDir, readFile); err != nil {
+				return pr, err
+			}
 		}
 		// Merge entry-level overrides on top of manifest components.
-		applyEntryOverrides(entry, &pr, cacheDir)
+		if err := applyEntryOverrides(entry, &pr, cacheDir, readFile); err != nil {
+			return pr, err
+		}
 	} else {
-		applyEntryFull(entry, &pr, cacheDir)
+		if err := applyEntryFull(entry, &pr, cacheDir, readFile); err != nil {
+			return pr, err
+		}
 	}
 	return pr, nil
 }
@@ -81,7 +95,7 @@ func resolvePluginRootInArgs(args []string, cacheDir string) []string {
 }
 
 // applyManifest converts a PluginManifest into ProjectionResult entries.
-func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string) {
+func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error)) error {
 	for name, raw := range manifest.MCPServers {
 		spec := parseMCPSpec(raw, cacheDir)
 		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
@@ -90,24 +104,41 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		spec := parseLSPSpec(raw, cacheDir)
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
 	}
-	// Skills and commands from manifest are markdown paths; for now we record
-	// them as stub entries so adapters can at least enumerate them.
 	for _, sk := range toStringSlice(manifest.Skills) {
-		pr.Skills = append(pr.Skills, source.Skill{Name: resolvePluginRoot(sk, cacheDir)})
+		skill, err := loadSkillEntry(resolvePluginRoot(sk, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load skill %q: %w", sk, err)
+		}
+		if skill != nil {
+			pr.Skills = append(pr.Skills, *skill)
+		}
 	}
 	for _, cmd := range toStringSlice(manifest.Commands) {
-		pr.Commands = append(pr.Commands, source.Command{Name: resolvePluginRoot(cmd, cacheDir)})
+		command, err := loadMarkdownEntry(resolvePluginRoot(cmd, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load command %q: %w", cmd, err)
+		}
+		if command != nil {
+			pr.Commands = append(pr.Commands, source.Command{Name: command.name, Frontmatter: command.fm, Body: command.body})
+		}
 	}
 	for _, ag := range toStringSlice(manifest.Agents) {
-		pr.Subagents = append(pr.Subagents, source.Subagent{Name: resolvePluginRoot(ag, cacheDir)})
+		agent, err := loadMarkdownEntry(resolvePluginRoot(ag, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load agent %q: %w", ag, err)
+		}
+		if agent != nil {
+			pr.Subagents = append(pr.Subagents, source.Subagent{Name: agent.name, Frontmatter: agent.fm, Body: agent.body})
+		}
 	}
 	// Hooks: may be a string command or an object with event+command shape.
 	applyHooks(manifest.Hooks, pr, cacheDir)
+	return nil
 }
 
 // applyEntryOverrides merges component fields from a PluginEntry into an
 // already-seeded ProjectionResult (strict mode overlay).
-func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir string) {
+func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error)) error {
 	for name, raw := range entry.MCPServers {
 		spec := parseMCPSpec(raw, cacheDir)
 		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
@@ -117,20 +148,118 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
 	}
 	for _, sk := range toStringSlice(entry.Skills) {
-		pr.Skills = append(pr.Skills, source.Skill{Name: resolvePluginRoot(sk, cacheDir)})
+		skill, err := loadSkillEntry(resolvePluginRoot(sk, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load skill %q: %w", sk, err)
+		}
+		if skill != nil {
+			pr.Skills = append(pr.Skills, *skill)
+		}
 	}
 	for _, cmd := range toStringSlice(entry.Commands) {
-		pr.Commands = append(pr.Commands, source.Command{Name: resolvePluginRoot(cmd, cacheDir)})
+		command, err := loadMarkdownEntry(resolvePluginRoot(cmd, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load command %q: %w", cmd, err)
+		}
+		if command != nil {
+			pr.Commands = append(pr.Commands, source.Command{Name: command.name, Frontmatter: command.fm, Body: command.body})
+		}
 	}
 	for _, ag := range toStringSlice(entry.Agents) {
-		pr.Subagents = append(pr.Subagents, source.Subagent{Name: resolvePluginRoot(ag, cacheDir)})
+		agent, err := loadMarkdownEntry(resolvePluginRoot(ag, cacheDir), readFile)
+		if err != nil {
+			return fmt.Errorf("load agent %q: %w", ag, err)
+		}
+		if agent != nil {
+			pr.Subagents = append(pr.Subagents, source.Subagent{Name: agent.name, Frontmatter: agent.fm, Body: agent.body})
+		}
 	}
 	applyHooks(entry.Hooks, pr, cacheDir)
+	return nil
 }
 
 // applyEntryFull applies all component fields from a non-strict PluginEntry.
-func applyEntryFull(entry PluginEntry, pr *ProjectionResult, cacheDir string) {
-	applyEntryOverrides(entry, pr, cacheDir)
+func applyEntryFull(entry PluginEntry, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error)) error {
+	return applyEntryOverrides(entry, pr, cacheDir, readFile)
+}
+
+// markdownEntry holds the parsed result of a single markdown file.
+type markdownEntry struct {
+	name string
+	fm   map[string]any
+	body string
+}
+
+// loadSkillEntry reads a skill path which may be either a directory containing
+// SKILL.md or a SKILL.md file directly. Returns nil (no error) if the file is
+// simply missing — the caller should skip that entry with a warning.
+// Returns an error only for real I/O problems or malformed frontmatter.
+func loadSkillEntry(path string, readFile func(string) ([]byte, error)) (*source.Skill, error) {
+	// Try directory convention first: <path>/SKILL.md
+	skillPath := filepath.Join(path, "SKILL.md")
+	data, err := readFile(skillPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Try treating path itself as the file (e.g. skills/foo/SKILL.md directly).
+			data, err = readFile(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					slog.Warn("plugin skill file not found, skipping", "path", path)
+					return nil, nil
+				}
+				return nil, fmt.Errorf("read %s: %w", path, err)
+			}
+			skillPath = path
+		} else {
+			return nil, fmt.Errorf("read %s: %w", skillPath, err)
+		}
+	}
+
+	fm, body, err := source.ParseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse frontmatter in %s: %w", skillPath, err)
+	}
+
+	// Derive name: prefer frontmatter "name" key, fall back to basename of the resolved path.
+	name := ""
+	if v, ok := fm["name"].(string); ok && v != "" {
+		name = v
+	}
+	if name == "" {
+		name = filepath.Base(path)
+	}
+
+	return &source.Skill{Name: name, Frontmatter: fm, Body: body}, nil
+}
+
+// loadMarkdownEntry reads a markdown file at path. Returns nil (no error) if
+// the file is simply missing — the caller should skip that entry with a
+// warning. Returns an error for I/O failures or malformed frontmatter.
+func loadMarkdownEntry(path string, readFile func(string) ([]byte, error)) (*markdownEntry, error) {
+	data, err := readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("plugin component file not found, skipping", "path", path)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	fm, body, err := source.ParseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse frontmatter in %s: %w", path, err)
+	}
+
+	// Derive name: prefer frontmatter "name" key, fall back to basename without .md.
+	name := ""
+	if v, ok := fm["name"].(string); ok && v != "" {
+		name = v
+	}
+	if name == "" {
+		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+
+	return &markdownEntry{name: name, fm: fm, body: body}, nil
 }
 
 // applyHooks interprets the hooks field (string | []string | map) and appends

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -87,8 +87,31 @@ func projectWithFuncs(entry PluginEntry, cacheDir string, readFile func(string) 
 }
 
 // resolvePluginRoot replaces the ${CLAUDE_PLUGIN_ROOT} placeholder with cacheDir.
+// Used for command/arg/url substitution where we want only env-style expansion,
+// not filesystem path joining.
 func resolvePluginRoot(s, cacheDir string) string {
 	return strings.ReplaceAll(s, "${CLAUDE_PLUGIN_ROOT}", cacheDir)
+}
+
+// resolveComponentPath resolves a manifest-listed component path (skill,
+// subagent, command) against cacheDir. Resolution order:
+//  1. ${CLAUDE_PLUGIN_ROOT} substitution if present (the literal placeholder
+//     wins; result is treated as already-rooted).
+//  2. Absolute paths returned as-is.
+//  3. Relative paths joined to cacheDir.
+//
+// This separates "make a command portable" semantics (resolvePluginRoot) from
+// "find a file inside the plugin cache" semantics (this function), which the
+// Claude marketplace plugin convention conflates: manifest entries like
+// "./skills/foo" are relative to the plugin root, not the process cwd.
+func resolveComponentPath(s, cacheDir string) string {
+	if strings.Contains(s, "${CLAUDE_PLUGIN_ROOT}") {
+		return strings.ReplaceAll(s, "${CLAUDE_PLUGIN_ROOT}", cacheDir)
+	}
+	if filepath.IsAbs(s) {
+		return s
+	}
+	return filepath.Join(cacheDir, s)
 }
 
 // resolvePluginRootInArgs applies resolvePluginRoot to each element of args.
@@ -127,7 +150,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, sk := range skillPaths {
-		skill, err := loadSkillEntry(resolvePluginRoot(sk, cacheDir), readFile)
+		skill, err := loadSkillEntry(resolveComponentPath(sk, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -137,7 +160,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	}
 
 	for _, cmd := range toStringSlice(manifest.Commands) {
-		command, err := loadMarkdownEntry(resolvePluginRoot(cmd, cacheDir), readFile)
+		command, err := loadMarkdownEntry(resolveComponentPath(cmd, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load command %q: %w", cmd, err)
 		}
@@ -146,7 +169,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, ag := range toStringSlice(manifest.Agents) {
-		agent, err := loadMarkdownEntry(resolvePluginRoot(ag, cacheDir), readFile)
+		agent, err := loadMarkdownEntry(resolveComponentPath(ag, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load agent %q: %w", ag, err)
 		}
@@ -191,7 +214,7 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
 	}
 	for _, sk := range toStringSlice(entry.Skills) {
-		skill, err := loadSkillEntry(resolvePluginRoot(sk, cacheDir), readFile)
+		skill, err := loadSkillEntry(resolveComponentPath(sk, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -200,7 +223,7 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, cmd := range toStringSlice(entry.Commands) {
-		command, err := loadMarkdownEntry(resolvePluginRoot(cmd, cacheDir), readFile)
+		command, err := loadMarkdownEntry(resolveComponentPath(cmd, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load command %q: %w", cmd, err)
 		}
@@ -209,7 +232,7 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, ag := range toStringSlice(entry.Agents) {
-		agent, err := loadMarkdownEntry(resolvePluginRoot(ag, cacheDir), readFile)
+		agent, err := loadMarkdownEntry(resolveComponentPath(ag, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load agent %q: %w", ag, err)
 		}

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -32,6 +32,8 @@ type ProjectionResult struct {
 //
 // Strict mode (entry.Strict == nil || *entry.Strict):
 //   - Reads cacheDir/.claude-plugin/plugin.json for the primary component list.
+//   - If the manifest lists no skills, falls back to convention-based discovery:
+//     scans cacheDir/skills/*/ for SKILL.md files.
 //   - Then merges in any component fields on the PluginEntry itself (overrides).
 //
 // Non-strict mode:
@@ -40,13 +42,20 @@ type ProjectionResult struct {
 // In both cases, ${CLAUDE_PLUGIN_ROOT} in command/url strings is replaced with
 // cacheDir so non-Claude adapters can resolve binary paths.
 func Project(entry PluginEntry, cacheDir string) (ProjectionResult, error) {
-	return ProjectWithReader(entry, cacheDir, os.ReadFile)
+	return projectWithFuncs(entry, cacheDir, os.ReadFile, os.ReadDir)
 }
 
 // ProjectWithReader is like Project but uses a caller-supplied readFile function
 // for loading plugin.json and component markdown files. This enables in-memory
-// filesystem use in tests.
+// filesystem use in tests. Convention-based discovery (skills/ directory scan)
+// is disabled when using ProjectWithReader; use Project for full behavior.
 func ProjectWithReader(entry PluginEntry, cacheDir string, readFile func(string) ([]byte, error)) (ProjectionResult, error) {
+	return projectWithFuncs(entry, cacheDir, readFile, nil)
+}
+
+// projectWithFuncs is the internal implementation shared by Project and ProjectWithReader.
+// listDir may be nil to disable convention-based skills discovery.
+func projectWithFuncs(entry PluginEntry, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) (ProjectionResult, error) {
 	var pr ProjectionResult
 	strict := entry.Strict == nil || *entry.Strict
 
@@ -61,7 +70,7 @@ func ProjectWithReader(entry PluginEntry, cacheDir string, readFile func(string)
 			if err := json.Unmarshal(data, &manifest); err != nil {
 				return pr, fmt.Errorf("parse plugin.json: %w", err)
 			}
-			if err := applyManifest(manifest, &pr, cacheDir, readFile); err != nil {
+			if err := applyManifest(manifest, &pr, cacheDir, readFile, listDir); err != nil {
 				return pr, err
 			}
 		}
@@ -95,7 +104,9 @@ func resolvePluginRootInArgs(args []string, cacheDir string) []string {
 }
 
 // applyManifest converts a PluginManifest into ProjectionResult entries.
-func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error)) error {
+// listDir may be nil; when non-nil and the manifest lists no skills, skills
+// are discovered by convention from cacheDir/skills/*/SKILL.md.
+func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) error {
 	for name, raw := range manifest.MCPServers {
 		spec := parseMCPSpec(raw, cacheDir)
 		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
@@ -104,7 +115,18 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		spec := parseLSPSpec(raw, cacheDir)
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
 	}
-	for _, sk := range toStringSlice(manifest.Skills) {
+
+	skillPaths := toStringSlice(manifest.Skills)
+	if len(skillPaths) == 0 && listDir != nil {
+		// Convention-based discovery: scan cacheDir/skills/*/SKILL.md
+		discovered, err := discoverSkillDirs(filepath.Join(cacheDir, "skills"), listDir)
+		if err != nil {
+			slog.Warn("plugin skills convention-discovery failed", "cacheDir", cacheDir, "error", err)
+		} else {
+			skillPaths = discovered
+		}
+	}
+	for _, sk := range skillPaths {
 		skill, err := loadSkillEntry(resolvePluginRoot(sk, cacheDir), readFile)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
@@ -113,6 +135,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 			pr.Skills = append(pr.Skills, *skill)
 		}
 	}
+
 	for _, cmd := range toStringSlice(manifest.Commands) {
 		command, err := loadMarkdownEntry(resolvePluginRoot(cmd, cacheDir), readFile)
 		if err != nil {
@@ -134,6 +157,26 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	// Hooks: may be a string command or an object with event+command shape.
 	applyHooks(manifest.Hooks, pr, cacheDir)
 	return nil
+}
+
+// discoverSkillDirs scans skillsDir for subdirectories and returns a list of
+// absolute paths to each subdirectory (each of which is expected to contain
+// a SKILL.md file). The caller resolves the actual SKILL.md via loadSkillEntry.
+func discoverSkillDirs(skillsDir string, listDir func(string) ([]os.DirEntry, error)) ([]string, error) {
+	entries, err := listDir(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() {
+			paths = append(paths, filepath.Join(skillsDir, e.Name()))
+		}
+	}
+	return paths, nil
 }
 
 // applyEntryOverrides merges component fields from a PluginEntry into an

--- a/internal/marketplace/projection_live_test.go
+++ b/internal/marketplace/projection_live_test.go
@@ -1,0 +1,113 @@
+//go:build live
+
+// Package marketplace_test contains live integration tests that make real
+// network calls. These tests are opt-in: they are excluded from all standard
+// CI runs and must be explicitly enabled via the build tag and env var.
+//
+// Run with:
+//
+//	AGENTSYNC_LIVE_PLUGIN_TEST=1 go test -tags=live ./internal/marketplace/... -run LiveSuperpowers -v
+package marketplace_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/marketplace"
+)
+
+// TestLiveSuperpowers fetches the obra/superpowers Claude plugin from GitHub
+// and verifies that its skills/commands/agents are fully projected (frontmatter
+// + body + clean Name). It is gated behind AGENTSYNC_LIVE_PLUGIN_TEST=1 so
+// it never runs unintentionally.
+func TestLiveSuperpowers(t *testing.T) {
+	if os.Getenv("AGENTSYNC_LIVE_PLUGIN_TEST") != "1" {
+		t.Skip("set AGENTSYNC_LIVE_PLUGIN_TEST=1 to run the live obra/superpowers test")
+	}
+
+	cacheDir := t.TempDir()
+
+	// Fetch obra/superpowers via the existing GitFetcher.
+	fetcher := &marketplace.GitFetcher{}
+	src := marketplace.Source{
+		Kind: "github",
+		Repo: "obra/superpowers",
+	}
+	result, err := fetcher.Fetch(src, cacheDir)
+	if err != nil {
+		t.Fatalf("GitFetcher.Fetch obra/superpowers: %v", err)
+	}
+	t.Logf("fetched obra/superpowers at HEAD %s", result.HeadSHA)
+
+	// Project the fetched plugin.
+	entry := marketplace.PluginEntry{Name: "superpowers"}
+	pr, err := marketplace.Project(entry, cacheDir)
+	if err != nil {
+		t.Fatalf("Project: %v", err)
+	}
+
+	t.Logf("projection result: %d skills, %d commands, %d subagents, %d mcp servers",
+		len(pr.Skills), len(pr.Commands), len(pr.Subagents), len(pr.MCPServers))
+
+	// Assert at least 5 skills land with non-empty Body and a populated name.
+	const minSkills = 5
+	if len(pr.Skills) < minSkills {
+		t.Errorf("expected at least %d skills, got %d", minSkills, len(pr.Skills))
+	}
+	for _, sk := range pr.Skills {
+		if sk.Name == "" {
+			t.Errorf("skill has empty name (frontmatter name and basename both empty?)")
+		}
+		if sk.Body == "" {
+			t.Errorf("skill %q has empty body", sk.Name)
+		}
+		if sk.Frontmatter == nil {
+			t.Errorf("skill %q has nil frontmatter map", sk.Name)
+		}
+		t.Logf("  skill: %q (frontmatter keys: %v)", sk.Name, frontmatterKeys(sk.Frontmatter))
+	}
+
+	// Commands: log how many landed; assert at least 1 if any exist.
+	if len(pr.Commands) > 0 {
+		t.Logf("commands (%d):", len(pr.Commands))
+		for _, cmd := range pr.Commands {
+			t.Logf("  command: %q", cmd.Name)
+			if cmd.Name == "" {
+				t.Errorf("command has empty name")
+			}
+			if cmd.Body == "" {
+				t.Errorf("command %q has empty body", cmd.Name)
+			}
+		}
+	} else {
+		t.Logf("no commands in obra/superpowers (that's fine, it may not ship any)")
+	}
+
+	// Subagents: same as commands.
+	if len(pr.Subagents) > 0 {
+		t.Logf("subagents (%d):", len(pr.Subagents))
+		for _, ag := range pr.Subagents {
+			t.Logf("  subagent: %q", ag.Name)
+			if ag.Name == "" {
+				t.Errorf("subagent has empty name")
+			}
+			if ag.Body == "" {
+				t.Errorf("subagent %q has empty body", ag.Name)
+			}
+		}
+	} else {
+		t.Logf("no subagents in obra/superpowers (that's fine)")
+	}
+}
+
+// frontmatterKeys returns a sorted list of keys in a frontmatter map.
+func frontmatterKeys(fm map[string]any) []string {
+	if fm == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(fm))
+	for k := range fm {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -279,7 +279,7 @@ func TestProjectWithReader_SkillsFullyLoaded(t *testing.T) {
 			"skills": ["./skills/tdd", "./skills/refactor"]
 		}`),
 		// Directory-based skill: <path>/SKILL.md
-		"/fake/cache/skills/tdd/SKILL.md":     []byte("---\nname: test-driven-development\ndescription: TDD skill\n---\nWrite tests first.\n"),
+		"/fake/cache/skills/tdd/SKILL.md":      []byte("---\nname: test-driven-development\ndescription: TDD skill\n---\nWrite tests first.\n"),
 		"/fake/cache/skills/refactor/SKILL.md": []byte("---\nname: refactor\ndescription: Refactoring skill\n---\nMake it clean.\n"),
 	}
 	pr, err := marketplace.ProjectWithReader(

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -1,6 +1,7 @@
 package marketplace_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,10 +54,28 @@ func TestProject_StrictPluginJSON_MultipleComponents(t *testing.T) {
 			"lsp-x": {"command": "${CLAUDE_PLUGIN_ROOT}/lsp"}
 		},
 		"skills": ["skill-one", "skill-two"],
-		"commands": "my-cmd",
-		"agents": ["agent-alpha"]
+		"commands": "my-cmd.md",
+		"agents": ["agent-alpha.md"]
 	}`
 	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the skill directories and SKILL.md files so projection finds them.
+	for _, sk := range []string{"skill-one", "skill-two"} {
+		if err := os.MkdirAll(filepath.Join(cache, sk), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "---\nname: " + sk + "\n---\nSkill body.\n"
+		if err := os.WriteFile(filepath.Join(cache, sk, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create the command and agent markdown files.
+	if err := os.WriteFile(filepath.Join(cache, "my-cmd.md"), []byte("---\nname: my-cmd\n---\nDo things.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "agent-alpha.md"), []byte("---\nname: agent-alpha\n---\nAgent body.\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -234,5 +253,292 @@ func TestProject_MCPSpec_FullFields(t *testing.T) {
 	}
 	if len(spec.Agents) != 2 {
 		t.Errorf("agents = %v", spec.Agents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for full component projection (skills / commands / subagents).
+// These use ProjectWithReader and an in-memory readFile to avoid real FS.
+// ---------------------------------------------------------------------------
+
+// fakeFS builds a readFile that maps absolute paths to content.
+func fakeFS(files map[string][]byte) func(string) ([]byte, error) {
+	return func(path string) ([]byte, error) {
+		if data, ok := files[path]; ok {
+			return data, nil
+		}
+		return nil, os.ErrNotExist
+	}
+}
+
+func TestProjectWithReader_SkillsFullyLoaded(t *testing.T) {
+	const cacheDir = "/fake/cache"
+	files := map[string][]byte{
+		"/fake/cache/.claude-plugin/plugin.json": []byte(`{
+			"name": "sp",
+			"skills": ["./skills/tdd", "./skills/refactor"]
+		}`),
+		// Directory-based skill: <path>/SKILL.md
+		"/fake/cache/skills/tdd/SKILL.md":     []byte("---\nname: test-driven-development\ndescription: TDD skill\n---\nWrite tests first.\n"),
+		"/fake/cache/skills/refactor/SKILL.md": []byte("---\nname: refactor\ndescription: Refactoring skill\n---\nMake it clean.\n"),
+	}
+	pr, err := marketplace.ProjectWithReader(
+		marketplace.PluginEntry{Name: "sp"},
+		cacheDir,
+		fakeFS(files),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Skills) != 2 {
+		t.Fatalf("skills count = %d, want 2", len(pr.Skills))
+	}
+
+	// Build a name set for order-independent assertions.
+	byName := make(map[string]struct{})
+	for _, sk := range pr.Skills {
+		byName[sk.Name] = struct{}{}
+	}
+	for _, wantName := range []string{"test-driven-development", "refactor"} {
+		if _, ok := byName[wantName]; !ok {
+			names := make([]string, 0, len(pr.Skills))
+			for _, s := range pr.Skills {
+				names = append(names, s.Name)
+			}
+			t.Errorf("skill %q not found; got names %v", wantName, names)
+		}
+	}
+
+	// All skills must have non-empty body and frontmatter with description.
+	for _, sk := range pr.Skills {
+		if sk.Body == "" {
+			t.Errorf("skill %q has empty body", sk.Name)
+		}
+		if sk.Frontmatter == nil {
+			t.Errorf("skill %q has nil frontmatter", sk.Name)
+		}
+		if _, ok := sk.Frontmatter["description"]; !ok {
+			t.Errorf("skill %q missing description in frontmatter", sk.Name)
+		}
+	}
+}
+
+func TestProjectWithReader_SkillsFullyLoaded_NamesAndBodies(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","skills":["./skills/alpha","./skills/beta","./skills/gamma"]}`),
+		"/plugin/skills/alpha/SKILL.md":      []byte("---\nname: alpha-skill\ndescription: Alpha\n---\nAlpha body text.\n"),
+		"/plugin/skills/beta/SKILL.md":       []byte("---\nname: beta-skill\ndescription: Beta\n---\nBeta body text.\n"),
+		"/plugin/skills/gamma/SKILL.md":      []byte("---\nname: gamma-skill\ndescription: Gamma\n---\nGamma body text.\n"),
+	}
+	pr, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Skills) != 3 {
+		t.Fatalf("skills = %d, want 3", len(pr.Skills))
+	}
+	for _, sk := range pr.Skills {
+		if sk.Name == "" {
+			t.Errorf("empty skill name")
+		}
+		if sk.Body == "" {
+			t.Errorf("skill %q has empty body", sk.Name)
+		}
+		if sk.Frontmatter["name"] == "" {
+			t.Errorf("skill %q frontmatter name empty", sk.Name)
+		}
+	}
+}
+
+func TestProjectWithReader_CommandsFullyLoaded(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","commands":["./commands/deploy.md","./commands/lint.md"]}`),
+		// deploy.md has no name in frontmatter → fallback to filename sans .md
+		"/plugin/commands/deploy.md": []byte("---\ndescription: Deploy the app\n---\nRun the deploy script.\n"),
+		// lint.md has name in frontmatter
+		"/plugin/commands/lint.md": []byte("---\nname: run-lint\ndescription: Lint the code\n---\nRun linter.\n"),
+	}
+	pr, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Commands) != 2 {
+		t.Fatalf("commands = %d, want 2", len(pr.Commands))
+	}
+	byName := make(map[string]struct{})
+	for _, cmd := range pr.Commands {
+		byName[cmd.Name] = struct{}{}
+		if cmd.Body == "" {
+			t.Errorf("command %q has empty body", cmd.Name)
+		}
+	}
+	// deploy.md has no frontmatter name → derives from filename
+	if _, ok := byName["deploy"]; !ok {
+		names := make([]string, 0, len(pr.Commands))
+		for _, c := range pr.Commands {
+			names = append(names, c.Name)
+		}
+		t.Errorf("expected command named 'deploy' (from filename), got names: %v", names)
+	}
+	// lint.md has frontmatter name → "run-lint"
+	if _, ok := byName["run-lint"]; !ok {
+		names := make([]string, 0, len(pr.Commands))
+		for _, c := range pr.Commands {
+			names = append(names, c.Name)
+		}
+		t.Errorf("expected command named 'run-lint' (from frontmatter), got names: %v", names)
+	}
+}
+
+func TestProjectWithReader_SubagentsFullyLoaded(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","agents":["./agents/reviewer.md","./agents/coder.md"]}`),
+		"/plugin/agents/reviewer.md":         []byte("---\nname: code-reviewer\ndescription: Reviews code\n---\nReview all the things.\n"),
+		"/plugin/agents/coder.md":            []byte("---\ndescription: Writes code\n---\nWrite it.\n"),
+	}
+	pr, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Subagents) != 2 {
+		t.Fatalf("subagents = %d, want 2", len(pr.Subagents))
+	}
+	byName := make(map[string]struct{})
+	for _, ag := range pr.Subagents {
+		byName[ag.Name] = struct{}{}
+		if ag.Body == "" {
+			t.Errorf("subagent %q has empty body", ag.Name)
+		}
+	}
+	// reviewer.md has frontmatter name → "code-reviewer"
+	if _, ok := byName["code-reviewer"]; !ok {
+		names := make([]string, 0, len(pr.Subagents))
+		for _, a := range pr.Subagents {
+			names = append(names, a.Name)
+		}
+		t.Errorf("expected subagent 'code-reviewer', got: %v", names)
+	}
+	// coder.md has no frontmatter name → filename fallback
+	if _, ok := byName["coder"]; !ok {
+		names := make([]string, 0, len(pr.Subagents))
+		for _, a := range pr.Subagents {
+			names = append(names, a.Name)
+		}
+		t.Errorf("expected subagent 'coder', got: %v", names)
+	}
+}
+
+func TestProjectWithReader_MissingFile_Skipped(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","skills":["./skills/present","./skills/missing"],"commands":["./cmds/existing.md","./cmds/gone.md"]}`),
+		"/plugin/skills/present/SKILL.md":    []byte("---\nname: present\n---\nPresent.\n"),
+		"/plugin/cmds/existing.md":           []byte("---\nname: existing\n---\nExists.\n"),
+		// skills/missing and cmds/gone.md intentionally absent
+	}
+	pr, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("missing file should be skipped, not error: %v", err)
+	}
+	if len(pr.Skills) != 1 {
+		t.Errorf("skills = %d, want 1 (missing entry skipped)", len(pr.Skills))
+	}
+	if pr.Skills[0].Name != "present" {
+		t.Errorf("skill name = %q, want present", pr.Skills[0].Name)
+	}
+	if len(pr.Commands) != 1 {
+		t.Errorf("commands = %d, want 1 (missing entry skipped)", len(pr.Commands))
+	}
+}
+
+func TestProjectWithReader_MalformedFrontmatter_Error(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","skills":["./skills/bad"]}`),
+		// Unterminated frontmatter — no closing ---
+		"/plugin/skills/bad/SKILL.md": []byte("---\nname: bad\ndescription: broken\nno closing delimiter\n"),
+	}
+	_, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err == nil {
+		t.Fatal("expected error for malformed frontmatter, got nil")
+	}
+	if !strings.Contains(err.Error(), "frontmatter") && !strings.Contains(err.Error(), "load skill") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestProjectWithReader_SkillNameFallbackToBasename(t *testing.T) {
+	const cacheDir = "/plugin"
+	files := map[string][]byte{
+		"/plugin/.claude-plugin/plugin.json": []byte(`{"name":"p","skills":["./skills/my-skill"]}`),
+		// No name in frontmatter → use dirname
+		"/plugin/skills/my-skill/SKILL.md": []byte("---\ndescription: A skill\n---\nBody.\n"),
+	}
+	pr, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Skills) != 1 {
+		t.Fatalf("skills = %d, want 1", len(pr.Skills))
+	}
+	if pr.Skills[0].Name != "my-skill" {
+		t.Errorf("skill name = %q, want my-skill (basename fallback)", pr.Skills[0].Name)
+	}
+}
+
+func TestProjectWithReader_NonStrict_FullyLoaded(t *testing.T) {
+	const cacheDir = "/plugin"
+	f := false
+	files := map[string][]byte{
+		"/plugin/skills/inline-skill/SKILL.md": []byte("---\nname: inline-skill\n---\nInline body.\n"),
+		"/plugin/agents/inline-agent.md":       []byte("---\nname: inline-agent\n---\nAgent body.\n"),
+	}
+	entry := marketplace.PluginEntry{
+		Name:   "ns",
+		Strict: &f,
+		Skills: []interface{}{"./skills/inline-skill"},
+		Agents: []interface{}{"./agents/inline-agent.md"},
+	}
+	pr, err := marketplace.ProjectWithReader(entry, cacheDir, fakeFS(files))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pr.Skills) != 1 {
+		t.Errorf("skills = %d, want 1", len(pr.Skills))
+	}
+	if len(pr.Subagents) != 1 {
+		t.Errorf("subagents = %d, want 1", len(pr.Subagents))
+	}
+	if len(pr.Skills) > 0 && pr.Skills[0].Body == "" {
+		t.Errorf("non-strict skill has empty body")
+	}
+}
+
+// errorFS returns a readFile that errors for all paths with the given error.
+func errorFS(wrapped error) func(string) ([]byte, error) {
+	return func(path string) ([]byte, error) {
+		return nil, wrapped
+	}
+}
+
+// _ is used to suppress unused import lint for errorFS.
+var _ = errorFS
+
+func TestProjectWithReader_IOError_Propagates(t *testing.T) {
+	const cacheDir = "/plugin"
+	ioErr := errors.New("disk failure")
+	// plugin.json reads fine, but skill file returns a hard I/O error
+	readFile := func(path string) ([]byte, error) {
+		if strings.HasSuffix(path, "plugin.json") {
+			return []byte(`{"name":"p","skills":["./skills/bad"]}`), nil
+		}
+		return nil, ioErr
+	}
+	_, err := marketplace.ProjectWithReader(marketplace.PluginEntry{Name: "p"}, cacheDir, readFile)
+	if err == nil {
+		t.Fatal("expected I/O error to propagate, got nil")
 	}
 }

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -358,7 +358,7 @@ func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
 			}
 			return nil, fmt.Errorf("read SKILL.md for %s: %w", e.Name(), err)
 		}
-		fm, body, err := parseFrontmatter(raw)
+		fm, body, err := ParseFrontmatter(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -387,7 +387,7 @@ func loadSubagents(fs afero.Fs, home string) ([]Subagent, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
-		fm, body, err := parseFrontmatter(raw)
+		fm, body, err := ParseFrontmatter(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -417,7 +417,7 @@ func loadCommands(fs afero.Fs, home string) ([]Command, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
-		fm, body, err := parseFrontmatter(raw)
+		fm, body, err := ParseFrontmatter(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -512,10 +512,10 @@ func loadLSP(fs afero.Fs, home string) ([]LSPServer, error) {
 	return out, nil
 }
 
-// parseFrontmatter extracts YAML frontmatter and body from a markdown file.
+// ParseFrontmatter extracts YAML frontmatter and body from a markdown file.
 // If the input doesn't begin with "---\n", returns an empty map and the
 // entire input as body.
-func parseFrontmatter(data []byte) (map[string]any, string, error) {
+func ParseFrontmatter(data []byte) (map[string]any, string, error) {
 	if !bytes.HasPrefix(data, []byte("---\n")) {
 		return map[string]any{}, string(data), nil
 	}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -112,15 +112,21 @@ func projectPlugins(fs afero.Fs, c *Canonical, cacheDir string) error {
 
 // pluginManifestJSON is the minimal structure we need from plugin.json to build
 // a PluginProjection. It intentionally mirrors marketplace.PluginManifest but
-// lives here to avoid the import cycle.
+// lives here to avoid the import cycle (marketplace imports source).
 type pluginManifestJSON struct {
 	MCPServers map[string]json.RawMessage `json:"mcpServers"`
 	LSPServers map[string]json.RawMessage `json:"lspServers"`
+	Skills     json.RawMessage            `json:"skills"`
+	Commands   json.RawMessage            `json:"commands"`
+	Agents     json.RawMessage            `json:"agents"`
 }
 
 // readPluginProjection reads <pluginCacheDir>/.claude-plugin/plugin.json and
-// builds a PluginProjection from the MCP and LSP server entries. If the file is
-// absent, an empty projection is returned without error (plugin not yet cached).
+// builds a PluginProjection. MCP and LSP server entries are parsed inline to
+// avoid the source↔marketplace import cycle. Skills, commands, and subagents
+// are loaded by reading the markdown files the manifest points at (using
+// resolveComponentPath so relative paths are joined against pluginCacheDir).
+// If the file is absent, an empty projection is returned without error.
 func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection, error) {
 	var pr PluginProjection
 	manifestPath := filepath.Join(pluginCacheDir, ".claude-plugin", "plugin.json")
@@ -146,7 +152,177 @@ func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection,
 		spec := parseLSPSpecJSON(raw, root)
 		pr.LSPServers = append(pr.LSPServers, LSPServer{ID: name, Spec: spec})
 	}
+
+	// Skills: each entry is a path to a directory containing SKILL.md, or
+	// a direct SKILL.md path. Relative entries are resolved against pluginCacheDir.
+	skillPaths := rawToStringSlice(manifest.Skills)
+	if len(skillPaths) == 0 {
+		// Convention-based discovery: scan pluginCacheDir/skills/ for subdirs.
+		discovered, _ := discoverSkillDirsFS(fs, filepath.Join(pluginCacheDir, "skills"))
+		skillPaths = discovered
+	}
+	for _, sk := range skillPaths {
+		abs := resolveComponentPathFS(sk, pluginCacheDir)
+		skill, err := loadSkillEntryFS(fs, abs)
+		if err != nil {
+			return pr, fmt.Errorf("load skill %q: %w", sk, err)
+		}
+		if skill != nil {
+			pr.Skills = append(pr.Skills, *skill)
+		}
+	}
+
+	// Commands: each entry is a path to a <name>.md file.
+	for _, cmd := range rawToStringSlice(manifest.Commands) {
+		abs := resolveComponentPathFS(cmd, pluginCacheDir)
+		entry, err := loadMarkdownEntryFS(fs, abs)
+		if err != nil {
+			return pr, fmt.Errorf("load command %q: %w", cmd, err)
+		}
+		if entry != nil {
+			pr.Commands = append(pr.Commands, Command{Name: entry.name, Frontmatter: entry.fm, Body: entry.body})
+		}
+	}
+
+	// Subagents: each entry is a path to a <name>.md file.
+	for _, ag := range rawToStringSlice(manifest.Agents) {
+		abs := resolveComponentPathFS(ag, pluginCacheDir)
+		entry, err := loadMarkdownEntryFS(fs, abs)
+		if err != nil {
+			return pr, fmt.Errorf("load agent %q: %w", ag, err)
+		}
+		if entry != nil {
+			pr.Subagents = append(pr.Subagents, Subagent{Name: entry.name, Frontmatter: entry.fm, Body: entry.body})
+		}
+	}
+
 	return pr, nil
+}
+
+// resolveComponentPathFS resolves a manifest-listed component path against
+// pluginCacheDir. It mirrors marketplace.resolveComponentPath but lives here to
+// avoid the import cycle.
+//
+// Resolution order:
+//  1. ${CLAUDE_PLUGIN_ROOT} substitution if present.
+//  2. Absolute paths returned as-is.
+//  3. Relative paths joined to pluginCacheDir.
+func resolveComponentPathFS(s, pluginCacheDir string) string {
+	const placeholder = "${CLAUDE_PLUGIN_ROOT}"
+	if strings.Contains(s, placeholder) {
+		return strings.ReplaceAll(s, placeholder, pluginCacheDir)
+	}
+	if filepath.IsAbs(s) {
+		return s
+	}
+	return filepath.Join(pluginCacheDir, s)
+}
+
+// rawToStringSlice coerces a json.RawMessage that holds either a JSON string
+// or a JSON array of strings into a []string.
+func rawToStringSlice(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	// Try array first.
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr
+	}
+	// Try single string.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []string{s}
+	}
+	return nil
+}
+
+// markdownEntryFS holds the parsed result of a single markdown file (loader-side).
+type markdownEntryFS struct {
+	name string
+	fm   map[string]any
+	body string
+}
+
+// loadSkillEntryFS reads a skill from path, which may be a directory containing
+// SKILL.md or a SKILL.md file directly. Returns nil when the file is absent.
+func loadSkillEntryFS(fs afero.Fs, path string) (*Skill, error) {
+	skillPath := filepath.Join(path, "SKILL.md")
+	data, err := afero.ReadFile(fs, skillPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Try treating path itself as the file.
+			data, err = afero.ReadFile(fs, path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil, nil // silently skip missing skill
+				}
+				return nil, fmt.Errorf("read %s: %w", path, err)
+			}
+			skillPath = path
+		} else {
+			return nil, fmt.Errorf("read %s: %w", skillPath, err)
+		}
+	}
+
+	fm, body, err := ParseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse frontmatter in %s: %w", skillPath, err)
+	}
+
+	name := ""
+	if v, ok := fm["name"].(string); ok && v != "" {
+		name = v
+	}
+	if name == "" {
+		name = filepath.Base(path)
+	}
+	return &Skill{Name: name, Frontmatter: fm, Body: body}, nil
+}
+
+// loadMarkdownEntryFS reads a markdown file at path. Returns nil when absent.
+func loadMarkdownEntryFS(fs afero.Fs, path string) (*markdownEntryFS, error) {
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil // silently skip missing entry
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	fm, body, err := ParseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse frontmatter in %s: %w", path, err)
+	}
+
+	name := ""
+	if v, ok := fm["name"].(string); ok && v != "" {
+		name = v
+	}
+	if name == "" {
+		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+	return &markdownEntryFS{name: name, fm: fm, body: body}, nil
+}
+
+// discoverSkillDirsFS scans skillsDir for subdirectories (convention-based
+// discovery) and returns their absolute paths. Used when plugin.json lists no
+// skills. Mirrors marketplace.discoverSkillDirs but uses an afero.Fs.
+func discoverSkillDirsFS(fs afero.Fs, skillsDir string) ([]string, error) {
+	entries, err := afero.ReadDir(fs, skillsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() {
+			paths = append(paths, filepath.Join(skillsDir, e.Name()))
+		}
+	}
+	return paths, nil
 }
 
 // resolvePR replaces ${CLAUDE_PLUGIN_ROOT} with root in s.

--- a/justfile
+++ b/justfile
@@ -2,10 +2,13 @@
 #
 # Run `just` (no args) to see this list. Run `just <recipe>` to invoke one.
 #
-# Hermeticity contract: every `test*` recipe (except `test-fast`) runs
-# inside the container — podman-first, docker fallback. The repo is
-# mounted read-only and the network is off, so a misbehaving test can
-# never touch your real ~/.claude.json, ~/.config/opencode/, or ~/.agentsync/.
+# Hermeticity contract: every `test*` recipe (except `test-fast` and
+# `test-live`) runs inside the container — podman-first, docker fallback.
+# The repo is mounted read-only and the network is off, so a misbehaving
+# test can never touch your real ~/.claude.json, ~/.config/opencode/, or
+# ~/.agentsync/. `test-live` is the explicit exception: live tests need
+# network access (e.g. cloning github.com/obra/superpowers) and run on
+# host with their own permissive TestMain.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set dotenv-load := false
@@ -48,6 +51,16 @@ test-fast:
         ./internal/adapter \
         ./internal/adapter/noop/... \
         ./internal/testenv/...
+
+# Live tests fetch real upstream sources (e.g. cloning
+# github.com/obra/superpowers via go-git) so they run on host with their
+# own permissive TestMain. NOT part of test-release — the release gate
+# stays hermetic and offline. Run this manually before any change touching
+# internal/marketplace/projection or the source loader's plugin projection
+# path, and as a periodic check that upstream plugin shapes haven't drifted.
+# Live network-dependent tests (build tag `live`) on host. Opt-in.
+test-live:
+    AGENTSYNC_LIVE_PLUGIN_TEST=1 go test -tags=live -count=1 -v ./internal/marketplace/...
 
 # Run golangci-lint over every package.
 lint:

--- a/test/bdd/features/06_marketplace_plugins.feature
+++ b/test/bdd/features/06_marketplace_plugins.feature
@@ -33,3 +33,22 @@ Feature: Marketplaces and plugins
     Then the command succeeds
     And the output is valid JSON
     And the output contains "demo-plugin"
+
+  Scenario: explicit manifest skill/command/agent paths project to destination files with correct content
+    # Regression lock for 4b781b1: manifest-declared relative paths (skills/commands/agents)
+    # must be joined against the plugin cache dir, not used verbatim. Before the fix, these
+    # paths were passed directly to resolvePluginRoot which only substitutes ${CLAUDE_PLUGIN_ROOT},
+    # leaving relative paths unresolved and producing missing/stub destination files.
+    Given I create a local marketplace "fixture-proj-mp" with plugin "proj-plugin" with explicit skills commands and agents
+    When I run "agentsync marketplace add ./fixture-proj-mp"
+    Then the command succeeds
+    When I run "agentsync plugin install proj-plugin@fixture-proj-mp"
+    Then the command succeeds
+    When I run "agentsync apply"
+    Then the command succeeds
+    And the file ".claude/skills/proj-skill/SKILL.md" exists
+    And the file ".claude/skills/proj-skill/SKILL.md" contains "BODY_TOKEN_skill_proj-skill"
+    And the file ".claude/agents/proj-agent.md" exists
+    And the file ".claude/agents/proj-agent.md" contains "BODY_TOKEN_agent_proj-agent"
+    And the file ".claude/commands/proj-cmd.md" exists
+    And the file ".claude/commands/proj-cmd.md" contains "BODY_TOKEN_cmd_proj-cmd"

--- a/test/bdd/support/steps.go
+++ b/test/bdd/support/steps.go
@@ -32,6 +32,7 @@ func RegisterSteps(sc *godog.ScenarioContext, w *World) {
 	sc.Step(`^I append to "([^"]+)":$`, w.whenIAppendFile)
 	sc.Step(`^I tamper with "([^"]+)" by replacing "([^"]+)" with "([^"]+)"$`, w.whenITamperReplace)
 	sc.Step(`^I create a local marketplace "([^"]+)" with plugin "([^"]+)" exposing MCP "([^"]+)" command "([^"]+)"$`, w.whenICreateLocalMarketplace)
+	sc.Step(`^I create a local marketplace "([^"]+)" with plugin "([^"]+)" with explicit skills commands and agents$`, w.whenICreateProjectionTestMarketplace)
 	sc.Step(`^I configure age secrets$`, w.whenIConfigureAgeSecrets)
 	sc.Step(`^I encrypt secret "([^"]+)" = "([^"]+)"$`, w.whenIEncryptSecret)
 	sc.Step(`^I run two "agentsync apply" invocations concurrently$`, w.whenIRunConcurrentApplies)
@@ -155,6 +156,83 @@ func (w *World) whenICreateLocalMarketplace(dirRel, pluginID, mcpID, mcpCmd stri
 	}
 	pluginJSON, _ := json.MarshalIndent(plugin, "", "  ")
 	return os.WriteFile(filepath.Join(pluginDir, "plugin.json"), pluginJSON, 0o644)
+}
+
+// whenICreateProjectionTestMarketplace builds a local marketplace with a
+// single plugin that declares explicit "skills", "commands", and "agents"
+// arrays in its plugin.json manifest — i.e. the path through the projection
+// code that was broken by the regression fixed in 4b781b1.
+//
+// The three component files embed unique sentinel tokens in their bodies so
+// that downstream BDD assertions can confirm the rendered destination files
+// contain real content (not empty stubs).
+func (w *World) whenICreateProjectionTestMarketplace(dirRel, pluginID string) error {
+	dir := w.Resolve(dirRel)
+
+	// ── marketplace fixture ─────────────────────────────────────────────────
+	mpDir := filepath.Join(dir, ".claude-plugin")
+	if err := os.MkdirAll(mpDir, 0o755); err != nil {
+		return err
+	}
+	marketplace := map[string]any{
+		"name":  filepath.Base(dir),
+		"owner": map[string]any{"name": "bdd"},
+		"plugins": []map[string]any{
+			{"name": pluginID, "source": "./plugins/" + pluginID},
+		},
+	}
+	mpJSON, _ := json.MarshalIndent(marketplace, "", "  ")
+	if err := os.WriteFile(filepath.Join(mpDir, "marketplace.json"), mpJSON, 0o644); err != nil {
+		return err
+	}
+
+	// ── plugin source tree ──────────────────────────────────────────────────
+	pluginRoot := filepath.Join(dir, "plugins", pluginID)
+
+	// skills/proj-skill/SKILL.md
+	skillPath := filepath.Join(pluginRoot, "skills", "proj-skill")
+	if err := os.MkdirAll(skillPath, 0o755); err != nil {
+		return err
+	}
+	skillMD := "---\nname: proj-skill\ndescription: projection test skill\n---\nBODY_TOKEN_skill_proj-skill\n"
+	if err := os.WriteFile(filepath.Join(skillPath, "SKILL.md"), []byte(skillMD), 0o644); err != nil {
+		return err
+	}
+
+	// agents/proj-agent.md
+	agentPath := filepath.Join(pluginRoot, "agents")
+	if err := os.MkdirAll(agentPath, 0o755); err != nil {
+		return err
+	}
+	agentMD := "---\nname: proj-agent\ndescription: projection test subagent\n---\nBODY_TOKEN_agent_proj-agent\n"
+	if err := os.WriteFile(filepath.Join(agentPath, "proj-agent.md"), []byte(agentMD), 0o644); err != nil {
+		return err
+	}
+
+	// commands/proj-cmd.md
+	cmdPath := filepath.Join(pluginRoot, "commands")
+	if err := os.MkdirAll(cmdPath, 0o755); err != nil {
+		return err
+	}
+	cmdMD := "---\nname: proj-cmd\ndescription: projection test command\n---\nBODY_TOKEN_cmd_proj-cmd\n"
+	if err := os.WriteFile(filepath.Join(cmdPath, "proj-cmd.md"), []byte(cmdMD), 0o644); err != nil {
+		return err
+	}
+
+	// .claude-plugin/plugin.json — explicit manifest listing relative paths
+	pluginManifestDir := filepath.Join(pluginRoot, ".claude-plugin")
+	if err := os.MkdirAll(pluginManifestDir, 0o755); err != nil {
+		return err
+	}
+	plugin := map[string]any{
+		"name":     pluginID,
+		"version":  "1.0.0",
+		"skills":   []string{"./skills/proj-skill"},
+		"agents":   []string{"./agents/proj-agent.md"},
+		"commands": []string{"./commands/proj-cmd.md"},
+	}
+	pluginJSON, _ := json.MarshalIndent(plugin, "", "  ")
+	return os.WriteFile(filepath.Join(pluginManifestDir, "plugin.json"), pluginJSON, 0o644)
 }
 
 func (w *World) whenIConfigureAgeSecrets() error {


### PR DESCRIPTION
## Summary

Closes the plugin component projection gap — `LAUNCH_CHECKLIST.md` §5 and the
one real correctness gap from issue #13. Skills/subagents/commands from a
Claude marketplace plugin's manifest are now fully loaded (frontmatter +
body + clean Name) instead of recorded as stub entries with only the path.

**This PR now includes two layers of fix:**

1. **`marketplace.Project()`** — fully loads plugin component markdown files (frontmatter + body + clean Name) so the library function is correct.
2. **`source.readPluginProjection`** — the apply pipeline path (`LoadWithCache → readPluginProjection`) previously only handled MCP/LSP inline; now mirrors the marketplace loading logic via afero-backed FS helpers to avoid the `source↔marketplace` import cycle. Without this second fix, `agentsync apply` would still emit empty/wrong-named destination files for plugins that ship skills, commands, or subagents.

Verified against the real `obra/superpowers` plugin via a live integration test (env-gated, opt-in via `AGENTSYNC_LIVE_PLUGIN_TEST=1`), and locked by a new BDD regression scenario.

Stacked on `claude/launch-checklist` (LAUNCH_CHECKLIST.md), which is stacked on PR #14 (test suite).

### Key changes

- **`internal/source/loader.go`**: 
  - Export `parseFrontmatter` → `ParseFrontmatter`; update 3 internal callers
  - Add `loadSkillEntryFS`, `loadMarkdownEntryFS`, `resolveComponentPathFS`, `discoverSkillDirsFS`, `rawToStringSlice` helpers (afero-backed mirrors of the marketplace equivalents)
  - Extend `readPluginProjection` to load skills, commands, and subagents from manifest-declared paths
- **`internal/marketplace/projection.go`**:
  - `applyManifest`, `applyEntryOverrides`, `applyEntryFull` now load each skill/command/agent markdown file via the injected `readFile` function (frontmatter + body + name derivation)
  - `loadSkillEntry`: handles directory-based skills (`<path>/SKILL.md`) and direct file paths; missing = skip with warning, malformed = hard error
  - `loadMarkdownEntry`: same for commands/subagents; name from frontmatter `name:` or `strings.TrimSuffix(filepath.Base, ".md")`
  - Convention-based skill discovery: when `plugin.json` lists no skills and `listDir` is available (i.e. `Project()` path), scans `cacheDir/skills/*/` for SKILL.md files
  - `Project()` uses `os.ReadFile` + `os.ReadDir`; `ProjectWithReader()` uses caller-supplied readFile + nil lister
- **`internal/marketplace/projection_test.go`**: updated `TestProject_StrictPluginJSON_MultipleComponents` to create real skill/command/agent files; added 8 new `TestProjectWithReader_*` unit tests
- **`internal/marketplace/main_test.go`**: add `//go:build !live` constraint
- **`internal/marketplace/main_live_test.go`**: permissive `TestMain` for live build tag
- **`internal/marketplace/projection_live_test.go`**: env-gated live test against `obra/superpowers`
- **`test/bdd/features/06_marketplace_plugins.feature`**: new regression scenario asserting skill/command/agent body tokens appear in rendered destination files
- **`test/bdd/support/steps.go`**: `whenICreateProjectionTestMarketplace` step builds a fixture plugin with explicit manifest paths
- **`LAUNCH_CHECKLIST.md`**: mark §5 done

## Live test output

```
=== RUN   TestLiveSuperpowers
    fetched obra/superpowers at HEAD f2cbfbefebbfef77321e4c9abc9e949826bea9d7
    projection result: 14 skills, 0 commands, 0 subagents, 0 mcp servers
    skill: "brainstorming" (frontmatter keys: [description name])
    ...
    skill: "writing-skills" (frontmatter keys: [description name])
--- PASS: TestLiveSuperpowers (0.48s)
PASS
```

## Test plan
- [x] go vet ./...
- [x] go build ./...
- [x] gofumpt -d (no diff)
- [x] No import cycle: source does not import marketplace
- [x] just test-fast (pure-unit packages)
- [x] Full BDD suite passes in container (all gates green)
- [x] New BDD regression scenario: asserts skill/command/agent body tokens in rendered files
- [x] New unit tests in projection_test.go cover happy + missing-file + malformed-frontmatter paths
- [x] Live integration test with obra/superpowers (run locally with AGENTSYNC_LIVE_PLUGIN_TEST=1)
- [x] LAUNCH_CHECKLIST.md §5 marked complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)