### PR TITLE
Fix 18 second-wave audit findings: mcp add, init git-url, doctor/verify, schema migration, http policy, dry-run lock

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -95,6 +95,59 @@ commented out with `# TODO: enable when going public`. Each item below is
 - [ ] **Companion repo READMEs** — each Homebrew tap / Scoop bucket / AUR
       repo needs at minimum a one-paragraph README + LICENSE.
 
+## §4.5 — Audit findings addressed (second review wave)
+
+Captured here so the v1.0 audit trail stays in one place. Each was a
+finding flagged in a follow-up review of the M0–M7 + PR #18 stack;
+each has a corresponding commit on the integration branch.
+
+- [x] **README quickstart command did not exist** — `agentsync mcp add` is
+      now implemented (subcommands: add/remove/list). set/enable/disable
+      remain deferred (add-after-remove covers same need).
+- [x] **`init [<git-url>]`** — clones bootstrap source repo when a URL
+      is given (matches design spec line 361). https/ssh/file accepted;
+      http/git:// gated by AGENTSYNC_ALLOW_INSECURE_URLS=1.
+- [x] **Stale `opensync.toml` references** — error messages in
+      cli/secrets.go and a type name in cli/agent.go now use
+      `agentsync.toml`/`agentsyncCfg`.
+- [x] **`apply --dry-run` held the global lock** — dry-run is read-only;
+      lock acquisition moved to the real-apply branch only.
+- [x] **`agent add codex` / `cursor` were silent noops** — rejected at
+      `agent add` time with a v1.x status message and an
+      AGENTSYNC_ALLOW_UNIMPLEMENTED override for plan/spec work.
+- [x] **`agent add` did not check that the agent's binary was on PATH**
+      — warns (not fails) so authoring on a control machine still works.
+- [x] **`doctor` only checked PATH** — now validates home, .state/
+      writability, agentsync.toml schema, and (when [secrets] block is
+      present) backend / recipient / identity_file existence + perms.
+- [x] **`verify` was a near-noop** — now validates secrets config and
+      runs the same SubstituteCanonical apply uses, surfacing every
+      unresolved `${secret:}`/`${env:}` reference.
+- [x] **Plugin id path-traversal** — `pluginCacheDir`/`marketplaceCacheDir`
+      validated up-front in plugin install; loader rejects projection
+      of plugins whose derived id contains `..`/`/`.
+- [x] **Backup destination escape** — `backupPathFor` cleans the input,
+      drops volume names, and asserts containment via filepath.Rel;
+      falls back to a `_escaped/` subdir if anchor check fails.
+- [x] **State schema version was silently accepted** — `migrate()`
+      handles legacy zero, no-ops current, refuses newer with an
+      "upgrade agentsync" message, refuses older without a migrator.
+- [x] **No HTTPS policy for plugin fetches** — `Dispatch` rejects
+      http://, git:// unless AGENTSYNC_ALLOW_INSECURE_URLS=1.
+- [x] **No symlink protection in npm tarballs** — TypeSymlink/TypeLink
+      hard-reject. Prior implicit silent-drop is gone.
+- [x] **Spec-required concurrent-apply lock test** — added.
+- [x] **`init` re-init guard swallowed ReadDir errors** — three cases
+      distinguished: populated/refuse, empty/proceed, missing/proceed,
+      other/error-with-hint.
+- [x] **First-apply UX** — `init` ends with a Next-steps block that
+      pushes the user at `apply --dry-run` before the real thing.
+- [x] **README known-limits expanded** — owned-key overwrite, codex/cursor
+      reject, http-scheme policy now spelled out.
+- [ ] **Comment-preservation fuzz** — still deferred (§6). The
+      underlying preservation isn't implemented in TOML or JSONC; fuzz
+      lands when either does.
+
 ## §4 — Adapter coverage gaps (deliberate v1.0 cuts; review before public)
 
 Each of these is documented in `README.md`'s "Known limitations" section. They

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 - **OpenCode hooks**: OpenCode hooks are JS/TS plugins, not declarative shell commands. agentsync v1 does NOT auto-translate Claude hooks to OpenCode. Hand-author a small JS/TS plugin if you need a hook on OpenCode.
 - **Cursor user-level rules**: Cursor stores user-level rules in app-local storage (not the filesystem). agentsync's Cursor adapter manages project-scope rules only.
 - **LSP projection beyond Claude**: OpenCode/Codex/Cursor LSP support is deferred. Claude plugins that include LSP servers install correctly on Claude itself; on other agents you'll see `lsp server X skipped` in the apply translation report.
+- **codex / cursor agent registration**: `agent add codex` and `agent add cursor` are rejected in v1.0 because their adapters are noops. Set `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` to register anyway (apply will silently emit zero ops for them).
+- **TOML / JSONC comment preservation**: comments in `~/.agentsync/mcp/*.toml` and in agent-side `opencode.json` are NOT preserved across reconcile `[w]`rite-back or import. Hand-edited comments survive in unrelated sections; the rewritten section will be re-emitted without comments. Deferred to v1.x.
+- **Hand-edits to agentsync-owned keys** in shared agent files (e.g. an MCP server entry in `~/.claude.json` that agentsync owns): the next `apply` overwrites them with NO foreign-collision backup, because agentsync considers them its own. Use `agentsync reconcile` (the drift classifier catches the edit and offers `[w]`rite-back) BEFORE the next apply if you want to keep them.
+- **Plain-http / git:// plugin sources** are rejected by default to prevent MITM swap. Set `AGENTSYNC_ALLOW_INSECURE_URLS=1` for internal mirrors.
 - **Continue, Gemini CLI, Aider**: not on the v1.x roadmap.
 
 ## Troubleshooting
@@ -86,6 +90,13 @@ For fast in-place iteration without spinning up the container, `just test-fast`
 runs the unit/integration layer directly on the host. The existing tests
 already redirect `HOME` via `AGENTSYNC_TARGET_ROOT`, so they are still safe;
 the container is the release gate.
+
+If you reach for the obvious `go test ./...`, the filesystem-touching
+packages refuse to run on the host and print a long banner pointing you
+at the recipes above. To bypass the guard manually (e.g. for `go test -run`
+on a single test), set `AGENTSYNC_TEST_IN_CONTAINER=1`:
+
+    AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run TestApply_FirstRun
 
 `just test-live` runs the **live cohort** (build tag `live`) — currently the
 `obra/superpowers` projection check, which clones the real upstream plugin

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Centrally manage AI coding-agent configurations across Claude Code, OpenCode, Co
     agentsync agent add claude
     agentsync agent add opencode
     agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
+    agentsync apply --dry-run    # preview translation report before writing
     agentsync apply
 
 ## Install

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,6 +16,16 @@ import (
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// agentBinaries maps an agent name to the executable agentsync should
+// look for on PATH at `agent add` time. Used to produce a warning when
+// the user registers an agent whose binary is not installed.
+var agentBinaries = map[string]string{
+	"claude":   "claude",
+	"opencode": "opencode",
+	"codex":    "codex",
+	"cursor":   "cursor",
+}
 
 // boolStr returns "true" or "false" as a string.
 func boolStr(b bool) string {
@@ -168,6 +179,21 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "added agent: %s\n", name)
+
+	// Warn (don't fail) if the agent's binary is not on PATH. The user
+	// may be authoring config on machine A to apply on machine B, so we
+	// don't want a hard reject — but a silent success when Claude Code
+	// isn't installed leaves them debugging "why didn't apply do
+	// anything?" later.
+	if bin, ok := agentBinaries[name]; ok {
+		if _, err := exec.LookPath(bin); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: %s binary not found on PATH; "+
+					"agentsync will still write config to its destination dirs "+
+					"but %s itself must be installed to read it\n",
+				bin, name)
+		}
+	}
 	return nil
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -61,7 +61,7 @@ func newAgentDisableCmd() *cobra.Command {
 	return cmd
 }
 
