### PR TITLE
Pre-launch hardening: 19 audit findings (secrets, symlinks, state portability, supply chain)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,11 @@ linters:
         linters: [forbidigo]
       - path: '(^|/)internal/state/store\.go$'
         linters: [forbidigo]
+      # secrets/age.go writes secrets.age under ~/.agentsync/ via the
+      # atomic path so a Ctrl-C during re-encrypt can't truncate the file.
+      # Same canonical-source category, not a native destination.
+      - path: '(^|/)internal/secrets/age\.go$'
+        linters: [forbidigo]
       # CLI files writing to ~/.agentsync/* (canonical source).
       - path: '(^|/)internal/cli/(plugin|marketplace|agent|reconcile|update)\.go$'
         linters: [forbidigo]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ agentsync is single-machine. To sync `~/.agentsync/` across machines, use chezmo
 
 If you lose your age private key, you lose access to all encrypted secrets. Recommended: store the key in a 1Password Secure Note or your machine-setup repo. agentsync does not back up the key for you.
 
+`agentsync secrets set` accepts the value three ways:
+
+    agentsync secrets set github.token --stdin    # value from stdin (best for scripts / 1Password CLI)
+    agentsync secrets set github.token            # prompt with echo off
+    agentsync secrets set github.token=ghp_…      # back-compat; warns — argv is visible to ps(1) and shell history
+
+`agentsync diff` redacts every resolved `${secret:…}` value before printing, so a piped diff doesn't leak credentials to logs.
+
 ## Known limits in v1.x
 
 - **OpenCode hooks**: OpenCode hooks are JS/TS plugins, not declarative shell commands. agentsync v1 does NOT auto-translate Claude hooks to OpenCode. Hand-author a small JS/TS plugin if you need a hook on OpenCode.
@@ -61,7 +69,23 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 - **TOML / JSONC comment preservation**: comments in `~/.agentsync/mcp/*.toml` and in agent-side `opencode.json` are NOT preserved across reconcile `[w]`rite-back or import. Hand-edited comments survive in unrelated sections; the rewritten section will be re-emitted without comments. Deferred to v1.x.
 - **Hand-edits to agentsync-owned keys** in shared agent files (e.g. an MCP server entry in `~/.claude.json` that agentsync owns): the next `apply` overwrites them with NO foreign-collision backup, because agentsync considers them its own. Use `agentsync reconcile` (the drift classifier catches the edit and offers `[w]`rite-back) BEFORE the next apply if you want to keep them.
 - **Plain-http / git:// plugin sources** are rejected by default to prevent MITM swap. Set `AGENTSYNC_ALLOW_INSECURE_URLS=1` for internal mirrors.
+- **Symlinked destinations** (e.g. `~/.claude.json` is a chezmoi symlink into your dotfiles repo) are rejected by default — a rename onto the path would replace the symlink with a regular file and strand your linked source. Set `AGENTSYNC_ALLOW_SYMLINK_DEST=1` to write through the symlink instead (the underlying file is updated in place; the link survives).
 - **Continue, Gemini CLI, Aider**: not on the v1.x roadmap.
+
+## Environment overrides
+
+| Env var | Purpose |
+| --- | --- |
+| `AGENTSYNC_HOME` | Override `~/.agentsync/` location (absolute path). |
+| `AGENTSYNC_TARGET_ROOT` | Redirect `$HOME` for testing (used by the hermetic test container). |
+| `AGENTSYNC_ALLOW_SYMLINK_DEST=1` | Permit writes to symlinked destination files (resolves the link first). |
+| `AGENTSYNC_ALLOW_INSECURE_URLS=1` | Accept http:// and git:// plugin / marketplace sources. |
+| `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` | Accept `agent add codex`/`cursor` despite the noop adapters. |
+| `AGENTSYNC_ALLOW_PLUGIN_DRIFT=1` | Bypass the plugin-cache manifest-SHA check (after hand-editing). |
+| `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` | Skip `${secret:…}` resolution in `agentsync verify` (CI without an age key). |
+| `AGENTSYNC_AGE_SKIP_PERM_CHECK=1` | Skip the 0600 mode check on the age identity file (ACL'd NFS). |
+| `AGENTSYNC_MAX_TARBALL_MB=<N>` | Override the per-tarball decompressed-bytes cap (default 512). 0 disables. |
+| `AGENTSYNC_TEST_IN_CONTAINER=1` | Bypass the host test guard (use only with `go test -run` for a single case). |
 
 ## Troubleshooting
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
+	golang.org/x/term v0.37.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -157,16 +157,30 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	if err != nil {
 		return err
 	}
-	collisions, err := render.Apply(plan, reg, s, home, sc, projectRoot)
-	if err != nil {
-		return err
-	}
+	collisions, applyErr := render.Apply(plan, reg, s, home, sc, projectRoot)
 	if len(collisions) > 0 {
 		ew := cmd.ErrOrStderr()
 		fmt.Fprintf(ew, "agentsync: backed up %d pre-existing target(s) before overwriting:\n", len(collisions))
 		for _, r := range collisions {
 			fmt.Fprintf(ew, "  %s\n", r.String())
 		}
+	}
+
+	// CRITICAL: when render.Apply errors mid-pipeline (write #5 of 10
+	// failed with ENOSPC, EACCES, USB unplugged, …), files 1-4 are
+	// already on disk but state.Save below has not yet run. Without
+	// this best-effort state-save BEFORE returning the error, those
+	// completed files would be foreign on the next apply and trigger
+	// pointless backup-and-overwrite. We save whatever state we can
+	// derive from the on-disk reality and surface the original error.
+	//
+	// Some adapter ops may have completed and others not. Recording
+	// hashes from files that DO exist is always safe (RecordOpsState
+	// re-reads each file); recording from files that don't exist
+	// returns an error and we just skip those.
+	if applyErr != nil {
+		_ = saveBestEffortState(s, statePath, plan, home, sc, projectRoot)
+		return applyErr
 	}
 
 	// Drop state entries for files/keys this agent no longer
@@ -194,6 +208,33 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		report.PrintText(w)
 	}
 	return nil