-type opensyncCfg struct {
+type agentsyncCfg struct {
 	Agents map[string]map[string]any `toml:"agents"`
 	// other top-level keys preserved verbatim via decoder
 }
@@ -84,7 +84,7 @@ func readAgentsyncTOML() (string, []byte, map[string]map[string]any, error) {
 	if err != nil {
 		return p, nil, nil, fmt.Errorf("read %s: %w", p, err)
 	}
-	var cfg opensyncCfg
+	var cfg agentsyncCfg
 	if err := toml.Unmarshal(raw, &cfg); err != nil {
 		return p, raw, nil, fmt.Errorf("parse %s: %w", p, err)
 	}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -37,6 +37,16 @@ func boolStr(b bool) string {
 
 const validAgents = "claude, opencode, codex, cursor"
 
+// v1Supported lists agents whose adapter actually emits ops today.
+// codex and cursor are registered as NoopAdapter in registry_internal.go;
+// adding them silently would produce `applied: 0 ops` for those agents
+// with no diagnostic — so `agent add` rejects them with a status hint.
+// (Allow override with AGENTSYNC_ALLOW_UNIMPLEMENTED=1 for plan/spec work.)
+var v1Supported = map[string]bool{
+	"claude":   true,
+	"opencode": true,
+}
+
 func newAgentCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "agent", Short: "manage which agents agentsync targets"}
 	cmd.AddCommand(
@@ -165,6 +175,11 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	if err := validateAgent(name); err != nil {
 		return err
+	}
+	if !v1Supported[name] && os.Getenv("AGENTSYNC_ALLOW_UNIMPLEMENTED") != "1" {
+		return fmt.Errorf("agent %q is not yet implemented in v1.0 "+
+			"(codex is planned for v1.1, cursor for v1.2); "+
+			"set AGENTSYNC_ALLOW_UNIMPLEMENTED=1 to register anyway and accept noop apply", name)
 	}
 	p, raw, agents, err := readAgentsyncTOML()
 	if err != nil {

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -28,6 +28,13 @@ func newApplyCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
+			// Dry-run is read-only — it touches neither destinations nor
+			// state. Acquiring the global lock would needlessly block
+			// concurrent `status` / `diff` / other dry-runs behind a long
+			// real apply.
+			if dryRun {
+				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag)
+			}
 			return withGlobalLock(home, func() error {
 				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag)
 			})

--- a/internal/cli/concurrent_apply_test.go
+++ b/internal/cli/concurrent_apply_test.go
@@ -1,0 +1,124 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spxrogers/agentsync/internal/iox"
+)
+
+// TestConcurrentApply_LockSerializes is the spec-required test from
+// docs/superpowers/specs/2026-05-04-agentsync-design.md line 483:
+// "spawn two `apply` invocations against the same AGENTSYNC_TARGET_ROOT,
+// assert serialization." We can't actually fork the process from a Go
+// test cheaply, so we model the same condition by holding the global
+// lock externally and asserting a fresh apply blocks (returns a clear
+// "another agentsync process running?" error after the 30s lock
+// timeout) — capped short via a separate apply.lock check below.
+//
+// The contract under test: a second apply against the same lockfile
+// MUST NOT proceed concurrently with the first. flock guarantees this
+// at the OS level; the test asserts the CLI surfaces it as a clear
+// error rather than blocking forever or silently racing.
+func TestConcurrentApply_LockSerializes(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+
+	// Hold the lock from another goroutine using the same iox helper
+	// the CLI uses. The CLI's apply path must observe contention and
+	// return an error rather than proceeding.
+	lockPath := filepath.Join(tmp, ".agentsync", ".state", "agentsync.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	holder, err := iox.AcquireLock(lockPath)
+	if err != nil {
+		t.Fatalf("could not seed-hold lock: %v", err)
+	}
+	defer func() { _ = holder.Release() }()
+
+	// Race a real apply against the held lock. We accept either:
+	//   1. error containing "busy" (the canonical contention message), or
+	//   2. error containing "another agentsync process running"
+	// Either is proof of serialization; both make the failure mode
+	// obvious to a human user.
+	done := make(chan struct {
+		out string
+		err error
+	}, 1)
+	go func() {
+		// Subtle: the CLI tests share process state through cobra's
+		// flag mutation; isolate this run inside a goroutine and wait
+		// with a deadline so a hang would still fail the test rather
+		// than blocking forever.
+		out, runErr := runCLI(t, env, "apply")
+		done <- struct {
+			out string
+			err error
+		}{out, runErr}
+	}()
+
+	// flock contention surfaces within the 30s lockTimeout. Cap the
+	// test deadline well above that to allow CI variance.
+	select {
+	case res := <-done:
+		if res.err == nil {
+			t.Fatalf("apply with externally-held lock should fail, got success:\n%s", res.out)
+		}
+		msg := res.err.Error()
+		lower := strings.ToLower(msg)
+		if !strings.Contains(lower, "busy") && !strings.Contains(lower, "another agentsync") {
+			t.Fatalf("apply error should name contention; got: %v", res.err)
+		}
+	case <-time.After(45 * time.Second):
+		t.Fatal("apply never returned; lock contention not surfaced as error")
+	}
+}
+
+// TestConcurrentApply_DryRunDoesNotContend asserts the dry-run path is
+// not gated on the global lock (sister regression to the apply-skip-
+// lock-on-dry-run fix), so a long real apply does not block previews.
+func TestConcurrentApply_DryRunDoesNotContend(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+
+	lockPath := filepath.Join(tmp, ".agentsync", ".state", "agentsync.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	holder, err := iox.AcquireLock(lockPath)
+	if err != nil {
+		t.Fatalf("could not seed-hold lock: %v", err)
+	}
+	defer func() { _ = holder.Release() }()
+
+	// Dry-run must finish promptly even with the lock held.
+	done := make(chan error, 1)
+	go func() {
+		_, runErr := runCLI(t, env, "apply", "--dry-run")
+		done <- runErr
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("dry-run should succeed under contention: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dry-run blocked behind held lock; should not acquire it")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,27 +1,54 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/source"
 )
 
 func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
-		Short: "print environment + adapter detection",
+		Short: "diagnose first-run readiness: environment, schema, secrets, adapters",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
+			home := paths.AgentsyncHome(paths.OSEnv{})
+
 			fmt.Fprintln(w, "agentsync doctor")
-			fmt.Fprintln(w, "  AGENTSYNC_HOME:", paths.AgentsyncHome(paths.OSEnv{}))
+			fmt.Fprintln(w, "  AGENTSYNC_HOME:", home)
 			fmt.Fprintln(w, "  Go version:    ", runtime.Version())
 			fmt.Fprintln(w, "  OS / arch:     ", runtime.GOOS, runtime.GOARCH)
+
 			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Adapter detection (M0: PATH-only)")
+			fmt.Fprintln(w, "Source repo")
+			fails := 0
+			fails += checkHomeDir(w, home)
+			fails += checkStateDir(w, home)
+			cfg, schemaOK := checkSchema(w, home)
+			if !schemaOK {
+				fails++
+			}
+
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Secrets")
+			if schemaOK {
+				fails += checkSecrets(w, cfg.Secrets, home)
+			} else {
+				fmt.Fprintln(w, "  skipped (schema invalid above)")
+			}
+
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Adapter detection (PATH-only)")
 			for _, agent := range []struct {
 				name string
 				bin  string
@@ -38,7 +65,154 @@ func newDoctorCmd() *cobra.Command {
 				}
 				fmt.Fprintf(w, "  %-10s %s\n", agent.name, p)
 			}
+
+			fmt.Fprintln(w, "")
+			if fails > 0 {
+				fmt.Fprintf(w, "%d issue(s) detected — fix before running `agentsync apply`\n", fails)
+				return fmt.Errorf("doctor: %d issue(s) detected", fails)
+			}
+			fmt.Fprintln(w, "all checks passed")
 			return nil
 		},
 	}
+}
+
+// checkHomeDir verifies that AGENTSYNC_HOME exists and is a directory.
+// Returns 1 if the check fails, 0 otherwise.
+func checkHomeDir(w io.Writer, home string) int {
+	info, err := os.Stat(home)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(w, "  home dir   missing — run `agentsync init`\n")
+			return 1
+		}
+		fmt.Fprintf(w, "  home dir   unreadable: %v\n", err)
+		return 1
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(w, "  home dir   exists but is not a directory: %s\n", home)
+		return 1
+	}
+	fmt.Fprintf(w, "  home dir   ok\n")
+	return 0
+}
+
+// checkStateDir verifies that .state/ is writable.
+func checkStateDir(w io.Writer, home string) int {
+	stateDir := filepath.Join(home, ".state")
+	if info, err := os.Stat(stateDir); err != nil {
+		fmt.Fprintf(w, "  .state/    missing — run `agentsync init`\n")
+		return 1
+	} else if !info.IsDir() {
+		fmt.Fprintf(w, "  .state/    exists but is not a directory\n")
+		return 1
+	}
+	probe := filepath.Join(stateDir, ".doctor-write-probe")
+	if err := os.WriteFile(probe, []byte{}, 0o600); err != nil {
+		fmt.Fprintf(w, "  .state/    not writable: %v\n", err)
+		return 1
+	}
+	_ = os.Remove(probe)
+	fmt.Fprintf(w, "  .state/    ok (writable)\n")
+	return 0
+}
+
+// checkSchema validates agentsync.toml. Returns the parsed Config plus a
+// success flag so secrets checks can reuse it.
+func checkSchema(w io.Writer, home string) (source.Config, bool) {
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		fmt.Fprintf(w, "  schema     invalid: %v\n", err)
+		return source.Config{}, false
+	}
+	fmt.Fprintf(w, "  schema     ok (%d mcp, %d plugin(s), %d marketplace(s))\n",
+		len(c.MCPServers), len(c.Plugins), len(c.Marketplaces))
+	return c.Config, true
+}
+
+// checkSecrets validates the [secrets] block: backend present, identity
+// file exists with restrictive permissions, recipient set.
+func checkSecrets(w io.Writer, cfg source.SecretsConfig, home string) int {
+	if cfg.Backend == "" {
+		fmt.Fprintf(w, "  backend    not configured (skip — no [secrets] block)\n")
+		return 0
+	}
+	if cfg.Backend != "age" {
+		fmt.Fprintf(w, "  backend    unsupported: %q (want \"age\")\n", cfg.Backend)
+		return 1
+	}
+	fmt.Fprintf(w, "  backend    age\n")
+
+	fails := 0
+	if cfg.Recipient == "" {
+		fmt.Fprintf(w, "  recipient  missing — set [secrets].recipient in agentsync.toml\n")
+		fails++
+	} else {
+		fmt.Fprintf(w, "  recipient  set\n")
+	}
+
+	idPath := cfg.IdentityFile
+	if idPath == "" {
+		fmt.Fprintf(w, "  identity   missing — set [secrets].identity_file in agentsync.toml\n")
+		return fails + 1
+	}
+	// Expand ${env:HOME} so the doctor message reflects the real path.
+	if h := os.Getenv("HOME"); h != "" {
+		idPath = expandEnvHome(idPath, h)
+	}
+	info, err := os.Stat(idPath)
+	if err != nil {
+		fmt.Fprintf(w, "  identity   %s — not readable (%v)\n", idPath, err)
+		return fails + 1
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		fmt.Fprintf(w, "  identity   %s — too permissive (%v); chmod 600\n", idPath, info.Mode().Perm())
+		return fails + 1
+	}
+	fmt.Fprintf(w, "  identity   ok (%s)\n", idPath)
+
+	// Age-encrypted file location — warn if missing (legitimate on a
+	// fresh install where the user hasn't called `secrets set` yet).
+	agePath := cfg.File
+	if agePath == "" {
+		agePath = "secrets/secrets.age"
+	}
+	if !filepath.IsAbs(agePath) {
+		agePath = filepath.Join(home, agePath)
+	}
+	if _, err := os.Stat(agePath); err != nil {
+		fmt.Fprintf(w, "  age file   %s — not yet created (run `agentsync secrets edit` to author)\n", agePath)
+	} else {
+		fmt.Fprintf(w, "  age file   %s\n", agePath)
+	}
+	return fails
+}
+
+// expandEnvHome replaces ${env:HOME} with the supplied HOME value, mirroring
+// the (very small) substitution agentsync does for identity_file paths.
+func expandEnvHome(s, home string) string {
+	const tok = "${env:HOME}"
+	if len(s) == 0 {
+		return s
+	}
+	out := s
+	for {
+		i := indexOf(out, tok)
+		if i < 0 {
+			return out
+		}
+		out = out[:i] + home + out[i+len(tok):]
+	}
+}
+
+func indexOf(s, sub string) int {
+	if len(sub) == 0 || len(sub) > len(s) {
+		return -1
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -14,9 +16,60 @@ func TestDoctor_PrintsEnvAndAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doctor: %v\n%s", err, out)
 	}
-	for _, want := range []string{"AGENTSYNC_HOME", "Go version", "OS", "claude", "opencode"} {
+	for _, want := range []string{
+		"AGENTSYNC_HOME", "Go version", "OS",
+		"home dir   ok", ".state/    ok", "schema     ok",
+		"claude", "opencode",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing %q. Got:\n%s", want, out)
 		}
+	}
+}
+
+// TestDoctor_FailsOnMissingHome asserts that doctor exits non-zero when
+// the user runs it before `agentsync init`. The old PATH-only doctor
+// returned ok no matter what.
+func TestDoctor_FailsOnMissingHome(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	out, err := runCLI(t, env, "doctor")
+	if err == nil {
+		t.Fatalf("doctor should fail on missing home; got:\n%s", out)
+	}
+	if !strings.Contains(out, "agentsync init") {
+		t.Fatalf("doctor should suggest `agentsync init` on missing home; got:\n%s", out)
+	}
+}
+
+// TestDoctor_FailsOnBadIdentityPerms asserts that a too-permissive age
+// identity file fails the readiness check.
+func TestDoctor_FailsOnBadIdentityPerms(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp}
+	_, _ = runCLI(t, env, "init")
+
+	identity := filepath.Join(tmp, "age.key")
+	if err := os.WriteFile(identity, []byte("# fake key\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	body := `[agents]
+[secrets]
+backend       = "age"
+recipient     = "age1qqqq"
+identity_file = "` + identity + `"
+file          = "secrets/secrets.age"
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "doctor")
+	if err == nil {
+		t.Fatalf("doctor should fail on 0644 identity; got:\n%s", out)
+	}
+	if !strings.Contains(out, "too permissive") {
+		t.Fatalf("doctor should warn about identity perms; got:\n%s", out)
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -73,7 +73,14 @@ func newInitCmd() *cobra.Command {
 			if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(initialAgentsyncTOML), 0o644); err != nil {
 				return fmt.Errorf("write agentsync.toml: %w", err)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "agentsync home initialized at", home)
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, "agentsync home initialized at", home)
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Next steps:")
+			fmt.Fprintln(w, "  1. agentsync agent add claude        # register an agent")
+			fmt.Fprintln(w, "  2. agentsync mcp add github ...      # author an MCP server")
+			fmt.Fprintln(w, "  3. agentsync apply --dry-run         # preview before writing")
+			fmt.Fprintln(w, "  4. agentsync apply                   # write to agent destinations")
 			return nil
 		},
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -42,9 +42,9 @@ into ~/.agentsync/ instead of scaffolding — for bootstrapping a new
 machine from an existing source-of-truth repo (typically chezmoi-
 managed).
 
-The destination must not exist or be empty; init refuses to overwrite a
-populated home so a careless `+"`agentsync init`"+` on a working install does
-not nuke it.`,
+The destination must not exist or be empty; init refuses to overwrite
+a populated home so a careless re-run on a working install does not
+nuke it.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -36,8 +36,19 @@ func newInitCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
-			if entries, _ := os.ReadDir(home); len(entries) > 0 {
+			// Explicit-error guard: tell the user the difference between
+			// "directory exists with files" (refuse) and "path exists but
+			// is unreadable / is a file" (different actionable error).
+			entries, err := os.ReadDir(home)
+			switch {
+			case err == nil && len(entries) > 0:
 				return fmt.Errorf("%s already contains files; refusing to overwrite", home)
+			case err == nil:
+				// Empty directory — fall through and populate.
+			case os.IsNotExist(err):
+				// Path doesn't exist yet — MkdirAll below creates it.
+			default:
+				return fmt.Errorf("inspect %s: %w (remove the path or set $AGENTSYNC_HOME to a writable location)", home, err)
 			}
 
 			// Every canonical subdirectory the loader recognizes is created up

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/paths"
 )
@@ -31,57 +34,124 @@ default_interval = "24h"
 
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "init",
-		Short: "scaffold ~/.agentsync/ with empty subdirectories and stub agentsync.toml",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			home := paths.AgentsyncHome(paths.OSEnv{})
-			// Explicit-error guard: tell the user the difference between
-			// "directory exists with files" (refuse) and "path exists but
-			// is unreadable / is a file" (different actionable error).
-			entries, err := os.ReadDir(home)
-			switch {
-			case err == nil && len(entries) > 0:
-				return fmt.Errorf("%s already contains files; refusing to overwrite", home)
-			case err == nil:
-				// Empty directory — fall through and populate.
-			case os.IsNotExist(err):
-				// Path doesn't exist yet — MkdirAll below creates it.
-			default:
-				return fmt.Errorf("inspect %s: %w (remove the path or set $AGENTSYNC_HOME to a writable location)", home, err)
-			}
+		Use:   "init [<git-url>]",
+		Short: "scaffold ~/.agentsync/ (or clone an existing source repo)",
+		Long: `init scaffolds ~/.agentsync/ with the canonical subdirectory layout and
+a stub agentsync.toml. If a git URL is supplied, init clones that repo
+into ~/.agentsync/ instead of scaffolding — for bootstrapping a new
+machine from an existing source-of-truth repo (typically chezmoi-
+managed).
 
-			// Every canonical subdirectory the loader recognizes is created up
-			// front so `agentsync agent list`, `verify`, and the writer
-			// helpers find a populated tree even on an empty install.
-			subs := []string{
-				"mcp", "marketplaces", "plugins",
-				"memory", "memory/fragments",
-				"skills", "agents", "commands", "hooks", "lsp",
-				".state",
+The destination must not exist or be empty; init refuses to overwrite a
+populated home so a careless `+"`agentsync init`"+` on a working install does
+not nuke it.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			if err := guardEmptyHome(home); err != nil {
+				return err
 			}
-			for _, sub := range subs {
-				if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
-					return fmt.Errorf("mkdir %s: %w", sub, err)
-				}
+			if len(args) == 1 {
+				return cloneSourceRepo(cmd, home, args[0])
 			}
-			// Secrets dir holds the age-encrypted file; restrict to the user
-			// even though the file itself is written 0600.
-			if err := os.MkdirAll(filepath.Join(home, "secrets"), 0o700); err != nil {
-				return fmt.Errorf("mkdir secrets: %w", err)
-			}
-			if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(initialAgentsyncTOML), 0o644); err != nil {
-				return fmt.Errorf("write agentsync.toml: %w", err)
-			}
-			w := cmd.OutOrStdout()
-			fmt.Fprintln(w, "agentsync home initialized at", home)
-			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Next steps:")
-			fmt.Fprintln(w, "  1. agentsync agent add claude        # register an agent")
-			fmt.Fprintln(w, "  2. agentsync mcp add github ...      # author an MCP server")
-			fmt.Fprintln(w, "  3. agentsync apply --dry-run         # preview before writing")
-			fmt.Fprintln(w, "  4. agentsync apply                   # write to agent destinations")
-			return nil
+			return scaffoldHome(cmd, home)
 		},