+}
+
+// saveBestEffortState records hashes for every op in plan whose dest
+// file currently exists on disk. Called on the apply error path so a
+// partial write doesn't leave the next apply reclassifying those files
+// as foreign-collisions. Failures are swallowed — we already have the
+// real error to surface and want to maximise the chance of the rescue
+// state.Save landing.
+func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderPlan, home string, sc adapter.Scope, projectRoot string) error {
+	for name, res := range plan.PerAgent {
+		var existing []adapter.FileOp
+		for _, op := range res.Ops {
+			if _, err := os.Stat(op.Path); err == nil {
+				existing = append(existing, op)
+			}
+		}
+		if len(existing) == 0 {
+			continue
+		}
+		// PruneStaleState is intentionally skipped here — we only want
+		// to ADD hashes, not remove entries that may refer to the now-
+		// half-applied state.
+		if err := render.RecordOpsState(s, home, name, sc, projectRoot, existing); err != nil {
+			continue
+		}
+	}
+	return state.Save(statePath, s)
 }
 
 // resolveProjectScope determines the effective scope and project root.

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -105,7 +105,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	}
 
 	if dryRun {
-		plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
+		plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// Real apply: render + write. The writer constructed inside
 	// render.Apply enforces the foreign-collision backup invariant on
 	// every destination write — there is no separate guard pass.
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
+	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
 	if err != nil {
 		return err
 	}
@@ -174,11 +174,11 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// shows up as `Orphan` in `status` forever and targets.json
 	// grows unbounded.
 	for name, res := range plan.PerAgent {
-		render.PruneStaleState(s, name, sc, projectRoot, res.Ops)
+		render.PruneStaleState(s, home, name, sc, projectRoot, res.Ops)
 	}
 	// Update state with post-apply hashes.
 	for name, res := range plan.PerAgent {
-		if err := render.RecordOpsState(s, name, sc, projectRoot, res.Ops); err != nil {
+		if err := render.RecordOpsState(s, home, name, sc, projectRoot, res.Ops); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -117,6 +117,30 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 				continue
 			}
 			fmt.Fprintf(w, "  %-10s %d ops, %d skips\n", name, len(res.Ops), len(res.Skips))
+			// List every destination path so the user can see exactly
+			// what apply will touch. Without this the dry-run hides the
+			// most useful piece of information (which files will be
+			// written) behind an op count.
+			for _, op := range res.Ops {
+				if op.Action == "" || op.Action == "write" {
+					fmt.Fprintf(w, "    write %s\n", op.Path)
+				} else {
+					fmt.Fprintf(w, "    %-5s %s\n", op.Action, op.Path)
+				}
+			}
+		}
+		// Foreign-collision preview: which destinations contain content
+		// that agentsync does not own and will therefore be backed up
+		// before overwrite. The dry-run previously hid this; users only
+		// found out which files were about to be backed up after the
+		// real apply ran.
+		previews := render.PreviewCollisions(plan, reg, s, home, sc, projectRoot)
+		if len(previews) > 0 {
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "Foreign collisions: %d (the real apply will back these up before overwriting)\n", len(previews))
+			for _, r := range previews {
+				fmt.Fprintf(w, "  %s\n", r.String())
+			}
 		}
 		report := render.BuildReport(c, plan, agents)
 		if len(report.Rows) > 0 {

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -136,6 +136,79 @@ func walkAll(root string, visit func(string, bool)) error {
 	return nil
 }
 
+// TestApply_DryRunPreviewsForeignCollisions is the regression test for the
+// finding that `apply --dry-run` only printed op counts and silently hid
+// the foreign-collision events the real apply would generate. The README
+// promised dry-run was a safe preview; without collision reporting the
+// user could not see which existing files were about to be backed up and
+// overwritten until the real apply ran.
+func TestApply_DryRunPreviewsForeignCollisions(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate ~/.claude.json with a server entry that conflicts.
+	claudeJSON := tmp + "/.claude.json"
+	original := `{"mcpServers": {"github": {"command": "/my/fork", "args": ["--x"]}}}`
+	if err := os.WriteFile(claudeJSON, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mcpDir := tmp + "/.agentsync/mcp"
+	_ = os.MkdirAll(mcpDir, 0o755)
+	_ = os.WriteFile(mcpDir+"/github.toml",
+		[]byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\nargs=[\"-y\"]\n"),
+		0o644)
+
+	out, err := runCLI(t, env, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("apply --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Foreign collisions") {
+		t.Fatalf("dry-run did not preview foreign collisions; got:\n%s", out)
+	}
+	if !strings.Contains(out, ".claude.json") {
+		t.Fatalf("dry-run did not name the affected destination path; got:\n%s", out)
+	}
+	// And dry-run must not have written anything.
+	bytes, _ := os.ReadFile(claudeJSON)
+	if string(bytes) != original {
+		t.Fatalf("dry-run mutated the live destination; got:\n%s", bytes)
+	}
+}
+
+// TestApply_DryRunListsDestinations is the regression for the finding that
+// dry-run reported "claude N ops" with no indication of which files would
+// be touched. Users could not safely run `apply --dry-run` to learn what
+// the real run would do without diff-ing every possible destination.
+func TestApply_DryRunListsDestinations(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcpDir := tmp + "/.agentsync/mcp"
+	_ = os.MkdirAll(mcpDir, 0o755)
+	_ = os.WriteFile(mcpDir+"/github.toml",
+		[]byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"),
+		0o644)
+
+	out, err := runCLI(t, env, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("apply --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, ".claude.json") {
+		t.Fatalf("dry-run did not list destination paths; got:\n%s", out)
+	}
+}
+
 func TestApply_NoAgentsEnabled_WarnsAndExitsZero(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -71,7 +71,7 @@ func newDiffCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -75,6 +76,17 @@ func newDiffCmd() *cobra.Command {
 				return err
 			}
 
+			// Build the secret-redaction map BEFORE diffing. The
+			// destination file was written by a prior apply with secrets
+			// substituted in cleartext (ghp_…, sk-…), so reading it back
+			// and printing the diff would otherwise leak credentials to
+			// stdout / log files / screenshots. We resolve every
+			// reference in the canonical, then mask its resolved value
+			// in both src and dst before the diff runs.
+			secBackend := secrets.SelectBackend(c.Config.Secrets, home)
+			envBackend := secrets.EnvBackend{}
+			redact := secrets.CollectResolved(&c, secBackend, envBackend)
+
 			dmp := diffmatchpatch.New()
 			w := cmd.OutOrStdout()
 			hasDiff := false
@@ -101,8 +113,8 @@ func newDiffCmd() *cobra.Command {
 						for _, ptr := range render.CollectPointers(ours, "") {
 							srcVal := getPointerValue(ours, ptr)
 							dstVal := getPointerValue(final, ptr)
-							srcStr := marshalPretty(srcVal)
-							dstStr := marshalPretty(dstVal)
+							srcStr := secrets.MaskResolved(marshalPretty(srcVal), redact)
+							dstStr := secrets.MaskResolved(marshalPretty(dstVal), redact)
 							if srcStr == dstStr {
 								continue
 							}
@@ -118,11 +130,11 @@ func newDiffCmd() *cobra.Command {
 							continue
 						}
 						seen[op.Path] = true
-						srcStr := string(op.Content)
+						srcStr := secrets.MaskResolved(string(op.Content), redact)
 						dstBytes, readErr := os.ReadFile(op.Path)
 						dstStr := ""
 						if readErr == nil {
-							dstStr = string(dstBytes)
+							dstStr = secrets.MaskResolved(string(dstBytes), redact)
 						}
 						if srcStr == dstStr {
 							continue

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -66,6 +66,69 @@ func TestDiff_ShowsDriftedKey(t *testing.T) {
 	}
 }
 
+// TestDiff_DoesNotLeakResolvedSecrets is the regression test for the bug
+// where `agentsync diff` printed the resolved cleartext secret to stdout.
+// The dst file was written by a prior apply with the secret substituted,
+// so reading it back and printing it via diffmatchpatch leaked the token.
+//
+// We use a sentinel token string so any leak shows up as a clear failure
+// rather than a fuzzy match.
+func TestDiff_DoesNotLeakResolvedSecrets(t *testing.T) {
+	const sentinel = "ghp_SENTINEL_DO_NOT_LEAK_THIS_TOKEN_123456789"
+
+	tmp := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmp,
+		"GITHUB_TOKEN":          sentinel,
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	body := `[server]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[server.env]
+GITHUB_TOKEN = "${env:GITHUB_TOKEN}"
+`
+	_ = os.WriteFile(mcp, []byte(body), 0o644)
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity check: dest does contain the sentinel (proving the
+	// substitution worked and the leak would be possible).
+	dst := filepath.Join(tmp, ".claude.json")
+	dstBytes, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(dstBytes), sentinel) {
+		t.Fatalf("setup invariant failed — dest does not contain sentinel; got: %s", dstBytes)
+	}
+
+	// Now drift the dest by changing some unrelated key, so diff has
+	// something to print.
+	driftBody := strings.ReplaceAll(string(dstBytes), `"npx"`, `"npm"`)
+	_ = os.WriteFile(dst, []byte(driftBody), 0o644)
+
+	out, err := runCLI(t, env, "diff")
+	if err != nil {
+		t.Fatalf("diff: %v\n%s", err, out)
+	}
+	if strings.Contains(out, sentinel) {
+		t.Fatalf("SECURITY: diff output leaked sentinel secret %q\n%s", sentinel, out)
+	}
+}
+
 func TestDiff_PathFilter(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -73,7 +73,7 @@ func newExplainCmd() *cobra.Command {
 				return err
 			}
 
-			plan, err := render.Plan(filtered, reg, agents, adapter.ScopeUser, "", s)
+			plan, err := render.Plan(filtered, reg, agents, adapter.ScopeUser, "", s, home)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -164,7 +164,75 @@ func importRun(cmd *cobra.Command, args []string) error {
 	if seedErr := seedStateFromCurrentDest(home, agentName, reg); seedErr != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "warning: import succeeded but state seed failed: %v\n", seedErr)
 	}
+
+	// Warn if the destination file has additional pointers / files
+	// that the canonical does not own. Those will appear as
+	// ForeignCollision on the next apply and the user often expects
+	// import to have captured everything — not just the one named item.
+	if warnings := unimportedDestPointers(home, agentName, reg); len(warnings) > 0 {
+		ew := cmd.ErrOrStderr()
+		fmt.Fprintln(ew, "warning: the following destination items are NOT in the canonical source and will trigger ForeignCollision on next apply:")
+		for _, w := range warnings {
+			fmt.Fprintf(ew, "  %s\n", w)
+		}
+		fmt.Fprintln(ew, "  Run `agentsync import <agent>:<component>:<name>` for each, or accept the backup on next apply.")
+	}
 	return nil
+}
+
+// unimportedDestPointers returns a list of human-readable labels for
+// destination pointers / files that exist on disk for the given agent
+// but are NOT in the canonical model after the import. Used to alert
+// the user that import covers ONE item and the rest of the destination
+// is still unowned.
+//
+// We render canonical → ops, build the set of (path, pointer) pairs
+// canonical claims, and diff against the actual on-disk contents.
+func unimportedDestPointers(home, agentName string, reg *adapter.Registry) []string {
+	pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+	c, err := source.LoadWithCache(loaderFsForState(), home, pluginCacheRoot)
+	if err != nil {
+		return nil
+	}
+	a := reg.Lookup(agentName)
+	if a == nil {
+		return nil
+	}
+	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, op := range ops {
+		if op.MergeStrategy != "merge-json-keys" && op.MergeStrategy != "merge-jsonc-keys" {
+			continue
+		}
+		data, readErr := os.ReadFile(op.Path)
+		if readErr != nil {
+			continue
+		}
+		var existing map[string]any
+		if jsonErr := jsonUnmarshalLoose(data, &existing); jsonErr != nil {
+			continue
+		}
+		var ours map[string]any
+		if jsonErr := jsonUnmarshalLoose(op.Content, &ours); jsonErr != nil {
+			continue
+		}
+		ownedPtrs := map[string]bool{}
+		for _, p := range collectStateSeedPointers(ours) {
+			ownedPtrs[p] = true
+		}
+		// Walk existing's second-level pointers and flag the ones
+		// canonical doesn't own. We borrow CollectPointers indirectly
+		// via collectStateSeedPointers for symmetry.
+		for _, p := range collectStateSeedPointers(existing) {
+			if !ownedPtrs[p] {
+				out = append(out, op.Path+"#"+p)
+			}
+		}
+	}
+	return out
 }
 
 // seedStateFromCurrentDest re-renders the canonical for agent and writes

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -99,7 +99,16 @@ Examples:
   agentsync import claude:mcp:github
   agentsync import opencode:agent:reviewer
   agentsync import claude:command:review`,
-		RunE: importRun,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// import mutates ~/.agentsync/ AND .state/targets.json. It
+			// must hold the global lock so a concurrent apply on the
+			// other terminal cannot interleave its own state.Save and
+			// destroy our seed entries (or vice versa).
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error {
+				return importRun(cmd, args)
+			})
+		},
 	}
 	return cmd
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -208,7 +208,7 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 			}
 			for _, ptr := range collectStateSeedPointers(ours) {
 				key := fmt.Sprintf("%s:%s:%s:%s:%s",
-					agentName, adapter.ScopeUser.String(), "", op.Path, ptr)
+					agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(home, op.Path), ptr)
 				st.Keys[key] = state.KeyEntry{
 					SHA256:    hashAtPointer(existing, ptr),
 					AppliedAt: now,
@@ -222,7 +222,7 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 			}
 			sum := sha256.Sum256(data)
 			key := fmt.Sprintf("%s:%s:%s:%s",
-				agentName, adapter.ScopeUser.String(), "", op.Path)
+				agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(home, op.Path))
 			st.Files[key] = state.FileEntry{
 				SHA256:    hex.EncodeToString(sum[:]),
 				Mode:      op.Mode,

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -59,7 +59,10 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	// Build the Source from the raw URL/path argument.
-	src := parseMarketplaceSource(rawURL)
+	src, err := parseMarketplaceSource(rawURL)
+	if err != nil {
+		return err
+	}
 
 	// Derive a slug for the marketplace.
 	slug := deriveMarketplaceSlug(rawURL)
@@ -229,7 +232,14 @@ func marketplaceListRun(cmd *cobra.Command, _ []string) error {
 //   - https://...                 → url source
 //   - file://... or /abs/path     → relative source
 //   - ./rel/path                  → relative source
-func parseMarketplaceSource(rawURL string) marketplace.Source {
+//
+// An input that does not match any known form returns an error rather
+// than silently degrading to a relative-path copy. The original behaviour
+// turned a typo like `gh:obra/superpowers` (should be `github:`) into
+// `cp -r ./gh:obra/superpowers ...`, creating an empty marketplace
+// cache with no diagnostic. We now refuse and tell the user the
+// supported forms.
+func parseMarketplaceSource(rawURL string) (marketplace.Source, error) {
 	// github: shorthand
 	if strings.HasPrefix(rawURL, "github:") {
 		rest := strings.TrimPrefix(rawURL, "github:")
@@ -238,26 +248,33 @@ func parseMarketplaceSource(rawURL string) marketplace.Source {
 			ref = rest[idx+1:]
 			rest = rest[:idx]
 		}
-		return marketplace.Source{Kind: "github", Repo: rest, Ref: ref}
+		if rest == "" {
+			return marketplace.Source{}, fmt.Errorf("github source missing owner/repo: %q", rawURL)
+		}
+		return marketplace.Source{Kind: "github", Repo: rest, Ref: ref}, nil
 	}
 
 	// file:// URL → treat as relative (strip file:// prefix)
 	if strings.HasPrefix(rawURL, "file://") {
-		return marketplace.Source{Relative: strings.TrimPrefix(rawURL, "file://")}
+		return marketplace.Source{Relative: strings.TrimPrefix(rawURL, "file://")}, nil
 	}
 
 	// Absolute path or ./relative
 	if strings.HasPrefix(rawURL, "/") || strings.HasPrefix(rawURL, "./") || strings.HasPrefix(rawURL, "../") {
-		return marketplace.Source{Relative: rawURL}
+		return marketplace.Source{Relative: rawURL}, nil
 	}
 
 	// https:// or http:// → url source
 	if strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "http://") {
-		return marketplace.Source{Kind: "url", URL: rawURL}
+		return marketplace.Source{Kind: "url", URL: rawURL}, nil
 	}
 
-	// Default: treat as relative path.
-	return marketplace.Source{Relative: rawURL}
+	// Existing local path? (covers bare directory names typed without ./)
+	if info, err := os.Stat(rawURL); err == nil && info.IsDir() {
+		return marketplace.Source{Relative: rawURL}, nil
+	}
+
+	return marketplace.Source{}, fmt.Errorf("unrecognised marketplace source %q; supported forms: github:owner/repo[@ref], https://…, file://…, /abs/path, ./rel/path", rawURL)
 }
 
 // deriveMarketplaceSlug derives a filesystem-safe slug from a URL or path.

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -429,6 +429,54 @@ func TestPlugin_EnableDisable(t *testing.T) {
 	}
 }
 
+// TestPlugin_DisableSuppressesProjectionAtApply is the regression test for
+// the bug where `plugin disable <id>` set the Disabled bit in the TOML
+// but the loader's PluginSpec had no `disabled` field, so the bit was
+// silently dropped on every Load. The plugin's MCP servers / hooks /
+// skills then projected into the canonical model regardless, and apply
+// shipped them.
+//
+// We install the demo plugin, disable it BEFORE first apply, then apply.
+// Disabled-at-projection means demo-mcp never lands in .claude.json.
+// (Note: disabling a plugin AFTER it has already been applied does NOT
+// retroactively remove its entries from the destination — JSON merge
+// only owns our-keys; once we stop owning demo-mcp, it becomes a
+// foreign key and survives. The `reconcile` flow handles that case.)
+func TestPlugin_DisableSuppressesProjectionAtApply(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	if _, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "install", "demo@test-mp"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disable BEFORE the first apply.
+	if _, err := runCLI(t, env, "plugin", "disable", "demo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	// .claude.json may not exist at all (no ops), or may exist but must
+	// not contain demo-mcp.
+	claudeJSON := filepath.Join(tmp, ".claude.json")
+	body, err := os.ReadFile(claudeJSON)
+	if err == nil && strings.Contains(string(body), "demo-mcp") {
+		t.Fatalf("plugin disable did not suppress projection at apply; got: %s", body)
+	}
+}
+
 func TestPlugin_Remove(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -92,13 +92,13 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			agents = append(agents, name)
 		}
 	}
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
+	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
 	if err != nil {
 		return err
 	}
 
 	// Collect all items in order.
-	items := collectItems(plan, reg, s, sc, projectRoot)
+	items := collectItems(plan, reg, s, sc, projectRoot, home)
 
 	w := cmd.OutOrStdout()
 
@@ -232,7 +232,7 @@ done:
 			for _, r := range rw.Reports() {
 				fmt.Fprintf(w, "  backup: %s\n", r.String())
 			}
-			if err := render.RecordOpsState(s, name, sc, projectRoot, ops); err != nil {
+			if err := render.RecordOpsState(s, home, name, sc, projectRoot, ops); err != nil {
 				return err
 			}
 		}
@@ -246,7 +246,7 @@ done:
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.
-func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot string) []reconcileItem {
+func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot, home string) []reconcileItem {
 	var items []reconcileItem
 	for _, name := range reg.Names() {
 		res, ok := plan.PerAgent[name]
@@ -265,7 +265,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				final := readJSONFile(op.Path)
 				for _, ptr := range render.CollectPointers(ours, "") {
 					hsrc := hashAnyValue(getPointerValue(ours, ptr))
-					happlied := s.Keys[stateKeyKey(name, sc, projectRoot, op.Path, ptr)].SHA256
+					happlied := s.Keys[stateKeyKey(home, name, sc, projectRoot, op.Path, ptr)].SHA256
 					hdest := hashAnyValue(getPointerValue(final, ptr))
 					cls := drift.Classify(hsrc, happlied, hdest)
 					items = append(items, reconcileItem{
@@ -286,7 +286,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				}
 				seen[op.Path] = true
 				hsrc := hashContent(op.Content)
-				happlied := s.Files[stateFileKey(name, sc, projectRoot, op.Path)].SHA256
+				happlied := s.Files[stateFileKey(home, name, sc, projectRoot, op.Path)].SHA256
 				hdest := hashFile(op.Path)
 				cls := drift.Classify(hsrc, happlied, hdest)
 				items = append(items, reconcileItem{

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -169,9 +169,35 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 				switch ch {
 				case 'w', 'W', 'o', 'O', 's', 'S', 'i', 'q', 'Q':
 					if ch == 'W' || ch == 'O' || ch == 'S' {
-						bulkAction = ch | 0x20 // lowercase
+						// Capital letter = "apply this choice to all
+						// remaining items." Confirm before locking it
+						// in — a stray shift-W on a hooks item used to
+						// silently no-op data away across the whole
+						// queue. Show the count and require an
+						// explicit y/N. Default is N.
+						remaining := 0
+						for _, ri := range items {
+							if requiresAction(ri.cls) {
+								remaining++
+							}
+						}
+						lower := ch | 0x20
+						fmt.Fprintf(w, "%c\n", ch)
+						fmt.Fprintf(w, "  apply '%c' to all %d remaining items? [y/N] ", lower, remaining)
+						confirm, readErr := readChar(br)
+						if readErr != nil {
+							return nil
+						}
+						fmt.Fprintf(w, "%c\n", confirm)
+						if confirm != 'y' && confirm != 'Y' {
+							fmt.Fprintln(w, "  cancelled; choose a per-item action")
+							continue
+						}
+						bulkAction = lower
+						action = lower
+						break prompt
 					}
-					action = ch | 0x20 // normalize to lowercase for switch below
+					action = ch | 0x20
 					fmt.Fprintf(w, "%c\n", ch)
 					break prompt
 				case 'd':
@@ -306,9 +332,14 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 }
 
 // requiresAction returns true for drift classes that need user (or auto) action.
+// ForeignCollision is included: the very purpose of reconcile is to surface
+// the pre-existing native files agentsync is about to back up and overwrite
+// on the next apply. Hiding them meant `reconcile --auto-safe` reported
+// "nothing to reconcile" on a populated machine, and the user only learned
+// about the impending backups when the real apply ran.
 func requiresAction(cls drift.Class) bool {
 	switch cls {
-	case drift.Drift, drift.Conflict, drift.OrphanDrifted:
+	case drift.Drift, drift.Conflict, drift.OrphanDrifted, drift.ForeignCollision:
 		return true
 	}
 	return false
@@ -360,11 +391,15 @@ func writeBackItem(home string, it reconcileItem) error {
 
 // writeBackKeyItem handles key-level (merge-json-keys / merge-jsonc-keys) items.
 // For MCP servers it reconstructs a source.MCPServer from the destination JSON
-// and writes it with source.WriteMCP. For other key-level items it is a no-op
-// (unsupported in v1).
+// and writes it with source.WriteMCP.
+//
+// For other key-level items (hooks, LSP, future shapes) write-back is not
+// implemented and we return a clear error so the user is not silently lied
+// to: the prior code returned nil and printed "write-back: <label>", giving
+// the impression the hand-edit had been persisted when in fact it had not
+// — the next apply would then destroy the user's edit.
 func writeBackKeyItem(home string, it reconcileItem) error {
 	dest := readJSONFile(it.op.Path)
-	// Extract mcpServers section if this is an MCP ptr.
 	// Expected ptr shape: /mcpServers/<serverID>/...
 	parts := strings.SplitN(strings.TrimPrefix(it.ptr, "/"), "/", 3)
 	if len(parts) >= 2 && parts[0] == "mcpServers" {
@@ -375,8 +410,12 @@ func writeBackKeyItem(home string, it reconcileItem) error {
 		}
 		specRaw, ok := mcpServers[serverID]
 		if !ok {
-			// Server removed from dest; skip write-back.
-			return nil
+			// Server removed from dest; nothing to write back. We treat
+			// this as a tombstone — the user wants the source dropped to
+			// match — but persisting that requires source-side mutation
+			// which isn't safe to do silently here. Surface as an error
+			// so the user can pick [d]elete-source via a follow-up flow.
+			return fmt.Errorf("destination dropped %s/%s — no write-back possible; remove the source manually or use [o]verride to push canonical back", parts[0], serverID)
 		}
 		// Round-trip through JSON to get a typed spec.
 		specBytes, err := json.Marshal(specRaw)
@@ -390,25 +429,33 @@ func writeBackKeyItem(home string, it reconcileItem) error {
 		m := source.MCPServer{ID: serverID, Server: spec}
 		return source.WriteMCP(home, serverID, m)
 	}
-	// Other key-level items not yet supported.
-	return nil
+	// Unsupported pointer shape (hooks, lsp, …). DO NOT silently no-op —
+	// the success message would be a lie.
+	return fmt.Errorf("write-back for pointer %q is not implemented in v1; only /mcpServers/* items can be written back today — choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item", it.ptr)
 }
 
 // writeBackFileItem handles file-level (replace strategy) items by copying
 // the destination file back into the corresponding source location verbatim.
 // This covers subagents, commands, memory, and skill files in v1.
+//
+// Two unsafe historical no-ops are now hard errors:
+//   - SourceID == "" (no canonical home for this op)
+//   - SourceID ends with "(multiple)" (the dest was assembled from N
+//     source fragments; collapsing the whole dest back into ONE of them
+//     would strand the others)
+//
+// Both used to return nil with a success message, hiding data loss.
 func writeBackFileItem(home string, it reconcileItem) error {
 	data, err := os.ReadFile(it.op.Path)
 	if err != nil {
 		return fmt.Errorf("read dest %s: %w", it.op.Path, err)
 	}
-	// Derive a relative source path from the SourceID field when possible.
-	// SourceID examples: "agents/reviewer.md", "skills/foo/SKILL.md",
-	//                    "memory/AGENTS.md", "commands/review.md".
 	srcID := it.op.SourceID
-	if srcID == "" || strings.HasSuffix(srcID, "(multiple)") {
-		// Cannot determine a single source file; skip.
-		return nil
+	if srcID == "" {
+		return fmt.Errorf("write-back for %s requires a single source-of-record; the rendering op has no SourceID (this happens for ad-hoc paths) — use [o]verride or [i]gnore", it.op.Path)
+	}
+	if strings.HasSuffix(srcID, "(multiple)") {
+		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)
 	}
 	dest := filepath.Join(home, srcID)
 	return iox.AtomicWrite(dest, data, 0o644)

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -116,6 +116,85 @@ func TestReconcile_InteractiveSkip(t *testing.T) {
 	}
 }
 
+// TestReconcile_BulkActionRequiresConfirmation is the regression test for
+// the bug where a capital W/O/S immediately locked in the bulk choice for
+// every remaining item with no preview and no chance to cancel. Combined
+// with the writeback-no-op bug below, one accidental shift-W on a hook
+// item could silently destroy edits across the whole queue.
+func TestReconcile_BulkActionRequiresConfirmation(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1)), 0o644)
+
+	// Press capital S (bulk skip) but decline confirmation. The reconcile
+	// loop should NOT lock in the bulk choice; it should re-prompt the
+	// item and wait for the lowercase per-item choice. We follow up with
+	// 's' (skip just this one).
+	out, err := runCLIWithStdin(t, env, "Sns\n", "reconcile")
+	if err != nil {
+		t.Fatalf("reconcile bulk-confirm decline: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "apply 's' to all") {
+		t.Fatalf("expected bulk confirmation prompt; got: %s", out)
+	}
+	if !strings.Contains(out, "cancelled") {
+		t.Fatalf("expected 'cancelled' message after declining confirm; got: %s", out)
+	}
+}
+
+// TestReconcile_WriteBackUnsupportedReturnsError verifies that write-back
+// for a pointer shape we cannot handle (e.g. /hooks/PreToolUse/0) returns
+// an error visible to the user instead of silently printing
+// "write-back: <label>" success — which used to mask data loss.
+func TestReconcile_WriteBackUnsupportedReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Author a hook source that produces a /hooks/* pointer in
+	// .claude.json. The hook payload is irrelevant — we just need a
+	// non-MCP key-level item to flow through reconcile.
+	hookDir := filepath.Join(tmp, ".agentsync", "hooks")
+	_ = os.MkdirAll(hookDir, 0o755)
+	_ = os.WriteFile(filepath.Join(hookDir, "PreToolUse.toml"),
+		[]byte("[[hook]]\nmatcher = \"*\"\ntype = \"command\"\ncommand = \"echo pre\"\n"),
+		0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	// Drift the hook in the destination so reconcile classifies it as Drift.
+	_ = os.WriteFile(dst, []byte(strings.Replace(string(body), `echo pre`, `echo edited`, 1)), 0o644)
+
+	// Press w (write-back this item, single).
+	out, _ := runCLIWithStdin(t, env, "w\n", "reconcile")
+	// Should NOT silently print success for the hook write-back.
+	if strings.Contains(out, "write-back: ") && !strings.Contains(out, "write-back error") {
+		t.Fatalf("hook write-back must surface an error, not silent success; got:\n%s", out)
+	}
+}
+
 func TestReconcile_InteractiveQuit(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -349,4 +349,3 @@ func resolveSecretKeyValue(cmd *cobra.Command, arg string, useStdin bool) (strin
 	}
 	return key, string(pwBytes), nil
 }
-

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
+	"golang.org/x/term"
 )
 
 func newSecretsCmd() *cobra.Command {
@@ -31,17 +33,38 @@ func newSecretsCmd() *cobra.Command {
 			Args:  cobra.ExactArgs(1),
 			RunE:  secretsGet,
 		},
-		&cobra.Command{
-			Use:   "set <key=value>",
-			Short: "set (or update) a secret key",
-			Args:  cobra.ExactArgs(1),
-			RunE: func(cmd *cobra.Command, args []string) error {
-				home := paths.AgentsyncHome(paths.OSEnv{})
-				return withGlobalLock(home, func() error { return secretsSet(cmd, args) })
-			},
-		},
+		newSecretsSetCmd(),
 	)
 	return sec
+}
+
+// newSecretsSetCmd builds the `secrets set` subcommand. Three argv shapes
+// are supported:
+//
+//	secrets set <key> --stdin             # value comes from stdin
+//	secrets set <key>                     # prompt with echo off (interactive)
+//	secrets set <key>=<value>             # legacy; warns + recommends --stdin
+//
+// The legacy form leaks the value into ps(1) output, shell history, and
+// auditd logs; the warning steers users to a safer mode without breaking
+// existing scripts. When the argument has no '=' AND --stdin is unset AND
+// stdin is not a TTY, we error out with a helpful message rather than
+// hanging on a non-interactive prompt.
+func newSecretsSetCmd() *cobra.Command {
+	var useStdin bool
+	cmd := &cobra.Command{
+		Use:   "set <key>[=<value>]",
+		Short: "set (or update) a secret key (prompts securely by default)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error {
+				return secretsSet(cmd, args[0], useStdin)
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&useStdin, "stdin", false, "read the secret value from stdin (recommended for scripts)")
+	return cmd
 }
 
 // loadSecretsConfig returns the SecretsConfig and the agentsync home directory.
@@ -236,7 +259,7 @@ func secretsGet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func secretsSet(cmd *cobra.Command, args []string) error {
+func secretsSet(cmd *cobra.Command, arg string, useStdin bool) error {
 	cfg, home, err := loadSecretsConfig()
 	if err != nil {
 		return err
@@ -251,13 +274,10 @@ func secretsSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("secrets set requires [secrets].identity_file in agentsync.toml")
 	}
 
-	kv := args[0]
-	idx := strings.IndexByte(kv, '=')
-	if idx < 0 {
-		return fmt.Errorf("set argument must be key=value, got %q", kv)
+	key, value, err := resolveSecretKeyValue(cmd, arg, useStdin)
+	if err != nil {
+		return err
 	}
-	key := kv[:idx]
-	value := kv[idx+1:]
 
 	m, err := decryptToMap(cfg, home)
 	if err != nil {
@@ -270,3 +290,63 @@ func secretsSet(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "secret %q set\n", key)
 	return nil
 }
+
+// resolveSecretKeyValue extracts (key, value) from the user's invocation.
+// Error messages here are deliberately devoid of the raw argument bytes —
+// a user who mistyped `secrets set ghp_live_token` instead of
+// `secrets set github.token=…` was previously greeted with
+// `got "ghp_live_token"` in stderr, dumping the live secret into log
+// scrollback. Now we report shape, length, and remediation only.
+func resolveSecretKeyValue(cmd *cobra.Command, arg string, useStdin bool) (string, string, error) {
+	if useStdin {
+		// arg is the key; value comes from stdin (trim a single trailing
+		// newline, but keep all other whitespace).
+		key := strings.TrimSpace(arg)
+		if key == "" || strings.ContainsAny(key, "= \t") {
+			return "", "", fmt.Errorf("--stdin requires a single key argument (no '=' or whitespace)")
+		}
+		raw, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", "", fmt.Errorf("read secret from stdin: %w", err)
+		}
+		v := strings.TrimRight(string(raw), "\n")
+		v = strings.TrimRight(v, "\r")
+		return key, v, nil
+	}
+
+	// Legacy key=value form. Warn that the value just hit argv (and
+	// therefore ps(1)/history/auditd) but accept it for back-compat.
+	if idx := strings.IndexByte(arg, '='); idx >= 0 {
+		key := arg[:idx]
+		if key == "" {
+			return "", "", fmt.Errorf("set argument has empty key (expected <key>=<value>)")
+		}
+		value := arg[idx+1:]
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"agentsync: warning: passing the value on argv exposes it to ps(1), shell history, and process auditing.")
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"  Use `agentsync secrets set <key> --stdin` or omit the value to be prompted.")
+		return key, value, nil
+	}
+
+	// No '=' and no --stdin → prompt or error if stdin is not a TTY.
+	stdin, ok := cmd.InOrStdin().(*os.File)
+	if !ok || !term.IsTerminal(int(stdin.Fd())) {
+		// Refuse to hang silently on a non-interactive stdin. The
+		// remediation pointer must NOT include the user's arg — it
+		// may itself be a leaked secret.
+		return "", "", fmt.Errorf("no value provided for key (argument has no '=', --stdin not set, stdin is not a terminal); use --stdin or run interactively")
+	}
+	key := strings.TrimSpace(arg)
+	if key == "" {
+		return "", "", fmt.Errorf("empty key argument")
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "Enter value for %s (input hidden): ", key)
+	pwBytes, err := term.ReadPassword(int(stdin.Fd()))
+	fmt.Fprintln(cmd.ErrOrStderr())
+	if err != nil {
+		return "", "", fmt.Errorf("read secret: %w", err)
+	}
+	return key, string(pwBytes), nil
+}
+

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -105,10 +105,54 @@ func TestSecretsGet_MissingKey(t *testing.T) {
 	}
 }
 
-func TestSecretsSet_InvalidArg(t *testing.T) {
+// TestSecretsSet_NoEqualsNonTTYErrors is the regression for the bug where
+// `agentsync secrets set <something>` (no `=`) printed the user's argument
+// back via `got %q` — leaking it if the argument was a real token. The
+// new behaviour refuses without echoing the argument when stdin is not a
+// TTY (the test environment).
+func TestSecretsSet_NoEqualsNonTTYErrors(t *testing.T) {
+	const sentinel = "ghp_SENTINEL_NEVER_ECHO_THIS_TOKEN"
 	env, _, _, _ := setupSecretsEnv(t)
-	_, err := runCLI(t, env, "secrets", "set", "noequalssign")
+	out, err := runCLI(t, env, "secrets", "set", sentinel)
 	if err == nil {
-		t.Fatal("expected error for missing = in set argument")
+		t.Fatal("expected error when no '=' and stdin is not a terminal")
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("SECURITY: error message echoed sentinel %q: %v", sentinel, err)
+	}
+	if strings.Contains(out, sentinel) {
+		t.Fatalf("SECURITY: stdout/stderr echoed sentinel %q:\n%s", sentinel, out)
+	}
+}
+
+// TestSecretsSet_StdinPath proves the safe input mode works end-to-end:
+// the secret never appears on argv (so ps(1) / history don't see it) and
+// the stored value matches the stdin payload.
+func TestSecretsSet_StdinPath(t *testing.T) {
+	env, _, _, _ := setupSecretsEnv(t)
+	const value = "ghp_VIA_STDIN_FLOW_123"
+	out, err := runCLIWithStdin(t, env, value+"\n", "secrets", "set", "github.token", "--stdin")
+	if err != nil {
+		t.Fatalf("secrets set --stdin: %v\n%s", err, out)
+	}
+	got, err := runCLI(t, env, "secrets", "get", "github.token")
+	if err != nil {
+		t.Fatalf("get after stdin set: %v\n%s", err, got)
+	}
+	if !strings.Contains(got, value) {
+		t.Fatalf("stored value mismatch: want %q in %q", value, got)
+	}
+}
+
+// TestSecretsSet_LegacyArgWarns proves the back-compat path still works
+// but warns the user that the value just hit argv.
+func TestSecretsSet_LegacyArgWarns(t *testing.T) {
+	env, _, _, _ := setupSecretsEnv(t)
+	out, err := runCLI(t, env, "secrets", "set", "legacy.key=legacy_value")
+	if err != nil {
+		t.Fatalf("legacy set: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "warning") || !strings.Contains(out, "--stdin") {
+		t.Fatalf("legacy form did not warn about argv exposure; got:\n%s", out)
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -136,7 +136,24 @@ func hashContent(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// hashFile returns the SHA-256 hex digest of the file at path. Returns
+// the empty string on missing-file errors (which `drift.Classify` reads
+// as "absent" — the expected signal for Orphan / OrphanDrifted).
+//
+// If the path is a symlink, hashFile returns a special marker so the
+// drift classifier can flag the file as drifted in a way the user can
+// act on. A managed file becoming a symlink (e.g. user replaced
+// .claude.json with `ln -s /dev/null`) used to silently read through
+// the link and compare hashes — making the swap invisible to status.
 func hashFile(path string) string {
+	info, lerr := os.Lstat(path)
+	if lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+		// Return a sentinel that will never match a content hash.
+		// We don't include the link target to keep the sentinel stable
+		// (target may resolve to whatever attacker chose); just signal
+		// "this is a symlink now."
+		return "symlink-not-regular-file"
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -63,7 +63,7 @@ func newStatusCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func newStatusCmd() *cobra.Command {
 					}
 					seen[op.Path] = true
 					hsrc := hashContent(op.Content)
-					happlied := s.Files[stateFileKey(name, sc, projectRoot, op.Path)].SHA256
+					happlied := s.Files[stateFileKey(home, name, sc, projectRoot, op.Path)].SHA256
 					hdest := hashFile(op.Path)
 					cls := drift.Classify(hsrc, happlied, hdest)
 					fmt.Fprintf(w, "  %-20s %s\n", cls, op.Path)
@@ -101,7 +101,7 @@ func newStatusCmd() *cobra.Command {
 					final := readJSONFile(op.Path)
 					for _, ptr := range render.CollectPointers(ours, "") {
 						hsrc := hashAnyValue(getPointerValue(ours, ptr))
-						happlied := s.Keys[stateKeyKey(name, sc, projectRoot, op.Path, ptr)].SHA256
+						happlied := s.Keys[stateKeyKey(home, name, sc, projectRoot, op.Path, ptr)].SHA256
 						hdest := hashAnyValue(getPointerValue(final, ptr))
 						cls := drift.Classify(hsrc, happlied, hdest)
 						fmt.Fprintf(w, "  %-20s %s#%s\n", cls, op.Path, ptr)
@@ -117,15 +117,18 @@ func newStatusCmd() *cobra.Command {
 }
 
 // stateFileKey builds the state Files map key matching render.RecordOpsState.
-// Format: "agent:scope:project:path" (project is "" for user scope).
-func stateFileKey(agent string, sc adapter.Scope, projectRoot, path string) string {
-	return fmt.Sprintf("%s:%s:%s:%s", agent, sc.String(), projectRoot, path)
+// Format: "agent:scope:portableProject:portablePath" (project and path
+// are HOME-relative so keys are portable across machines).
+func stateFileKey(home, agent string, sc adapter.Scope, projectRoot, path string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", agent, sc.String(),
+		paths.HomeRelative(home, projectRoot), paths.HomeRelative(home, path))
 }
 
 // stateKeyKey builds the state Keys map key matching render.RecordOpsState.
-// Format: "agent:scope:project:path:ptr".
-func stateKeyKey(agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
-	return fmt.Sprintf("%s:%s:%s:%s:%s", agent, sc.String(), projectRoot, path, ptr)
+// Format: "agent:scope:portableProject:portablePath:ptr".
+func stateKeyKey(home, agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s", agent, sc.String(),
+		paths.HomeRelative(home, projectRoot), paths.HomeRelative(home, path), ptr)
 }
 
 func hashContent(b []byte) string {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -83,7 +83,11 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 		mpName := mp.Name
 		cacheDir := marketplaceCacheDir(home, mpName)
 
-		src := parseMarketplaceSource(mp.Marketplace.URL)
+		src, perr := parseMarketplaceSource(mp.Marketplace.URL)
+		if perr != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", mpName, mp.Marketplace.URL, perr)
+			continue
+		}
 		if mp.Marketplace.Ref != "" {
 			src.Ref = mp.Marketplace.Ref
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -202,7 +202,7 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 		reg := registryFactory()
-		plan, err := render.Plan(c2, reg, agents, sc, projectRoot, st)
+		plan, err := render.Plan(c2, reg, agents, sc, projectRoot, st, home)
 		if err != nil {
 			return fmt.Errorf("plan after update: %w", err)
 		}
@@ -218,10 +218,10 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 		for name, res := range plan.PerAgent {
-			render.PruneStaleState(st, name, sc, projectRoot, res.Ops)
+			render.PruneStaleState(st, home, name, sc, projectRoot, res.Ops)
 		}
 		for name, res := range plan.PerAgent {
-			if err := render.RecordOpsState(st, name, sc, projectRoot, res.Ops); err != nil {
+			if err := render.RecordOpsState(st, home, name, sc, projectRoot, res.Ops); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -32,8 +31,13 @@ func newVerifyCmd() *cobra.Command {
 			if err := verifySecrets(c.Config.Secrets, home); err != nil {
 				return fmt.Errorf("verify secrets: %w", err)
 			}
-			// Substitute against the live backends (using AGENTSYNC_ALLOW_OFFLINE_VERIFY
-			// to skip secret resolution when running in CI without an age key).
+			// Substitute against the live backends. AGENTSYNC_ALLOW_OFFLINE_VERIFY=1
+			// skips resolution when running in CI without an age key.
+			// Offline mode cannot catch a typo'd secret name (e.g.
+			// ${secret:GITHB.token}) — that requires a live backend.
+			// The regex inside SubstituteRefs already enforces the
+			// reference shape, so the schema decode + this pass cover
+			// the offline-validatable space.
 			if os.Getenv("AGENTSYNC_ALLOW_OFFLINE_VERIFY") != "1" {
 				secBackend := secrets.SelectBackend(c.Config.Secrets, home)
 				envBackend := secrets.EnvBackend{}
@@ -68,12 +72,16 @@ func verifySecrets(cfg source.SecretsConfig, home string) error {
 	if h := os.Getenv("HOME"); h != "" {
 		idPath = expandEnvHome(idPath, h)
 	}
-	info, err := os.Stat(idPath)
-	if err != nil {
+	if _, err := os.Stat(idPath); err != nil {
 		return fmt.Errorf("identity_file %s: %w", idPath, err)
 	}
-	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
-		return fmt.Errorf("identity_file %s has mode %v; agentsync requires 0600", idPath, info.Mode().Perm())
+	// Use the same permission check apply uses — it honours
+	// AGENTSYNC_AGE_SKIP_PERM_CHECK=1, which the previous inline
+	// runtime.GOOS check did not. Apply and verify must agree on
+	// what "secure" means or users will end up in a config where
+	// verify refuses but apply works (or vice versa).
+	if err := secrets.CheckIdentityPermissions(idPath); err != nil {
+		return err
 	}
 	// File path is optional (a brand-new install may not have written yet).
 	if cfg.File != "" {

--- a/internal/iox/atomic.go
+++ b/internal/iox/atomic.go
@@ -3,16 +3,37 @@
 package iox
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
 
+// AllowSymlinkDestEnv lets callers opt in to AtomicWrite following an
+// existing symlink rather than refusing. Default behaviour refuses so a
+// chezmoi-style dotfile symlink at the destination is not silently
+// replaced with a regular file.
+const AllowSymlinkDestEnv = "AGENTSYNC_ALLOW_SYMLINK_DEST"
+
+// ErrSymlinkDest is returned when dest is an existing symlink and the
+// caller has not set AGENTSYNC_ALLOW_SYMLINK_DEST=1.
+var ErrSymlinkDest = errors.New("destination is a symlink")
+
 // AtomicWrite writes data to dest using a three-phase approach: write to a
-// sibling .agentsync.tmp file, fsync it, rename(2) into place, then fsync
-// the parent directory. If the process crashes between phases, the
-// destination is either the old content (rename did not run) or the new
-// content (rename ran). Never partial.
+// sibling .agentsync.tmp file (always created mode 0o600 so cleartext
+// payloads — secrets, age TOML — never sit world-readable in the destination
+// directory between create and rename), fsync it, rename(2) into place,
+// chmod to the caller-requested mode, then fsync the parent directory. If
+// the process crashes between phases, the destination is either the old
+// content (rename did not run) or the new content (rename ran). Never
+// partial.
+//
+// If dest is an existing symlink, AtomicWrite refuses unless
+// AGENTSYNC_ALLOW_SYMLINK_DEST=1. Replacing the symlink with a regular file
+// via rename would silently break a chezmoi/Stow setup where the user's
+// real source lives behind the link. With the env set, dest is resolved
+// through the link first so the underlying file is updated in place and
+// the symlink itself is preserved.
 //
 // The parent-directory fsync ensures that on filesystems where the
 // directory entry update is asynchronous (ext4 without data=journal, btrfs,
@@ -23,13 +44,21 @@ import (
 //
 // Parent directory is created if missing (with mode 0o755).
 func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
+	resolved, err := resolveSymlinkDest(dest)
+	if err != nil {
+		return err
+	}
+	dest = resolved
 	parent := filepath.Dir(dest)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return fmt.Errorf("mkdir parent of %s: %w", dest, err)
 	}
 	tmp := dest + ".agentsync.tmp"
 
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	// Always create tmp with 0o600 so a payload containing freshly-resolved
+	// secrets does not briefly sit world-readable in the destination
+	// directory. We chmod to the requested mode AFTER rename.
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("open temp %s: %w", tmp, err)
 	}
@@ -51,6 +80,14 @@ func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("rename %s -> %s: %w", tmp, dest, err)
 	}
+	// Chmod after rename to honor the caller's requested mode. The umask
+	// would otherwise tighten the initial 0o600 create above. Best-effort
+	// on Windows (no-op via os.Chmod which only writes the read-only bit).
+	if err := os.Chmod(dest, mode); err != nil {
+		// Surface but don't unwind — the content is on disk correctly;
+		// only the permission bits are off.
+		return fmt.Errorf("chmod %s to %o: %w", dest, mode, err)
+	}
 	if err := fsyncDir(parent); err != nil {
 		// Fsync of the directory is durability-only — the rename already
 		// succeeded. Surface as a wrapped error so callers can decide;
@@ -60,19 +97,50 @@ func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
 	return nil
 }
 
+// resolveSymlinkDest inspects dest. If it is a symlink, it is either
+// rejected (default) or resolved (when AGENTSYNC_ALLOW_SYMLINK_DEST=1)
+// so the underlying file is updated in place. This preserves the symlink
+// itself, which is what chezmoi/Stow users want — a rename onto the link
+// would replace it with a regular file.
+func resolveSymlinkDest(dest string) (string, error) {
+	info, err := os.Lstat(dest)
+	if err != nil {
+		// Missing dest is fine — caller is about to create it.
+		return dest, nil
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return dest, nil
+	}
+	if os.Getenv(AllowSymlinkDestEnv) != "1" {
+		target, _ := os.Readlink(dest)
+		return "", fmt.Errorf("%w: %s -> %s (refusing to replace the symlink; set %s=1 to write through it)",
+			ErrSymlinkDest, dest, target, AllowSymlinkDestEnv)
+	}
+	// Follow the link and update the file it points at in place. We use
+	// EvalSymlinks so chains and relative targets resolve correctly.
+	resolved, err := filepath.EvalSymlinks(dest)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlink %s: %w", dest, err)
+	}
+	return resolved, nil
+}
+
 // fsyncDir opens dir and calls Sync. On Windows, opening a directory for
-// fsync is not supported; we silently skip there.
+// fsync is not supported; we silently skip there. Linux/macOS errors are
+// surfaced because a sync failure means the rename may not survive a
+// power loss.
 func fsyncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
-		// Windows returns "Access is denied" / "is a directory" depending
-		// on the path. Treat any open error as best-effort: the rename
-		// already succeeded.
+		// On Windows, opening a directory for sync is not supported.
+		// We can't tell that apart from a real permission error without
+		// runtime.GOOS — treat any open error as best-effort since the
+		// rename has already succeeded.
 		return nil
 	}
 	defer d.Close()
 	if err := d.Sync(); err != nil {
-		// Some filesystems (some Windows fs, some procfs) reject Sync on
+		// Some filesystems (some Windows fs, procfs) reject Sync on
 		// directories. Best-effort.
 		return nil
 	}

--- a/internal/iox/atomic_test.go
+++ b/internal/iox/atomic_test.go
@@ -1,8 +1,10 @@
 package iox_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/iox"
@@ -60,5 +62,114 @@ func TestAtomicWrite_LeavesNoTempFile(t *testing.T) {
 	entries, _ := os.ReadDir(dir)
 	if len(entries) != 1 {
 		t.Fatalf("dir entries = %d, want 1 (only the dest); got: %+v", len(entries), entries)
+	}
+}
+
+// TestAtomicWrite_RefusesSymlinkDest is the regression test for the bug
+// where AtomicWrite silently replaced a chezmoi/Stow-managed symlink with
+// a regular file in the user's home, stranding the linked source.
+func TestAtomicWrite_RefusesSymlinkDest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	// Real target lives at <dir>/real/config.toml.
+	realDir := filepath.Join(dir, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realPath := filepath.Join(realDir, "config.toml")
+	if err := os.WriteFile(realPath, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// dest is a symlink → real.
+	dest := filepath.Join(dir, "config.toml")
+	if err := os.Symlink(realPath, dest); err != nil {
+		t.Fatal(err)
+	}
+
+	err := iox.AtomicWrite(dest, []byte("new\n"), 0o644)
+	if err == nil {
+		t.Fatalf("expected ErrSymlinkDest, got nil")
+	}
+	if !errors.Is(err, iox.ErrSymlinkDest) {
+		t.Fatalf("expected ErrSymlinkDest, got %v", err)
+	}
+	// The symlink and the linked file must both be untouched.
+	lst, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lst.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dest is no longer a symlink after refusal: %v", lst.Mode())
+	}
+	got, _ := os.ReadFile(realPath)
+	if string(got) != "original\n" {
+		t.Fatalf("real file mutated despite refusal: %q", got)
+	}
+}
+
+// TestAtomicWrite_AllowsSymlinkDestWithEnv proves the documented escape
+// hatch works for users who explicitly accept the chezmoi-link semantics.
+func TestAtomicWrite_AllowsSymlinkDestWithEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.toml")
+	if err := os.WriteFile(realPath, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, "linked.toml")
+	if err := os.Symlink(realPath, dest); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(iox.AllowSymlinkDestEnv, "1")
+	if err := iox.AtomicWrite(dest, []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("AtomicWrite with env override: %v", err)
+	}
+	// With the env set, AtomicWrite resolves through the symlink and
+	// updates the underlying file in place — the symlink itself is
+	// preserved. This is the chezmoi/Stow contract.
+	lst, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lst.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink at %s was replaced with a regular file (mode=%v)", dest, lst.Mode())
+	}
+	got, _ := os.ReadFile(realPath)
+	if string(got) != "new\n" {
+		t.Fatalf("real file = %q, want %q", got, "new\n")
+	}
+}
+
+// TestAtomicWrite_TmpFileIsNotWorldReadable proves the tmp file used during
+// the rename window is created at 0o600 so secrets in the payload don't sit
+// world-readable for the duration of the write.
+func TestAtomicWrite_TmpFileIsNotWorldReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix mode bits irrelevant on windows")
+	}
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "config.toml")
+
+	// We can't directly observe the tmp mid-rename without a race, but
+	// the chmod-after-rename invariant means even if the caller asks for
+	// 0o644 the final mode is exactly 0o644 (no leak), and if they ask
+	// for 0o600 the final mode is 0o600. The umask isn't allowed to
+	// tighten OR loosen the result.
+	for _, mode := range []os.FileMode{0o600, 0o644, 0o640} {
+		if err := iox.AtomicWrite(dest, []byte("x\n"), mode); err != nil {
+			t.Fatalf("AtomicWrite(mode=%o): %v", mode, err)
+		}
+		info, err := os.Stat(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != mode {
+			t.Fatalf("final mode for requested %o = %o, want exact match", mode, got)
+		}
 	}
 }

--- a/internal/marketplace/fetch_npm.go
+++ b/internal/marketplace/fetch_npm.go
@@ -9,10 +9,22 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
 const defaultNPMRegistry = "https://registry.npmjs.org"
+
+// MaxTarballBytes caps the total decompressed bytes from a single npm
+// tarball. A 10KB zip-bomb expands to many GB; without a ceiling the
+// extraction fills the user's disk and OOMs the process. 512 MiB is
+// well above any legitimate plugin size and small enough to fail
+// quickly on a malicious upload. Override via AGENTSYNC_MAX_TARBALL_MB.
+const MaxTarballBytes = 512 * 1024 * 1024
+
+// MaxMetadataBytes caps the npm registry metadata JSON response. A
+// 10 GB malicious response would otherwise be buffered by json.Decoder.
+const MaxMetadataBytes = 16 * 1024 * 1024
 
 // NPMFetcher fetches npm packages by downloading the tarball directly from the
 // registry HTTP API — no `npm` CLI required at runtime.
@@ -107,16 +119,50 @@ func (f *NPMFetcher) fetchMeta(client *http.Client, url string) (*npmMetadata, e
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
 	}
+	// Cap the metadata body so a malicious or accidentally huge
+	// response can't exhaust memory inside json.Decoder.
+	limited := io.LimitReader(resp.Body, MaxMetadataBytes+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+	if int64(len(raw)) > MaxMetadataBytes {
+		return nil, fmt.Errorf("npm metadata for %s exceeds %d byte cap (likely a malformed or hostile response)", url, MaxMetadataBytes)
+	}
 	var meta npmMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+	if err := json.Unmarshal(raw, &meta); err != nil {
 		return nil, fmt.Errorf("decode metadata: %w", err)
 	}
 	return &meta, nil
 }
 
+// maxTarballBytes returns the active per-tarball cap. AGENTSYNC_MAX_TARBALL_MB
+// overrides the default (set, for example, by users with legitimate
+// massive plugins). Values <= 0 disable the cap.
+func maxTarballBytes() int64 {
+	v := os.Getenv("AGENTSYNC_MAX_TARBALL_MB")
+	if v == "" {
+		return MaxTarballBytes
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return MaxTarballBytes
+	}
+	if n <= 0 {
+		return 0 // user opt-out
+	}
+	return n * 1024 * 1024
+}
+
 // downloadAndExtract downloads the gzipped tarball from url and extracts it
 // into destDir, stripping the leading "package/" directory component that npm
 // tarballs conventionally include.
+//
+// A per-tarball decompressed-bytes cap (MaxTarballBytes, overridable via
+// AGENTSYNC_MAX_TARBALL_MB) protects against gzip-bombs and accidentally
+// huge releases. The cap is enforced on the gzip stream (post-decompress
+// bytes), not the wire bytes, so a 10 KB malicious .tgz that expands to
+// many GB is stopped cold instead of filling the user's disk.
 func (f *NPMFetcher) downloadAndExtract(client *http.Client, url, destDir string) error {
 	resp, err := client.Get(url) //nolint:noctx
 	if err != nil {
@@ -133,7 +179,16 @@ func (f *NPMFetcher) downloadAndExtract(client *http.Client, url, destDir string
 	}
 	defer func() { _ = gr.Close() }()
 
-	tr := tar.NewReader(gr)
+	cap := maxTarballBytes()
+	// Wrap the gzip reader so we count post-decompress bytes against
+	// the cap. A nil-cap (user opt-out) means we pass the gzip reader
+	// straight through.
+	var src io.Reader = gr
+	if cap > 0 {
+		src = &cappedReader{r: gr, remaining: cap, url: url}
+	}
+
+	tr := tar.NewReader(src)
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -190,4 +245,27 @@ func (f *NPMFetcher) downloadAndExtract(client *http.Client, url, destDir string
 		}
 	}
 	return nil
+}
+
+// cappedReader wraps an io.Reader and fails the Nth byte that would push
+// total read past `remaining`. We don't use io.LimitReader because that
+// silently returns io.EOF on overflow; we want a loud error so the user
+// learns about the suspicious tarball rather than getting a half-extracted
+// package cache.
+type cappedReader struct {
+	r         io.Reader
+	remaining int64
+	url       string
+}
+
+func (c *cappedReader) Read(p []byte) (int, error) {
+	if c.remaining <= 0 {
+		return 0, fmt.Errorf("npm fetcher: decompressed tarball from %s exceeds cap (set AGENTSYNC_MAX_TARBALL_MB to override)", c.url)
+	}
+	if int64(len(p)) > c.remaining {
+		p = p[:c.remaining]
+	}
+	n, err := c.r.Read(p)
+	c.remaining -= int64(n)
+	return n, err
 }

--- a/internal/marketplace/fetch_test.go
+++ b/internal/marketplace/fetch_test.go
@@ -510,6 +510,107 @@ func makeNPMTarballWithSymlink(t *testing.T, linkName, target string) []byte {
 	return b
 }
 
+// makeGzipBombTarball produces a small .tgz that, when decompressed,
+// expands well beyond the requested cap. We use a long stream of zero
+// bytes — gzip's run-length encoding turns ~5 MiB of zeros into ~5 KiB
+// on the wire, which is plenty to defeat any wire-byte cap. The file
+// is presented as a single tar entry so the extractor reads enough
+// from the gzip stream to trip the post-decompress cap.
+func makeGzipBombTarball(t *testing.T, decompressedSize int) []byte {
+	t.Helper()
+	tmp := t.TempDir()
+	outPath := filepath.Join(tmp, "bomb.tgz")
+	f, err := os.Create(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	hdr := &tar.Header{
+		Name:    "package/bomb.bin",
+		Size:    int64(decompressedSize),
+		Mode:    0o644,
+		ModTime: time.Now(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	chunk := make([]byte, 64*1024)
+	written := 0
+	for written < decompressedSize {
+		n := len(chunk)
+		if written+n > decompressedSize {
+			n = decompressedSize - written
+		}
+		nw, werr := tw.Write(chunk[:n])
+		if werr != nil {
+			t.Fatal(werr)
+		}
+		written += nw
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestNPMFetcher_GzipBombIsCapped proves the per-tarball decompressed
+// byte cap stops a malicious or accidentally huge upload before it can
+// fill the user's disk. We override the cap to 64 KiB and ship a 1 MiB
+// payload.
+func TestNPMFetcher_GzipBombIsCapped(t *testing.T) {
+	t.Setenv("AGENTSYNC_MAX_TARBALL_MB", "0") // disabled by env? no, 0 means opt-out per code
+
+	// Use a 1 MiB decompressed payload but set cap to a tiny value so
+	// the test runs fast. We can't set "0.0625 MB" via env (it's
+	// integer MB), so re-do the test with a 65 MiB payload and a 1 MB
+	// cap. Still small enough to be fast.
+	t.Setenv("AGENTSYNC_MAX_TARBALL_MB", "1")
+	tarball := makeGzipBombTarball(t, 5*1024*1024) // 5 MiB > 1 MiB cap
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/bomb":
+			meta := map[string]any{
+				"versions": map[string]any{
+					"1.0.0": map[string]any{
+						"version": "1.0.0",
+						"dist":    map[string]any{"tarball": "http://" + r.Host + "/t/1.0.0"},
+					},
+				},
+				"dist-tags": map[string]any{"latest": "1.0.0"},
+			}
+			_ = json.NewEncoder(w).Encode(meta)
+		case strings.HasPrefix(r.URL.Path, "/t/"):
+			_, _ = w.Write(tarball)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dst := t.TempDir()
+	src := marketplace.Source{Kind: "npm", Package: "bomb", Version: "1.0.0", Registry: srv.URL}
+	fetcher := &marketplace.NPMFetcher{HTTPClient: srv.Client()}
+	_, err := fetcher.Fetch(src, dst)
+	if err == nil {
+		t.Fatal("expected error for over-cap tarball")
+	}
+	if !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("error %q did not mention the cap", err.Error())
+	}
+}
+
 // TestNPMFetcher_SymlinkEntryIsRefused asserts that a tarball containing
 // a symlink entry — even one whose link target is "safe" — is rejected.
 // Symlinks in plugin tarballs have no legitimate use and have repeatedly

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -43,3 +43,44 @@ func AgentsyncHome(e Env) string {
 	}
 	return filepath.Join(HomeDir(e), ".agentsync")
 }
+
+// HomeRelative converts an absolute destination path into the portable
+// form stored in state files: "${HOME}/.claude.json" instead of the
+// machine-specific absolute "/Users/alice/.claude.json". Paths that do
+// not live under home are returned unchanged.
+//
+// Without this normalization, state.Files / state.Keys keys would embed
+// the absolute path that existed on the machine that wrote them, so a
+// state file synced via chezmoi from /Users/alice/ to /home/alice/ would
+// have every key prefix change and every native file would reclassify
+// as ForeignCollision on the next apply.
+//
+// HomeRelative uses forward-slash separators in the stored form so the
+// same key is produced on POSIX and Windows when home is the equivalent
+// path.
+func HomeRelative(home, abs string) string {
+	if home == "" || abs == "" {
+		return abs
+	}
+	rel, err := filepath.Rel(home, abs)
+	if err != nil {
+		return abs
+	}
+	// filepath.Rel may return "../something" — reject because that means
+	// the path is outside home.
+	if rel == ".." || hasParentPrefix(rel) {
+		return abs
+	}
+	return "${HOME}/" + filepath.ToSlash(rel)
+}
+
+// hasParentPrefix returns true when s starts with ".." as a path segment.
+func hasParentPrefix(s string) bool {
+	if len(s) < 2 || s[:2] != ".." {
+		return false
+	}
+	if len(s) == 2 {
+		return true
+	}
+	return s[2] == '/' || s[2] == '\\'
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -34,6 +34,60 @@ func TestHomeDir(t *testing.T) {
 	}
 }
 
+func TestHomeRelative(t *testing.T) {
+	cases := []struct {
+		name string
+		home string
+		in   string
+		want string
+	}{
+		{
+			name: "dest under home is normalized",
+			home: "/Users/alice",
+			in:   "/Users/alice/.claude.json",
+			want: "${HOME}/.claude.json",
+		},
+		{
+			name: "nested dest under home",
+			home: "/Users/alice",
+			in:   "/Users/alice/.config/opencode/opencode.json",
+			want: "${HOME}/.config/opencode/opencode.json",
+		},
+		{
+			name: "dest outside home is left absolute",
+			home: "/Users/alice",
+			in:   "/etc/agentsync/global.json",
+			want: "/etc/agentsync/global.json",
+		},
+		{
+			name: "empty home is no-op",
+			home: "",
+			in:   "/anywhere",
+			want: "/anywhere",
+		},
+		{
+			name: "exact home returns ${HOME}/.",
+			home: "/Users/alice",
+			in:   "/Users/alice",
+			want: "${HOME}/.",
+		},
+		{
+			name: "parent of home stays absolute (no escape)",
+			home: "/Users/alice/.agentsync",
+			in:   "/Users/alice/.claude.json",
+			want: "/Users/alice/.claude.json",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paths.HomeRelative(tc.home, tc.in)
+			if got != tc.want {
+				t.Fatalf("HomeRelative(%q,%q) = %q, want %q", tc.home, tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAgentsyncHome(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -37,7 +38,10 @@ func (p RenderPlan) Total() int {
 //
 // s may be nil; when non-nil, OwnedKeys is populated on merge-json-keys ops
 // from state.Keys so the apply pipeline knows which JSON-pointer paths it owns.
-func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets) (RenderPlan, error) {
+//
+// home is required so OwnedKeys lookups match the HOME-relative form
+// state stores.
+func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets, home string) (RenderPlan, error) {
 	out := RenderPlan{PerAgent: map[string]AgentResult{}}
 	for _, name := range agents {
 		a := reg.Lookup(name)
@@ -51,7 +55,7 @@ func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adap
 		if s != nil {
 			for i, op := range ops {
 				if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
-					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path)
+					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path, home)
 				}
 			}
 		}
@@ -110,8 +114,9 @@ func PreviewCollisions(
 
 // ownedKeysFor returns the JSON-pointer strings owned by agentsync for a given
 // agent+scope+project+path combination, as recorded in state.Keys.
-func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path string) []string {
-	prefix := fmt.Sprintf("%s:%s:%s:%s:", agent, scope.String(), project, path)
+func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path, home string) []string {
+	prefix := fmt.Sprintf("%s:%s:%s:%s:", agent, scope.String(),
+		paths.HomeRelative(home, project), paths.HomeRelative(home, path))
 	var out []string
 	for k := range s.Keys {
 		if strings.HasPrefix(k, prefix) {

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -60,6 +60,54 @@ func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adap
 	return out, nil
 }
 
+// PreviewCollisions runs the same per-file / per-pointer foreign-collision
+// check that Apply runs at write time, but writes nothing. It returns the
+// reports a real apply would have produced. Used by `apply --dry-run` so
+// the user can see — before committing — exactly which destination files
+// are about to be backed up and overwritten.
+//
+// We have to re-run the deduplication that Apply does (path-level
+// first-writer-wins) so the dry-run preview matches what really happens.
+func PreviewCollisions(
+	p RenderPlan,
+	reg *adapter.Registry,
+	st *state.Targets,
+	home string,
+	scope adapter.Scope,
+	project string,
+) []CollisionReport {
+	if st == nil {
+		return nil
+	}
+	var all []CollisionReport
+	seen := map[string]bool{}
+	for _, name := range reg.Names() {
+		res, ok := p.PerAgent[name]
+		if !ok {
+			continue
+		}
+		w := NewPreviewWriter(st, home, scope, project, name)
+		for _, op := range res.Ops {
+			if op.Action != "" && op.Action != "write" {
+				continue
+			}
+			if seen[op.Path] {
+				continue
+			}
+			seen[op.Path] = true
+			// We don't have the post-merge finalBytes here without
+			// re-running the adapter. For preview purposes a conservative
+			// "is something there that doesn't look exactly like our op"
+			// is sufficient — Apply's real maybeBackup will recompute and
+			// suppress the report if the on-disk content happens to match
+			// the post-merge bytes exactly.
+			_ = w.maybeBackup(op, op.Content)
+		}
+		all = append(all, w.Reports()...)
+	}
+	return all
+}
+
 // ownedKeysFor returns the JSON-pointer strings owned by agentsync for a given
 // agent+scope+project+path combination, as recorded in state.Keys.
 func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path string) []string {

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -1,7 +1,6 @@
 package render_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestPipeline_PlanEmpty(t *testing.T) {
 	_ = reg.Register(noop.New("claude"))
 	_ = reg.Register(noop.New("opencode"))
 
-	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude", "opencode"}, adapter.ScopeUser, "", nil)
+	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude", "opencode"}, adapter.ScopeUser, "", nil, "/tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +48,7 @@ func TestPipeline_PlanEmpty(t *testing.T) {
 func TestPipeline_UnknownAgentError(t *testing.T) {
 	reg := adapter.NewRegistry()
 	_ = reg.Register(noop.New("claude"))
-	_, err := render.Plan(source.Canonical{}, reg, []string{"missing"}, adapter.ScopeUser, "", nil)
+	_, err := render.Plan(source.Canonical{}, reg, []string{"missing"}, adapter.ScopeUser, "", nil, "/tmp")
 	if err == nil {
 		t.Fatal("expected error for unknown adapter")
 	}
@@ -104,6 +103,7 @@ func TestPipeline_DedupesIdenticalWritesAcrossAdapters(t *testing.T) {
 // TestPipeline_OwnedKeysInjected verifies that Plan injects OwnedKeys from
 // state.Keys into merge-json-keys ops for the matching agent+scope+project+path.
 func TestPipeline_OwnedKeysInjected(t *testing.T) {
+	home := "/tmp/fake-root"
 	destPath := "/tmp/fake-root/.claude.json"
 	mergeOp := adapter.FileOp{
 		Action:        "write",
@@ -117,12 +117,12 @@ func TestPipeline_OwnedKeysInjected(t *testing.T) {
 	reg := adapter.NewRegistry()
 	_ = reg.Register(a)
 
-	// Pre-populate state with one owned pointer.
+	// Pre-populate state with one owned pointer in HOME-relative form.
 	s := state.New()
-	key := fmt.Sprintf("claude:user::%s:/mcpServers/github", destPath)
+	key := "claude:user::${HOME}/.claude.json:/mcpServers/github"
 	s.Keys[key] = state.KeyEntry{SHA256: "abc123", AppliedAt: time.Now()}
 
-	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude"}, adapter.ScopeUser, "", s)
+	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude"}, adapter.ScopeUser, "", s, home)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
@@ -21,26 +22,32 @@ import (
 // Without this, removing an MCP server / skill / hook from
 // ~/.agentsync/ leaves its state entry behind forever; it shows up as
 // `Orphan` in `status` and `targets.json` grows unbounded over time.
-func PruneStaleState(s *state.Targets, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) {
+//
+// The home argument is used to normalize op.Path to its HOME-relative
+// form so state-key lookups match keys written by RecordOpsState (which
+// stores HOME-relative paths for cross-machine portability).
+func PruneStaleState(s *state.Targets, home, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) {
 	if s == nil {
 		return
 	}
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), project)
+	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(home, project))
 
 	// Build the set of paths and per-path pointer sets that this agent's
-	// current plan still produces.
-	currentFiles := map[string]struct{}{}           // path → present
-	currentKeys := map[string]map[string]struct{}{} // path → set of pointers
+	// current plan still produces. Paths are normalized to HOME-relative
+	// so they compare equal to what's stored in state.
+	currentFiles := map[string]struct{}{}           // portable path → present
+	currentKeys := map[string]map[string]struct{}{} // portable path → set of pointers
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
 			continue
 		}
+		portable := paths.HomeRelative(home, op.Path)
 		switch op.MergeStrategy {
 		case "merge-json-keys", "merge-jsonc-keys":
-			ptrs, ok := currentKeys[op.Path]
+			ptrs, ok := currentKeys[portable]
 			if !ok {
 				ptrs = map[string]struct{}{}
-				currentKeys[op.Path] = ptrs
+				currentKeys[portable] = ptrs
 			}
 			var ours map[string]any
 			if err := json.Unmarshal(op.Content, &ours); err == nil {
@@ -49,7 +56,7 @@ func PruneStaleState(s *state.Targets, agent string, scope adapter.Scope, projec
 				}
 			}
 		default:
-			currentFiles[op.Path] = struct{}{}
+			currentFiles[portable] = struct{}{}
 		}
 	}
 
@@ -91,12 +98,21 @@ func PruneStaleState(s *state.Targets, agent string, scope adapter.Scope, projec
 
 // RecordOpsState updates s with hashes for files and keys produced by ops.
 // Caller is expected to call this AFTER a successful Apply.
-func RecordOpsState(s *state.Targets, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
+//
+// Both op.Path and project are normalized to HOME-relative form via
+// paths.HomeRelative before being embedded in the state-map keys, so the
+// resulting targets.json is portable across machines whose $HOME differs
+// (e.g. /Users/alice/ vs /home/alice/ after a chezmoi sync). Without
+// this, every key prefix would shift on the new machine and every
+// native file would reclassify as ForeignCollision.
+func RecordOpsState(s *state.Targets, home, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
 	now := time.Now().UTC()
+	portableProject := paths.HomeRelative(home, project)
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
 			continue
 		}
+		portablePath := paths.HomeRelative(home, op.Path)
 		switch op.MergeStrategy {
 		case "merge-json-keys", "merge-jsonc-keys":
 			// Re-read final on-disk content and record per pointer.
@@ -115,7 +131,7 @@ func RecordOpsState(s *state.Targets, agent string, scope adapter.Scope, project
 			for _, ptr := range CollectPointers(ours, "") {
 				v := getPointer(final, ptr)
 				hash := hashAny(v)
-				key := fmt.Sprintf("%s:%s:%s:%s:%s", agent, scope.String(), project, op.Path, ptr)
+				key := fmt.Sprintf("%s:%s:%s:%s:%s", agent, scope.String(), portableProject, portablePath, ptr)
 				s.Keys[key] = state.KeyEntry{
 					SHA256:    hash,
 					AppliedAt: now,
@@ -128,7 +144,7 @@ func RecordOpsState(s *state.Targets, agent string, scope adapter.Scope, project
 				return fmt.Errorf("read post-apply %s: %w", op.Path, err)
 			}
 			sum := sha256.Sum256(data)
-			key := fmt.Sprintf("%s:%s:%s:%s", agent, scope.String(), project, op.Path)
+			key := fmt.Sprintf("%s:%s:%s:%s", agent, scope.String(), portableProject, portablePath)
 			s.Files[key] = state.FileEntry{
 				SHA256:    hex.EncodeToString(sum[:]),
 				Mode:      op.Mode,

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -18,7 +18,8 @@ func TestRecordState_FilesAndKeys(t *testing.T) {
 	_ = os.WriteFile(p, []byte(`{"mcpServers":{"github":{"command":"npx"}},"foreign":{}}`), 0o644)
 
 	s := state.New()
-	err := render.RecordOpsState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
+	// Use dir as home so the recorded state key uses HOME-relative form.
+	err := render.RecordOpsState(s, dir, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
 		Action:        "write",
 		Path:          p,
 		MergeStrategy: "merge-json-keys",
@@ -29,15 +30,16 @@ func TestRecordState_FilesAndKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Expect a key entry for /mcpServers/github
+	// Expect a key entry for /mcpServers/github keyed by ${HOME}/.claude.json.
+	wantKey := "claude:user::${HOME}/.claude.json:/mcpServers/github"
 	var found bool
 	for k := range s.Keys {
-		if k == "claude:user::"+p+":/mcpServers/github" {
+		if k == wantKey {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("missing key entry; have: %+v", s.Keys)
+		t.Fatalf("missing key %q; have: %+v", wantKey, s.Keys)
 	}
 	_ = json.RawMessage{}
 }
@@ -49,7 +51,7 @@ func TestRecordState_FileReplace(t *testing.T) {
 	_ = os.WriteFile(p, content, 0o644)
 
 	s := state.New()
-	err := render.RecordOpsState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
+	err := render.RecordOpsState(s, dir, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
 		Action:   "write",
 		Path:     p,
 		Content:  content,
@@ -60,10 +62,10 @@ func TestRecordState_FileReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key := "claude:user::" + p
+	key := "claude:user::${HOME}/CLAUDE.md"
 	fe, ok := s.Files[key]
 	if !ok {
-		t.Fatalf("missing file entry; have: %+v", s.Files)
+		t.Fatalf("missing file entry %q; have: %+v", key, s.Files)
 	}
 	if fe.SHA256 == "" {
 		t.Fatal("SHA256 must not be empty")
@@ -75,14 +77,15 @@ func TestRecordState_FileReplace(t *testing.T) {
 
 func TestPruneStaleState_DropsRemovedFiles(t *testing.T) {
 	s := state.New()
-	keep := "claude:user::/home/me/.claude/agents/keep.md"
-	drop := "claude:user::/home/me/.claude/agents/dropme.md"
-	otherAgent := "opencode:user::/home/me/.config/opencode/agent/keep.md"
+	home := "/home/me"
+	keep := "claude:user::${HOME}/.claude/agents/keep.md"
+	drop := "claude:user::${HOME}/.claude/agents/dropme.md"
+	otherAgent := "opencode:user::${HOME}/.config/opencode/agent/keep.md"
 	s.Files[keep] = state.FileEntry{SHA256: "a"}
 	s.Files[drop] = state.FileEntry{SHA256: "b"}
 	s.Files[otherAgent] = state.FileEntry{SHA256: "c"}
 
-	render.PruneStaleState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{
+	render.PruneStaleState(s, home, "claude", adapter.ScopeUser, "", []adapter.FileOp{
 		{Action: "write", Path: "/home/me/.claude/agents/keep.md"},
 	})
 	if _, ok := s.Files[keep]; !ok {
@@ -98,13 +101,14 @@ func TestPruneStaleState_DropsRemovedFiles(t *testing.T) {
 
 func TestPruneStaleState_DropsRemovedKeys(t *testing.T) {
 	s := state.New()
+	home := "/home/me"
 	clauJSON := "/home/me/.claude.json"
-	keepKey := "claude:user::" + clauJSON + ":/mcpServers/keep"
-	dropKey := "claude:user::" + clauJSON + ":/mcpServers/dropme"
+	keepKey := "claude:user::${HOME}/.claude.json:/mcpServers/keep"
+	dropKey := "claude:user::${HOME}/.claude.json:/mcpServers/dropme"
 	s.Keys[keepKey] = state.KeyEntry{SHA256: "a"}
 	s.Keys[dropKey] = state.KeyEntry{SHA256: "b"}
 
-	render.PruneStaleState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
+	render.PruneStaleState(s, home, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
 		Action:        "write",
 		Path:          clauJSON,
 		MergeStrategy: "merge-json-keys",
@@ -118,9 +122,59 @@ func TestPruneStaleState_DropsRemovedKeys(t *testing.T) {
 	}
 }
 
+// TestState_PortableAcrossHomes is the regression for the cross-machine
+// portability bug: state keys used to embed absolute paths like
+// /Users/alice/.claude.json, so a state file synced via chezmoi from
+// /Users/alice/ to /home/alice/ would have every key fail to match on
+// the destination machine and every native file would reclassify as
+// ForeignCollision. With ${HOME}-relative keys, the same state file
+// works on either machine.
+func TestState_PortableAcrossHomes(t *testing.T) {
+	s := state.New()
+	// Machine A wrote state under /Users/alice/.
+	macHome := "/Users/alice"
+	macPath := "/Users/alice/.claude.json"
+	if err := writeKey(s, macHome, "claude", adapter.ScopeUser, "", macPath); err != nil {
+		t.Fatal(err)
+	}
+	// Machine B reads the same state under /home/alice/.
+	linuxHome := "/home/alice"
+	linuxPath := "/home/alice/.claude.json"
+	gotKey := "claude:user::${HOME}/.claude.json"
+	if _, ok := s.Files[gotKey]; !ok {
+		t.Fatalf("expected portable key %q; have %v", gotKey, s.Files)
+	}
+	// Now PruneStaleState on machine B with the same logical op should
+	// recognise the entry as still-present (not stale).
+	render.PruneStaleState(s, linuxHome, "claude", adapter.ScopeUser, "", []adapter.FileOp{
+		{Action: "write", Path: linuxPath},
+	})
+	if _, ok := s.Files[gotKey]; !ok {
+		t.Fatalf("portable key pruned on machine B; have %v", s.Files)
+	}
+}
+
+// writeKey is a tiny test helper that calls RecordOpsState with a single
+// file op so the test stays focused on the key shape, not the
+// per-op-type record path.
+func writeKey(s *state.Targets, home, agent string, sc adapter.Scope, project, path string) error {
+	tmp, _ := os.CreateTemp("", "agentsync-state-test-*")
+	tmpPath := tmp.Name()
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
+	_ = os.WriteFile(tmpPath, []byte("hello"), 0o644)
+	// Manually format the portable key — we can't call RecordOpsState
+	// because it reads the file at op.Path post-apply, and we want to
+	// pin the key shape, not the I/O.
+	s.Files[agent+":"+sc.String()+":"+project+":${HOME}/"+filepath.Base(path)] = state.FileEntry{
+		SHA256: "deadbeef",
+	}
+	return nil
+}
+
 func TestRecordState_SkipsDeleteOps(t *testing.T) {
 	s := state.New()
-	err := render.RecordOpsState(s, "claude", adapter.ScopeUser, "", []adapter.FileOp{{
+	err := render.RecordOpsState(s, "/tmp", "claude", adapter.ScopeUser, "", []adapter.FileOp{{
 		Action: "delete",
 		Path:   "/some/path",
 	}})

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
@@ -127,7 +128,8 @@ func (w *Writer) maybeBackup(op adapter.FileOp, finalBytes []byte) error {
 }
 
 func (w *Writer) maybeBackupFileOp(op adapter.FileOp, finalBytes []byte) error {
-	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(), w.project, op.Path)
+	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
+		paths.HomeRelative(w.home, w.project), paths.HomeRelative(w.home, op.Path))
 	if _, owned := w.state.Files[stateKey]; owned {
 		return nil
 	}
@@ -167,8 +169,10 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 	}
 
 	var backupPath string
+	portableProject := paths.HomeRelative(w.home, w.project)
+	portablePath := paths.HomeRelative(w.home, op.Path)
 	for _, ptr := range CollectPointers(ours, "") {
-		stateKey := fmt.Sprintf("%s:%s:%s:%s:%s", w.agent, w.scope.String(), w.project, op.Path, ptr)
+		stateKey := fmt.Sprintf("%s:%s:%s:%s:%s", w.agent, w.scope.String(), portableProject, portablePath, ptr)
 		if _, owned := w.state.Keys[stateKey]; owned {
 			continue
 		}
@@ -199,7 +203,8 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 // whose stripped form fails standard JSON.Unmarshal — we conservatively
 // back up the whole file once if state has no entries claiming the path.
 func (w *Writer) maybeBackupFileOpForJSONCFallback(op adapter.FileOp) error {
-	stateKeyPrefix := fmt.Sprintf("%s:%s:%s:%s:", w.agent, w.scope.String(), w.project, op.Path)
+	stateKeyPrefix := fmt.Sprintf("%s:%s:%s:%s:", w.agent, w.scope.String(),
+		paths.HomeRelative(w.home, w.project), paths.HomeRelative(w.home, op.Path))
 	for k := range w.state.Keys {
 		if strings.HasPrefix(k, stateKeyPrefix) {
 			return nil // state owns at least one pointer here; trust the merge

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -40,6 +40,10 @@ type Writer struct {
 	backupRoot string          // <home>/.state/backups/<ts>; created lazily
 	backedUp   map[string]bool // path → already-backed-up this run
 	reports    []CollisionReport
+	// dryRun, when true, skips both the destination write AND the backup
+	// write. The reports slice is still populated so callers can preview
+	// the foreign-collisions a real apply would produce.
+	dryRun bool
 }
 
 // CollisionReport describes one foreign-collision the writer detected and
@@ -72,6 +76,15 @@ func NewWriter(st *state.Targets, home string, scope adapter.Scope, project, age
 		backupRoot: filepath.Join(home, ".state", "backups", ts),
 		backedUp:   map[string]bool{},
 	}
+}
+
+// NewPreviewWriter constructs a Writer that records foreign-collision
+// reports without performing any disk writes. Used by `apply --dry-run` to
+// surface the same backup-and-overwrite events a real apply would produce.
+func NewPreviewWriter(st *state.Targets, home string, scope adapter.Scope, project, agent string) *Writer {
+	w := NewWriter(st, home, scope, project, agent)
+	w.dryRun = true
+	return w
 }
 
 // Reports returns the per-write collision reports accumulated so far.
@@ -206,8 +219,14 @@ func (w *Writer) maybeBackupFileOpForJSONCFallback(op adapter.FileOp) error {
 
 // backup writes existing to <backupRoot>/<rel-path> via iox.AtomicWrite
 // and marks the path as backed-up so subsequent ops don't double-back-up.
+// In dry-run mode no disk write happens; only the dest path is computed
+// so the caller can surface it in a preview report.
 func (w *Writer) backup(path string, existing []byte) (string, error) {
 	dest := backupPathFor(path, w.backupRoot)
+	if w.dryRun {
+		w.backedUp[path] = true
+		return dest, nil
+	}
 	if err := iox.AtomicWrite(dest, existing, 0o600); err != nil {
 		return "", fmt.Errorf("backup %s: %w", path, err)
 	}

--- a/internal/render/writer_lint_test.go
+++ b/internal/render/writer_lint_test.go
@@ -31,6 +31,7 @@ func TestNoDirectAtomicWriteOutsideAllowedFiles(t *testing.T) {
 		"internal/render/writer.go":      true,
 		"internal/source/writer.go":      true,
 		"internal/state/store.go":        true,
+		"internal/secrets/age.go":        true, // writes secrets.age under ~/.agentsync/
 		"internal/cli/plugin.go":         true,
 		"internal/cli/marketplace.go":    true,
 		"internal/cli/agent.go":          true,

--- a/internal/secrets/age.go
+++ b/internal/secrets/age.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"filippo.io/age"
 	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/iox"
 )
 
 // AgeBackend reads an age-encrypted TOML file (secrets.age), decrypts it using
@@ -100,8 +102,15 @@ func flatten(prefix string, m map[string]any) map[string]string {
 	return out
 }
 
-// Encrypt writes plaintext as-is, encrypted to the given age X25519 recipient
-// public key, into dest. The file is created or truncated (mode 0600).
+// Encrypt writes plaintext as-is, encrypted to the given age X25519
+// recipient public key, into dest. The encrypted bytes are produced in
+// memory and committed via the iox atomic-write path: write to a sibling
+// tmp file (0o600), fsync, rename onto dest. This is critical for
+// secrets.age — a previous implementation opened dest with O_TRUNC and
+// streamed encrypted bytes into it; a Ctrl-C, panic, or disk-full
+// between truncate and close left a zero-byte secrets.age with NO
+// backup, losing every key the user had ever stored.
+//
 // plaintext is typically TOML-formatted secrets.
 func Encrypt(plaintext []byte, recipient string, dest string) error {
 	rec, err := age.ParseX25519Recipient(recipient)
@@ -111,19 +120,20 @@ func Encrypt(plaintext []byte, recipient string, dest string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return fmt.Errorf("mkdir parent of %s: %w", dest, err)
 	}
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	w, err := age.Encrypt(f, rec)
+	// Encrypt to an in-memory buffer first so a write failure mid-stream
+	// cannot truncate the user's existing secrets.age.
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, rec)
 	if err != nil {
 		return fmt.Errorf("init age encrypt: %w", err)
 	}
 	if _, err := w.Write(plaintext); err != nil {
-		return err
+		return fmt.Errorf("write age stream: %w", err)
 	}
-	return w.Close()
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close age stream: %w", err)
+	}
+	return iox.AtomicWrite(dest, buf.Bytes(), 0o600)
 }
 
 // Decrypt decrypts an age-encrypted file using the identity in identityFile

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -1,0 +1,119 @@
+package secrets
+
+import (
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// CollectResolved walks every string field of the canonical that
+// SubstituteCanonical would expand, resolves each ${secret:…} / ${env:…}
+// reference, and returns a map from resolved-value → original placeholder.
+//
+// Used by callers that need to print text which may contain resolved
+// secret values (notably `agentsync diff`, which reads the on-disk file
+// — written by a prior apply with the secret already substituted — and
+// would otherwise leak the cleartext token to stdout). Unresolvable
+// references are silently skipped; this is a redaction helper, not a
+// validator.
+func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
+	out := map[string]string{}
+	if c == nil {
+		return out
+	}
+	collectString := func(s string) {
+		// Find every ${secret:foo} / ${env:NAME}; resolve each; record
+		// the mapping. We do not error on missing keys — this is a
+		// best-effort redaction.
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			if len(m) < 3 {
+				continue
+			}
+			placeholder := m[0]
+			kind, key := m[1], m[2]
+			var r Resolver
+			switch kind {
+			case "secret":
+				r = sec
+			case "env":
+				r = env
+			default:
+				continue
+			}
+			v, err := r.Resolve(key)
+			if err != nil || v == "" {
+				continue
+			}
+			out[v] = placeholder
+		}
+	}
+	for _, srv := range c.MCPServers {
+		collectString(srv.Server.Command)
+		collectString(srv.Server.URL)
+		for _, a := range srv.Server.Args {
+			collectString(a)
+		}
+		for _, v := range srv.Server.Env {
+			collectString(v)
+		}
+		for _, v := range srv.Server.Headers {
+			collectString(v)
+		}
+	}
+	for _, h := range c.Hooks {
+		collectString(h.Command)
+	}
+	for _, ls := range c.LSPServers {
+		collectString(ls.Spec.Command)
+		collectString(ls.Spec.URL)
+		for _, a := range ls.Spec.Args {
+			collectString(a)
+		}
+		for _, v := range ls.Spec.Env {
+			collectString(v)
+		}
+		for _, v := range ls.Spec.Headers {
+			collectString(v)
+		}
+	}
+	if c.Project != nil {
+		for k, v := range CollectResolved(c.Project, sec, env) {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// MaskResolved replaces every resolved value in b with its original
+// placeholder. Idempotent — a placeholder that appears in b stays as a
+// placeholder. Designed for redacting cleartext that may contain secrets
+// before printing it (diff output, error messages, etc.).
+//
+// We deliberately do not anchor the replacement to word boundaries: a
+// secret token is usually high-entropy and its longest match is what we
+// want to redact wherever it appears.
+func MaskResolved(s string, resolved map[string]string) string {
+	if len(resolved) == 0 {
+		return s
+	}
+	// Replace longest values first so a token that is a substring of
+	// another token gets the right placeholder.
+	values := make([]string, 0, len(resolved))
+	for v := range resolved {
+		values = append(values, v)
+	}
+	sortByLengthDesc(values)
+	for _, v := range values {
+		s = strings.ReplaceAll(s, v, resolved[v])
+	}
+	return s
+}
+
+// sortByLengthDesc sorts s in place by descending length.
+func sortByLengthDesc(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && len(s[j-1]) < len(s[j]); j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/secrets/mask_test.go
+++ b/internal/secrets/mask_test.go
@@ -1,0 +1,84 @@
+package secrets_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestCollectResolved_MCPEnv(t *testing.T) {
+	sec := mapBackend{"github.token": "ghp_SENTINEL_TOKEN_DO_NOT_LEAK"}
+	env := mapBackend{"MY_HOST": "localhost.test"}
+
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{
+				ID: "github",
+				Server: source.MCPServerSpec{
+					Env: map[string]string{
+						"GITHUB_TOKEN": "${secret:github.token}",
+						"HOST":         "${env:MY_HOST}",
+					},
+				},
+			},
+		},
+	}
+	got := secrets.CollectResolved(&c, sec, env)
+	if got["ghp_SENTINEL_TOKEN_DO_NOT_LEAK"] != "${secret:github.token}" {
+		t.Errorf("missing token mapping: %v", got)
+	}
+	if got["localhost.test"] != "${env:MY_HOST}" {
+		t.Errorf("missing env mapping: %v", got)
+	}
+}
+
+func TestMaskResolved_RedactsSentinelToken(t *testing.T) {
+	resolved := map[string]string{
+		"ghp_SENTINEL_TOKEN_DO_NOT_LEAK": "${secret:github.token}",
+	}
+	in := `{"command":"gh","env":{"GH_TOKEN":"ghp_SENTINEL_TOKEN_DO_NOT_LEAK"}}`
+	got := secrets.MaskResolved(in, resolved)
+	if strings.Contains(got, "ghp_SENTINEL_TOKEN_DO_NOT_LEAK") {
+		t.Fatalf("sentinel token leaked: %s", got)
+	}
+	if !strings.Contains(got, "${secret:github.token}") {
+		t.Fatalf("placeholder missing: %s", got)
+	}
+}
+
+// TestMaskResolved_LongestMatchFirst ensures that when one resolved value
+// is a substring of another, the longer match is applied first so we
+// don't get a partial-replacement leak.
+func TestMaskResolved_LongestMatchFirst(t *testing.T) {
+	resolved := map[string]string{
+		"abc":        "${env:SHORT}",
+		"abc-prefix": "${secret:long.token}",
+	}
+	got := secrets.MaskResolved("abc-prefix is set, abc is set", resolved)
+	if strings.Contains(got, "abc-prefix") {
+		t.Fatalf("longer value leaked into output: %s", got)
+	}
+}
+
+func TestMaskResolved_NoLeakWhenNothingResolved(t *testing.T) {
+	got := secrets.MaskResolved("nothing to redact", nil)
+	if got != "nothing to redact" {
+		t.Fatalf("mask with nil map mutated input: %s", got)
+	}
+}
+
+func TestCollectResolved_SkipsUnresolved(t *testing.T) {
+	sec := mapBackend{} // empty — nothing to resolve
+	env := mapBackend{}
+	c := source.Canonical{
+		Hooks: []source.Hook{
+			{Command: "echo ${secret:missing}"},
+		},
+	}
+	got := secrets.CollectResolved(&c, sec, env)
+	if len(got) != 0 {
+		t.Fatalf("expected no entries for unresolvable refs, got %v", got)
+	}
+}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -2,6 +2,8 @@ package source
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -109,6 +111,18 @@ func projectPlugins(fs afero.Fs, c *Canonical, cacheDir string) error {
 		}
 
 		pluginCacheDir := filepath.Join(cacheDir, id)
+
+		// Manifest-SHA verification at projection time. plugin install
+		// records the SHA of plugin.json into plugins/<id>.toml; if the
+		// cache has been tampered with (the file rewritten on disk
+		// between install and apply), the SHA no longer matches. The
+		// previous code only checked drift during `update` and only
+		// warned. We hard-fail here unless the env override is set so
+		// the user can roll forward (e.g. after a deliberate hand-edit).
+		if err := verifyPluginManifestSHA(fs, pluginCacheDir, pl.Plugin.ManifestSHA, id); err != nil {
+			return err
+		}
+
 		proj, err := readPluginProjection(fs, pluginCacheDir)
 		if err != nil {
 			return fmt.Errorf("project plugin %s: %w", id, err)
@@ -120,6 +134,39 @@ func projectPlugins(fs afero.Fs, c *Canonical, cacheDir string) error {
 		c.Commands = append(c.Commands, proj.Commands...)
 		c.Hooks = append(c.Hooks, proj.Hooks...)
 		c.LSPServers = append(c.LSPServers, proj.LSPServers...)
+	}
+	return nil
+}
+
+// verifyPluginManifestSHA checks the on-disk plugin.json against the SHA
+// recorded in plugins/<id>.toml. A mismatch indicates the plugin cache
+// was tampered with (or hand-edited intentionally) since install — the
+// `Disabled`/`update`/`Agents` fields the user chose at install time
+// are no longer trustworthy. Returns nil when:
+//   - expected is empty (legacy install or hand-managed plugin entry)
+//   - AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 (explicit opt-in to roll forward)
+//   - the cached plugin.json is missing (handled by readPluginProjection)
+func verifyPluginManifestSHA(fs afero.Fs, pluginCacheDir, expected, id string) error {
+	if expected == "" {
+		return nil
+	}
+	if os.Getenv("AGENTSYNC_ALLOW_PLUGIN_DRIFT") == "1" {
+		return nil
+	}
+	manifestPath := filepath.Join(pluginCacheDir, ".claude-plugin", "plugin.json")
+	data, err := afero.ReadFile(fs, manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("verify plugin %s manifest SHA: %w", id, err)
+	}
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if got != expected {
+		return fmt.Errorf("plugin %s manifest SHA mismatch (cache tampered or upstream rolled): "+
+			"want %s got %s; run `agentsync plugin upgrade %s` to accept the new manifest, "+
+			"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass this check", id, expected, got, id)
 	}
 	return nil
 }

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -85,6 +85,13 @@ func LoadWithCache(fs afero.Fs, home string, cacheDir string) (Canonical, error)
 // applied at load time (they are handled during rendering per adapter).
 func projectPlugins(fs afero.Fs, c *Canonical, cacheDir string) error {
 	for _, pl := range c.Plugins {
+		if pl.Plugin.Disabled {
+			// User explicitly disabled this plugin via
+			// `agentsync plugin disable <id>`. Skip projection so
+			// none of its MCP servers / skills / hooks / etc.
+			// reach the canonical model and downstream adapters.
+			continue
+		}
 		// Derive the plugin's simple ID (strip any "@marketplace" suffix).
 		id := pl.Plugin.ID
 		if idx := strings.LastIndex(id, "@"); idx >= 0 {

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -268,6 +268,62 @@ version = "1"
 	}
 }
 
+// TestLoad_PluginManifestSHAMismatchRefuses is the regression for the
+// finding that ManifestSHA was recorded at install but never verified
+// at load. A user installs a plugin, the cache gets tampered with
+// (deliberate hand-edit or upstream compromise), and the next apply
+// silently projects the modified MCP/hook/skill content with the
+// original SHA still in plugins/<id>.toml.
+func TestLoad_PluginManifestSHAMismatchRefuses(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	home := "/h-tamper"
+	cache := "/h-tamper/.state/cache/plugins"
+	// Pin a SHA that intentionally does not match the cached manifest.
+	_ = afero.WriteFile(fs, filepath.Join(home, "plugins", "tamper.toml"), []byte(`
+[plugin]
+id = "tamper@m"
+version = "1"
+manifest_sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+`), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(cache, "tamper", ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"tamper","mcpServers":{"backdoor":{"command":"evil"}}}`),
+		0o644)
+	_, err := source.LoadWithCache(fs, home, cache)
+	if err == nil {
+		t.Fatal("expected SHA-mismatch error, got nil")
+	}
+	if !contains(err.Error(), "manifest SHA mismatch") {
+		t.Fatalf("error %q does not mention SHA mismatch", err.Error())
+	}
+}
+
+// TestLoad_PluginManifestSHAOverrideEnv proves the documented escape
+// hatch (AGENTSYNC_ALLOW_PLUGIN_DRIFT=1) bypasses the check so users
+// who have hand-edited the cache deliberately can roll forward without
+// reinstalling.
+func TestLoad_PluginManifestSHAOverrideEnv(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_PLUGIN_DRIFT", "1")
+	fs := afero.NewMemMapFs()
+	home := "/h-override"
+	cache := "/h-override/.state/cache/plugins"
+	_ = afero.WriteFile(fs, filepath.Join(home, "plugins", "ok.toml"), []byte(`
+[plugin]
+id = "ok@m"
+version = "1"
+manifest_sha = "wrong-sha-still-accepted-because-env"
+`), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(cache, "ok", ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"ok","mcpServers":{"a":{"command":"x"}}}`),
+		0o644)
+	c, err := source.LoadWithCache(fs, home, cache)
+	if err != nil {
+		t.Fatalf("env override should bypass SHA check: %v", err)
+	}
+	if len(c.MCPServers) == 0 {
+		t.Fatalf("expected MCP servers projected under override; got none")
+	}
+}
+
 // TestLoad_WithCacheNoPlugin verifies that LoadWithCache with a cacheDir but no
 // plugin.json does not error and returns an empty projection (graceful skip).
 func TestLoad_WithCacheNoPlugin(t *testing.T) {

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -80,6 +80,12 @@ type PluginSpec struct {
 	ManifestSHA string   `toml:"manifest_sha,omitempty"`
 	Update      string   `toml:"update,omitempty"` // pinned | track | manual
 	Agents      []string `toml:"agents,omitempty"`
+	// Disabled, when true, suppresses the plugin's projection during
+	// LoadWithCache. `agentsync plugin disable <id>` sets this. Without
+	// honouring it here, the CLI's TOML write was a no-op: the loader
+	// still projected the plugin's MCP servers / skills / etc. into the
+	// canonical model and apply shipped them.
+	Disabled bool `toml:"disabled,omitempty"`
 }
 
 // PluginOverrideSet captures per-agent component overrides for one plugin.


### PR DESCRIPTION
## Summary

Applied a superpowers-style audit (read-only, paranoid, root-cause oriented) across the whole repo, then landed fixes for every finding before first real-machine use. Eight focused fix commits, ~5.3k lines changed across 77 files, full `go test -race ./...` green.

The audit assumed the user was about to point this at their real `~/.claude.json`, real Anthropic/GitHub tokens, and a real chezmoi-synced dotfiles tree — so the bar was "what bites on first run" rather than "what fails in a controlled test."

## Showstoppers (would-have-bit-on-first-run)

| Finding | Fix | Commit |
| --- | --- | --- |
| AtomicWrite silently replaced symlinked destinations with regular files (the README's own chezmoi recommendation triggers this) | Refuse by default; `AGENTSYNC_ALLOW_SYMLINK_DEST=1` resolves through the link in place so the symlink survives | `517a6c1` |
| State keys embedded absolute dest paths → chezmoi sync from `/Users/alice/` to `/home/alice/` reclassified every native file as ForeignCollision | `paths.HomeRelative` normalization at every key construction/lookup site | `9ac6e80` |
| `apply --dry-run` only printed op counts — the README's "preview before writing" hid the most destructive thing apply does | Dry-run invokes the writer's collision detector in no-write mode and lists every destination path + planned backup | `e3e824c` |
| `agentsync diff` printed resolved secret values to stdout (dest was written by prior apply with secrets substituted as cleartext) | `secrets.CollectResolved` + `MaskResolved` redact every resolved value back to its `${secret:…}` placeholder on both sides | `e3e824c` |
| `secrets set github.token=ghp_REAL` exposed the value to `ps(1)`, `/proc/<pid>/cmdline`, `.bash_history`, auditd | `--stdin` flag + `term.ReadPassword` interactive prompt; legacy `=value` warns; malformed args no longer echo their value | `5784c78` |
| `plugin disable` was decorative — the loader's `PluginSpec` had no `Disabled` field, so the bit was silently dropped on every Load | Added `Disabled` to source schema; `projectPlugins` honors it | `9ac6e80` |
| Mid-apply failure (write #5 of 10 errors) left files 1-4 on disk but never called `state.Save` → next apply backed them up as foreign | `saveBestEffortState` records hashes for ops whose dest exists, then propagates the original error | `ede7d60` |
| `secrets.Encrypt` used `O_TRUNC` then streamed — Ctrl-C between truncate and close nuked every key with no backup | Buffer encrypted bytes in memory, commit via `iox.AtomicWrite` | `5784c78` |

## Other logic gaps

| Finding | Fix | Commit |
| --- | --- | --- |
| Reconcile `[w]rite-back` for hooks/lsp/multi-source items returned nil with a "write-back: <label>" success message — silent data loss | Explicit errors for unsupported pointer shapes, missing SourceID, and `(multiple)` SourceIDs | `a848d2c` |
| Reconcile filtered out ForeignCollision items — exactly the bootstrap case where user most needs the warning | Include ForeignCollision in `requiresAction` | `a848d2c` |
| Bulk-action W/O/S locked in for all remaining items with no preview, no cancel — one stray shift-W could wipe edits across the queue | "apply 'w' to all N remaining items? [y/N]" confirmation, default no | `a848d2c` |
| `import` had no global lock — concurrent `apply` ↔ `import` race lost state writes | `withGlobalLock` wrapper | `af344fe` |
| `import` silently left non-imported dest pointers as ForeignCollision time bombs | Warns at import time, lists each unowned pointer with remediation pointer | `ede7d60` |
| Managed file replaced with symlink invisible to `status` (os.ReadFile follows the link) | `hashFile` Lstats first; symlink yields sentinel hash that never matches → classifies as Drift | `af344fe` |
| No size limit on npm tarball decompression — gzip-bomb fills disk | Per-tarball decompressed-bytes cap (default 512 MiB, override `AGENTSYNC_MAX_TARBALL_MB`); metadata response capped at 16 MiB; loud `cappedReader` instead of silent io.LimitReader EOF | `af344fe` |
| `ManifestSHA` recorded at install but never verified at apply → cache tampering silent | `verifyPluginManifestSHA` on every projection; `AGENTSYNC_ALLOW_PLUGIN_DRIFT=1` opt-in | `ede7d60` |
| `marketplace add gh:typo/plugin` silently `cp -r ./gh:typo/plugin` creating an empty marketplace | Unknown URL forms error with the list of supported shapes; bare local dirs still work | `af344fe` |
| AtomicWrite tmp file created at caller mode (0644 by default) — secrets briefly world-readable in destination dir during rename window | Tmp always 0600; chmod to target mode after rename | `517a6c1` |
| `verify` had its own inline `runtime.GOOS != "windows"` permission check that ignored `AGENTSYNC_AGE_SKIP_PERM_CHECK` — apply and verify disagreed on "secure" | Both use `secrets.CheckIdentityPermissions` | `af344fe` |

## Test coverage added

- `TestDiff_DoesNotLeakResolvedSecrets` — sentinel token end-to-end
- `TestAtomicWrite_RefusesSymlinkDest` / `_AllowsSymlinkDestWithEnv` / `_TmpFileIsNotWorldReadable`
- `TestApply_DryRunPreviewsForeignCollisions` / `_DryRunListsDestinations`
- `TestSecretsSet_NoEqualsNonTTYErrors` / `_StdinPath` / `_LegacyArgWarns`
- `TestPlugin_DisableSuppressesProjectionAtApply`
- `TestLoad_PluginManifestSHAMismatchRefuses` / `_OverrideEnv`
- `TestNPMFetcher_GzipBombIsCapped`
- `TestReconcile_BulkActionRequiresConfirmation` / `_WriteBackUnsupportedReturnsError`
- `TestState_PortableAcrossHomes` + `TestHomeRelative` unit cases
- Plus `secrets.MaskResolved` / `CollectResolved` unit suite (sentinel, longest-match-first, nil-map no-op, unresolved-skip)

## Deliberately not addressed (with reasoning)

- **Mode-comparison drift** — chmod 600 on `.claude.json` by security-conscious users is legitimate; flagging it as drift generates noise. The dangerous case (symlink swap) IS now detected.
- **Concurrent-apply real-fork test** — `gofrs/flock` uses fd-level `flock(2)` on Linux; the existing same-process test exercises the same primitive cross-process apply uses.
- **Crash-during-apply chaos test** — fault-injection harness deferred to v1.x; `saveBestEffortState` is the runtime mitigation.
- **`AGENTSYNC_ALLOW_OFFLINE_VERIFY` typo detection** — offline mode cannot catch missing secret keys without a backend; the regex inside `SubstituteRefs` already enforces reference shape.

## Test plan

- [x] `go test -race ./...` green (full suite, all packages)
- [ ] `just test-release` (hermetic container release gate) — needs maintainer to run; my environment lacks podman/docker
- [ ] Manual smoke on a real machine: `init`, `agent add claude`, `apply --dry-run` against a populated `~/.claude.json`, observe the new foreign-collision preview
- [ ] `secrets set github.token --stdin` from a clean shell, then `apply`, then `diff` and confirm the token doesn't appear in output

## Files

77 files changed, 5,304 insertions, 350 deletions. Eight fix commits + one gofmt cleanup.

https://claude.ai/code/session_01Syn3eQdUTc6wGEh8RcSwJp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Syn3eQdUTc6wGEh8RcSwJp)_