+	}
+}
+
+// guardEmptyHome refuses to operate when home already contains files.
+// Missing path is fine — caller's MkdirAll / clone will create it.
+func guardEmptyHome(home string) error {
+	entries, err := os.ReadDir(home)
+	switch {
+	case err == nil && len(entries) > 0:
+		return fmt.Errorf("%s already contains files; refusing to overwrite", home)
+	case err == nil:
+		return nil
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return fmt.Errorf("inspect %s: %w (remove the path or set $AGENTSYNC_HOME to a writable location)", home, err)
+	}
+}
+
+// scaffoldHome populates an empty home directory with the canonical
+// subdirectory layout and a stub agentsync.toml.
+func scaffoldHome(cmd *cobra.Command, home string) error {
+	subs := []string{
+		"mcp", "marketplaces", "plugins",
+		"memory", "memory/fragments",
+		"skills", "agents", "commands", "hooks", "lsp",
+		".state",
+	}
+	for _, sub := range subs {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", sub, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(home, "secrets"), 0o700); err != nil {
+		return fmt.Errorf("mkdir secrets: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(initialAgentsyncTOML), 0o644); err != nil {
+		return fmt.Errorf("write agentsync.toml: %w", err)
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "agentsync home initialized at", home)
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Next steps:")
+	fmt.Fprintln(w, "  1. agentsync agent add claude        # register an agent")
+	fmt.Fprintln(w, "  2. agentsync mcp add github ...      # author an MCP server")
+	fmt.Fprintln(w, "  3. agentsync apply --dry-run         # preview before writing")
+	fmt.Fprintln(w, "  4. agentsync apply                   # write to agent destinations")
+	return nil
+}
+
+// cloneSourceRepo clones rawURL into home. The URL must use https://,
+// ssh://, git+ssh://, or file:// — plain http and git:// are rejected
+// because the clone target is the user's canonical config.
+// After clone, `.state/` is created (gitignored on the source side, but
+// the directory must exist for later commands).
+func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
+	if err := validateCloneURL(rawURL); err != nil {
+		return err
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "cloning %s into %s ...\n", rawURL, home)
+	if _, err := git.PlainClone(home, false, &git.CloneOptions{URL: rawURL, Depth: 1}); err != nil {
+		return fmt.Errorf("clone %s: %w", rawURL, err)
+	}
+	// .state/ is always local — never tracked by the source repo.
+	if err := os.MkdirAll(filepath.Join(home, ".state"), 0o755); err != nil {
+		return fmt.Errorf("mkdir .state: %w", err)
+	}
+	fmt.Fprintln(w, "cloned. Run `agentsync apply --dry-run` to preview against this machine.")
+	return nil
+}
+
+// validateCloneURL rejects unsafe URL schemes for the source-repo
+// bootstrap (where unrestricted user execution flows are likely).
+func validateCloneURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("git URL is empty")
+	}
+	if strings.HasPrefix(raw, "git@") {
+		// scp-style ssh URL — go-git accepts these.
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse %q: %w", raw, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https", "ssh", "git+ssh", "file":
+		return nil
+	case "http", "git":
+		if os.Getenv("AGENTSYNC_ALLOW_INSECURE_URLS") == "1" {
+			return nil
+		}
+		return fmt.Errorf("init URL %q uses insecure scheme %q; "+
+			"set AGENTSYNC_ALLOW_INSECURE_URLS=1 to override", raw, u.Scheme)
+	default:
+		return fmt.Errorf("init URL %q has unsupported scheme %q (want https/ssh/file)", raw, u.Scheme)
 	}
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -41,6 +41,22 @@ func TestInit_FreshScaffold(t *testing.T) {
 	}
 }
 
+// TestInit_RejectsBadCloneURL covers the scheme-validation path so a user
+// who pastes "http://..." or a typo gets a clear error before go-git is
+// even called.
+func TestInit_RejectsBadCloneURL(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	out, err := runCLI(t, env, "init", "http://example.com/foo.git")
+	if err == nil {
+		t.Fatalf("init should reject http://; got:\n%s", out)
+	}
+	out, err = runCLI(t, env, "init", "rsync://example.com/foo")
+	if err == nil {
+		t.Fatalf("init should reject unsupported scheme; got:\n%s", out)
+	}
+}
+
 func TestInit_RefusesPopulatedHome(t *testing.T) {
 	tmp := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(tmp, ".agentsync"), 0o755)

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// newMCPCmd implements `agentsync mcp {add,remove,list}`. The design
+// spec also lists `set`, `enable`, `disable`; today add overwrites
+// (effectively set) and the [enabled] field on MCPServerSpec is read by
+// the loader, but the dedicated subcommands are deferred to v1.x.
+func newMCPCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "manage MCP servers in the canonical source",
+	}
+	cmd.AddCommand(
+		newMCPAddCmd(),
+		newMCPRemoveCmd(),
+		newMCPListCmd(),
+	)
+	return cmd
+}
+
+func newMCPAddCmd() *cobra.Command {
+	var (
+		serverType string
+		command    string
+		argsCSV    string
+		url        string
+		envCSV     string
+		agentsCSV  string
+	)
+	cmd := &cobra.Command{
+		Use:   "add <id>",
+		Short: "author mcp/<id>.toml in the canonical source",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error {
+				return mcpAddRun(cmd, home, id, serverType, command, argsCSV, url, envCSV, agentsCSV)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&serverType, "type", "stdio", "server transport (stdio|http|sse)")
+	cmd.Flags().StringVar(&command, "command", "", "executable for stdio transport")
+	cmd.Flags().StringVar(&argsCSV, "args", "", "comma-separated args (escape commas with \\,)")
+	cmd.Flags().StringVar(&url, "url", "", "server URL for http/sse transport")
+	cmd.Flags().StringVar(&envCSV, "env", "", "KEY=VAL,KEY=VAL environment overrides")
+	cmd.Flags().StringVar(&agentsCSV, "agents", "*", "comma-separated agent allowlist (\"*\" = all enabled)")
+	return cmd
+}
+
+func mcpAddRun(cmd *cobra.Command, home, id, serverType, command, argsCSV, url, envCSV, agentsCSV string) error {
+	if err := validateMCPID(id); err != nil {
+		return err
+	}
+	if err := validateMCPSpec(serverType, command, url); err != nil {
+		return err
+	}
+
+	spec := source.MCPServerSpec{Type: serverType}
+	switch serverType {
+	case "stdio":
+		spec.Command = command
+		spec.Args = splitArgs(argsCSV)
+	case "http", "sse":
+		spec.URL = url
+	}
+	if envCSV != "" {
+		env, err := parseEnvCSV(envCSV)
+		if err != nil {
+			return err
+		}
+		spec.Env = env
+	}
+	if agentsCSV != "" {
+		spec.Agents = splitAgents(agentsCSV)
+	}
+
+	dest := filepath.Join(home, "mcp", id+".toml")
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Errorf("mcp/%s.toml already exists; remove it first or edit by hand", id)
+	}
+	if err := source.WriteMCP(home, id, source.MCPServer{Server: spec}); err != nil {
+		return fmt.Errorf("write %s: %w", dest, err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "added mcp server: %s -> %s\n", id, dest)
+	return nil
+}
+
+func newMCPRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "delete mcp/<id>.toml from the canonical source",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			if err := validateMCPID(id); err != nil {
+				return err
+			}
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error {
+				p := filepath.Join(home, "mcp", id+".toml")
+				if err := os.Remove(p); err != nil {
+					if os.IsNotExist(err) {
+						return fmt.Errorf("mcp/%s.toml not found", id)
+					}
+					return fmt.Errorf("remove %s: %w", p, err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "removed mcp server: %s\n", id)
+				return nil
+			})
+		},
+	}
+}
+
+func newMCPListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "list MCP servers in the canonical source",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			dir := filepath.Join(home, "mcp")
+			entries, err := os.ReadDir(dir)
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("read %s: %w", dir, err)
+			}
+			var ids []string
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+					continue
+				}
+				ids = append(ids, strings.TrimSuffix(e.Name(), ".toml"))
+			}
+			sort.Strings(ids)
+			if len(ids) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "(no MCP servers; try: agentsync mcp add github --command npx --args \"-y,@modelcontextprotocol/server-github\")")
+				return nil
+			}
+			for _, id := range ids {
+				fmt.Fprintln(cmd.OutOrStdout(), id)
+			}
+			return nil
+		},
+	}
+}
+
+// validateMCPID rejects ids that would not produce a clean
+// mcp/<id>.toml file path.
+func validateMCPID(id string) error {
+	if id == "" {
+		return fmt.Errorf("mcp id is empty")
+	}
+	if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
+		return fmt.Errorf("mcp id %q contains a path component", id)
+	}
+	return nil
+}
+
+// validateMCPSpec enforces the type ⇄ command/url contract.
+func validateMCPSpec(serverType, command, url string) error {
+	switch serverType {
+	case "stdio":
+		if command == "" {
+			return fmt.Errorf("--command required for stdio transport")
+		}
+		if url != "" {
+			return fmt.Errorf("--url not allowed for stdio transport")
+		}
+	case "http", "sse":
+		if url == "" {
+			return fmt.Errorf("--url required for %s transport", serverType)
+		}
+		if command != "" {
+			return fmt.Errorf("--command not allowed for %s transport", serverType)
+		}
+	default:
+		return fmt.Errorf("unknown --type %q (want stdio|http|sse)", serverType)
+	}
+	return nil
+}
+
+// splitArgs splits a comma-separated args string, honoring \, as an
+// escaped literal comma so users can pass values containing commas.
+func splitArgs(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var (
+		out []string
+		buf strings.Builder
+	)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if i+1 < len(s) && s[i+1] == ',' {
+				buf.WriteByte(',')
+				i++
+				continue
+			}
+			buf.WriteByte(s[i])
+		case ',':
+			out = append(out, buf.String())
+			buf.Reset()
+		default:
+			buf.WriteByte(s[i])
+		}
+	}
+	out = append(out, buf.String())
+	return out
+}
+
+// parseEnvCSV parses "KEY=VAL,KEY=VAL" into a map.
+func parseEnvCSV(s string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, pair := range splitArgs(s) {
+		i := strings.IndexByte(pair, '=')
+		if i <= 0 {
+			return nil, fmt.Errorf("--env entry %q must be KEY=VAL", pair)
+		}
+		out[pair[:i]] = pair[i+1:]
+	}
+	return out, nil
+}
+
+// splitAgents normalizes a comma-separated agents allowlist.
+func splitAgents(s string) []string {
+	parts := splitArgs(s)
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -1,0 +1,108 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestMCP_AddStdio_WritesCanonicalTOML(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	_, _ = runCLI(t, env, "init")
+
+	out, err := runCLI(t, env, "mcp", "add", "github",
+		"--command", "npx",
+		"--args", "-y,@modelcontextprotocol/server-github")
+	if err != nil {
+		t.Fatalf("mcp add: %v\n%s", err, out)
+	}
+
+	p := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	var m source.MCPServer
+	if err := toml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse written toml: %v\n%s", err, data)
+	}
+	if m.Server.Type != "stdio" {
+		t.Errorf("type = %q, want stdio", m.Server.Type)
+	}
+	if m.Server.Command != "npx" {
+		t.Errorf("command = %q, want npx", m.Server.Command)
+	}
+	want := []string{"-y", "@modelcontextprotocol/server-github"}
+	if len(m.Server.Args) != len(want) {
+		t.Fatalf("args len = %d, want %d (%v)", len(m.Server.Args), len(want), m.Server.Args)
+	}
+	for i, a := range want {
+		if m.Server.Args[i] != a {
+			t.Errorf("args[%d] = %q, want %q", i, m.Server.Args[i], a)
+		}
+	}
+}
+
+func TestMCP_AddRejectsDuplicates(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	_, _ = runCLI(t, env, "init")
+	_, _ = runCLI(t, env, "mcp", "add", "github", "--command", "npx", "--args", "-y,server")
+	out, err := runCLI(t, env, "mcp", "add", "github", "--command", "npx", "--args", "-y,server")
+	if err == nil {
+		t.Fatalf("second add should refuse; got:\n%s", out)
+	}
+}
+
+func TestMCP_AddHTTPRequiresURL(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	_, _ = runCLI(t, env, "init")
+	_, err := runCLI(t, env, "mcp", "add", "x", "--type", "http")
+	if err == nil {
+		t.Fatal("http add without --url should fail")
+	}
+}
+
+func TestMCP_ListAndRemove(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	_, _ = runCLI(t, env, "init")
+	_, _ = runCLI(t, env, "mcp", "add", "github", "--command", "npx", "--args", "-y,server")
+	_, _ = runCLI(t, env, "mcp", "add", "gitlab", "--command", "npx", "--args", "-y,server")
+
+	out, err := runCLI(t, env, "mcp", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, want := range []string{"github", "gitlab"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list missing %q\n%s", want, out)
+		}
+	}
+
+	if _, err := runCLI(t, env, "mcp", "remove", "github"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", "github.toml")); !os.IsNotExist(err) {
+		t.Fatalf("github.toml should be removed; stat err = %v", err)
+	}
+}
+
+func TestMCP_IDValidation(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	_, _ = runCLI(t, env, "init")
+	bad := []string{"../escape", "a/b", "a\\b"}
+	for _, id := range bad {
+		_, err := runCLI(t, env, "mcp", "add", id, "--command", "x", "--args", "y")
+		if err == nil {
+			t.Errorf("id %q should be rejected", id)
+		}
+	}
+}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -60,6 +60,14 @@ func newPluginInstallCmd() *cobra.Command {
 
 func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	id, mpName := splitPluginRef(args[0])
+	if err := validateCacheKey("plugin", id); err != nil {
+		return err
+	}
+	if mpName != "" {
+		if err := validateCacheKey("marketplace", mpName); err != nil {
+			return err
+		}
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	// Resolve marketplace.json from the marketplace cache.
@@ -358,14 +366,52 @@ func resolveMarketplaceName(name string) string {
 	return name
 }
 
-// pluginCacheDir returns the cache directory for a plugin.
+// pluginCacheDir returns the cache directory for a plugin. The id is
+// sanitized so a hostile marketplace publishing a plugin named
+// "../../etc/foo" cannot cause writes outside .state/cache/plugins/.
 func pluginCacheDir(home, id string) string {
-	return filepath.Join(home, ".state", "cache", "plugins", id)
+	return filepath.Join(home, ".state", "cache", "plugins", sanitizeCacheKey(id))
 }
 
 // marketplaceCacheDir returns the cache directory for a marketplace.
+// Same sanitization applies — the marketplace name is user-supplied at
+// `marketplace add` time and must not escape the cache root.
 func marketplaceCacheDir(home, mpName string) string {
-	return filepath.Join(home, ".state", "cache", "marketplaces", mpName)
+	return filepath.Join(home, ".state", "cache", "marketplaces", sanitizeCacheKey(mpName))
+}
+
+// sanitizeCacheKey strips path separators and ".." components so the
+// returned string is safe to use as a single path segment. Callers can
+// also validate up-front via ValidateCacheKey before any filesystem
+// operation; this helper is the last line of defense for read-only
+// lookups where validation might be too aggressive.
+func sanitizeCacheKey(s string) string {
+	// Replace separators and walk-up components with an underscore.
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, "..", "_")
+	if s == "" || s == "." {
+		s = "_"
+	}
+	return s
+}
+
+// validateCacheKey is the up-front guard for write paths: it rejects
+// plugin / marketplace ids that contain path components which could
+// escape the cache root. Callers should prefer this to sanitizeCacheKey
+// when the id flows from user input or marketplace metadata so the user
+// sees the real problem name in the error, not a silently-mangled one.
+func validateCacheKey(kind, s string) error {
+	if s == "" {
+		return fmt.Errorf("%s id is empty", kind)
+	}
+	if strings.ContainsAny(s, "/\\") {
+		return fmt.Errorf("%s id %q contains path separators", kind, s)
+	}
+	if s == "." || s == ".." || strings.Contains(s, "..") {
+		return fmt.Errorf("%s id %q contains a path-traversal component", kind, s)
+	}
+	return nil
 }
 
 // resolveMarketplaceEntry loads the marketplace's marketplace.json from cache

--- a/internal/cli/plugin_validate_test.go
+++ b/internal/cli/plugin_validate_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import "testing"
+
+func TestSanitizeCacheKey(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"simple", "simple"},
+		{"../../etc/passwd", "____etc_passwd"},
+		{"a/b", "a_b"},
+		{"a\\b", "a_b"},
+		{"", "_"},
+		{".", "_"},
+		{"..", "_"},
+	}
+	for _, tc := range cases {
+		got := sanitizeCacheKey(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeCacheKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateCacheKey(t *testing.T) {
+	bad := []string{"", "..", ".", "a/b", "a\\b", "a/../b", "../etc/passwd"}
+	for _, s := range bad {
+		if err := validateCacheKey("plugin", s); err == nil {
+			t.Errorf("validateCacheKey(%q) should reject", s)
+		}
+	}
+	good := []string{"atlassian", "obra-superpowers", "a.b.c", "abc123"}
+	for _, s := range good {
+		if err := validateCacheKey("plugin", s); err != nil {
+			t.Errorf("validateCacheKey(%q) should accept: %v", s, err)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRoot() *cobra.Command {
 		newStatusCmd(),
 		newDiffCmd(),
 		newReconcileCmd(),
+		newMCPCmd(),
 		newPluginCmd(),
 		newMarketplaceCmd(),
 		newUpdateCmd(),

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -151,13 +151,13 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if cfg.Backend != "age" {
-		return fmt.Errorf("secrets edit requires backend = \"age\" in opensync.toml [secrets]")
+		return fmt.Errorf("secrets edit requires backend = \"age\" in agentsync.toml [secrets]")
 	}
 	if cfg.Recipient == "" {
-		return fmt.Errorf("secrets edit requires [secrets].recipient in opensync.toml")
+		return fmt.Errorf("secrets edit requires [secrets].recipient in agentsync.toml")
 	}
 	if cfg.IdentityFile == "" {
-		return fmt.Errorf("secrets edit requires [secrets].identity_file in opensync.toml")
+		return fmt.Errorf("secrets edit requires [secrets].identity_file in agentsync.toml")
 	}
 
 	agePath := resolveAgePath(cfg, home)
@@ -221,7 +221,7 @@ func secretsGet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if cfg.Backend != "age" {
-		return fmt.Errorf("secrets get requires backend = \"age\" in opensync.toml [secrets]")
+		return fmt.Errorf("secrets get requires backend = \"age\" in agentsync.toml [secrets]")
 	}
 
 	m, err := decryptToMap(cfg, home)
@@ -242,13 +242,13 @@ func secretsSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if cfg.Backend != "age" {
-		return fmt.Errorf("secrets set requires backend = \"age\" in opensync.toml [secrets]")
+		return fmt.Errorf("secrets set requires backend = \"age\" in agentsync.toml [secrets]")
 	}
 	if cfg.Recipient == "" {
-		return fmt.Errorf("secrets set requires [secrets].recipient in opensync.toml")
+		return fmt.Errorf("secrets set requires [secrets].recipient in agentsync.toml")
 	}
 	if cfg.IdentityFile == "" {
-		return fmt.Errorf("secrets set requires [secrets].identity_file in opensync.toml")
+		return fmt.Errorf("secrets set requires [secrets].identity_file in agentsync.toml")
 	}
 
 	kv := args[0]

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -2,17 +2,21 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
 func newVerifyCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "verify",
-		Short: "schema-lint ~/.agentsync/ on demand",
+		Short: "schema-lint ~/.agentsync/ and validate secrets resolvability on demand",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
@@ -25,8 +29,63 @@ func newVerifyCmd() *cobra.Command {
 					return fmt.Errorf("agents.%s: %w", name, err)
 				}
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "ok: schema valid; all referenced agents are recognized adapters")
+			if err := verifySecrets(c.Config.Secrets, home); err != nil {
+				return fmt.Errorf("verify secrets: %w", err)
+			}
+			// Substitute against the live backends (using AGENTSYNC_ALLOW_OFFLINE_VERIFY
+			// to skip secret resolution when running in CI without an age key).
+			if os.Getenv("AGENTSYNC_ALLOW_OFFLINE_VERIFY") != "1" {
+				secBackend := secrets.SelectBackend(c.Config.Secrets, home)
+				envBackend := secrets.EnvBackend{}
+				if err := secrets.SubstituteCanonical(&c, secBackend, envBackend); err != nil {
+					return fmt.Errorf("verify ${secret:}/${env:} resolution: %w", err)
+				}
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "ok: schema valid; all references resolve")
 			return nil
 		},
 	}
+}
+
+// verifySecrets validates the [secrets] block beyond the schema decode:
+// recipient and identity_file are required when backend is age, the
+// identity file must be readable, and on POSIX the file must not be
+// world- or group-readable.
+func verifySecrets(cfg source.SecretsConfig, home string) error {
+	if cfg.Backend == "" || cfg.Backend == "env" {
+		return nil
+	}
+	if cfg.Backend != "age" {
+		return fmt.Errorf("backend %q not supported (want \"age\" or \"env\")", cfg.Backend)
+	}
+	if cfg.Recipient == "" {
+		return fmt.Errorf("[secrets].recipient is required for backend = \"age\"")
+	}
+	if cfg.IdentityFile == "" {
+		return fmt.Errorf("[secrets].identity_file is required for backend = \"age\"")
+	}
+	idPath := cfg.IdentityFile
+	if h := os.Getenv("HOME"); h != "" {
+		idPath = expandEnvHome(idPath, h)
+	}
+	info, err := os.Stat(idPath)
+	if err != nil {
+		return fmt.Errorf("identity_file %s: %w", idPath, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("identity_file %s has mode %v; agentsync requires 0600", idPath, info.Mode().Perm())
+	}
+	// File path is optional (a brand-new install may not have written yet).
+	if cfg.File != "" {
+		agePath := cfg.File
+		if !filepath.IsAbs(agePath) {
+			agePath = filepath.Join(home, agePath)
+		}
+		// Stat the path but don't require existence — secrets edit creates
+		// it lazily. Only flag if it's there but unreadable.
+		if _, err := os.Stat(agePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("secrets.file %s: %w", agePath, err)
+		}
+	}
+	return nil
 }

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -36,6 +36,56 @@ func TestVerify_BadTOML(t *testing.T) {
 	}
 }
 
+// TestVerify_AgeMissingRecipient asserts verify catches a half-configured
+// [secrets] block (backend = age but no recipient).
+func TestVerify_AgeMissingRecipient(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp}
+	_, _ = runCLI(t, env, "init")
+
+	identity := filepath.Join(tmp, "age.key")
+	_ = os.WriteFile(identity, []byte("AGE-SECRET-KEY-...\n"), 0o600)
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	body := `[agents]
+[secrets]
+backend       = "age"
+identity_file = "` + identity + `"
+`
+	_ = os.WriteFile(cfgPath, []byte(body), 0o644)
+
+	out, err := runCLI(t, env, "verify")
+	if err == nil {
+		t.Fatalf("verify should fail when recipient is missing; got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "recipient") {
+		t.Fatalf("verify should name the missing field; got err=%q out=%s", err, out)
+	}
+}
+
+// TestVerify_AgeIdentityPerms asserts verify rejects a world-readable
+// identity file.
+func TestVerify_AgeIdentityPerms(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp}
+	_, _ = runCLI(t, env, "init")
+
+	identity := filepath.Join(tmp, "age.key")
+	_ = os.WriteFile(identity, []byte("AGE-SECRET-KEY-...\n"), 0o644)
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	body := `[agents]
+[secrets]
+backend       = "age"
+recipient     = "age1qqqq"
+identity_file = "` + identity + `"
+`
+	_ = os.WriteFile(cfgPath, []byte(body), 0o644)
+
+	out, err := runCLI(t, env, "verify")
+	if err == nil {
+		t.Fatalf("verify should fail on 0644 identity; got:\n%s", out)
+	}
+}
+
 func TestVerify_UnknownAgent(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/marketplace/fetch_npm.go
+++ b/internal/marketplace/fetch_npm.go
@@ -181,6 +181,12 @@ func (f *NPMFetcher) downloadAndExtract(client *http.Client, url, destDir string
 				return err
 			}
 			out.Close()
+		case tar.TypeSymlink, tar.TypeLink:
+			// Explicit reject: even with destPath bounded, a symlink
+			// could later be written through (TOCTOU) or surprise the
+			// adapter expecting regular files. Plugin tarballs don't
+			// need links — fail loud rather than silently drop.
+			return fmt.Errorf("npm fetcher: tarball entry %q is a symlink/hardlink (refusing — plugin tarballs must be regular files)", hdr.Name)
 		}
 	}
 	return nil

--- a/internal/marketplace/fetch_test.go
+++ b/internal/marketplace/fetch_test.go
@@ -470,3 +470,88 @@ func TestNPMFetcher_TraversalEntryIsHardError(t *testing.T) {
 		t.Fatalf("error %q did not mention escape", err.Error())
 	}
 }
+
+// makeNPMTarballWithSymlink builds a tarball containing a single
+// symlink entry. Used to assert npm fetcher refuses to extract links
+// (TOCTOU-escape risk).
+func makeNPMTarballWithSymlink(t *testing.T, linkName, target string) []byte {
+	t.Helper()
+	tmp := t.TempDir()
+	outPath := filepath.Join(tmp, "pkg.tgz")
+	f, err := os.Create(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	hdr := &tar.Header{
+		Name:     "package/" + linkName,
+		Linkname: target,
+		Typeflag: tar.TypeSymlink,
+		Mode:     0o777,
+		ModTime:  time.Now(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestNPMFetcher_SymlinkEntryIsRefused asserts that a tarball containing
+// a symlink entry — even one whose link target is "safe" — is rejected.
+// Symlinks in plugin tarballs have no legitimate use and have repeatedly
+// been the TOCTOU vector in similar projects (extract symlink, then a
+// later TypeReg entry writes through it to escape destDir).
+func TestNPMFetcher_SymlinkEntryIsRefused(t *testing.T) {
+	tarball := makeNPMTarballWithSymlink(t, "innocent.txt", "/etc/passwd")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/linkpkg":
+			meta := map[string]any{
+				"versions": map[string]any{
+					"1.0.0": map[string]any{
+						"version": "1.0.0",
+						"dist":    map[string]any{"tarball": "http://" + r.Host + "/tarball/1.0.0"},
+					},
+				},
+				"dist-tags": map[string]any{"latest": "1.0.0"},
+			}
+			_ = json.NewEncoder(w).Encode(meta)
+		case strings.HasPrefix(r.URL.Path, "/tarball/"):
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dst := t.TempDir()
+	src := marketplace.Source{Kind: "npm", Package: "linkpkg", Version: "1.0.0", Registry: srv.URL}
+	fetcher := &marketplace.NPMFetcher{HTTPClient: srv.Client()}
+	_, err := fetcher.Fetch(src, dst)
+	if err == nil {
+		t.Fatal("expected error for symlink tarball entry")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error %q did not mention symlink", err.Error())
+	}
+	// Defense check: nothing should be written under dst either.
+	entries, _ := os.ReadDir(dst)
+	for _, e := range entries {
+		t.Errorf("dst should be empty after refused extract; saw %s", e.Name())
+	}
+}

--- a/internal/marketplace/fetcher.go
+++ b/internal/marketplace/fetcher.go
@@ -1,6 +1,11 @@
 package marketplace
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
 
 // Fetcher fetches one plugin source into a local directory.
 type Fetcher interface {
@@ -28,6 +33,9 @@ func Dispatch(src Source) Fetcher {
 	if src.Relative != "" {
 		return &RelativeFetcher{}
 	}
+	if err := enforceSecureScheme(src); err != nil {
+		return &errFetcher{err: err}
+	}
 	switch src.Kind {
 	case "github", "url", "git-subdir":
 		return &GitFetcher{}
@@ -35,4 +43,38 @@ func Dispatch(src Source) Fetcher {
 		return &NPMFetcher{}
 	}
 	return &errFetcher{err: fmt.Errorf("unknown source kind %q", src.Kind)}
+}
+
+// enforceSecureScheme rejects plain-text URL schemes (http://, git://) so a
+// MITM cannot swap plugin content. Loopback file:// is allowed for test
+// fixtures, and ssh:// is allowed since SSH provides its own integrity. Users
+// who need a plain-http internal mirror can set AGENTSYNC_ALLOW_INSECURE_URLS=1.
+func enforceSecureScheme(src Source) error {
+	if os.Getenv("AGENTSYNC_ALLOW_INSECURE_URLS") == "1" {
+		return nil
+	}
+	candidates := []string{src.URL, src.Repo}
+	for _, raw := range candidates {
+		if raw == "" {
+			continue
+		}
+		// GitHub repos are written as "owner/repo" with no scheme; the
+		// GitFetcher prepends https://. Skip those.
+		if !strings.Contains(raw, "://") {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("parse plugin URL %q: %w", raw, err)
+		}
+		switch strings.ToLower(u.Scheme) {
+		case "https", "ssh", "git+ssh", "file":
+			// ok
+		case "http", "git":
+			return fmt.Errorf("plugin URL %q uses insecure scheme %q; "+
+				"set AGENTSYNC_ALLOW_INSECURE_URLS=1 to override (internal mirrors only)",
+				raw, u.Scheme)
+		}
+	}
+	return nil
 }

--- a/internal/marketplace/secure_scheme_test.go
+++ b/internal/marketplace/secure_scheme_test.go
@@ -1,0 +1,52 @@
+package marketplace
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDispatch_RejectsHTTP(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	f := Dispatch(Source{Kind: "url", URL: "http://example.com/plugin.git"})
+	_, err := f.Fetch(Source{Kind: "url", URL: "http://example.com/plugin.git"}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "insecure scheme") {
+		t.Fatalf("http URL should be rejected; got err=%v", err)
+	}
+}
+
+func TestDispatch_RejectsGitProtocol(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	f := Dispatch(Source{Kind: "url", URL: "git://example.com/plugin.git"})
+	_, err := f.Fetch(Source{Kind: "url", URL: "git://example.com/plugin.git"}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "insecure scheme") {
+		t.Fatalf("git:// URL should be rejected; got err=%v", err)
+	}
+}
+
+func TestDispatch_AllowsHTTPS(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	src := Source{Kind: "url", URL: "https://example.com/plugin.git"}
+	// We don't actually clone; just verify Dispatch returns the git
+	// fetcher, not the errFetcher.
+	f := Dispatch(src)
+	if _, ok := f.(*GitFetcher); !ok {
+		t.Fatalf("https URL should dispatch to GitFetcher; got %T", f)
+	}
+}
+
+func TestDispatch_AllowsGitHubShorthand(t *testing.T) {
+	src := Source{Kind: "github", Repo: "owner/repo"}
+	f := Dispatch(src)
+	if _, ok := f.(*GitFetcher); !ok {
+		t.Fatalf("github shorthand should dispatch to GitFetcher; got %T", f)
+	}
+}
+
+func TestDispatch_OverrideAllowsHTTP(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "1")
+	src := Source{Kind: "url", URL: "http://example.com/plugin.git"}
+	f := Dispatch(src)
+	if _, ok := f.(*GitFetcher); !ok {
+		t.Fatalf("env override should allow http; got %T", f)
+	}
+}

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -216,9 +216,34 @@ func (w *Writer) backup(path string, existing []byte) (string, error) {
 }
 
 // backupPathFor computes the deterministic backup destination for src.
+//
+// Defense-in-depth: filepath.Join cleans the joined path, so a src that
+// contains ".." segments could resolve outside backupRoot. We guarantee
+// containment by:
+//  1. Cleaning src first so ".." sequences are collapsed.
+//  2. Re-rooting via filepath.Rel to drop any prefix that would escape.
+//  3. Asserting the result is still under backupRoot.
+//
+// Today's adapters never produce ".." in destination paths, but the
+// guard means a future bug or hostile plugin component path can't turn
+// a backup into a write-anywhere primitive.
 func backupPathFor(src, backupRoot string) string {
-	clean := strings.TrimLeft(src, string(os.PathSeparator))
-	return filepath.Join(backupRoot, clean)
+	cleaned := filepath.Clean(src)
+	// Drop the leading separator(s) and any drive letter so Join treats
+	// the path as relative.
+	trimmed := strings.TrimLeft(cleaned, string(os.PathSeparator))
+	if vol := filepath.VolumeName(cleaned); vol != "" {
+		trimmed = strings.TrimLeft(strings.TrimPrefix(cleaned, vol), string(os.PathSeparator))
+	}
+	dest := filepath.Join(backupRoot, trimmed)
+	// Final containment check — if Clean leaves dest above backupRoot
+	// (e.g. trimmed started with ".."), fall back to a hash-style segment
+	// so we never escape.
+	rel, err := filepath.Rel(backupRoot, dest)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return filepath.Join(backupRoot, "_escaped", filepath.Base(cleaned))
+	}
+	return dest
 }
 
 // bytesEqual returns true iff a and b have identical contents.

--- a/internal/render/writer_internal_test.go
+++ b/internal/render/writer_internal_test.go
@@ -1,0 +1,34 @@
+package render
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBackupPathFor_NeverEscapesRoot asserts that no src — including
+// adversarial inputs containing ".." or absolute paths — can place the
+// backup destination outside backupRoot.
+func TestBackupPathFor_NeverEscapesRoot(t *testing.T) {
+	root := filepath.Join("/tmp", "agentsync-backup-root")
+	cases := []string{
+		"/home/user/.claude/settings.json",
+		"/home/user/../../../etc/passwd",
+		"../../etc/passwd",
+		"/./././tmp/foo",
+		"",
+		".",
+		"..",
+	}
+	for _, src := range cases {
+		dest := backupPathFor(src, root)
+		rel, err := filepath.Rel(root, dest)
+		if err != nil {
+			t.Errorf("backupPathFor(%q): Rel failed: %v", src, err)
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			t.Errorf("backupPathFor(%q) = %q escapes root %q (rel=%q)", src, dest, root, rel)
+		}
+	}
+}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -93,6 +93,13 @@ func projectPlugins(fs afero.Fs, c *Canonical, cacheDir string) error {
 		if id == "" {
 			id = pl.ID
 		}
+		// Defense-in-depth: a malicious plugins/<id>.toml whose id field
+		// contains "../" must not let plugin.json reads escape cacheDir.
+		// The CLI install path validates ids up-front, but this loader is
+		// also reachable from `apply` against a hand-edited plugins/ dir.
+		if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
+			return fmt.Errorf("project plugin %q: id contains path-traversal component", id)
+		}
 
 		pluginCacheDir := filepath.Join(cacheDir, id)
 		proj, err := readPluginProjection(fs, pluginCacheDir)

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -1,0 +1,37 @@
+package state
+
+import "fmt"
+
+// migrate brings a loaded Targets up to SchemaVersion. Today the only
+// recognized states are:
+//   - schema_version == 0 (legacy implicit-v1 file, written before the
+//     field was stamped): upgrade in place to current.
+//   - schema_version == SchemaVersion: nothing to do.
+//
+// A higher schema_version means a newer agentsync binary wrote this
+// file and the current binary cannot safely interpret it. We refuse
+// rather than silently treat unknown future fields as missing.
+//
+// When v2 ships, add a case here that walks v1 fields into the v2
+// shape. The Save() side stamps SchemaVersion = current, so post-
+// migration writes commit the upgrade.
+func migrate(t *Targets) error {
+	switch t.SchemaVersion {
+	case 0:
+		t.SchemaVersion = SchemaVersion
+	case SchemaVersion:
+		// no-op
+	default:
+		if t.SchemaVersion > SchemaVersion {
+			return fmt.Errorf("state schema_version=%d is newer than this binary supports (%d); "+
+				"upgrade agentsync or remove ~/.agentsync/.state/targets.json to start fresh",
+				t.SchemaVersion, SchemaVersion)
+		}
+		// Older but non-zero — no migrator registered yet. Bail loud so
+		// the user can decide rather than silently treating it as
+		// current.
+		return fmt.Errorf("no migrator registered for state schema_version=%d (current=%d)",
+			t.SchemaVersion, SchemaVersion)
+	}
+	return nil
+}

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -1,0 +1,34 @@
+package state
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMigrate_LegacyZeroBecomesCurrent(t *testing.T) {
+	tt := &Targets{SchemaVersion: 0}
+	if err := migrate(tt); err != nil {
+		t.Fatalf("legacy zero should migrate cleanly: %v", err)
+	}
+	if tt.SchemaVersion != SchemaVersion {
+		t.Errorf("schema not stamped: got %d want %d", tt.SchemaVersion, SchemaVersion)
+	}
+}
+
+func TestMigrate_CurrentIsNoop(t *testing.T) {
+	tt := &Targets{SchemaVersion: SchemaVersion}
+	if err := migrate(tt); err != nil {
+		t.Fatalf("current schema should be no-op: %v", err)
+	}
+}
+
+func TestMigrate_FutureRejected(t *testing.T) {
+	tt := &Targets{SchemaVersion: SchemaVersion + 1}
+	err := migrate(tt)
+	if err == nil {
+		t.Fatal("future schema should be rejected")
+	}
+	if !strings.Contains(err.Error(), "newer than this binary supports") {
+		t.Errorf("error should explain upgrade path; got %q", err)
+	}
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -23,8 +23,8 @@ func Load(path string) (*Targets, error) {
 	if err := json.Unmarshal(data, &t); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
-	if t.SchemaVersion == 0 {
-		t.SchemaVersion = SchemaVersion
+	if err := migrate(&t); err != nil {
+		return nil, fmt.Errorf("migrate %s: %w", path, err)
 	}
 	if t.Files == nil {
 		t.Files = map[string]FileEntry{}


### PR DESCRIPTION
Second-wave audit of the post-PR-#18 stack, applying the superpowers
framing (evidence over claims, TDD, complexity reduction). One focused
commit per finding, ordered surgical → architectural → feature so each
layer of the test suite stays green throughout.

Test gate: `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` green (incl. the
new 30-second concurrent-apply lock test); `go vet ./...` clean;
`go build ./...` clean.

## The first-run-bites-you items (Tier 1)

| # | Severity | Commit | Finding |
|---|---|---|---|
| 1 | high | `fix(cli): rename stale opensync references to agentsync` | `secrets.go` error messages told users to fix `opensync.toml` — a file that doesn't exist. Type `opensyncCfg` was the same leftover. |
| 2 | high | `feat(cli): implement mcp add/remove/list commands` | README quickstart line 10 promised `agentsync mcp add github ...` since v1.0 design lock; the command never landed. An internal test comment in `m1_integration_test.go` acknowledged the gap then M4 shipped without it. A new user following the README hit "unknown command" on the second instruction. |
| 3 | med | `feat(cli): init [<git-url>] clones bootstrap source repo` | Design spec line 361 documented `agentsync init [<git-url>]` for bootstrapping a new machine; `Args` was `cobra.NoArgs`. Anyone passing a URL got "unknown command argument" instead. |
| 4 | med | `fix(cli): doctor checks first-run readiness, not just PATH` | Old doctor only ran `exec.LookPath` for four binaries. Users saw green, then apply failed on missing schema, missing age key, or unwritable `.state/`. Doctor now exits non-zero for any of those + bad identity perms. |
| 5 | med | `fix(cli): reject agent add for codex/cursor with v1 status message` | `agent add codex/cursor` registered NoopAdapter silently; `apply` then produced 0 ops for that agent with no diagnostic. Reject by default with an actionable message; `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` for plan/spec work. |
| 6 | med | `fix(cli): warn at agent add when the agent binary is not on PATH` | `agent add` succeeded on machines without the agent installed. `apply` then wrote to `~/.claude/` and the user wondered why nothing happened. |
| 7 | med | `fix(cli): skip global lock for apply --dry-run` | Dry-run wrapped the whole RunE in `withGlobalLock`; a 30s real apply blocked every preview, status, diff. Real applies still acquire the lock. |
| 8 | low | `fix(cli): print first-run next-steps hint after init` | `init` printed one line, then silence. New user had to leave the CLI to read the README. Now ends with a numbered next-steps block. |
| 9 | low | `fix(cli): handle init guard errors explicitly` | `os.ReadDir` error was discarded; if home was a file (not dir), the guard slipped past and produced a worse mkdir error later. Three cases now distinguished. |

## Logic gaps (Tier 2)

| # | Severity | Commit | Finding |
|---|---|---|---|
| 10 | med | `fix(plugin,source): sanitize plugin/marketplace id against path traversal` | `pluginCacheDir(home, id)` joined an unsanitized id. A hostile marketplace publishing a plugin named `../../etc/foo` — or a hand-edited `plugins/<id>.toml` — let writes/reads escape `.state/cache/`. Up-front validation at install time + loader-side rejection of projection ids containing path components. |
| 11 | med | `fix(render): anchor backup destination under backupRoot` | `backupPathFor` did `filepath.Join(backupRoot, strings.TrimLeft(src, "/"))`. `filepath.Join` Cleans, so a src with `..` segments could resolve above backupRoot. Defense-in-depth: clean input, drop volume names, assert containment via `filepath.Rel`. |
| 12 | med | `fix(state): reject unknown schema_version instead of silent accept` | `Load` upgraded `SchemaVersion == 0` and silently accepted any other value. Future-v2 file loaded by v1 binary read as v1 with no error. New `migrate()` registers cases explicitly; refuses newer with "upgrade agentsync" message. |
| 13 | high | `fix(cli): verify validates secrets config and resolves ${secret:} refs` | Old verify only checked agent names. Now validates `[secrets]` (backend, recipient, identity_file existence + perms) and runs the same `SubstituteCanonical` apply uses, surfacing every unresolved marker. |
| 14 | med | `fix(marketplace): reject plain-http plugin URLs by default` | `Dispatch` accepted any URL scheme. A MITM (corp proxy, hotel wifi) could swap plugin content. Now refuses `http://` and `git://` unless `AGENTSYNC_ALLOW_INSECURE_URLS=1`. https/ssh/file/git+ssh stay allowed. |
| 15 | med | `fix(marketplace): refuse symlink entries in npm tarballs` | npm extractor handled `TypeDir`/`TypeReg` and silently dropped everything else. Symlinks in plugin tarballs have no legitimate use and are repeatedly the TOCTOU escape vector. Hard-reject with explicit error. |

## Test coverage gaps (Tier 3)

| # | Commit | Finding |
|---|---|---|
| 16 | `test(cli): spec-required concurrent apply lock contention test` | Design spec line 483 mandated "spawn two apply invocations against the same AGENTSYNC_TARGET_ROOT, assert serialization." The lock primitive had unit tests; the actual race the lock exists to prevent did not. Two scenarios: contention surfaces clear error AND dry-run finishes promptly under contention. |

## Documentation (Tier 4)

| # | Commit | Finding |
|---|---|---|
| 17 | `docs(readme): document owned-key overwrite, codex/cursor reject, http policy` | Three v1.0 behaviors that needed naming in Known Limits: hand-edits to agentsync-owned keys are silently re-overwritten on next apply (drift classifier catches one cycle late), `agent add codex/cursor` now rejects, http plugin URLs are rejected by default. Also added the `AGENTSYNC_TEST_IN_CONTAINER=1` escape hatch for `go test ./...` on host. |
| 18 | `docs(launch): record the second-wave audit findings + status` | Adds §4.5 to LAUNCH_CHECKLIST listing every finding from this review pass with shipped/deferred status so the audit trail lives next to §5. |

## What's intentionally NOT in this PR

- **Comment-preservation fuzz tests** (design spec line 485, LAUNCH_CHECKLIST §6) — the underlying TOML/JSONC preservation isn't implemented in v1.0; fuzz lands when either does.
- **`mcp set/enable/disable`** subcommands — `add` overwrite-after-remove covers the same need for v1.
- **A full schema-v2 migration framework** — `migrate()` now has the case-switch scaffolding; the actual v2 migrators land when v2 schema is defined.

## New regression tests

- `cli`: doctor failure modes (missing home, bad identity perms), verify secrets validation, mcp add/list/remove with id-validation, init clone URL rejection, concurrent-apply lock + dry-run-skips-lock, plugin id sanitization.
- `render`: `backupPathFor` containment under adversarial inputs.
- `state`: `migrate` for legacy zero / current / future / older paths.
- `marketplace`: HTTPS enforcement (http/git rejected, ssh/file allowed, env override works), npm tarball symlink rejection.

## Test plan

- [x] `AGENTSYNC_TEST_IN_CONTAINER=1 go test -timeout 120s ./...` — all 17 packages green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `just test-release` (hermetic gate) — green in CI
- [x] `just test-e2e` and `just test-bdd` — green in CI

## Migration notes

- New env vars: `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` (agent add codex/cursor), `AGENTSYNC_ALLOW_INSECURE_URLS=1` (http plugin URLs), `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` (skip secret substitution in verify for CI without an age key).
- `mcp add` writes `mcp/<id>.toml` matching the existing on-disk shape; no migration needed for hand-authored MCP files.
- `state.Load` now refuses to load a future-schema `targets.json`. Users who manually downgrade the binary after a v2 ships will need to remove `~/.agentsync/.state/targets.json`.
- `init [<git-url>]` is additive — no-arg form unchanged.

https://claude.ai/code/session_01EDzjzwLymmCh8PZsfMEisa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDzjzwLymmCh8PZsfMEisa)_
