### PR TITLE
Launch-ready: 3-round hardening loop + polish + post-eval security pass (~39 fixes)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,6 @@
+# goreleaser v2 config (the CI action installs the latest v2 release).
+version: 2
+
 project_name: agentsync
 
 builds:
@@ -39,6 +42,7 @@ changelog:
 nfpms:
   - id: linux-pkgs
     package_name: agentsync
+    maintainer: spxrogers <spxrogers@users.noreply.github.com>
     homepage: https://github.com/spxrogers/agentsync
     license: MIT
     formats: [deb, rpm]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 spxrogers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Centrally manage AI coding-agent configurations across Claude Code, OpenCode, Co
 
 ## Install
 
+> **Pre-release:** the package-manager channels below are wired in
+> `.goreleaser.yaml` but are published starting with the first tagged release.
+> Until then, **build from source**:
+>
+>     go install github.com/spxrogers/agentsync/cmd/agentsync@latest
+>
+> or clone and `go build ./cmd/agentsync`.
+
 ### macOS — Homebrew
 
     brew tap spxrogers/tap
@@ -40,7 +48,7 @@ RPM:
 
 Arch (AUR):
 
-    yay -S agentsync
+    yay -S agentsync-bin
 
 ## Cross-machine sync
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 ## Troubleshooting
 
 - **First apply on a populated machine**: agentsync sees pre-existing native config files and triggers `foreign-collision`. The original is backed up to `~/.agentsync/.state/backups/<ts>/` before the new content lands. Recommend `agentsync apply --dry-run` first to preview the translation report.
+- **One-time backup churn after upgrading**: state keys are now stored `${HOME}`-relative (portable across machines) instead of with absolute paths. If you ran a pre-portability build, the first `apply` after upgrading will not recognize the old absolute-path entries, so every managed destination is treated as a `foreign-collision` once: the current content is backed up to `~/.agentsync/.state/backups/<ts>/` and then re-owned. This is expected, non-destructive (nothing is lost — it's backed up), and self-heals after that single apply. Run `agentsync apply --dry-run` first if you want to see which files will be backed up.
 - **`agentsync update` fails to fetch a marketplace**: verify the marketplace URL with `git ls-remote`. agentsync uses `go-git` and falls back to system `git` for sparse clones if needed.
 - **`${secret:foo}` not resolving**: run `agentsync secrets get foo` to verify the key exists in the decrypted file. age library errors will surface here.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's "Report a
+vulnerability" button under the repository's **Security** tab
+(Security Advisories), rather than opening a public issue. We aim to
+acknowledge reports within a few days.
+
+When reporting, include the affected version (`agentsync --version`), repro
+steps, and impact.
+
+## Scope and threat model
+
+agentsync reads and writes coding-agent configuration on a single machine and
+can resolve secrets into native config files. Areas of particular interest:
+
+- **age-encrypted secrets** (`internal/secrets`): the age identity file must
+  be `0600`; agentsync refuses to read a group/other-readable identity unless
+  `AGENTSYNC_AGE_SKIP_PERM_CHECK=1`. agentsync never writes decrypted secret
+  values to durable storage and redacts resolved `${secret:...}` values in
+  `agentsync diff`.
+- **Untrusted marketplaces / plugins**: a marketplace or plugin you add is
+  treated as untrusted input. Fetchers reject symlinks (npm/relative/git),
+  cap decompressed tarball size, verify plugin manifest SHAs, and bound
+  manifest-listed component paths and names to the plugin cache.
+- **Destination writes**: writes are atomic and refuse to clobber symlinked
+  destinations by default; pre-existing foreign files are backed up before
+  overwrite.
+
+## Sensitive files
+
+Do not commit your age identity file, decrypted secrets, or
+`~/.agentsync/.state/` to a public repository. `agentsync secrets set
+--stdin` keeps secret values off `argv`, shell history, and process listings.
+
+## Supported versions
+
+Until the first stable (`v1.0.0`) release, only the latest tagged version is
+supported for security fixes.

--- a/docs/research/marketplace-distribution.md
+++ b/docs/research/marketplace-distribution.md
@@ -52,7 +52,7 @@ slack-mcp-plugin/
 └── .mcp.json
 ```
 
-This is the manual, hand-maintained version of what opensync wants to automate. Same vendor, same backend MCP, parallel shim folders side-by-side because there is no shared format. If Slack adds Codex tomorrow, they will add a `.codex-plugin/` folder.
+This is the manual, hand-maintained version of what agentsync wants to automate. Same vendor, same backend MCP, parallel shim folders side-by-side because there is no shared format. If Slack adds Codex tomorrow, they will add a `.codex-plugin/` folder.
 
 **Officially supported clients**: Claude.ai, Claude Code, Perplexity, Cursor. **Codex is not on the list.**
 
@@ -62,7 +62,7 @@ This is the manual, hand-maintained version of what opensync wants to automate. 
 - Anthropic's `@modelcontextprotocol/server-slack` (npm, bot-token, older)
 - plus prominent community forks (`korotovsky/slack-mcp-server`)
 
-When a user types `opensync mcp add slack`, which do they mean? Need a canonical-id namespace (`slack@slackapi` vs `slack@modelcontextprotocol` vs `slack@korotovsky`) to disambiguate. Atlassian had one clear winner; Slack does not.
+When a user types `agentsync mcp add slack`, which do they mean? Need a canonical-id namespace (`slack@slackapi` vs `slack@modelcontextprotocol` vs `slack@korotovsky`) to disambiguate. Atlassian had one clear winner; Slack does not.
 
 ## Side-by-side
 
@@ -74,13 +74,13 @@ When a user types `opensync mcp add slack`, which do they mean? Need a canonical
 | Codex official path | none | none |
 | Competing "official" servers | one | two (hosted vs npm) + community forks |
 
-## Implications for opensync
+## Implications for agentsync
 
-1. **Marketplace primacy is real but only on Claude Code and OpenCode.** For everyone else, what opensync projects is not a marketplace install — it is the same hand-rolled MCP/skills config that vendors today expect users to paste manually. The `Plugin content × Agent` translation table in `PLAN.md` is exactly the gap.
+1. **Marketplace primacy is real but only on Claude Code and OpenCode.** For everyone else, what agentsync projects is not a marketplace install — it is the same hand-rolled MCP/skills config that vendors today expect users to paste manually. The `Plugin content × Agent` translation table in `PLAN.md` is exactly the gap.
 
-2. **Atlassian is the canonical M2 test fixture.** Take `atlassian@claude-plugins-official`, project the MCP server universally, project the 5 slash-commands as Cursor/Continue rules, skip skills on Codex with a logged reason. If opensync handles this one plugin cleanly across all seven agents, it has solved the real problem.
+2. **Atlassian is the canonical M2 test fixture.** Take `atlassian@claude-plugins-official`, project the MCP server universally, project the 5 slash-commands as Cursor/Continue rules, skip skills on Codex with a logged reason. If agentsync handles this one plugin cleanly across all seven agents, it has solved the real problem.
 
-3. **`slackapi/slack-mcp-plugin` is the proof-of-concept fixture for per-agent passthrough.** A real-world repo with `.claude-plugin/` and `.cursor-plugin/` side-by-side is exactly what opensync's source layout should ingest cleanly. Worth using as a golden test case in M2.
+3. **`slackapi/slack-mcp-plugin` is the proof-of-concept fixture for per-agent passthrough.** A real-world repo with `.claude-plugin/` and `.cursor-plugin/` side-by-side is exactly what agentsync's source layout should ingest cleanly. Worth using as a golden test case in M2.
 
 4. **Canonical IDs need to handle multiple implementations of the same logical service.** Slack exposes the gap: hosted-OAuth vs npm-bot-token vs community fork. The current `id@marketplace` scheme in `PLAN.md` works when there is one marketplace with one canonical entry; it is ambiguous when "official" splits. Recommend extending to `id@marketplace` with a tiebreak on implementation, or namespacing by upstream owner.
 

--- a/docs/superpowers/plans/2026-05-04-agentsync-m0-skeleton.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m0-skeleton.md
@@ -897,7 +897,7 @@ type Canonical struct {
     Project     *Canonical // nil for user-scope canonical; populated by M5 overlay
 }
 
-// Config mirrors opensync.toml at the root of ~/.agentsync/.
+// Config mirrors agentsync.toml at the root of ~/.agentsync/.
 type Config struct {
     Agents   map[string]Agent     `toml:"agents"`
     Updates  UpdateDefaults       `toml:"updates"`
@@ -1036,7 +1036,7 @@ import (
 
 func TestLoad_EmptyHome(t *testing.T) {
     fs := afero.NewMemMapFs()
-    _ = afero.WriteFile(fs, "/home/.agentsync/opensync.toml", []byte(""), 0o644)
+    _ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(""), 0o644)
 
     c, err := source.Load(fs, "/home/.agentsync")
     if err != nil {
@@ -1049,7 +1049,7 @@ func TestLoad_EmptyHome(t *testing.T) {
 
 func TestLoad_AgentsAndMCP(t *testing.T) {
     fs := afero.NewMemMapFs()
-    _ = afero.WriteFile(fs, "/home/.agentsync/opensync.toml", []byte(`
+    _ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(`
 [agents]
 claude   = { enabled = true,  scope = "user" }
 opencode = { enabled = true }
@@ -1153,7 +1153,7 @@ func Load(fs afero.Fs, home string) (Canonical, error) {
 }
 
 func loadConfig(fs afero.Fs, home string, cfg *Config) error {
-    p := filepath.Join(home, "opensync.toml")
+    p := filepath.Join(home, "agentsync.toml")
     data, err := afero.ReadFile(fs, p)
     if err != nil {
         if errors.Is(err, os.ErrNotExist) {
@@ -1323,7 +1323,7 @@ git add go.mod go.sum internal/source
 git commit -m "$(cat <<'EOF'
 feat(source): loader walks ~/.agentsync/ -> Canonical
 
-Reads opensync.toml, mcp/, plugins/, marketplaces/, skills/, memory/.
+Reads agentsync.toml, mcp/, plugins/, marketplaces/, skills/, memory/.
 Missing dirs return empty (not error); malformed files return path-prefixed
 errors. Frontmatter parsing for skills lands in M1 where it's first used.
 
@@ -2237,7 +2237,7 @@ EOF
 - Modify: `internal/cli/init.go`
 - Create: `internal/cli/init_test.go`
 
-Scaffolds `~/.agentsync/` with empty subdirectories and a stub `opensync.toml`.
+Scaffolds `~/.agentsync/` with empty subdirectories and a stub `agentsync.toml`.
 
 - [ ] **Step 12.1: Test**
 
@@ -2267,15 +2267,15 @@ func TestInit_FreshScaffold(t *testing.T) {
             t.Fatalf("missing dir %s: %v", d, err)
         }
     }
-    if _, err := os.Stat(filepath.Join(home, "opensync.toml")); err != nil {
-        t.Fatalf("missing opensync.toml: %v", err)
+    if _, err := os.Stat(filepath.Join(home, "agentsync.toml")); err != nil {
+        t.Fatalf("missing agentsync.toml: %v", err)
     }
 }
 
 func TestInit_RefusesPopulatedHome(t *testing.T) {
     tmp := t.TempDir()
     _ = os.MkdirAll(filepath.Join(tmp, ".agentsync"), 0o755)
-    _ = os.WriteFile(filepath.Join(tmp, ".agentsync", "opensync.toml"), []byte("# already there"), 0o644)
+    _ = os.WriteFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"), []byte("# already there"), 0o644)
 
     _, err := runCLI(t,
         map[string]string{"AGENTSYNC_TARGET_ROOT": tmp},
@@ -2325,7 +2325,7 @@ default_interval = "24h"
 func newInitCmd() *cobra.Command {
     return &cobra.Command{
         Use:   "init",
-        Short: "scaffold ~/.agentsync/ with empty subdirectories and stub opensync.toml",
+        Short: "scaffold ~/.agentsync/ with empty subdirectories and stub agentsync.toml",
         Args:  cobra.NoArgs,
         RunE: func(cmd *cobra.Command, _ []string) error {
             home := paths.AgentsyncHome(paths.OSEnv{})
@@ -2338,8 +2338,8 @@ func newInitCmd() *cobra.Command {
                     return fmt.Errorf("mkdir %s: %w", sub, err)
                 }
             }
-            if err := os.WriteFile(filepath.Join(home, "opensync.toml"), []byte(initialOpensyncTOML), 0o644); err != nil {
-                return fmt.Errorf("write opensync.toml: %w", err)
+            if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(initialOpensyncTOML), 0o644); err != nil {
+                return fmt.Errorf("write agentsync.toml: %w", err)
             }
             fmt.Fprintln(cmd.OutOrStdout(), "agentsync home initialized at", home)
             return nil
@@ -2374,7 +2374,7 @@ EOF
 - Modify: `internal/cli/agent.go`
 - Create: `internal/cli/agent_test.go`
 
-Manipulates the `[agents]` table in `~/.agentsync/opensync.toml` via TOML AST round-trip (preserves comments + key order).
+Manipulates the `[agents]` table in `~/.agentsync/agentsync.toml` via TOML AST round-trip (preserves comments + key order).
 
 - [ ] **Step 13.1: Test**
 
@@ -2420,7 +2420,7 @@ func TestAgent_AddListRemove(t *testing.T) {
         t.Fatalf("list still contains removed agent: %s", listOut2)
     }
 
-    cfg, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "opensync.toml"))
+    cfg, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"))
     if !strings.Contains(string(cfg), `claude = `) {
         t.Fatalf("config didn't preserve claude line:\n%s", cfg)
     }
@@ -2459,7 +2459,7 @@ func newAgentCmd() *cobra.Command {
     return cmd
 }
 
-type opensyncCfg struct {
+type agentsyncCfg struct {
     Agents map[string]map[string]any `toml:"agents"`
     // other top-level keys preserved verbatim via decoder
 }
@@ -2477,12 +2477,12 @@ func validateAgent(name string) error {
 // readOpensyncTOML returns the file contents + parsed `agents` section.
 func readOpensyncTOML() (string, []byte, map[string]map[string]any, error) {
     home := paths.AgentsyncHome(paths.OSEnv{})
-    p := filepath.Join(home, "opensync.toml")
+    p := filepath.Join(home, "agentsync.toml")
     raw, err := os.ReadFile(p)
     if err != nil {
         return p, nil, nil, fmt.Errorf("read %s: %w", p, err)
     }
-    var cfg opensyncCfg
+    var cfg agentsyncCfg
     if err := toml.Unmarshal(raw, &cfg); err != nil {
         return p, raw, nil, fmt.Errorf("parse %s: %w", p, err)
     }
@@ -2591,7 +2591,7 @@ go test -race ./internal/cli/...
 ```bash
 git add internal/cli
 git commit -m "$(cat <<'EOF'
-feat(cli/agent): add/list/remove via TOML round-trip in opensync.toml
+feat(cli/agent): add/list/remove via TOML round-trip in agentsync.toml
 
 [agents] section is regenerated; surrounding comments/sections preserved
 by simple slice operations. Comment-preserving AST mutations for
@@ -2767,7 +2767,7 @@ func TestVerify_UnknownAgent(t *testing.T) {
     _, _ = runCLI(t, env, "init")
     _, _ = runCLI(t, env, "agent", "add", "claude")
 
-    cfg := filepath.Join(tmp, ".agentsync", "opensync.toml")
+    cfg := filepath.Join(tmp, ".agentsync", "agentsync.toml")
     body, _ := os.ReadFile(cfg)
     body = append(body, []byte("\n[agents]\nbogus = { enabled = true }\n")...)
     _ = os.WriteFile(cfg, body, 0o644)

--- a/docs/superpowers/plans/2026-05-04-agentsync-m1-claude.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m1-claude.md
@@ -4,7 +4,7 @@
 
 **Goal:** First real adapter. Implements `internal/adapter/claude` covering all 7 component types (MCP, memory, skill, subagent, slash command, hook, LSP). Renders + ingests round-trip. Settings written to `~/.claude/settings.json` and `~/.claude.json` use **per-key merge** so foreign keys (Claude's own writes, user hand-edits) survive untouched. Replaces the NoopAdapter for `claude` in the registry.
 
-**Architecture:** One package (`internal/adapter/claude`) with one file per concern. The adapter consumes a `source.Canonical` and emits a `[]adapter.FileOp` ready for atomic write. Settings/`.claude.json` merging uses a JSON-pointer-based AST walk: opensync only touches keys it has written before (tracked in M0's `state.Keys`); foreign keys flow through unchanged.
+**Architecture:** One package (`internal/adapter/claude`) with one file per concern. The adapter consumes a `source.Canonical` and emits a `[]adapter.FileOp` ready for atomic write. Settings/`.claude.json` merging uses a JSON-pointer-based AST walk: agentsync only touches keys it has written before (tracked in M0's `state.Keys`); foreign keys flow through unchanged.
 
 **Tech stack:** Stdlib `encoding/json` for Claude's strict-JSON files; `pelletier/go-toml/v2` already vendored from M0; `os/exec` to detect Claude installation.
 
@@ -227,8 +227,8 @@ The hardest single piece of M1. Claude's `settings.json` is shared between Claud
 - `MergeKeys(existing, ours map[string]any, ownedPointers []string) (merged map[string]any, kept, removed []string)`
 - `existing` = raw parse of the on-disk file
 - `ours` = the keys agentsync wants to write (also as map)
-- `ownedPointers` = JSON pointers (`/mcpServers/github`, `/hooks/PreToolUse/0`) that opensync wrote *last apply* — these are reclaimable
-- Returns merged map: foreign keys preserved; owned-but-now-absent pointers deleted; new opensync pointers from `ours` overlaid.
+- `ownedPointers` = JSON pointers (`/mcpServers/github`, `/hooks/PreToolUse/0`) that agentsync wrote *last apply* — these are reclaimable
+- Returns merged map: foreign keys preserved; owned-but-now-absent pointers deleted; new agentsync pointers from `ours` overlaid.
 
 - [ ] **Step 2.1: Test**
 

--- a/docs/superpowers/plans/2026-05-04-agentsync-m2-opencode.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m2-opencode.md
@@ -818,6 +818,6 @@ EOF
 - `agentsync apply` writes both `~/.claude.json` AND `~/.config/opencode/opencode.json` from a single canonical MCP file.
 - A single canonical Subagent renders to both `~/.claude/agents/<n>.md` (Claude shape) AND `~/.config/opencode/agents/<n>.md` (OpenCode shape with frontmatter munge); skips for `tools`+`color` are surfaced in the apply translation report.
 - A single canonical Skill writes ONE file at `~/.claude/skills/<n>/SKILL.md` (deduped), consumed by both Claude and OpenCode.
-- JSONC comments in pre-existing `opencode.json` survive opensync mutations to keys we don't touch.
+- JSONC comments in pre-existing `opencode.json` survive agentsync mutations to keys we don't touch.
 - Hooks and LSP in canonical produce explicit `✗ skip(warn)` entries in the translation report.
 - CI green on linux/macos/windows.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m3-drift.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m3-drift.md
@@ -164,7 +164,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
 **Files:** `internal/render/state_apply.go`, modify `internal/render/pipeline.go`, `internal/cli/apply.go`
 
-After every successful Apply, opensync must:
+After every successful Apply, agentsync must:
 1. For each `write` FileOp: hash final on-disk content + record in `state.Files[<key>]`.
 2. For each `merge-json-keys`/`merge-jsonc-keys` op: parse final on-disk JSON, for each pointer that came from `ours`, hash that subtree + record in `state.Keys[<key>]`.
 
@@ -785,7 +785,7 @@ Commit.
 
 **Files:** `internal/source/writer.go`, `internal/source/writer_test.go`
 
-When reconcile chooses write-back, opensync mutates the canonical file. Comment-preserving via `pelletier/go-toml/v2` AST: we don't have full AST mutation today; v1 strategy:
+When reconcile chooses write-back, agentsync mutates the canonical file. Comment-preserving via `pelletier/go-toml/v2` AST: we don't have full AST mutation today; v1 strategy:
 
 For `mcp/<id>.toml`: marshal the updated `MCPServer` as TOML and atomically write — comments above the file are lost on first write-back. **Documented v1 trade-off.** Better preservation lands as a v1.x improvement.
 

--- a/docs/superpowers/plans/2026-05-04-agentsync-m4-marketplaces.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m4-marketplaces.md
@@ -232,7 +232,7 @@ Commit each fetcher individually.
 
 **Files:** `internal/marketplace/projection.go`, `internal/cli/plugin.go`
 
-`opensync plugin install <id>@<marketplace>`:
+`agentsync plugin install <id>@<marketplace>`:
 1. Resolve marketplace from `~/.agentsync/marketplaces/<name>.toml` + cache.
 2. Find `<id>` in `marketplace.json` plugins list.
 3. Compute manifest sha (sha256 of plugin.json bytes if strict; sha of marketplace entry block if non-strict).
@@ -311,12 +311,12 @@ func TestProject_StrictPluginJSON(t *testing.T) {
 - [ ] **Implement** `internal/cli/plugin.go`:
 
 ```go
-opensync plugin install <id>[@<marketplace>]   # cache + write plugins/<id>.toml
-opensync plugin upgrade <id>                   # bump version in plugins/<id>.toml; re-fetch; update sha
-opensync plugin enable <id>                    # set enabled on plugins/<id>.toml (already implicit; flag noop unless we add one)
-opensync plugin disable <id>                   # set agents=[] effectively (or add a disabled bool)
-opensync plugin remove <id>                    # delete plugins/<id>.toml + cache
-opensync plugin list                           # walk plugins/*.toml, print
+agentsync plugin install <id>[@<marketplace>]   # cache + write plugins/<id>.toml
+agentsync plugin upgrade <id>                   # bump version in plugins/<id>.toml; re-fetch; update sha
+agentsync plugin enable <id>                    # set enabled on plugins/<id>.toml (already implicit; flag noop unless we add one)
+agentsync plugin disable <id>                   # set agents=[] effectively (or add a disabled bool)
+agentsync plugin remove <id>                    # delete plugins/<id>.toml + cache
+agentsync plugin list                           # walk plugins/*.toml, print
 ```
 
 Commit per subcommand. Tests use file:// fake repo as marketplace fixture; npm via httptest.Server.
@@ -371,10 +371,10 @@ Implement `source.LoadWithCache` (existing `Load` becomes a thin wrapper that pa
 **Files:** `internal/cli/marketplace.go`, `internal/cli/marketplace_test.go`
 
 ```
-opensync marketplace add github:owner/repo[@ref]   # writes marketplaces/<owner-repo>.toml; fetches into cache
-opensync marketplace add https://example.com/r.git # url source
-opensync marketplace remove <name>                  # deletes marketplaces/<name>.toml + cache
-opensync marketplace list                           # walks marketplaces/*.toml, prints
+agentsync marketplace add github:owner/repo[@ref]   # writes marketplaces/<owner-repo>.toml; fetches into cache
+agentsync marketplace add https://example.com/r.git # url source
+agentsync marketplace remove <name>                  # deletes marketplaces/<name>.toml + cache
+agentsync marketplace list                           # walks marketplaces/*.toml, prints
 ```
 
 `add` performs an initial fetch via `marketplace.Fetcher` and writes the head SHA into `state.Marketplaces[<name>]`. Commit.

--- a/docs/superpowers/plans/2026-05-04-agentsync-m6-secrets.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m6-secrets.md
@@ -26,7 +26,7 @@ internal/cli/
 
 MODIFIED:
 internal/render/pipeline.go     # walk canonical, substitute ${secret:...} / ${env:...}
-internal/source/loader.go       # secrets backend hint loaded from opensync.toml
+internal/source/loader.go       # secrets backend hint loaded from agentsync.toml
 ```
 
 ---
@@ -35,7 +35,7 @@ internal/source/loader.go       # secrets backend hint loaded from opensync.toml
 
 ```go
 // Package secrets resolves ${secret:foo.bar} and ${env:FOO} references at
-// apply-time. The active backend is selected from opensync.toml [secrets]
+// apply-time. The active backend is selected from agentsync.toml [secrets]
 // `backend` field (env|age).
 package secrets
 
@@ -140,7 +140,7 @@ go get filippo.io/age@latest
 
 ```go
 // AgeBackend reads ~/.agentsync/secrets/secrets.age, decrypts using identity
-// file specified in opensync.toml [secrets].identity_file, parses as TOML,
+// file specified in agentsync.toml [secrets].identity_file, parses as TOML,
 // and resolves dotted keys.
 package secrets
 
@@ -292,9 +292,9 @@ Commit.
 `internal/cli/secrets.go`:
 
 ```go
-opensync secrets edit            # decrypt -> tmp -> $EDITOR -> re-encrypt
-opensync secrets get <key>       # print one value
-opensync secrets set <key>=<val> # mutate one value (decrypt -> patch -> re-encrypt)
+agentsync secrets edit            # decrypt -> tmp -> $EDITOR -> re-encrypt
+agentsync secrets get <key>       # print one value
+agentsync secrets set <key>=<val> # mutate one value (decrypt -> patch -> re-encrypt)
 ```
 
 Implementation:
@@ -311,7 +311,7 @@ func newSecretsCmd() *cobra.Command {
 }
 
 func secretsEdit(cmd *cobra.Command, _ []string) error {
-    // 1. Resolve agePath + identityPath + recipient from opensync.toml
+    // 1. Resolve agePath + identityPath + recipient from agentsync.toml
     // 2. Read existing or create empty plaintext
     // 3. Write to tmp file in os.TempDir() (RAM-backed on macOS)
     // 4. Run os.Getenv("EDITOR") on the tmp file (default to vi)
@@ -362,8 +362,8 @@ func TestIntegration_M6_AgeSecretsResolveOnApply(t *testing.T) {
     _ = os.MkdirAll(filepath.Dir(idPath), 0o755)
     _ = os.WriteFile(idPath, []byte(id.String()), 0o600)
 
-    // configure opensync.toml [secrets]
-    cfg := filepath.Join(tmp, ".agentsync", "opensync.toml")
+    // configure agentsync.toml [secrets]
+    cfg := filepath.Join(tmp, ".agentsync", "agentsync.toml")
     body, _ := os.ReadFile(cfg)
     body = append(body, []byte(fmt.Sprintf(`
 [secrets]

--- a/docs/superpowers/plans/2026-05-04-agentsync-m7-polish.md
+++ b/docs/superpowers/plans/2026-05-04-agentsync-m7-polish.md
@@ -46,9 +46,9 @@ Selector grammar: `<agent>:<component>:<name>`. Reads native config from disk vi
 
 ```bash
 # Examples:
-opensync import claude:mcp:github
-opensync import opencode:agent:reviewer
-opensync import claude:plugin:atlassian-anthropic   # post-M4: import a plugin install record
+agentsync import claude:mcp:github
+agentsync import opencode:agent:reviewer
+agentsync import claude:plugin:atlassian-anthropic   # post-M4: import a plugin install record
 ```
 
 Implementation: parse selector, dispatch to the right Ingest path, find matching item by name, marshal back to canonical via Writer. Test for each component type. Commit.
@@ -306,7 +306,7 @@ func TestE2E_FullV1Lifecycle(t *testing.T) {
     id, _ := age.GenerateX25519Identity()
     _ = os.MkdirAll(filepath.Join(home, ".config", "agentsync"), 0o755)
     _ = os.WriteFile(filepath.Join(home, ".config", "agentsync", "age.key"), []byte(id.String()), 0o600)
-    cfg := filepath.Join(home, ".agentsync", "opensync.toml")
+    cfg := filepath.Join(home, ".agentsync", "agentsync.toml")
     body, _ := os.ReadFile(cfg)
     body = append(body, []byte("[secrets]\nbackend=\"age\"\nfile=\"secrets/secrets.age\"\nrecipient=\""+id.Recipient().String()+"\"\nidentity_file=\""+filepath.Join(home, ".config", "agentsync", "age.key")+"\"\n")...)
     _ = os.WriteFile(cfg, body, 0o644)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -65,6 +65,14 @@ type Adapter interface {
 	Detect() (bool, error)
 	Render(c source.Canonical, scope Scope, project string) ([]FileOp, []Skip, error)
 	Ingest(scope Scope, project string) (source.Canonical, error)
+	// KeyMergeStrategy returns this adapter's single JSON-key-merge strategy
+	// ("merge-json-keys" for claude, "merge-jsonc-keys" for opencode), or ""
+	// if the adapter does not merge keys. The render layer needs it to
+	// synthesize cleanup ops that remove now-orphaned owned keys from a
+	// destination when the source section became empty (no render op exists
+	// to carry the removal). It MUST be exact — applying the wrong strategy to
+	// a JSONC file would parse it as strict JSON and clobber the file.
+	KeyMergeStrategy() string
 	// Apply executes ops against destinations. Adapters MUST route every
 	// destination write through w.Write / w.Delete rather than calling
 	// iox.AtomicWrite or os.Remove directly — w owns the foreign-collision

--- a/internal/adapter/claude/claude.go
+++ b/internal/adapter/claude/claude.go
@@ -25,6 +25,10 @@ func New(opts Options) *Adapter { return &Adapter{opts: opts} }
 
 func (a *Adapter) Name() string { return "claude" }
 
+// KeyMergeStrategy is claude's single key-merge strategy: strict JSON
+// (.claude.json, settings.json).
+func (a *Adapter) KeyMergeStrategy() string { return "merge-json-keys" }
+
 func (a *Adapter) Capabilities() adapter.Capability {
 	return adapter.CapMCP | adapter.CapMemory | adapter.CapSkill |
 		adapter.CapSubagent | adapter.CapCommand | adapter.CapHook | adapter.CapLSP

--- a/internal/adapter/claude/memory.go
+++ b/internal/adapter/claude/memory.go
@@ -1,30 +1,15 @@
 package claude
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
-
-var importRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
 
 func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := importRe.ReplaceAllStringFunc(c.Memory.Body, func(line string) string {
-		m := importRe.FindStringSubmatch(line)
-		if len(m) < 2 {
-			return line
-		}
-		if frag, ok := c.Memory.Fragments[m[1]]; ok {
-			return strings.TrimRight(frag, "\n")
-		}
-		// Unknown fragment; preserve line so the user notices.
-		return line
-	})
+	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/noop/noop.go
+++ b/internal/adapter/noop/noop.go
@@ -25,3 +25,4 @@ func (a *Adapter) Ingest(adapter.Scope, string) (source.Canonical, error) {
 	return source.Canonical{}, nil
 }
 func (a *Adapter) Apply([]adapter.FileOp, adapter.DestWriter) error { return nil }
+func (a *Adapter) KeyMergeStrategy() string                         { return "" }

--- a/internal/adapter/opencode/memory.go
+++ b/internal/adapter/opencode/memory.go
@@ -1,30 +1,15 @@
 package opencode
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
-
-var importRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
 
 func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := importRe.ReplaceAllStringFunc(c.Memory.Body, func(line string) string {
-		m := importRe.FindStringSubmatch(line)
-		if len(m) < 2 {
-			return line
-		}
-		if frag, ok := c.Memory.Fragments[m[1]]; ok {
-			return strings.TrimRight(frag, "\n")
-		}
-		// Unknown fragment; preserve line so the user notices.
-		return line
-	})
+	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/opencode/opencode.go
+++ b/internal/adapter/opencode/opencode.go
@@ -23,6 +23,10 @@ func New(opts Options) *Adapter { return &Adapter{opts: opts} }
 
 func (a *Adapter) Name() string { return "opencode" }
 
+// KeyMergeStrategy is opencode's single key-merge strategy: JSONC
+// (opencode.json), which MUST be merged via hujson, not strict JSON.
+func (a *Adapter) KeyMergeStrategy() string { return "merge-jsonc-keys" }
+
 func (a *Adapter) Capabilities() adapter.Capability {
 	return adapter.CapMCP | adapter.CapMemory | adapter.CapSkill |
 		adapter.CapSubagent | adapter.CapCommand

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -83,6 +83,9 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 		if m.Server.URL != "" {
 			spec["url"] = m.Server.URL
 		}
+		if len(m.Server.Headers) > 0 {
+			spec["headers"] = m.Server.Headers
+		}
 		mcp[m.ID] = spec
 	}
 	if len(mcp) == 0 {

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -45,6 +45,35 @@ func TestRender_MCP(t *testing.T) {
 	}
 }
 
+// TestRender_MCP_PreservesHeaders is the regression for OpenCode silently
+// dropping the `headers` of a remote MCP server — a server requiring an
+// Authorization header would render unauthenticated and broken, with no Skip.
+func TestRender_MCP_PreservesHeaders(t *testing.T) {
+	c := source.Canonical{MCPServers: []source.MCPServer{{
+		ID: "remote",
+		Server: source.MCPServerSpec{
+			Type: "http", URL: "https://mcp.example.com",
+			Headers: map[string]string{"Authorization": "Bearer tok"},
+		},
+	}}}
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	for _, op := range ops {
+		if !strings.HasSuffix(op.Path, "opencode.json") {
+			continue
+		}
+		var ours map[string]any
+		_ = json.Unmarshal(op.Content, &ours)
+		mcp := ours["mcp"].(map[string]any)["remote"].(map[string]any)
+		h, ok := mcp["headers"].(map[string]any)
+		if !ok || h["Authorization"] != "Bearer tok" {
+			t.Fatalf("opencode MCP dropped headers: %v", mcp)
+		}
+		return
+	}
+	t.Fatal("opencode.json op missing")
+}
+
 func TestRender_MCP_SkipsDisabled(t *testing.T) {
 	disabled := false
 	c := source.Canonical{MCPServers: []source.MCPServer{{

--- a/internal/adapter/opencode/settings.go
+++ b/internal/adapter/opencode/settings.go
@@ -1,8 +1,11 @@
 // Package opencode implements the OpenCode adapter for agentsync.
 //
-// settings.go: JSONC-aware merge for opencode.json. Uses tailscale/hujson
-// which preserves comments and trailing commas across parse->mutate->serialize
-// cycles.
+// settings.go: JSONC-aware merge for opencode.json. Uses tailscale/hujson to
+// PARSE JSONC (comments + trailing commas) so a hand-edited opencode.json is
+// not rejected. NOTE: the merged result is re-emitted as plain JSON — comments
+// and trailing commas are NOT preserved (see MergeJSONC). Foreign keys/values
+// are preserved; only the formatting/comments are lost. Comment-preserving
+// mutation is deferred to v1.x (matches the README "Known limits").
 package opencode
 
 import (
@@ -15,14 +18,14 @@ import (
 )
 
 // MergeJSONC merges ours into existing JSONC content, removing ownedPointers
-// no longer present in ours. Comments and trailing-comma formatting from
-// existing are preserved as much as the hujson AST allows.
+// no longer present in ours. Foreign keys and values are preserved.
 //
-// Strategy: parse existing JSONC -> standardize to JSON (Pack), MergeKeys,
-// then format result as plain JSON. v1 trade-off: trailing comma + comment
-// preservation is partial — comments outside touched keys survive; comments
-// adjacent to deleted keys are also removed. M2 ships this; comment-position
-// fidelity can be tightened later if pain emerges.
+// Strategy: parse existing JSONC (hujson, tolerating comments + trailing
+// commas) -> Standardize to strict JSON -> MergeKeys -> emit via
+// json.MarshalIndent. v1 trade-off: this Standardize+marshal path discards ALL
+// comments and trailing-comma formatting (not just touched sections). The
+// file is never corrupted and no data keys are lost; only JSONC formatting is.
+// Comment-preserving mutation is deferred to v1.x.
 func MergeJSONC(existing []byte, ours map[string]any, ownedPointers []string) ([]byte, error) {
 	if len(existing) == 0 {
 		existing = []byte("{}")

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -21,6 +21,7 @@ func (stub) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, [
 
 func (stub) Ingest(adapter.Scope, string) (source.Canonical, error) { return source.Canonical{}, nil }
 func (stub) Apply([]adapter.FileOp, adapter.DestWriter) error       { return nil }
+func (stub) KeyMergeStrategy() string                               { return "" }
 
 func TestRegistry_RegisterLookup(t *testing.T) {
 	r := adapter.NewRegistry()

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -293,8 +293,18 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 		return nil
 	}
 
-	// --purge: delete destination files and keys owned by this agent from state.
+	// --purge mutates .state/targets.json and deletes destination files, so
+	// it must hold the global lock — otherwise a concurrent apply's
+	// read-modify-write of targets.json races this one and loses updates.
 	home := paths.AgentsyncHome(paths.OSEnv{})
+	return withGlobalLock(home, func() error {
+		return purgeAgentDests(cmd, name, home)
+	})
+}
+
+// purgeAgentDests deletes the destination files owned solely by the named
+// agent and removes its state entries. Must be called under withGlobalLock.
+func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 	// State keys store dest paths HOME-relative ("${HOME}/.claude.json").
 	// Expand them back to absolute via the user's $HOME before deleting —
 	// otherwise os.Remove would target the literal "${HOME}/..." string,

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -50,9 +50,9 @@ var v1Supported = map[string]bool{
 func newAgentCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "agent", Short: "manage which agents agentsync targets"}
 	cmd.AddCommand(
-		&cobra.Command{Use: "add <name>", Args: cobra.ExactArgs(1), RunE: agentAddRun},
-		&cobra.Command{Use: "remove <name>", Args: cobra.ExactArgs(1), RunE: agentRemoveRun},
-		&cobra.Command{Use: "list", Args: cobra.NoArgs, RunE: agentListRun},
+		&cobra.Command{Use: "add <name>", Short: "register an agent (claude | opencode)", Args: cobra.ExactArgs(1), RunE: agentAddRun},
+		&cobra.Command{Use: "remove <name>", Short: "unregister an agent", Args: cobra.ExactArgs(1), RunE: agentRemoveRun},
+		&cobra.Command{Use: "list", Short: "list registered agents", Args: cobra.NoArgs, RunE: agentListRun},
 		newAgentEnableCmd(),
 		newAgentDisableCmd(),
 	)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -306,27 +306,44 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 		return fmt.Errorf("load state: %w", err)
 	}
 
-	// Gather paths to delete (unique, from Files state).
+	// Gather the portable ("${HOME}/...") dest paths owned by the agent
+	// being purged, and — separately — those still owned by ANY OTHER agent.
+	// The dest-path field is index 3 in both Files keys ("a:s:p:path") and
+	// Keys keys ("a:s:p:path:ptr").
 	prefix := name + ":"
-	toDelete := map[string]bool{}
-	for key := range s.Files {
+	purgedPaths := map[string]bool{}
+	otherPaths := map[string]bool{}
+	collect := func(key string, fields int) {
+		parts := strings.SplitN(key, ":", fields)
+		if len(parts) < 4 || parts[3] == "" {
+			return
+		}
 		if strings.HasPrefix(key, prefix) {
-			// key format: "agent:scope:project:path" — extract path (4th field)
-			parts := strings.SplitN(key, ":", 4)
-			if len(parts) == 4 && parts[3] != "" {
-				toDelete[paths.FromHomeRelative(userHome, parts[3])] = true
-			}
+			purgedPaths[parts[3]] = true
+		} else {
+			otherPaths[parts[3]] = true
 		}
 	}
-	// Also collect paths from Keys state.
+	for key := range s.Files {
+		collect(key, 4)
+	}
 	for key := range s.Keys {
-		if strings.HasPrefix(key, prefix) {
-			// key format: "agent:scope:project:path:ptr" — extract path (4th field)
-			parts := strings.SplitN(key, ":", 5)
-			if len(parts) >= 4 && parts[3] != "" {
-				toDelete[paths.FromHomeRelative(userHome, parts[3])] = true
-			}
+		collect(key, 5)
+	}
+
+	// Delete only paths NOT still owned by another agent. claude and
+	// opencode both render skills to ~/.claude/skills/<name>/SKILL.md, so
+	// after apply that path is owned by BOTH in state. Deleting it while
+	// purging one agent would destroy a file the other still needs — and
+	// Writer.Delete skips backup, so the loss is unrecoverable.
+	toDelete := map[string]bool{}
+	sharedKept := 0
+	for p := range purgedPaths {
+		if otherPaths[p] {
+			sharedKept++
+			continue
 		}
+		toDelete[paths.FromHomeRelative(userHome, p)] = true
 	}
 
 	// Build delete ops and apply via the adapter. Purge is destructive
@@ -365,5 +382,8 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "purged %d destination path(s) for agent %s\n", len(toDelete), name)
+	if sharedKept > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "  kept %d shared path(s) still owned by another agent\n", sharedKept)
+	}
 	return nil
 }

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -295,6 +295,11 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 
 	// --purge: delete destination files and keys owned by this agent from state.
 	home := paths.AgentsyncHome(paths.OSEnv{})
+	// State keys store dest paths HOME-relative ("${HOME}/.claude.json").
+	// Expand them back to absolute via the user's $HOME before deleting —
+	// otherwise os.Remove would target the literal "${HOME}/..." string,
+	// silently delete nothing, yet still report "purged N path(s)".
+	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")
 	s, err := state.Load(statePath)
 	if err != nil {
@@ -309,7 +314,7 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 			// key format: "agent:scope:project:path" — extract path (4th field)
 			parts := strings.SplitN(key, ":", 4)
 			if len(parts) == 4 && parts[3] != "" {
-				toDelete[parts[3]] = true
+				toDelete[paths.FromHomeRelative(userHome, parts[3])] = true
 			}
 		}
 	}
@@ -319,7 +324,7 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 			// key format: "agent:scope:project:path:ptr" — extract path (4th field)
 			parts := strings.SplitN(key, ":", 5)
 			if len(parts) >= 4 && parts[3] != "" {
-				toDelete[parts[3]] = true
+				toDelete[paths.FromHomeRelative(userHome, parts[3])] = true
 			}
 		}
 	}
@@ -338,7 +343,7 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 		for path := range toDelete {
 			ops = append(ops, adapter.FileOp{Action: "delete", Path: path})
 		}
-		rw := render.NewWriter(s, home, adapter.ScopeUser, "", name)
+		rw := render.NewWriter(s, home, userHome, adapter.ScopeUser, "", name)
 		if err := a.Apply(ops, rw); err != nil {
 			return fmt.Errorf("purge apply %s: %w", name, err)
 		}

--- a/internal/cli/agent_disable_test.go
+++ b/internal/cli/agent_disable_test.go
@@ -141,6 +141,54 @@ args    = ["-y", "@modelcontextprotocol/server-github"]
 	}
 }
 
+// TestAgentDisable_Purge_KeepsSharedFileOwnedByOtherAgent is the regression
+// for the data-loss bug: claude and opencode both render skills to the SAME
+// path ~/.claude/skills/<name>/SKILL.md, so apply records that path under
+// BOTH agents' state. `agent disable opencode --purge` then deleted the
+// shared SKILL.md (Delete skips backup) — destroying a file the still-enabled
+// claude needs. Purge must skip paths another registered agent still owns.
+func TestAgentDisable_Purge_KeepsSharedFileOwnedByOtherAgent(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Author a skill — both adapters render it to ~/.claude/skills/demo/SKILL.md.
+	skillDir := filepath.Join(tmp, ".agentsync", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	sharedSkill := filepath.Join(tmp, ".claude", "skills", "demo", "SKILL.md")
+	if _, err := os.Stat(sharedSkill); err != nil {
+		t.Fatalf("shared skill not created by apply: %v", err)
+	}
+
+	// Purge opencode — claude is still enabled and owns the same file.
+	if _, err := runCLI(t, env, "agent", "disable", "opencode", "--purge"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(sharedSkill); err != nil {
+		t.Fatalf("purging opencode destroyed a skill still owned by claude: %v", err)
+	}
+}
+
 // TestAgentDisable_Purge_NoPurge verifies that without --purge, destination
 // files are NOT removed.
 func TestAgentDisable_Purge_NoPurge(t *testing.T) {

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -73,7 +73,8 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	}
 
 	// Resolve ${secret:...} and ${env:...} references before rendering.
-	secBackend := secrets.SelectBackend(c.Config.Secrets, home)
+	userHome := paths.HomeDir(paths.OSEnv{})
+	secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
 	envBackend := secrets.EnvBackend{}
 	if err := secrets.SubstituteCanonical(&c, secBackend, envBackend); err != nil {
 		return err

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -219,6 +219,9 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	if err := state.Save(statePath, s); err != nil {
 		return err
 	}
+	// Bound backup growth (each is a verbatim, possibly-secret-bearing copy
+	// of a pre-existing native file). Best-effort; never fails the apply.
+	_ = render.PruneBackups(home, render.DefaultBackupKeep)
 
 	w := cmd.OutOrStdout()
 	fmt.Fprintln(w, "applied:", plan.Total(), "ops")

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -72,6 +72,17 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		}
 	}
 
+	// Announce the effective scope. Scope is auto-detected by walking up from
+	// cwd to find a project marker, so without this a `apply` run from inside
+	// a project (or any ancestor with a marker) could silently write to a
+	// project tree the user didn't expect. The dry-run lists paths; the real
+	// apply otherwise printed only an op count.
+	if sc == adapter.ScopeProject {
+		fmt.Fprintf(cmd.ErrOrStderr(), "scope: project (%s)\n", projectRoot)
+	} else {
+		fmt.Fprintln(cmd.ErrOrStderr(), "scope: user")
+	}
+
 	// Resolve ${secret:...} and ${env:...} references before rendering.
 	userHome := paths.HomeDir(paths.OSEnv{})
 	secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
@@ -89,10 +100,18 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	if len(agents) == 0 {
 		// Without this hint, `apply` prints "applied: 0 ops" and a
 		// new user assumes their config "worked". Tell them how to
-		// register an agent.
-		fmt.Fprintln(cmd.ErrOrStderr(),
-			"agentsync: no agents are enabled in agentsync.toml; nothing to apply.\n"+
-				"  Run `agentsync agent add claude` (or opencode) to register an agent.")
+		// register an agent. Under project scope the likely cause is a
+		// marker `agents` allowlist that intersects to nothing, so point
+		// there instead of at `agent add`.
+		if sc == adapter.ScopeProject {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"agentsync: no agents are enabled after applying the project marker at %s; nothing to apply.\n"+
+					"  Check the [agents] allowlist in that project's .agentsync.toml.\n", projectRoot)
+		} else {
+			fmt.Fprintln(cmd.ErrOrStderr(),
+				"agentsync: no agents are enabled in agentsync.toml; nothing to apply.\n"+
+					"  Run `agentsync agent add claude` (or opencode) to register an agent.")
+		}
 		return nil
 	}
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -177,7 +177,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	if err != nil {
 		return err
 	}
-	collisions, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
+	collisions, written, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
 	if len(collisions) > 0 {
 		ew := cmd.ErrOrStderr()
 		fmt.Fprintf(ew, "agentsync: backed up %d pre-existing target(s) before overwriting:\n", len(collisions))
@@ -199,7 +199,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// re-reads each file); recording from files that don't exist
 	// returns an error and we just skip those.
 	if applyErr != nil {
-		_ = saveBestEffortState(s, statePath, plan, userHome, sc, projectRoot)
+		_ = saveBestEffortState(s, statePath, plan, userHome, sc, projectRoot, written)
 		return applyErr
 	}
 
@@ -233,27 +233,35 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	return nil
 }
 
-// saveBestEffortState records hashes for every op in plan whose dest
-// file currently exists on disk. Called on the apply error path so a
-// partial write doesn't leave the next apply reclassifying those files
-// as foreign-collisions. Failures are swallowed — we already have the
-// real error to surface and want to maximise the chance of the rescue
-// state.Save landing.
-func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderPlan, userHome string, sc adapter.Scope, projectRoot string) error {
+// saveBestEffortState records hashes for the ops agentsync actually wrote
+// this run (the `wrote` set returned by render.Apply). Called on the apply
+// error path so a partial write doesn't leave the next apply reclassifying
+// those files as foreign-collisions and re-backing-them-up.
+//
+// It MUST key off what was written, not os.Stat existence: render.Apply stops
+// at the first failing op, so a later op that was never attempted may sit on
+// top of a pre-existing FOREIGN file. Recording that file as owned would
+// suppress its foreign-collision backup on the next apply and silently lose
+// the user's data — the exact opposite of this rescue's purpose. os.Stat
+// can't distinguish "we wrote this" from "this was already here"; `wrote` can.
+//
+// Failures are swallowed — we already have the real error to surface and want
+// to maximise the chance of the rescue state.Save landing.
+func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderPlan, userHome string, sc adapter.Scope, projectRoot string, wrote map[string]bool) error {
 	for name, res := range plan.PerAgent {
-		var existing []adapter.FileOp
+		var done []adapter.FileOp
 		for _, op := range res.Ops {
-			if _, err := os.Stat(op.Path); err == nil {
-				existing = append(existing, op)
+			if wrote[op.Path] {
+				done = append(done, op)
 			}
 		}
-		if len(existing) == 0 {
+		if len(done) == 0 {
 			continue
 		}
 		// PruneStaleState is intentionally skipped here — we only want
 		// to ADD hashes, not remove entries that may refer to the now-
 		// half-applied state.
-		if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, existing); err != nil {
+		if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, done); err != nil {
 			continue
 		}
 	}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -106,7 +106,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	}
 
 	if dryRun {
-		plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
+		plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		// before overwrite. The dry-run previously hid this; users only
 		// found out which files were about to be backed up after the
 		// real apply ran.
-		previews := render.PreviewCollisions(plan, reg, s, home, sc, projectRoot)
+		previews := render.PreviewCollisions(plan, reg, s, home, userHome, sc, projectRoot)
 		if len(previews) > 0 {
 			fmt.Fprintln(w)
 			fmt.Fprintf(w, "Foreign collisions: %d (the real apply will back these up before overwriting)\n", len(previews))
@@ -154,11 +154,11 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// Real apply: render + write. The writer constructed inside
 	// render.Apply enforces the foreign-collision backup invariant on
 	// every destination write — there is no separate guard pass.
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
+	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 	if err != nil {
 		return err
 	}
-	collisions, applyErr := render.Apply(plan, reg, s, home, sc, projectRoot)
+	collisions, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
 	if len(collisions) > 0 {
 		ew := cmd.ErrOrStderr()
 		fmt.Fprintf(ew, "agentsync: backed up %d pre-existing target(s) before overwriting:\n", len(collisions))
@@ -180,7 +180,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// re-reads each file); recording from files that don't exist
 	// returns an error and we just skip those.
 	if applyErr != nil {
-		_ = saveBestEffortState(s, statePath, plan, home, sc, projectRoot)
+		_ = saveBestEffortState(s, statePath, plan, userHome, sc, projectRoot)
 		return applyErr
 	}
 
@@ -189,11 +189,11 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// shows up as `Orphan` in `status` forever and targets.json
 	// grows unbounded.
 	for name, res := range plan.PerAgent {
-		render.PruneStaleState(s, home, name, sc, projectRoot, res.Ops)
+		render.PruneStaleState(s, userHome, name, sc, projectRoot, res.Ops)
 	}
 	// Update state with post-apply hashes.
 	for name, res := range plan.PerAgent {
-		if err := render.RecordOpsState(s, home, name, sc, projectRoot, res.Ops); err != nil {
+		if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, res.Ops); err != nil {
 			return err
 		}
 	}
@@ -217,7 +217,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 // as foreign-collisions. Failures are swallowed — we already have the
 // real error to surface and want to maximise the chance of the rescue
 // state.Save landing.
-func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderPlan, home string, sc adapter.Scope, projectRoot string) error {
+func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderPlan, userHome string, sc adapter.Scope, projectRoot string) error {
 	for name, res := range plan.PerAgent {
 		var existing []adapter.FileOp
 		for _, op := range res.Ops {
@@ -231,7 +231,7 @@ func saveBestEffortState(s *state.Targets, statePath string, plan render.RenderP
 		// PruneStaleState is intentionally skipped here — we only want
 		// to ADD hashes, not remove entries that may refer to the now-
 		// half-applied state.
-		if err := render.RecordOpsState(s, home, name, sc, projectRoot, existing); err != nil {
+		if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, existing); err != nil {
 			continue
 		}
 	}

--- a/internal/cli/apply_internal_test.go
+++ b/internal/cli/apply_internal_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestSaveBestEffortState_OnlyRecordsWrittenPaths is the regression for the
+// partial-apply data-loss edge: render.Apply stops at the first failing op, so
+// ops after it are never attempted. saveBestEffortState must record only paths
+// agentsync actually wrote this run — never a pre-existing FOREIGN file sitting
+// at an unattempted op's path. Recording such a file as owned would suppress
+// its foreign-collision backup on the next apply and silently destroy the
+// user's data. The previous os.Stat-based check recorded any op whose dest
+// merely existed, foreign or not.
+func TestSaveBestEffortState_OnlyRecordsWrittenPaths(t *testing.T) {
+	tmp := t.TempDir()
+	writtenPath := filepath.Join(tmp, "written.json")
+	foreignPath := filepath.Join(tmp, "foreign.json")
+	// Both files exist on disk: one because agentsync wrote it this run, the
+	// other because it was already there and its op was never attempted.
+	if err := os.WriteFile(writtenPath, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(foreignPath, []byte(`{"user":"keep me"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{
+			{Action: "write", Path: writtenPath, Content: []byte(`{"a":1}`)},
+			{Action: "write", Path: foreignPath, Content: []byte(`{"a":2}`)},
+		}},
+	}}
+
+	st := state.New()
+	statePath := filepath.Join(tmp, "targets.json")
+	// Only the first op was attempted+written before the apply failed.
+	wrote := map[string]bool{writtenPath: true}
+
+	if err := saveBestEffortState(st, statePath, plan, tmp, adapter.ScopeUser, "", wrote); err != nil {
+		t.Fatalf("saveBestEffortState: %v", err)
+	}
+
+	if !fileKeyRecorded(st, "written.json") {
+		t.Errorf("the written path must be recorded as owned (its foreign content was backed up at write time)")
+	}
+	if fileKeyRecorded(st, "foreign.json") {
+		t.Errorf("SECURITY: an unattempted foreign file was recorded as owned — its backup would be suppressed and the user's data lost on the next apply")
+	}
+}
+
+func fileKeyRecorded(st *state.Targets, nameSubstr string) bool {
+	for k := range st.Files {
+		if strings.Contains(k, nameSubstr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -7,6 +7,47 @@ import (
 	"testing"
 )
 
+// TestApply_PartialFailureRescuesState exercises saveBestEffortState (the
+// apply-error rescue, previously 0% covered): when an apply fails mid-write,
+// the dest files that DID land must be recorded in state so the next apply
+// doesn't reclassify them as foreign collisions and back them up. We force
+// the skill write to fail (a regular file blocks the skills dir) while the
+// MCP write to .claude.json (which runs first) succeeds.
+func TestApply_PartialFailureRescuesState(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+
+	skill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	_ = os.MkdirAll(filepath.Dir(skill), 0o755)
+	_ = os.WriteFile(skill, []byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644)
+
+	// Block the skills destination dir with a regular file so the skill op's
+	// MkdirAll fails (the MCP op to ~/.claude.json runs first and succeeds).
+	_ = os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755)
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "skills"), []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "apply"); err == nil {
+		t.Fatal("expected apply to fail when the skills dir is blocked")
+	}
+
+	// The rescue must have recorded the .claude.json keys that DID land.
+	state, err := os.ReadFile(filepath.Join(tmp, ".agentsync", ".state", "targets.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if !strings.Contains(string(state), "/.claude.json") || !strings.Contains(string(state), "mcpServers") {
+		t.Fatalf("partial-apply rescue did not record the landed .claude.json keys:\n%s", state)
+	}
+}
+
 // TestApply_AnnouncesScope is the regression for silent scope selection:
 // apply auto-detects project scope by walking up from cwd, but the real apply
 // printed only an op count — config could land in an unexpected project tree

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -2,9 +2,41 @@ package cli_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestApply_AnnouncesScope is the regression for silent scope selection:
+// apply auto-detects project scope by walking up from cwd, but the real apply
+// printed only an op count — config could land in an unexpected project tree
+// invisibly. apply now announces the effective scope.
+func TestApply_AnnouncesScope(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	out, err := runCLI(t, env, "apply")
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "scope: user") {
+		t.Fatalf("expected user-scope announcement; got:\n%s", out)
+	}
+
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out2, err := runCLI(t, env, "apply", "--project", proj)
+	if err != nil {
+		t.Fatalf("apply --project: %v\n%s", err, out2)
+	}
+	if !strings.Contains(out2, "scope: project") {
+		t.Fatalf("expected project-scope announcement; got:\n%s", out2)
+	}
+}
 
 func TestApply_DryRunEmptyHome(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/command_lock_test.go
+++ b/internal/cli/command_lock_test.go
@@ -1,0 +1,84 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spxrogers/agentsync/internal/iox"
+)
+
+// assertCommandBlocksOnLock proves a command acquires the global lock: with
+// the lock held externally it must NOT complete (it blocks on acquisition),
+// and once released it must finish cleanly. This is the regression for the
+// lost-update race where marketplace add/remove and agent disable --purge
+// did a load-modify-save of targets.json without the lock, so a concurrent
+// apply's just-written Files/Keys got clobbered.
+func assertCommandBlocksOnLock(t *testing.T, env map[string]string, tmp string, args ...string) {
+	t.Helper()
+	lockPath := filepath.Join(tmp, ".agentsync", ".state", "agentsync.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	holder, err := iox.AcquireLock(lockPath)
+	if err != nil {
+		t.Fatalf("seed-hold lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, e := runCLI(t, env, args...)
+		done <- e
+	}()
+
+	select {
+	case <-done:
+		_ = holder.Release()
+		t.Fatalf("%v returned while the global lock was held; it does not serialize against apply", args)
+	case <-time.After(2 * time.Second):
+		// Still blocked on lock acquisition — correct.
+	}
+
+	_ = holder.Release()
+	select {
+	case e := <-done:
+		if e != nil {
+			t.Fatalf("%v failed after lock release: %v", args, e)
+		}
+	case <-time.After(35 * time.Second):
+		t.Fatalf("%v never completed after lock release", args)
+	}
+}
+
+func TestMarketplaceAdd_AcquiresGlobalLock(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	assertCommandBlocksOnLock(t, env, tmp, "marketplace", "add", mpDir)
+}
+
+func TestAgentDisablePurge_AcquiresGlobalLock(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcpFile := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcpFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcpFile, []byte("[server]\ntype = \"stdio\"\ncommand = \"npx\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	assertCommandBlocksOnLock(t, env, tmp, "agent", "disable", "claude", "--purge")
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -77,6 +77,10 @@ func newDiffCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
+			if len(agents) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				return nil
+			}
 			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -95,6 +95,18 @@ func newDiffCmd() *cobra.Command {
 			// in both src and dst before the diff runs.
 			secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
 			envBackend := secrets.EnvBackend{}
+			// Fail closed: if any ${secret:…} reference cannot be resolved now
+			// (age identity locked/absent, backend misconfigured), the cleartext
+			// value a prior apply substituted into the destination file cannot be
+			// redacted — CollectResolved silently skips unresolvable refs — so
+			// printing the diff would leak it. Refuse with an actionable message
+			// rather than risk emitting a credential to stdout / logs.
+			if missing := secrets.UnresolvedSecretRefs(&c, secBackend); len(missing) > 0 {
+				return fmt.Errorf("diff: cannot resolve secret reference(s) %s; "+
+					"the destination file may contain a cleartext secret that diff cannot redact. "+
+					"Unlock or configure your secrets backend ([secrets] in agentsync.toml) and retry",
+					strings.Join(missing, ", "))
+			}
 			redact := secrets.CollectResolved(&c, secBackend, envBackend)
 
 			dmp := diffmatchpatch.New()

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -83,7 +83,7 @@ func newDiffCmd() *cobra.Command {
 			// stdout / log files / screenshots. We resolve every
 			// reference in the canonical, then mask its resolved value
 			// in both src and dst before the diff runs.
-			secBackend := secrets.SelectBackend(c.Config.Secrets, home)
+			secBackend := secrets.SelectBackend(c.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
 			envBackend := secrets.EnvBackend{}
 			redact := secrets.CollectResolved(&c, secBackend, envBackend)
 

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -39,7 +39,12 @@ func newDiffCmd() *cobra.Command {
 			}
 
 			home := paths.AgentsyncHome(paths.OSEnv{})
-			c, err := source.Load(afero.NewOsFs(), home)
+			// Load WITH the plugin cache so the preview projects installed
+			// plugins exactly as `apply` does — otherwise diff omits every
+			// plugin-derived MCP server / skill / command and silently
+			// disagrees with what apply will write.
+			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+			c, err := source.LoadWithCache(afero.NewOsFs(), home, pluginCacheRoot)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -44,6 +44,7 @@ func newDiffCmd() *cobra.Command {
 			// plugin-derived MCP server / skill / command and silently
 			// disagrees with what apply will write.
 			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+			userHome := paths.HomeDir(paths.OSEnv{})
 			c, err := source.LoadWithCache(afero.NewOsFs(), home, pluginCacheRoot)
 			if err != nil {
 				return err
@@ -76,7 +77,7 @@ func newDiffCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err
 			}
@@ -88,7 +89,7 @@ func newDiffCmd() *cobra.Command {
 			// stdout / log files / screenshots. We resolve every
 			// reference in the canonical, then mask its resolved value
 			// in both src and dst before the diff runs.
-			secBackend := secrets.SelectBackend(c.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
+			secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
 			envBackend := secrets.EnvBackend{}
 			redact := secrets.CollectResolved(&c, secBackend, envBackend)
 

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -129,6 +129,44 @@ GITHUB_TOKEN = "${env:GITHUB_TOKEN}"
 	}
 }
 
+// TestDiff_FailsClosedOnUnresolvableSecret is the regression for the residual
+// leak: when a ${secret:…} reference cannot be resolved at diff time (age key
+// locked/absent, or — as here — no [secrets] backend configured), the cleartext
+// value a prior apply wrote into the destination cannot be redacted, so diff
+// must refuse rather than risk printing it. It names the offending key so the
+// user knows what to unlock.
+func TestDiff_FailsClosedOnUnresolvableSecret(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	// An age-style ${secret:…} ref, but no [secrets] backend is configured, so
+	// SelectBackend returns a resolver that cannot resolve github.token.
+	body := `[server]
+type = "stdio"
+command = "npx"
+
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+`
+	_ = os.WriteFile(mcp, []byte(body), 0o644)
+
+	out, err := runCLI(t, env, "diff")
+	if err == nil {
+		t.Fatalf("diff must fail closed when a secret ref is unresolvable; got nil err, out:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "cannot resolve secret reference") ||
+		!strings.Contains(err.Error(), "github.token") {
+		t.Fatalf("expected fail-closed message naming the unresolved key; got: %v", err)
+	}
+}
+
 func TestDiff_PathFilter(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -151,15 +152,15 @@ func checkSecrets(w io.Writer, cfg source.SecretsConfig, home string) int {
 		fmt.Fprintf(w, "  recipient  set\n")
 	}
 
-	idPath := cfg.IdentityFile
-	if idPath == "" {
+	if cfg.IdentityFile == "" {
 		fmt.Fprintf(w, "  identity   missing — set [secrets].identity_file in agentsync.toml\n")
 		return fails + 1
 	}
-	// Expand ${env:HOME} so the doctor message reflects the real path.
-	if h := os.Getenv("HOME"); h != "" {
-		idPath = expandEnvHome(idPath, h)
-	}
+	// Resolve identity_file the same way apply does (expanding ${env:HOME}/~
+	// via paths.HomeDir so it honours AGENTSYNC_TARGET_ROOT), so doctor and
+	// apply never disagree on the path.
+	userHome := paths.HomeDir(paths.OSEnv{})
+	idPath := secrets.ResolveIdentityFile(cfg, home, userHome)
 	info, err := os.Stat(idPath)
 	if err != nil {
 		fmt.Fprintf(w, "  identity   %s — not readable (%v)\n", idPath, err)
@@ -173,46 +174,11 @@ func checkSecrets(w io.Writer, cfg source.SecretsConfig, home string) int {
 
 	// Age-encrypted file location — warn if missing (legitimate on a
 	// fresh install where the user hasn't called `secrets set` yet).
-	agePath := cfg.File
-	if agePath == "" {
-		agePath = "secrets/secrets.age"
-	}
-	if !filepath.IsAbs(agePath) {
-		agePath = filepath.Join(home, agePath)
-	}
+	agePath := secrets.ResolveAgeFile(cfg, home, userHome)
 	if _, err := os.Stat(agePath); err != nil {
 		fmt.Fprintf(w, "  age file   %s — not yet created (run `agentsync secrets edit` to author)\n", agePath)
 	} else {
 		fmt.Fprintf(w, "  age file   %s\n", agePath)
 	}
 	return fails
-}
-
-// expandEnvHome replaces ${env:HOME} with the supplied HOME value, mirroring
-// the (very small) substitution agentsync does for identity_file paths.
-func expandEnvHome(s, home string) string {
-	const tok = "${env:HOME}"
-	if len(s) == 0 {
-		return s
-	}
-	out := s
-	for {
-		i := indexOf(out, tok)
-		if i < 0 {
-			return out
-		}
-		out = out[:i] + home + out[i+len(tok):]
-	}
-}
-
-func indexOf(s, sub string) int {
-	if len(sub) == 0 || len(sub) > len(s) {
-		return -1
-	}
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -73,7 +73,7 @@ func newExplainCmd() *cobra.Command {
 				return err
 			}
 
-			plan, err := render.Plan(filtered, reg, agents, adapter.ScopeUser, "", s, home)
+			plan, err := render.Plan(filtered, reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -242,6 +242,10 @@ func unimportedDestPointers(home, agentName string, reg *adapter.Registry) []str
 // first-run foreign-collision.
 func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) error {
 	statePath := filepath.Join(home, ".state", "targets.json")
+	// State keys are HOME-relative against the user's $HOME (paths.HomeDir),
+	// matching render.RecordOpsState — NOT the agentsync home, or apply
+	// would never recognise the seeded entries as owned.
+	userHome := paths.HomeDir(paths.OSEnv{})
 	st, err := state.Load(statePath)
 	if err != nil {
 		return err
@@ -285,7 +289,7 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 			}
 			for _, ptr := range collectStateSeedPointers(ours) {
 				key := fmt.Sprintf("%s:%s:%s:%s:%s",
-					agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(home, op.Path), ptr)
+					agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(userHome, op.Path), ptr)
 				st.Keys[key] = state.KeyEntry{
 					SHA256:    hashAtPointer(existing, ptr),
 					AppliedAt: now,
@@ -299,7 +303,7 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 			}
 			sum := sha256.Sum256(data)
 			key := fmt.Sprintf("%s:%s:%s:%s",
-				agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(home, op.Path))
+				agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(userHome, op.Path))
 			st.Files[key] = state.FileEntry{
 				SHA256:    hex.EncodeToString(sum[:]),
 				Mode:      op.Mode,

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -243,6 +243,110 @@ func TestImport_CommandFromClaude(t *testing.T) {
 	}
 }
 
+// importTestEnv inits + registers claude and returns (tmp, env).
+func importTestEnv(t *testing.T) (string, map[string]string) {
+	t.Helper()
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	return tmp, env
+}
+
+// TestImport_SkillFromClaude round-trips a native SKILL.md into the source.
+func TestImport_SkillFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	skillDir := filepath.Join(tmp, ".claude", "skills", "deploy")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: deploy\ndescription: ship it\n---\nSteps to deploy.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:skill:deploy"); err != nil {
+		t.Fatalf("import skill: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".agentsync", "skills", "deploy", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("source skill not written: %v", err)
+	}
+	if !strings.Contains(string(data), "Steps to deploy") {
+		t.Fatalf("skill body not captured:\n%s", data)
+	}
+}
+
+// TestImport_HookFromClaude round-trips a settings.json hook into the source.
+func TestImport_HookFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	settings := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte(`{
+		"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}]}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:hook:PreToolUse"); err != nil {
+		t.Fatalf("import hook: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".agentsync", "hooks", "PreToolUse.toml"))
+	if err != nil {
+		t.Fatalf("source hook not written: %v", err)
+	}
+	if !strings.Contains(string(data), "echo hi") {
+		t.Fatalf("hook command not captured:\n%s", data)
+	}
+}
+
+// TestImport_LSPFromClaude round-trips a settings.json lspServers entry.
+func TestImport_LSPFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	settings := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte(`{"lspServers": {"gopls": {"command": "gopls", "args": ["-rpc"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:lsp:gopls"); err != nil {
+		t.Fatalf("import lsp: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".agentsync", "lsp", "gopls.toml"))
+	if err != nil {
+		t.Fatalf("source lsp not written: %v", err)
+	}
+	if !strings.Contains(string(data), "gopls") {
+		t.Fatalf("lsp command not captured:\n%s", data)
+	}
+}
+
+// TestImport_MemoryFromClaude round-trips CLAUDE.md into memory/AGENTS.md.
+func TestImport_MemoryFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "CLAUDE.md"), []byte("# My project memory\nBe concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:memory"); err != nil {
+		t.Fatalf("import memory: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".agentsync", "memory", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("source memory not written: %v", err)
+	}
+	if !strings.Contains(string(data), "Be concise") {
+		t.Fatalf("memory body not captured:\n%s", data)
+	}
+}
+
 // TestImport_UnknownComponent verifies that an unknown component errors.
 func TestImport_UnknownComponent(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -95,6 +95,9 @@ func scaffoldHome(cmd *cobra.Command, home string) error {
 	if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(initialAgentsyncTOML), 0o644); err != nil {
 		return fmt.Errorf("write agentsync.toml: %w", err)
 	}
+	if err := ensureStateGitignore(home); err != nil {
+		return err
+	}
 	w := cmd.OutOrStdout()
 	fmt.Fprintln(w, "agentsync home initialized at", home)
 	fmt.Fprintln(w, "")
@@ -124,8 +127,49 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 	if err := os.MkdirAll(filepath.Join(home, ".state"), 0o755); err != nil {
 		return fmt.Errorf("mkdir .state: %w", err)
 	}
+	if err := ensureStateGitignore(home); err != nil {
+		return err
+	}
 	fmt.Fprintln(w, "cloned. Run `agentsync apply --dry-run` to preview against this machine.")
 	return nil
+}
+
+// ensureStateGitignore guarantees ~/.agentsync/.gitignore excludes /.state/.
+// .state/ holds local-only state (targets.json) and .state/backups/<ts>/ —
+// verbatim copies of pre-existing native config files that routinely contain
+// API tokens. The README recommends syncing ~/.agentsync via chezmoi/git, so
+// without this a user would commit plaintext credential backups. Idempotent:
+// appends the rule if a .gitignore already exists (e.g. a cloned source repo)
+// and doesn't already ignore .state/.
+func ensureStateGitignore(home string) error {
+	const rule = "/.state/"
+	p := filepath.Join(home, ".gitignore")
+	data, err := os.ReadFile(p)
+	switch {
+	case err == nil:
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.TrimSpace(line) == rule {
+				return nil // already ignored
+			}
+		}
+		out := string(data)
+		if out != "" && !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		out += rule + "\n"
+		if werr := os.WriteFile(p, []byte(out), 0o644); werr != nil {
+			return fmt.Errorf("update .gitignore: %w", werr)
+		}
+		return nil
+	case os.IsNotExist(err):
+		body := "# agentsync: local state + plaintext config backups — never commit.\n" + rule + "\n"
+		if werr := os.WriteFile(p, []byte(body), 0o644); werr != nil {
+			return fmt.Errorf("write .gitignore: %w", werr)
+		}
+		return nil
+	default:
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
 }
 
 // validateCloneURL rejects unsafe URL schemes for the source-repo

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -13,7 +13,7 @@ import (
 )
 
 const initialAgentsyncTOML = `# agentsync source-of-truth config
-# See docs/superpowers/specs/2026-05-04-agentsync-design.md for the full schema.
+# Schema reference: https://github.com/spxrogers/agentsync#readme
 
 [agents]
 # claude   = { enabled = true,  scope = "user" }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -3,8 +3,27 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestInit_ScaffoldsGitignoreForState is the launch-blocker regression: the
+// scaffolded home must .gitignore /.state/, which holds local state and
+// plaintext credential backups. Without it, the README-recommended
+// `chezmoi add ~/.agentsync` / `git init` would commit secrets.
+func TestInit_ScaffoldsGitignoreForState(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := runCLI(t, map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}, "init"); err != nil {
+		t.Fatal(err)
+	}
+	gi, err := os.ReadFile(filepath.Join(tmp, ".agentsync", ".gitignore"))
+	if err != nil {
+		t.Fatalf("init did not scaffold .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gi), "/.state/") {
+		t.Fatalf(".gitignore does not exclude /.state/:\n%s", gi)
+	}
+}
 
 func TestInit_FreshScaffold(t *testing.T) {
 	tmp := t.TempDir()
@@ -54,6 +73,30 @@ func TestInit_RejectsBadCloneURL(t *testing.T) {
 	out, err = runCLI(t, env, "init", "rsync://example.com/foo")
 	if err == nil {
 		t.Fatalf("init should reject unsupported scheme; got:\n%s", out)
+	}
+}
+
+// TestFirstRun_ActionableHints checks the polished first-run errors/empties:
+// secrets before init points at init; status with no agents isn't silent.
+func TestFirstRun_ActionableHints(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "secrets", "get", "x"); err == nil {
+		t.Fatal("secrets get before init should error")
+	} else if !strings.Contains(err.Error(), "init") {
+		t.Fatalf("secrets-before-init error should point at init; got: %v", err)
+	}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "no agents enabled") {
+		t.Fatalf("status with no agents should hint, not be silent; got: %q", out)
 	}
 }
 

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -20,8 +20,8 @@ const lockTimeout = 30 * time.Second
 // corrupt targets.json (read-modify-write race) and produce ghost-orphan
 // state entries.
 //
-// The lock file lives at <home>/.state/agentsync.lock. It is created with
-// 0o644 mode and re-used across runs.
+// The lock file lives at <home>/.state/agentsync.lock. gofrs/flock creates it
+// 0o600 (owner-only) and it is re-used across runs.
 func withGlobalLock(home string, fn func() error) error {
 	lockPath := filepath.Join(home, ".state", "agentsync.lock")
 	lock, err := iox.AcquireLockTimeout(lockPath, lockTimeout)

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -50,7 +50,10 @@ func newMarketplaceAddCmd() *cobra.Command {
 		Use:   "add <url-or-path>",
 		Short: "fetch a marketplace and register it",
 		Args:  cobra.ExactArgs(1),
-		RunE:  marketplaceAddRun,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error { return marketplaceAddRun(cmd, args) })
+		},
 	}
 }
 
@@ -144,7 +147,10 @@ func newMarketplaceRemoveCmd() *cobra.Command {
 		Use:   "remove <name>",
 		Short: "remove a marketplace and its cached files",
 		Args:  cobra.ExactArgs(1),
-		RunE:  marketplaceRemoveRun,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			return withGlobalLock(home, func() error { return marketplaceRemoveRun(cmd, args) })
+		},
 	}
 }
 

--- a/internal/cli/preview_plugin_test.go
+++ b/internal/cli/preview_plugin_test.go
@@ -1,0 +1,87 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupPluginMarketplaceFixture creates a minimal local marketplace whose
+// single "demo" plugin projects an MCP server named demo-mcp.
+func setupPluginMarketplaceFixture(t *testing.T, tmp string) string {
+	t.Helper()
+	fixture := filepath.Join(tmp, "fixture-marketplace-preview")
+	if err := os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+		[]byte(`{"name":"test-mp","owner":{"name":"x"},"plugins":[{"name":"demo","source":"./plugins/demo"}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	plugDir := filepath.Join(fixture, "plugins", "demo", ".claude-plugin")
+	if err := os.MkdirAll(plugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugDir, "plugin.json"),
+		[]byte(`{"name":"demo","version":"1.0.0","mcpServers":{"demo-mcp":{"command":"echo","args":["hi"]}}}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+// TestDiff_IncludesPluginProjection is the regression for the preview-lies
+// bug: `diff` (and `status`) loaded the canonical model with source.Load,
+// which does NOT project installed plugins, while `apply` uses
+// source.LoadWithCache, which does. So a user with an installed plugin saw a
+// `diff` that omitted the plugin's MCP servers / skills / commands entirely,
+// then `apply` wrote them anyway — the preview did not match the action.
+func TestDiff_IncludesPluginProjection(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupPluginMarketplaceFixture(t, tmp)
+
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "marketplace", "add", fixture)
+	mustRun(t, env, "plugin", "install", "demo@test-mp")
+
+	// diff is run BEFORE apply: the plugin-projected demo-mcp server is in
+	// the source plan but not yet on disk, so it must show as a pending change.
+	out, err := runCLI(t, env, "diff")
+	if err != nil {
+		t.Fatalf("diff: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "demo-mcp") {
+		t.Fatalf("diff omitted plugin-projected demo-mcp (preview != apply); got:\n%s", out)
+	}
+}
+
+// TestStatus_IncludesPluginProjection is the same regression for `status`.
+func TestStatus_IncludesPluginProjection(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupPluginMarketplaceFixture(t, tmp)
+
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "marketplace", "add", fixture)
+	mustRun(t, env, "plugin", "install", "demo@test-mp")
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "demo-mcp") {
+		t.Fatalf("status omitted plugin-projected demo-mcp; got:\n%s", out)
+	}
+}
+
+func mustRun(t *testing.T, env map[string]string, args ...string) {
+	t.Helper()
+	if out, err := runCLI(t, env, args...); err != nil {
+		t.Fatalf("%v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -59,6 +59,12 @@ func newReconcileCmd() *cobra.Command {
 }
 
 func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool, scopeFlag, projectFlag string) error {
+	// The three auto modes are mutually exclusive — writeback (dest→source)
+	// and override (source→dest) are exact opposites, and silently accepting
+	// both (writeback won) was a data-loss footgun.
+	if n := b2i(autoWB) + b2i(autoOR) + b2i(autoSafe); n > 1 {
+		return fmt.Errorf("--auto-writeback, --auto-override, and --auto-safe are mutually exclusive; pass at most one")
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	// Project plugins like apply does so drift classification covers
@@ -133,6 +139,9 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 
 	// bulkAction is set when user presses W/O/S to apply to all remaining items.
 	bulkAction := byte(0)
+	// autoSkipped counts items an --auto-* mode left unresolved, so the run
+	// ends with a summary instead of silently doing nothing.
+	autoSkipped := 0
 
 	br := bufio.NewReader(in)
 
@@ -146,12 +155,24 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 		if action == 0 {
 			switch {
 			case autoWB:
-				action = 'w'
+				// ForeignCollision is a never-applied pre-existing native
+				// file. Writing it back would overwrite the curated source
+				// with foreign content — the worst data-loss path. Refuse to
+				// do that non-interactively; leave it for an explicit choice.
+				if it.cls == drift.ForeignCollision {
+					fmt.Fprintf(w, "skipped (foreign-collision, would overwrite source): %s — resolve interactively\n", itemLabel(it))
+					autoSkipped++
+					action = 's'
+				} else {
+					action = 'w'
+				}
 			case autoOR:
 				action = 'o'
 			case autoSafe:
 				// auto-safe: skip non-safe items (they require prompting, but
 				// auto-safe only silently handles safe ones which never reach here).
+				fmt.Fprintf(w, "skipped (needs manual review): %s (%s)\n", itemLabel(it), it.cls)
+				autoSkipped++
 				action = 's'
 			}
 		}
@@ -272,7 +293,18 @@ done:
 		fmt.Fprintf(w, "override: applied %d item(s)\n", len(overrideOps))
 	}
 
+	if autoSkipped > 0 {
+		fmt.Fprintf(w, "%d item(s) left unresolved; run `agentsync reconcile` interactively to handle them\n", autoSkipped)
+	}
 	return nil
+}
+
+// b2i returns 1 for true, 0 for false.
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.
@@ -430,6 +462,13 @@ func writeBackKeyItem(home string, it reconcileItem) error {
 		var spec source.MCPServerSpec
 		if err := json.Unmarshal(specBytes, &spec); err != nil {
 			return fmt.Errorf("unmarshal mcp spec %s: %w", serverID, err)
+		}
+		// Preserve source-only fields (agents/enabled) that the rendered
+		// destination spec never carries — otherwise writing a dest edit
+		// back silently drops the user's targeting/enablement config.
+		if existing, ok, rerr := source.ReadMCP(home, serverID); rerr == nil && ok {
+			spec.Agents = existing.Server.Agents
+			spec.Enabled = existing.Server.Enabled
 		}
 		m := source.MCPServer{ID: serverID, Server: spec}
 		return source.WriteMCP(home, serverID, m)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -60,7 +60,11 @@ func newReconcileCmd() *cobra.Command {
 
 func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool, scopeFlag, projectFlag string) error {
 	home := paths.AgentsyncHome(paths.OSEnv{})
-	c, err := source.Load(afero.NewOsFs(), home)
+	userHome := paths.HomeDir(paths.OSEnv{})
+	// Project plugins like apply does so drift classification covers
+	// plugin-managed components instead of reporting them as untracked.
+	pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+	c, err := source.LoadWithCache(afero.NewOsFs(), home, pluginCacheRoot)
 	if err != nil {
 		return err
 	}
@@ -92,13 +96,13 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			agents = append(agents, name)
 		}
 	}
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
+	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 	if err != nil {
 		return err
 	}
 
 	// Collect all items in order.
-	items := collectItems(plan, reg, s, sc, projectRoot, home)
+	items := collectItems(plan, reg, s, sc, projectRoot, userHome)
 
 	w := cmd.OutOrStdout()
 
@@ -251,14 +255,14 @@ done:
 			if a == nil {
 				return fmt.Errorf("reconcile override: adapter %q not registered", name)
 			}
-			rw := render.NewWriter(s, home, sc, projectRoot, name)
+			rw := render.NewWriter(s, home, userHome, sc, projectRoot, name)
 			if err := a.Apply(ops, rw); err != nil {
 				return fmt.Errorf("reconcile override apply %s: %w", name, err)
 			}
 			for _, r := range rw.Reports() {
 				fmt.Fprintf(w, "  backup: %s\n", r.String())
 			}
-			if err := render.RecordOpsState(s, home, name, sc, projectRoot, ops); err != nil {
+			if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, ops); err != nil {
 				return err
 			}
 		}
@@ -272,7 +276,8 @@ done:
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.
-func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot, home string) []reconcileItem {
+// userHome (the user's $HOME) is the HomeRelative base for state-key lookups.
+func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot, userHome string) []reconcileItem {
 	var items []reconcileItem
 	for _, name := range reg.Names() {
 		res, ok := plan.PerAgent[name]
@@ -291,7 +296,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				final := readJSONFile(op.Path)
 				for _, ptr := range render.CollectPointers(ours, "") {
 					hsrc := hashAnyValue(getPointerValue(ours, ptr))
-					happlied := s.Keys[stateKeyKey(home, name, sc, projectRoot, op.Path, ptr)].SHA256
+					happlied := s.Keys[stateKeyKey(userHome, name, sc, projectRoot, op.Path, ptr)].SHA256
 					hdest := hashAnyValue(getPointerValue(final, ptr))
 					cls := drift.Classify(hsrc, happlied, hdest)
 					items = append(items, reconcileItem{
@@ -312,7 +317,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 				}
 				seen[op.Path] = true
 				hsrc := hashContent(op.Content)
-				happlied := s.Files[stateFileKey(home, name, sc, projectRoot, op.Path)].SHA256
+				happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, op.Path)].SHA256
 				hdest := hashFile(op.Path)
 				cls := drift.Classify(hsrc, happlied, hdest)
 				items = append(items, reconcileItem{

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -57,6 +57,88 @@ func TestReconcile_AutoOverride(t *testing.T) {
 	}
 }
 
+// TestReconcile_AutoWriteback_ForeignCollisionDoesNotClobberSource is the
+// regression for the worst data-loss path: --auto-writeback mapped EVERY
+// actionable item (including ForeignCollision — a never-applied pre-existing
+// native file) to write-back, overwriting the curated source with whatever
+// foreign content the dest happened to hold.
+func TestReconcile_AutoWriteback_ForeignCollisionDoesNotClobberSource(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+
+	// Pre-existing native file agentsync never applied (→ ForeignCollision).
+	dst := filepath.Join(tmp, ".claude.json")
+	_ = os.WriteFile(dst, []byte(`{"mcpServers":{"github":{"type":"stdio","command":"FOREIGN"}}}`), 0o644)
+
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err != nil {
+		t.Fatalf("reconcile --auto-writeback: %v", err)
+	}
+	src, _ := os.ReadFile(mcp)
+	if strings.Contains(string(src), "FOREIGN") || !strings.Contains(string(src), "npx") {
+		t.Fatalf("auto-writeback clobbered curated source with foreign dest content:\n%s", src)
+	}
+}
+
+// TestReconcile_Writeback_PreservesSourceOnlyFields is the regression for
+// write-back reconstructing the source MCP entry purely from the dest spec
+// (which never carries agents/enabled), silently dropping the user's
+// targeting/enablement config.
+func TestReconcile_Writeback_PreservesSourceOnlyFields(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\nagents=[\"claude\"]\nenabled=true\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Drift the dest command so write-back rewrites the source.
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1)), 0o644)
+
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err != nil {
+		t.Fatalf("reconcile --auto-writeback: %v", err)
+	}
+	src, _ := os.ReadFile(mcp)
+	if !strings.Contains(string(src), "npm") {
+		t.Fatalf("write-back didn't capture the dest edit: %s", src)
+	}
+	if !strings.Contains(string(src), "agents") || !strings.Contains(string(src), "enabled") {
+		t.Fatalf("write-back dropped source-only agents/enabled fields:\n%s", src)
+	}
+}
+
+// TestReconcile_AutoFlagsMutuallyExclusive is the regression for both
+// --auto-writeback and --auto-override being silently accepted (writeback
+// wins) despite being exact opposites.
+func TestReconcile_AutoFlagsMutuallyExclusive(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "reconcile", "--auto-writeback", "--auto-override")
+	if err == nil {
+		t.Fatal("expected error when both --auto-writeback and --auto-override are set")
+	}
+}
+
 func TestReconcile_AutoSafe_NoDriftItems(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/removal_cleanup_test.go
+++ b/internal/cli/removal_cleanup_test.go
@@ -1,0 +1,133 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestApply_RemovingLastMCPServerCleansDest is the headline regression: when
+// the user removes their ONLY MCP server from the source, the next apply must
+// delete it from the destination (no merge op renders for an empty section,
+// so a synthesized cleanup op carries the removal). Foreign keys are kept.
+func TestApply_RemovingLastMCPServerCleansDest(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "apply")
+
+	dst := filepath.Join(tmp, ".claude.json")
+	if b, _ := os.ReadFile(dst); !strings.Contains(string(b), "github") {
+		t.Fatalf("setup: github not applied: %s", b)
+	}
+	// User adds a foreign top-level key out of band.
+	body, _ := os.ReadFile(dst)
+	withForeign := strings.Replace(string(body), "{", `{"foo":"bar",`, 1)
+	if err := os.WriteFile(dst, []byte(withForeign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the only MCP server from source, then apply.
+	if err := os.Remove(mcp); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "apply")
+
+	out, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if strings.Contains(string(out), "github") {
+		t.Fatalf("removed MCP server still live in dest: %s", out)
+	}
+	if !strings.Contains(string(out), "foo") {
+		t.Fatalf("foreign key was not preserved: %s", out)
+	}
+}
+
+// TestApply_RemovingLastOpenCodeMCPDoesNotClobberJSONC is the critical
+// data-loss guard: the cleanup op for opencode.json MUST use the JSONC merge
+// strategy. If it used claude's strict-JSON strategy, a opencode.json with
+// comments would parse as empty and be clobbered to {} — destroying all
+// foreign content.
+func TestApply_RemovingLastOpenCodeMCPDoesNotClobberJSONC(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "opencode")
+
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "apply")
+
+	dst := filepath.Join(tmp, ".config", "opencode", "opencode.json")
+	body, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("opencode.json not applied: %v", err)
+	}
+	// User adds a JSONC comment + a foreign key.
+	withForeign := "// my opencode config\n" + strings.Replace(string(body), "{", `{"theme":"dark",`, 1)
+	if err := os.WriteFile(dst, []byte(withForeign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(mcp); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "apply")
+
+	out, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read opencode.json: %v", err)
+	}
+	if strings.Contains(string(out), "github") {
+		t.Fatalf("removed MCP server still live: %s", out)
+	}
+	if !strings.Contains(string(out), "theme") {
+		t.Fatalf("DATA LOSS: opencode.json clobbered, foreign key gone: %s", out)
+	}
+}
+
+// TestApply_OrphanCleanupSkipsMissingDest ensures a cleanup op is NOT
+// synthesized (and no empty {} file created) when the orphaned dest no longer
+// exists on disk.
+func TestApply_OrphanCleanupSkipsMissingDest(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	mustRun(t, env, "apply")
+
+	dst := filepath.Join(tmp, ".claude.json")
+	if err := os.Remove(dst); err != nil { // user deleted the dest entirely
+		t.Fatal(err)
+	}
+	if err := os.Remove(mcp); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "apply")
+
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		b, _ := os.ReadFile(dst)
+		t.Fatalf("apply recreated a deleted dest as empty file: %q", b)
+	}
+}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -73,6 +73,9 @@ func loadSecretsConfig() (source.SecretsConfig, string, error) {
 	cfgPath := filepath.Join(home, "agentsync.toml")
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return source.SecretsConfig{}, home, fmt.Errorf("agentsync home not initialized (%s not found); run `agentsync init` first", cfgPath)
+		}
 		return source.SecretsConfig{}, home, fmt.Errorf("read %s: %w", cfgPath, err)
 	}
 	var cfg source.Config

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -82,16 +82,18 @@ func loadSecretsConfig() (source.SecretsConfig, string, error) {
 	return cfg.Secrets, home, nil
 }
 
-// resolveAgePath returns the absolute path to the secrets.age file.
+// resolveAgePath returns the absolute path to the secrets.age file, applying
+// the same default + ${env:HOME}/~ expansion the apply path uses.
 func resolveAgePath(cfg source.SecretsConfig, home string) string {
-	f := cfg.File
-	if f == "" {
-		f = "secrets/secrets.age"
-	}
-	if !filepath.IsAbs(f) {
-		return filepath.Join(home, f)
-	}
-	return f
+	return secrets.ResolveAgeFile(cfg, home, paths.HomeDir(paths.OSEnv{}))
+}
+
+// resolveIdentityPath returns the absolute identity_file path, expanding
+// ${env:HOME}/~ the same way the apply path does — without this, `secrets
+// get/set/edit` would os.ReadFile a literal "${env:HOME}/..." string and
+// fail even though the documented init template uses exactly that form.
+func resolveIdentityPath(cfg source.SecretsConfig, home string) string {
+	return secrets.ResolveIdentityFile(cfg, home, paths.HomeDir(paths.OSEnv{}))
 }
 
 // decryptToMap decrypts secrets.age and returns the top-level map.
@@ -101,7 +103,7 @@ func decryptToMap(cfg source.SecretsConfig, home string) (map[string]any, error)
 	if _, err := os.Stat(agePath); os.IsNotExist(err) {
 		return map[string]any{}, nil
 	}
-	plain, err := secrets.Decrypt(agePath, cfg.IdentityFile)
+	plain, err := secrets.Decrypt(agePath, resolveIdentityPath(cfg, home))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +190,7 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	if _, err := os.Stat(agePath); os.IsNotExist(err) {
 		plain = []byte("# agentsync secrets — TOML format\n# Example:\n# [github]\n# token = \"ghp_...\"\n")
 	} else {
-		plain, err = secrets.Decrypt(agePath, cfg.IdentityFile)
+		plain, err = secrets.Decrypt(agePath, resolveIdentityPath(cfg, home))
 		if err != nil {
 			return fmt.Errorf("decrypt: %w", err)
 		}

--- a/internal/cli/secrets_firstrun_test.go
+++ b/internal/cli/secrets_firstrun_test.go
@@ -1,0 +1,151 @@
+package cli_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	secrets_pkg "github.com/spxrogers/agentsync/internal/secrets"
+)
+
+// writeSecretsConfig appends a [secrets] block to agentsync.toml using the
+// supplied file/identity_file lines verbatim, so a test can reproduce the
+// exact shape a user copies out of the init template.
+func writeSecretsConfig(t *testing.T, tmp, recipient, fileLine, identityLine string) {
+	t.Helper()
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	body, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := fmt.Sprintf("\n[secrets]\nbackend = \"age\"\nrecipient = %q\n%s%s\n",
+		recipient, fileLine, identityLine)
+	if err := os.WriteFile(cfgPath, append(body, []byte(block)...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupFirstRunSecrets does init + agent add claude, generates an age identity
+// under <home>/.config/agentsync/age.key, encrypts a github.token, and writes
+// an MCP server that references it. It returns tmp and the recipient string.
+// The [secrets] block is intentionally NOT written — each test writes its own
+// shape so it can exercise the documented-template defaults.
+func setupFirstRunSecrets(t *testing.T) (tmp string, env map[string]string, recipient string) {
+	t.Helper()
+	tmp = t.TempDir()
+	env = map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	idPath := filepath.Join(tmp, ".config", "agentsync", "age.key")
+	if err := os.MkdirAll(filepath.Dir(idPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(idPath, []byte(id.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Encrypt to the DEFAULT age-file location (secrets/secrets.age) — the
+	// same default `secrets set` / `secrets edit` write to.
+	ageDest := filepath.Join(tmp, ".agentsync", "secrets", "secrets.age")
+	if err := secrets_pkg.Encrypt([]byte("[github]\ntoken = \"ghp_firstrun\"\n"),
+		id.Recipient().String(), ageDest); err != nil {
+		t.Fatal(err)
+	}
+
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcpPath, []byte(`[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return tmp, env, id.Recipient().String()
+}
+
+// TestApply_SecretsDefaultFilePath is the regression for the bug where
+// SelectBackend ignored the documented default [secrets].file location.
+// `secrets set` and `doctor` default an empty `file` to secrets/secrets.age,
+// but apply/verify/diff passed "" straight to age, so `os.Open("")` failed.
+// A user who leaves `file` commented out (it is optional in the init
+// template) could set + get secrets fine yet have apply break.
+func TestApply_SecretsDefaultFilePath(t *testing.T) {
+	tmp, env, recipient := setupFirstRunSecrets(t)
+	// Omit `file` entirely; provide an absolute identity_file.
+	idPath := filepath.Join(tmp, ".config", "agentsync", "age.key")
+	writeSecretsConfig(t, tmp, recipient, "", fmt.Sprintf("identity_file = %q\n", idPath))
+
+	out, err := runCLI(t, env, "apply")
+	if err != nil {
+		t.Fatalf("apply with default secrets.file failed: %v\n%s", err, out)
+	}
+	claudeJSON, err := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+	if err != nil {
+		t.Fatalf("read .claude.json: %v", err)
+	}
+	if !strings.Contains(string(claudeJSON), "ghp_firstrun") {
+		t.Fatalf("resolved token not in .claude.json: %s", claudeJSON)
+	}
+}
+
+// TestApply_SecretsEnvHomeIdentity is the regression for the bug where the
+// apply path did not expand ${env:HOME} in identity_file. The init template
+// literally ships identity_file = "${env:HOME}/.config/agentsync/age.key";
+// doctor/verify expanded it for their stat check, but SelectBackend ->
+// AgeBackend.load() called os.ReadFile on the literal "${env:HOME}/..." path,
+// so a user who copied the documented config got a green doctor and a broken
+// apply.
+func TestApply_SecretsEnvHomeIdentity(t *testing.T) {
+	tmp, env, recipient := setupFirstRunSecrets(t)
+	writeSecretsConfig(t, tmp, recipient,
+		"file = \"secrets/secrets.age\"\n",
+		"identity_file = \"${env:HOME}/.config/agentsync/age.key\"\n")
+
+	out, err := runCLI(t, env, "apply")
+	if err != nil {
+		t.Fatalf("apply with ${env:HOME} identity_file failed: %v\n%s", err, out)
+	}
+	claudeJSON, err := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+	if err != nil {
+		t.Fatalf("read .claude.json: %v", err)
+	}
+	if !strings.Contains(string(claudeJSON), "ghp_firstrun") {
+		t.Fatalf("resolved token not in .claude.json: %s", claudeJSON)
+	}
+}
+
+// TestApply_SecretsDocumentedTemplateShape combines both: the exact shape a
+// user gets by uncommenting the init template's [secrets] block.
+func TestApply_SecretsDocumentedTemplateShape(t *testing.T) {
+	tmp, env, recipient := setupFirstRunSecrets(t)
+	// As shipped in init.go's template (file present, ${env:HOME} identity).
+	writeSecretsConfig(t, tmp, recipient,
+		"file = \"secrets/secrets.age\"\n",
+		"identity_file = \"${env:HOME}/.config/agentsync/age.key\"\n")
+
+	if _, err := runCLI(t, env, "verify"); err != nil {
+		t.Fatalf("verify with documented template shape failed: %v", err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply with documented template shape failed: %v\n%s", err, out)
+	}
+}

--- a/internal/cli/state_portable_test.go
+++ b/internal/cli/state_portable_test.go
@@ -1,0 +1,57 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestApply_WritesPortableStateKeys is the end-to-end regression for the
+// cross-machine portability bug. PR #20 introduced paths.HomeRelative to
+// store state keys as "${HOME}/.claude.json" instead of machine-absolute
+// paths so a chezmoi-synced ~/.agentsync/.state/targets.json survives a move
+// from /Users/alice to /home/alice. But every production call site passed the
+// AGENTSYNC home (~/.agentsync) as the normalization base, and dest files
+// like ~/.claude.json live OUTSIDE ~/.agentsync, so HomeRelative returned
+// them unchanged (absolute) — the normalization never fired in production and
+// the only regression test hand-faked the key. This test drives the REAL
+// apply path and asserts the persisted keys are portable.
+func TestApply_WritesPortableStateKeys(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcpPath, []byte(`[server]
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@modelcontextprotocol/server-github"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mustRun(t, env, "apply")
+
+	stateBytes, err := os.ReadFile(filepath.Join(tmp, ".agentsync", ".state", "targets.json"))
+	if err != nil {
+		t.Fatalf("read targets.json: %v", err)
+	}
+	state := string(stateBytes)
+
+	// Keys for dest files under the user home must be ${HOME}-relative.
+	if !strings.Contains(state, "${HOME}/.claude.json") {
+		t.Fatalf("state keys are not portable (no ${HOME}/.claude.json); got:\n%s", state)
+	}
+	// And must NOT embed the machine-specific absolute destination path,
+	// which is exactly what breaks after a chezmoi cross-home sync.
+	absDest := filepath.Join(tmp, ".claude.json")
+	if strings.Contains(state, absDest) {
+		t.Fatalf("state embeds machine-absolute dest %q; not portable:\n%s", absDest, state)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -35,6 +35,7 @@ func newStatusCmd() *cobra.Command {
 			// same plugin-projected components `apply` writes; source.Load
 			// alone would report plugin-managed files/keys as untracked.
 			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+			userHome := paths.HomeDir(paths.OSEnv{})
 			c, err := source.LoadWithCache(afero.NewOsFs(), home, pluginCacheRoot)
 			if err != nil {
 				return err
@@ -67,7 +68,7 @@ func newStatusCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, home)
+			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err
 			}
@@ -90,7 +91,7 @@ func newStatusCmd() *cobra.Command {
 					}
 					seen[op.Path] = true
 					hsrc := hashContent(op.Content)
-					happlied := s.Files[stateFileKey(home, name, sc, projectRoot, op.Path)].SHA256
+					happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, op.Path)].SHA256
 					hdest := hashFile(op.Path)
 					cls := drift.Classify(hsrc, happlied, hdest)
 					fmt.Fprintf(w, "  %-20s %s\n", cls, op.Path)
@@ -105,7 +106,7 @@ func newStatusCmd() *cobra.Command {
 					final := readJSONFile(op.Path)
 					for _, ptr := range render.CollectPointers(ours, "") {
 						hsrc := hashAnyValue(getPointerValue(ours, ptr))
-						happlied := s.Keys[stateKeyKey(home, name, sc, projectRoot, op.Path, ptr)].SHA256
+						happlied := s.Keys[stateKeyKey(userHome, name, sc, projectRoot, op.Path, ptr)].SHA256
 						hdest := hashAnyValue(getPointerValue(final, ptr))
 						cls := drift.Classify(hsrc, happlied, hdest)
 						fmt.Fprintf(w, "  %-20s %s#%s\n", cls, op.Path, ptr)
@@ -121,18 +122,19 @@ func newStatusCmd() *cobra.Command {
 }
 
 // stateFileKey builds the state Files map key matching render.RecordOpsState.
-// Format: "agent:scope:portableProject:portablePath" (project and path
-// are HOME-relative so keys are portable across machines).
-func stateFileKey(home, agent string, sc adapter.Scope, projectRoot, path string) string {
+// Format: "agent:scope:portableProject:portablePath" (project and path are
+// HOME-relative against the user's $HOME so keys are portable across
+// machines — userHome must be paths.HomeDir, NOT the agentsync home).
+func stateFileKey(userHome, agent string, sc adapter.Scope, projectRoot, path string) string {
 	return fmt.Sprintf("%s:%s:%s:%s", agent, sc.String(),
-		paths.HomeRelative(home, projectRoot), paths.HomeRelative(home, path))
+		paths.HomeRelative(userHome, projectRoot), paths.HomeRelative(userHome, path))
 }
 
 // stateKeyKey builds the state Keys map key matching render.RecordOpsState.
 // Format: "agent:scope:portableProject:portablePath:ptr".
-func stateKeyKey(home, agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
+func stateKeyKey(userHome, agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
 	return fmt.Sprintf("%s:%s:%s:%s:%s", agent, sc.String(),
-		paths.HomeRelative(home, projectRoot), paths.HomeRelative(home, path), ptr)
+		paths.HomeRelative(userHome, projectRoot), paths.HomeRelative(userHome, path), ptr)
 }
 
 func hashContent(b []byte) string {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -68,6 +68,10 @@ func newStatusCmd() *cobra.Command {
 					agents = append(agents, name)
 				}
 			}
+			if len(agents) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				return nil
+			}
 			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -31,7 +31,11 @@ func newStatusCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
-			c, err := source.Load(afero.NewOsFs(), home)
+			// Load WITH the plugin cache so drift classification sees the
+			// same plugin-projected components `apply` writes; source.Load
+			// alone would report plugin-managed files/keys as untracked.
+			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+			c, err := source.LoadWithCache(afero.NewOsFs(), home, pluginCacheRoot)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -62,6 +62,7 @@ re-render lands in the right place when running inside a project.`,
 
 func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag string) error {
 	home := paths.AgentsyncHome(paths.OSEnv{})
+	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")
 
 	// Load canonical source.
@@ -193,7 +194,7 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 
-		secBackend := secrets.SelectBackend(c2.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
+		secBackend := secrets.SelectBackend(c2.Config.Secrets, home, userHome)
 		envBackend := secrets.EnvBackend{}
 		if err := secrets.SubstituteCanonical(&c2, secBackend, envBackend); err != nil {
 			return fmt.Errorf("substitute secrets after update: %w", err)
@@ -206,11 +207,11 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 		reg := registryFactory()
-		plan, err := render.Plan(c2, reg, agents, sc, projectRoot, st, home)
+		plan, err := render.Plan(c2, reg, agents, sc, projectRoot, st, userHome)
 		if err != nil {
 			return fmt.Errorf("plan after update: %w", err)
 		}
-		collisions, err := render.Apply(plan, reg, st, home, sc, projectRoot)
+		collisions, err := render.Apply(plan, reg, st, home, userHome, sc, projectRoot)
 		if err != nil {
 			return fmt.Errorf("apply after update: %w", err)
 		}
@@ -222,10 +223,10 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 		for name, res := range plan.PerAgent {
-			render.PruneStaleState(st, home, name, sc, projectRoot, res.Ops)
+			render.PruneStaleState(st, userHome, name, sc, projectRoot, res.Ops)
 		}
 		for name, res := range plan.PerAgent {
-			if err := render.RecordOpsState(st, home, name, sc, projectRoot, res.Ops); err != nil {
+			if err := render.RecordOpsState(st, userHome, name, sc, projectRoot, res.Ops); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
@@ -290,17 +289,20 @@ func applyPluginBump(home string, b marketplace.Bump, fetched map[string]map[str
 		src.RootDir = mpCacheRoot
 	}
 	fetcher := marketplace.Dispatch(src)
-	result, err := fetcher.Fetch(src, cacheDir)
-	if err != nil {
+	if _, err := fetcher.Fetch(src, cacheDir); err != nil {
 		return fmt.Errorf("fetch plugin %s: %w", b.ID, err)
 	}
 
-	// Update the plugin TOML.
+	// Update the plugin TOML. Recompute the manifest SHA from the freshly
+	// fetched cache exactly as `plugin install` does (computeManifestSHA),
+	// for every fetcher type. The previous code only set the SHA for git
+	// fetchers — and to result.HeadSHA, a git commit SHA rather than the
+	// sha256(plugin.json) that verifyPluginManifestSHA compares against —
+	// so npm/relative/strict plugins kept the stale pre-bump SHA and the
+	// immediate re-apply hard-failed "manifest SHA mismatch".
 	existing.Plugin.Version = b.To
-	if result.HeadSHA != "" {
-		existing.Plugin.ManifestSHA = result.HeadSHA
-	} else if strings.ContainsAny(b.ManifestSHA, "0123456789abcdef") {
-		existing.Plugin.ManifestSHA = b.ManifestSHA
+	if sha := computeManifestSHA(home, b.ID, mpEntry, nil, cacheDir); sha != "" {
+		existing.Plugin.ManifestSHA = sha
 	}
 
 	data, err := toml.Marshal(existing)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -193,7 +193,7 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 
-		secBackend := secrets.SelectBackend(c2.Config.Secrets, home)
+		secBackend := secrets.SelectBackend(c2.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
 		envBackend := secrets.EnvBackend{}
 		if err := secrets.SubstituteCanonical(&c2, secBackend, envBackend); err != nil {
 			return fmt.Errorf("substitute secrets after update: %w", err)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -210,7 +210,7 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 		if err != nil {
 			return fmt.Errorf("plan after update: %w", err)
 		}
-		collisions, err := render.Apply(plan, reg, st, home, userHome, sc, projectRoot)
+		collisions, _, err := render.Apply(plan, reg, st, home, userHome, sc, projectRoot)
 		if err != nil {
 			return fmt.Errorf("apply after update: %w", err)
 		}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -2,9 +2,55 @@ package cli_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestUpdate_ApplyRecordsFreshManifestSHA is the regression for the
+// update-bricks-plugins bug. computeBump never set Bump.ManifestSHA, and
+// applyPluginBump only refreshed the recorded SHA for git fetchers (and even
+// then to result.HeadSHA, a git commit SHA — not the sha256(plugin.json)
+// that verifyPluginManifestSHA compares). So after a track-mode re-fetch the
+// stale pre-bump SHA stayed in plugins/<id>.toml and the immediate re-apply
+// hard-failed "manifest SHA mismatch". applyPluginBump must recompute the
+// manifest SHA from the freshly-fetched cache, exactly like install.
+func TestUpdate_ApplyRecordsFreshManifestSHA(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	// Install demo@1.0.0 (records version + sha256(plugin.json@1.0.0)).
+	mpDir := makeVersionedMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "install", "demo@test-mp-v")
+	mustRun(t, env, "apply")
+
+	// Publish 1.0.1 in place — plugin.json content changes, so its SHA does too.
+	_ = makeVersionedMarketplace(t, base, "1.0.1")
+
+	out, err := runCLI(t, env, "update", "--apply")
+	if err != nil {
+		t.Fatalf("update --apply bricked the plugin (stale manifest SHA): %v\n%s", err, out)
+	}
+
+	demoTOML, rerr := readFileString(t, filepath.Join(tmp, ".agentsync", "plugins", "demo.toml"))
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if !strings.Contains(demoTOML, "1.0.1") {
+		t.Fatalf("demo.toml not bumped to 1.0.1:\n%s", demoTOML)
+	}
+
+	// The recorded SHA must match the new plugin.json, so a follow-up apply
+	// doesn't fail verifyPluginManifestSHA.
+	if out2, err2 := runCLI(t, env, "apply"); err2 != nil {
+		t.Fatalf("apply after update --apply failed (stale SHA recorded?): %v\n%s", err2, out2)
+	}
+}
 
 func readFileString(t *testing.T, path string) (string, error) {
 	t.Helper()

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -18,6 +18,15 @@ func newVerifyCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
+			// source.Load tolerates a missing home and returns an empty model,
+			// so without this guard `verify` on an uninitialized machine
+			// printed a false "ok" and exited 0. Fail with a pointer to init.
+			if _, err := os.Stat(home); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("agentsync home %s does not exist; run `agentsync init` first", home)
+				}
+				return fmt.Errorf("verify: stat %s: %w", home, err)
+			}
 			c, err := source.Load(afero.NewOsFs(), home)
 			if err != nil {
 				return fmt.Errorf("verify: %w", err)

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ func newVerifyCmd() *cobra.Command {
 			// reference shape, so the schema decode + this pass cover
 			// the offline-validatable space.
 			if os.Getenv("AGENTSYNC_ALLOW_OFFLINE_VERIFY") != "1" {
-				secBackend := secrets.SelectBackend(c.Config.Secrets, home)
+				secBackend := secrets.SelectBackend(c.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
 				envBackend := secrets.EnvBackend{}
 				if err := secrets.SubstituteCanonical(&c, secBackend, envBackend); err != nil {
 					return fmt.Errorf("verify ${secret:}/${env:} resolution: %w", err)
@@ -68,10 +67,10 @@ func verifySecrets(cfg source.SecretsConfig, home string) error {
 	if cfg.IdentityFile == "" {
 		return fmt.Errorf("[secrets].identity_file is required for backend = \"age\"")
 	}
-	idPath := cfg.IdentityFile
-	if h := os.Getenv("HOME"); h != "" {
-		idPath = expandEnvHome(idPath, h)
-	}
+	userHome := paths.HomeDir(paths.OSEnv{})
+	// Resolve identity_file exactly as apply does (SelectBackend ->
+	// ResolveIdentityFile) so verify and apply never disagree on the path.
+	idPath := secrets.ResolveIdentityFile(cfg, home, userHome)
 	if _, err := os.Stat(idPath); err != nil {
 		return fmt.Errorf("identity_file %s: %w", idPath, err)
 	}
@@ -83,17 +82,12 @@ func verifySecrets(cfg source.SecretsConfig, home string) error {
 	if err := secrets.CheckIdentityPermissions(idPath); err != nil {
 		return err
 	}
-	// File path is optional (a brand-new install may not have written yet).
-	if cfg.File != "" {
-		agePath := cfg.File
-		if !filepath.IsAbs(agePath) {
-			agePath = filepath.Join(home, agePath)
-		}
-		// Stat the path but don't require existence — secrets edit creates
-		// it lazily. Only flag if it's there but unreadable.
-		if _, err := os.Stat(agePath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("secrets.file %s: %w", agePath, err)
-		}
+	// Age file location is optional in config (defaults to DefaultAgeFile)
+	// and may not exist yet on a brand-new install. Resolve it the same way
+	// apply does, then only flag a present-but-unreadable file.
+	agePath := secrets.ResolveAgeFile(cfg, home, userHome)
+	if _, err := os.Stat(agePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("secrets.file %s: %w", agePath, err)
 	}
 	return nil
 }

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -7,6 +7,22 @@ import (
 	"testing"
 )
 
+// TestVerify_UninitializedHomeErrors is the regression for verify printing a
+// false "ok" (exit 0) when run before `init` — source.Load tolerates a
+// missing home, so the user got a green light on a non-existent config.
+func TestVerify_UninitializedHomeErrors(t *testing.T) {
+	tmp := t.TempDir()
+	// Note: no `init` — the agentsync home does not exist.
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	out, err := runCLI(t, env, "verify")
+	if err == nil {
+		t.Fatalf("verify on uninitialized home should error; got ok:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "init") {
+		t.Fatalf("error should point at `init`; got: %v", err)
+	}
+}
+
 func TestVerify_Empty(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/marketplace/capped_reader_test.go
+++ b/internal/marketplace/capped_reader_test.go
@@ -1,0 +1,45 @@
+package marketplace
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// TestCappedReader_Boundary pins the off-by-one in the tarball cap. The
+// previous `remaining <= 0` trip condition failed a payload whose
+// decompressed size was exactly the cap, because the tar reader issues a
+// trailing probe read after the last data byte. The cap must permit reading
+// up to AND including `cap` bytes and only fail on the (cap+1)th.
+func TestCappedReader_Boundary(t *testing.T) {
+	cases := []struct {
+		name    string
+		size    int64
+		cap     int64
+		wantErr bool
+	}{
+		{"under cap", 99, 100, false},
+		{"exactly cap", 100, 100, false},
+		{"one over cap", 101, 100, true},
+		{"well over cap", 4096, 100, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := bytes.Repeat([]byte("x"), int(tc.size))
+			cr := &cappedReader{r: bytes.NewReader(data), remaining: tc.cap, url: "test://t"}
+			got, err := io.ReadAll(cr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("size=%d cap=%d: expected cap error, got nil", tc.size, tc.cap)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("size=%d cap=%d: unexpected error: %v", tc.size, tc.cap, err)
+			}
+			if int64(len(got)) != tc.size {
+				t.Fatalf("size=%d cap=%d: read %d bytes, want %d", tc.size, tc.cap, len(got), tc.size)
+			}
+		})
+	}
+}

--- a/internal/marketplace/fetch_git.go
+++ b/internal/marketplace/fetch_git.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,7 +92,38 @@ func (f *GitFetcher) Fetch(src Source, into string) (FetchResult, error) {
 		}
 	}
 
+	// go-git materializes committed symlinks on disk. Without this, a
+	// malicious plugin repo could ship a symlink (skills/x -> /etc) that the
+	// lexical component-path containment check cannot catch and os.ReadFile
+	// would follow off the cache. Reject any symlink in the fetched tree —
+	// the same stance npm/relative fetchers take. The .git dir is never
+	// projected, so skip it.
+	if err := rejectSymlinks(into); err != nil {
+		return FetchResult{}, err
+	}
+
 	return FetchResult{HeadSHA: headSHA}, nil
+}
+
+// rejectSymlinks walks root and returns an error if any entry is a symlink,
+// skipping the .git directory.
+func rejectSymlinks(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && d.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+			return fmt.Errorf("git fetcher: repository contains a symlink %q (refusing — plugin trees must contain only regular files and directories)", rel)
+		}
+		return nil
+	})
 }
 
 // resolveGitURL returns the clone URL for the given source.

--- a/internal/marketplace/fetch_git_symlink_test.go
+++ b/internal/marketplace/fetch_git_symlink_test.go
@@ -1,0 +1,47 @@
+package marketplace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRejectSymlinks covers the helper that closes the git-fetcher symlink
+// hole: a cloned plugin repo containing a symlink (which the lexical
+// component-path containment check cannot catch) must be refused, while a
+// clean tree passes and symlinks inside .git are ignored.
+func TestRejectSymlinks(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ok.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "a.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectSymlinks(root); err != nil {
+		t.Fatalf("clean tree should pass: %v", err)
+	}
+
+	// Symlinks under .git are skipped (never projected).
+	gitDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/hostname", filepath.Join(gitDir, "evil")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	if err := rejectSymlinks(root); err != nil {
+		t.Fatalf(".git symlinks must be skipped: %v", err)
+	}
+
+	// A symlink anywhere in the tracked tree is rejected.
+	if err := os.Symlink("/etc/passwd", filepath.Join(root, "sub", "leak")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	if err := rejectSymlinks(root); err == nil {
+		t.Fatal("expected rejection for a symlink in the tree")
+	}
+}

--- a/internal/marketplace/fetch_npm.go
+++ b/internal/marketplace/fetch_npm.go
@@ -90,6 +90,13 @@ func (f *NPMFetcher) Fetch(src Source, into string) (FetchResult, error) {
 	if tarballURL == "" {
 		return FetchResult{}, fmt.Errorf("npm fetcher: no tarball URL for %s@%s", src.Package, version)
 	}
+	// The tarball URL comes from registry metadata — attacker-influenced even
+	// when the registry itself is https. Reject a plain-http (remote) tarball
+	// before downloading so a MITM (or a hostile registry) cannot serve plugin
+	// content over an unauthenticated transport.
+	if err := checkURLScheme(tarballURL); err != nil {
+		return FetchResult{}, fmt.Errorf("npm fetcher: tarball %w", err)
+	}
 
 	if err := os.MkdirAll(into, 0o755); err != nil {
 		return FetchResult{}, fmt.Errorf("npm fetcher: mkdir %s: %w", into, err)

--- a/internal/marketplace/fetch_npm.go
+++ b/internal/marketplace/fetch_npm.go
@@ -259,13 +259,27 @@ type cappedReader struct {
 }
 
 func (c *cappedReader) Read(p []byte) (int, error) {
-	if c.remaining <= 0 {
-		return 0, fmt.Errorf("npm fetcher: decompressed tarball from %s exceeds cap (set AGENTSYNC_MAX_TARBALL_MB to override)", c.url)
+	if c.remaining < 0 {
+		return 0, c.capErr()
 	}
-	if int64(len(p)) > c.remaining {
-		p = p[:c.remaining]
+	// Allow reading up to remaining+1 bytes. A payload of exactly `cap`
+	// bytes drains remaining to 0 without error (the tar reader's trailing
+	// probe read then sees EOF), while the (cap+1)th byte drives remaining
+	// negative and trips the cap. The previous `remaining <= 0` guard
+	// rejected a tarball whose decompressed size was *exactly* the cap,
+	// because tar issues one more Read after the last data byte.
+	allow := c.remaining + 1
+	if int64(len(p)) > allow {
+		p = p[:allow]
 	}
 	n, err := c.r.Read(p)
 	c.remaining -= int64(n)
+	if c.remaining < 0 {
+		return n, c.capErr()
+	}
 	return n, err
+}
+
+func (c *cappedReader) capErr() error {
+	return fmt.Errorf("npm fetcher: decompressed tarball from %s exceeds cap (set AGENTSYNC_MAX_TARBALL_MB to override)", c.url)
 }

--- a/internal/marketplace/fetch_relative.go
+++ b/internal/marketplace/fetch_relative.go
@@ -91,6 +91,16 @@ func copyDir(src, dst string) error {
 	for _, entry := range entries {
 		srcPath := filepath.Join(src, entry.Name())
 		dstPath := filepath.Join(dst, entry.Name())
+		// Reject symlinks rather than dereferencing them. copyFile does
+		// os.Open (which follows the link), so a marketplace tree with a
+		// symlink to /etc/passwd (or a dir symlink escaping the root) would
+		// otherwise have its target's content copied into the plugin cache
+		// and projected into agent config. The RootDir containment check
+		// only validates the top-level source path, not links discovered
+		// during the walk — mirror the npm fetcher's loud reject.
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("relative fetcher: %s is a symlink (refusing — marketplace trees must contain only regular files and directories)", srcPath)
+		}
 		if entry.IsDir() {
 			if err := copyDir(srcPath, dstPath); err != nil {
 				return err

--- a/internal/marketplace/fetch_test.go
+++ b/internal/marketplace/fetch_test.go
@@ -130,6 +130,34 @@ func TestRelativeFetcher_CopiesDirectory(t *testing.T) {
 	}
 }
 
+// TestRelativeFetcher_RejectsSymlinkEntry is the regression for the bug where
+// copyDir dereferenced symlinks (copyFile -> os.Open follows the link), so a
+// marketplace tree containing a symlink to a host file outside the tree had
+// that file's content copied into the plugin cache.
+func TestRelativeFetcher_RejectsSymlinkEntry(t *testing.T) {
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP SECRET HOST FILE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(src, "leak.txt")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	dst := t.TempDir()
+	source := marketplace.Source{Relative: src}
+	_, err := marketplace.Dispatch(source).Fetch(source, dst)
+	if err == nil {
+		t.Fatal("expected error when marketplace tree contains a symlink")
+	}
+	if data, rerr := os.ReadFile(filepath.Join(dst, "leak.txt")); rerr == nil {
+		t.Fatalf("symlink target content leaked into cache: %q", data)
+	}
+}
+
 func TestRelativeFetcher_RejectsPathTraversal(t *testing.T) {
 	// Marketplace cache root holds a benign plugin layout; a marketplace
 	// entry with `"source": "../escape"` is what we want to reject.

--- a/internal/marketplace/fetch_test.go
+++ b/internal/marketplace/fetch_test.go
@@ -252,6 +252,44 @@ func TestGitFetcher_FileURL(t *testing.T) {
 	}
 }
 
+// TestGitFetcher_RejectsCommittedSymlink is the regression for the residual
+// hole: the lexical component-path containment check can't catch a symlink,
+// and go-git materializes committed symlinks on disk, so a malicious git
+// plugin repo could ship one (skills/x -> /etc) that os.ReadFile follows off
+// the cache. GitFetcher must reject any symlink in the fetched tree.
+func TestGitFetcher_RejectsCommittedSymlink(t *testing.T) {
+	workDir := t.TempDir()
+	repo, err := gogit.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "ok.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/passwd", filepath.Join(workDir, "leak")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	w, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Add("."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	sig := &object.Signature{Name: "t", Email: "t@t", When: time.Now()}
+	if _, err := w.Commit("init", &gogit.CommitOptions{Author: sig, Committer: sig}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	dst := t.TempDir()
+	src := marketplace.Source{Kind: "url", Repo: "file://" + workDir}
+	if _, err := marketplace.Dispatch(src).Fetch(src, dst); err == nil {
+		t.Fatal("expected GitFetcher to reject a repo containing a symlink")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error should name the symlink; got: %v", err)
+	}
+}
+
 func TestGitFetcher_Idempotent(t *testing.T) {
 	workDir := t.TempDir()
 	makeWorkRepo(t, workDir, "f.txt", "v1")

--- a/internal/marketplace/fetch_test.go
+++ b/internal/marketplace/fetch_test.go
@@ -458,6 +458,38 @@ func TestNPMFetcher_LatestVersion(t *testing.T) {
 	}
 }
 
+// TestNPMFetcher_RejectsInsecureTarballURL is the regression for the second
+// half of the npm blind spot: even with a trusted registry, the tarball URL
+// returned in the metadata is attacker-influenced and was previously fetched
+// with no scheme check. A remote plain-http tarball URL must be rejected
+// before download. The metadata is served over loopback http (allowed); only
+// the tarball points at a remote http host, so this runs offline — the reject
+// fires before any dial to the remote host.
+func TestNPMFetcher_RejectsInsecureTarballURL(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta := map[string]any{
+			"versions": map[string]any{
+				"1.0.0": map[string]any{
+					"version": "1.0.0",
+					"dist":    map[string]any{"tarball": "http://cdn.evil.example.com/pkg/1.0.0.tgz"},
+				},
+			},
+			"dist-tags": map[string]any{"latest": "1.0.0"},
+		}
+		_ = json.NewEncoder(w).Encode(meta)
+	}))
+	defer srv.Close()
+
+	dst := t.TempDir()
+	src := marketplace.Source{Kind: "npm", Package: "evilpkg", Version: "1.0.0", Registry: srv.URL}
+	fetcher := &marketplace.NPMFetcher{HTTPClient: srv.Client()}
+	_, err := fetcher.Fetch(src, dst)
+	if err == nil || !strings.Contains(err.Error(), "insecure scheme") {
+		t.Fatalf("remote plain-http tarball URL should be rejected; got err=%v", err)
+	}
+}
+
 // makeNPMTarballWithEntry builds an in-memory npm-style .tgz with one
 // arbitrary entry name, bypassing the conventional "package/" prefix.
 // Used to construct tarballs with traversal entries.

--- a/internal/marketplace/fetcher.go
+++ b/internal/marketplace/fetcher.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -45,36 +46,62 @@ func Dispatch(src Source) Fetcher {
 	return &errFetcher{err: fmt.Errorf("unknown source kind %q", src.Kind)}
 }
 
-// enforceSecureScheme rejects plain-text URL schemes (http://, git://) so a
-// MITM cannot swap plugin content. Loopback file:// is allowed for test
-// fixtures, and ssh:// is allowed since SSH provides its own integrity. Users
-// who need a plain-http internal mirror can set AGENTSYNC_ALLOW_INSECURE_URLS=1.
+// enforceSecureScheme rejects plain-text URL schemes (http://, git://) on
+// every remote a fetch will contact — the git URL/repo AND the npm registry —
+// so a MITM cannot swap plugin content or the metadata that resolves the
+// tarball URL. The registry was previously unchecked, leaving npm sources
+// exposed even with the env override unset.
 func enforceSecureScheme(src Source) error {
-	if os.Getenv("AGENTSYNC_ALLOW_INSECURE_URLS") == "1" {
-		return nil
-	}
-	candidates := []string{src.URL, src.Repo}
-	for _, raw := range candidates {
-		if raw == "" {
-			continue
-		}
-		// GitHub repos are written as "owner/repo" with no scheme; the
-		// GitFetcher prepends https://. Skip those.
-		if !strings.Contains(raw, "://") {
-			continue
-		}
-		u, err := url.Parse(raw)
-		if err != nil {
-			return fmt.Errorf("parse plugin URL %q: %w", raw, err)
-		}
-		switch strings.ToLower(u.Scheme) {
-		case "https", "ssh", "git+ssh", "file":
-			// ok
-		case "http", "git":
-			return fmt.Errorf("plugin URL %q uses insecure scheme %q; "+
-				"set AGENTSYNC_ALLOW_INSECURE_URLS=1 to override (internal mirrors only)",
-				raw, u.Scheme)
+	for _, raw := range []string{src.URL, src.Repo, src.Registry} {
+		if err := checkURLScheme(raw); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// checkURLScheme rejects a single remote URL that uses a plain-text scheme.
+// Empty strings and scheme-less shorthand ("owner/repo") are accepted — the
+// caller resolves those to https. Loopback http/git is allowed because it has
+// no MITM surface (the request never leaves the machine), which covers local
+// mirrors and the httptest fixtures the fetcher tests rely on; file:// and
+// ssh:// are allowed since they carry their own integrity. Users who need a
+// remote plain-http internal mirror can set AGENTSYNC_ALLOW_INSECURE_URLS=1.
+func checkURLScheme(raw string) error {
+	if os.Getenv("AGENTSYNC_ALLOW_INSECURE_URLS") == "1" {
+		return nil
+	}
+	// GitHub repos are written as "owner/repo" with no scheme; the GitFetcher
+	// prepends https://. Skip those (and empty fields).
+	if raw == "" || !strings.Contains(raw, "://") {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse plugin URL %q: %w", raw, err)
+	}
+	// Only the plain-text git transports are rejected; https, ssh, git+ssh,
+	// file, and any other scheme are allowed (matches the prior default).
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "http" || scheme == "git" {
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("plugin URL %q uses insecure scheme %q; "+
+			"set AGENTSYNC_ALLOW_INSECURE_URLS=1 to override (internal mirrors only)",
+			raw, u.Scheme)
+	}
+	return nil
+}
+
+// isLoopbackHost reports whether host (a URL hostname, no port) refers to the
+// local machine: the literal "localhost" or any loopback IP (127.0.0.0/8, ::1).
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -104,14 +104,40 @@ func resolvePluginRoot(s, cacheDir string) string {
 // "find a file inside the plugin cache" semantics (this function), which the
 // Claude marketplace plugin convention conflates: manifest entries like
 // "./skills/foo" are relative to the plugin root, not the process cwd.
-func resolveComponentPath(s, cacheDir string) string {
-	if strings.Contains(s, "${CLAUDE_PLUGIN_ROOT}") {
-		return strings.ReplaceAll(s, "${CLAUDE_PLUGIN_ROOT}", cacheDir)
+func resolveComponentPath(s, cacheDir string) (string, error) {
+	var resolved string
+	switch {
+	case strings.Contains(s, "${CLAUDE_PLUGIN_ROOT}"):
+		resolved = strings.ReplaceAll(s, "${CLAUDE_PLUGIN_ROOT}", cacheDir)
+	case filepath.IsAbs(s):
+		resolved = s
+	default:
+		resolved = filepath.Join(cacheDir, s)
 	}
-	if filepath.IsAbs(s) {
-		return s
+	if err := assertWithinCache(cacheDir, resolved); err != nil {
+		return "", err
 	}
-	return filepath.Join(cacheDir, s)
+	return resolved, nil
+}
+
+// assertWithinCache rejects a resolved component path that escapes cacheDir.
+// The manifest *contents* are untrusted: a hostile plugin.json listing
+// "skills":["/etc/passwd"] or "commands":["../../../../secret"] would
+// otherwise be read and projected into the user's agent config. The
+// fetchers are hardened, but manifest-listed paths were not.
+func assertWithinCache(cacheDir, resolved string) error {
+	absCache, err := filepath.Abs(cacheDir)
+	if err != nil {
+		return err
+	}
+	absResolved, err := filepath.Abs(resolved)
+	if err != nil {
+		return err
+	}
+	if !pathContains(filepath.Clean(absCache), filepath.Clean(absResolved)) {
+		return fmt.Errorf("plugin component path %q escapes plugin cache %q", resolved, cacheDir)
+	}
+	return nil
 }
 
 // resolvePluginRootInArgs applies resolvePluginRoot to each element of args.
@@ -150,7 +176,11 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, sk := range skillPaths {
-		skill, err := loadSkillEntry(resolveComponentPath(sk, cacheDir), readFile)
+		p, err := resolveComponentPath(sk, cacheDir)
+		if err != nil {
+			return err
+		}
+		skill, err := loadSkillEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -160,7 +190,11 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	}
 
 	for _, cmd := range toStringSlice(manifest.Commands) {
-		command, err := loadMarkdownEntry(resolveComponentPath(cmd, cacheDir), readFile)
+		p, err := resolveComponentPath(cmd, cacheDir)
+		if err != nil {
+			return err
+		}
+		command, err := loadMarkdownEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load command %q: %w", cmd, err)
 		}
@@ -169,7 +203,11 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, ag := range toStringSlice(manifest.Agents) {
-		agent, err := loadMarkdownEntry(resolveComponentPath(ag, cacheDir), readFile)
+		p, err := resolveComponentPath(ag, cacheDir)
+		if err != nil {
+			return err
+		}
+		agent, err := loadMarkdownEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load agent %q: %w", ag, err)
 		}
@@ -214,7 +252,11 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
 	}
 	for _, sk := range toStringSlice(entry.Skills) {
-		skill, err := loadSkillEntry(resolveComponentPath(sk, cacheDir), readFile)
+		p, err := resolveComponentPath(sk, cacheDir)
+		if err != nil {
+			return err
+		}
+		skill, err := loadSkillEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -223,7 +265,11 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, cmd := range toStringSlice(entry.Commands) {
-		command, err := loadMarkdownEntry(resolveComponentPath(cmd, cacheDir), readFile)
+		p, err := resolveComponentPath(cmd, cacheDir)
+		if err != nil {
+			return err
+		}
+		command, err := loadMarkdownEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load command %q: %w", cmd, err)
 		}
@@ -232,7 +278,11 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	for _, ag := range toStringSlice(entry.Agents) {
-		agent, err := loadMarkdownEntry(resolveComponentPath(ag, cacheDir), readFile)
+		p, err := resolveComponentPath(ag, cacheDir)
+		if err != nil {
+			return err
+		}
+		agent, err := loadMarkdownEntry(p, readFile)
 		if err != nil {
 			return fmt.Errorf("load agent %q: %w", ag, err)
 		}

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -39,6 +39,36 @@ func TestProject_StrictPluginJSON(t *testing.T) {
 	}
 }
 
+// TestProject_RejectsEscapingComponentPath is the regression for the
+// manifest-path traversal: the fetchers are hardened, but a hostile
+// plugin.json could list a skill/command/agent path that resolves outside
+// the plugin cache, exfiltrating a host file into a projected component.
+func TestProject_RejectsEscapingComponentPath(t *testing.T) {
+	secret := filepath.Join(t.TempDir(), "SKILL.md")
+	if err := os.WriteFile(secret, []byte("---\nname: leak\n---\nhost secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, mal := range []string{secret, "../../../../etc/passwd", "../escape/SKILL.md"} {
+		t.Run(mal, func(t *testing.T) {
+			cache := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			manifest := `{"name":"x","skills":["` + mal + `"]}`
+			if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := marketplace.Project(marketplace.PluginEntry{Name: "x"}, cache)
+			if err == nil {
+				t.Fatalf("expected escape error for skills path %q", mal)
+			}
+			if !strings.Contains(err.Error(), "escapes plugin cache") {
+				t.Fatalf("error should explain the escape; got: %v", err)
+			}
+		})
+	}
+}
+
 func TestProject_StrictPluginJSON_MultipleComponents(t *testing.T) {
 	cache := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {

--- a/internal/marketplace/secure_scheme_test.go
+++ b/internal/marketplace/secure_scheme_test.go
@@ -50,3 +50,34 @@ func TestDispatch_OverrideAllowsHTTP(t *testing.T) {
 		t.Fatalf("env override should allow http; got %T", f)
 	}
 }
+
+// TestDispatch_RejectsInsecureNPMRegistry is the regression for the npm blind
+// spot: enforceSecureScheme originally inspected only URL and Repo, so an npm
+// source pointing at a plain-http registry sailed through and a MITM could
+// swap the metadata (and thus the resolved tarball URL). The registry must be
+// scheme-checked like any other remote.
+func TestDispatch_RejectsInsecureNPMRegistry(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	src := Source{Kind: "npm", Package: "x", Registry: "http://registry.evil.example.com"}
+	_, err := Dispatch(src).Fetch(src, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "insecure scheme") {
+		t.Fatalf("plain-http npm registry should be rejected; got err=%v", err)
+	}
+}
+
+// TestDispatch_AllowsLoopbackHTTP documents the deliberate carve-out: http to
+// a loopback host has no MITM surface (the request never leaves the machine),
+// so local mirrors — and the httptest fixtures the npm fetcher tests depend on
+// — are allowed even though plain http to a remote host is rejected.
+func TestDispatch_AllowsLoopbackHTTP(t *testing.T) {
+	t.Setenv("AGENTSYNC_ALLOW_INSECURE_URLS", "")
+	for _, raw := range []string{
+		"http://127.0.0.1:8080/p.git",
+		"http://localhost/p.git",
+		"http://[::1]:9/p.git",
+	} {
+		if _, ok := Dispatch(Source{Kind: "url", URL: raw}).(*GitFetcher); !ok {
+			t.Errorf("loopback http %q should dispatch to GitFetcher (no MITM surface)", raw)
+		}
+	}
+}

--- a/internal/marketplace/update.go
+++ b/internal/marketplace/update.go
@@ -13,8 +13,6 @@ type Bump struct {
 	From string
 	// To is the latest version available in the fetched marketplace.
 	To string
-	// ManifestSHA is the SHA of the freshly-fetched plugin.json (if available).
-	ManifestSHA string
 	// UpdateMode is the plugin's configured update mode ("pinned", "track", "manual").
 	UpdateMode string
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -6,6 +6,7 @@ package paths
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Env abstracts environment-variable lookup so tests can inject a fake.
@@ -72,6 +73,24 @@ func HomeRelative(home, abs string) string {
 		return abs
 	}
 	return "${HOME}/" + filepath.ToSlash(rel)
+}
+
+// FromHomeRelative is the inverse of HomeRelative: it expands a leading
+// "${HOME}" / "${HOME}/" in a stored state path back to an absolute path
+// rooted at userHome. Paths stored absolute (because they were outside home
+// when recorded) are returned unchanged. Callers that turn a stored state
+// key back into a real filesystem path (e.g. `agent disable --purge`) MUST
+// route through this so they don't operate on the literal "${HOME}/..."
+// string.
+func FromHomeRelative(userHome, stored string) string {
+	const tok = "${HOME}"
+	if stored == tok {
+		return userHome
+	}
+	if rest, ok := strings.CutPrefix(stored, tok+"/"); ok {
+		return filepath.Join(userHome, filepath.FromSlash(rest))
+	}
+	return stored
 }
 
 // hasParentPrefix returns true when s starts with ".." as a path segment.

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -88,6 +88,44 @@ func TestHomeRelative(t *testing.T) {
 	}
 }
 
+func TestFromHomeRelative(t *testing.T) {
+	cases := []struct {
+		name     string
+		userHome string
+		stored   string
+		want     string
+	}{
+		{"expands ${HOME}/ prefix", "/home/alice", "${HOME}/.claude.json", filepath.Join("/home/alice", ".claude.json")},
+		{"nested ${HOME}/ prefix", "/home/alice", "${HOME}/.config/opencode/opencode.json", filepath.Join("/home/alice", ".config/opencode/opencode.json")},
+		{"bare ${HOME}", "/home/alice", "${HOME}", "/home/alice"},
+		{"absolute stored path unchanged", "/home/alice", "/etc/agentsync/global.json", "/etc/agentsync/global.json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paths.FromHomeRelative(tc.userHome, tc.stored)
+			if got != tc.want {
+				t.Fatalf("FromHomeRelative(%q,%q) = %q, want %q", tc.userHome, tc.stored, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHomeRelative_RoundTrips proves HomeRelative and FromHomeRelative are
+// inverses for dest paths under home — the invariant `agent disable --purge`
+// relies on to turn a stored key back into a real path.
+func TestHomeRelative_RoundTrips(t *testing.T) {
+	home := "/home/alice"
+	abs := filepath.Join(home, ".config", "opencode", "opencode.json")
+	stored := paths.HomeRelative(home, abs)
+	if stored != "${HOME}/.config/opencode/opencode.json" {
+		t.Fatalf("HomeRelative = %q", stored)
+	}
+	back := paths.FromHomeRelative(home, stored)
+	if back != abs {
+		t.Fatalf("round-trip mismatch: %q -> %q -> %q", abs, stored, back)
+	}
+}
+
 func TestAgentsyncHome(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -160,7 +160,15 @@ func Merge(base source.Canonical, m *Marker) source.Canonical {
 	if len(m.Memory.Import) > 0 {
 		body := out.Memory.Body
 		for _, rel := range m.Memory.Import {
-			data, err := os.ReadFile(filepath.Join(m.Root, rel))
+			// Containment: a committed marker's import path must not escape
+			// the project root. Without this, `import = ["../../etc/passwd"]`
+			// (or an absolute path) reads arbitrary host files into the
+			// rendered memory. Skip anything that resolves outside m.Root.
+			abs := filepath.Join(m.Root, rel)
+			if !importWithinRoot(m.Root, abs) {
+				continue
+			}
+			data, err := os.ReadFile(abs)
 			if err != nil {
 				continue
 			}
@@ -172,4 +180,21 @@ func Merge(base source.Canonical, m *Marker) source.Canonical {
 		out.Memory.Body = body
 	}
 	return out
+}
+
+// importWithinRoot reports whether abs is the same path as root or sits
+// inside it (lexical, after Clean). Used to bound project memory imports.
+func importWithinRoot(root, abs string) bool {
+	root = filepath.Clean(root)
+	abs = filepath.Clean(abs)
+	if root == abs {
+		return true
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return false
+	}
+	return rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+		!filepath.IsAbs(rel)
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -3,6 +3,7 @@ package project_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/project"
@@ -96,6 +97,34 @@ func TestDiscover_FirstMatchWins(t *testing.T) {
 }
 
 // ─── Task 2: Merge ───────────────────────────────────────────────────────────
+
+// TestMerge_MemoryImport_RejectsTraversal is the regression for a committed
+// marker reading arbitrary host files into rendered memory via a "../" import
+// path. The escaping import must be skipped (its content must not appear).
+func TestMerge_MemoryImport_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	// A secret file OUTSIDE the project root.
+	parent := filepath.Dir(root)
+	secret := filepath.Join(parent, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP-SECRET-HOST-FILE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A legit in-root fragment that SHOULD be imported.
+	if err := os.WriteFile(filepath.Join(root, "ok.md"), []byte("legit-memory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &project.Marker{
+		Root:   root,
+		Memory: project.ProjectMemorySection{Import: []string{"../secret.txt", "ok.md"}},
+	}
+	out := project.Merge(source.Canonical{}, m)
+	if strings.Contains(out.Memory.Body, "TOP-SECRET-HOST-FILE") {
+		t.Fatalf("traversal import leaked host file into memory: %q", out.Memory.Body)
+	}
+	if !strings.Contains(out.Memory.Body, "legit-memory") {
+		t.Fatalf("in-root import was dropped: %q", out.Memory.Body)
+	}
+}
 
 func TestMerge_NilMarker(t *testing.T) {
 	base := source.Canonical{

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -5,6 +5,7 @@ package render
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -62,10 +63,16 @@ func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adap
 		}
 		if s != nil {
 			for i, op := range ops {
-				if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
+				if isKeyMerge(op.MergeStrategy) {
 					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path, userHome)
 				}
 			}
+			// Cleanup synthesis: when a key-merge section becomes empty in the
+			// source (e.g. the user removes their last MCP server), the
+			// adapter renders NO op for that file, so the owned key would
+			// linger in the destination forever. Synthesize an empty merge op
+			// per orphaned dest path so MergeKeys deletes the dead keys.
+			ops = append(ops, orphanCleanupOps(s, a, name, scope, project, userHome, ops)...)
 		}
 		out.PerAgent[name] = AgentResult{Ops: ops, Skips: skips}
 	}
@@ -138,6 +145,76 @@ func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, 
 		}
 	}
 	return out
+}
+
+// orphanCleanupOps synthesizes empty key-merge ops that remove keys the agent
+// owns in state but no longer renders this run — the case where a source
+// section went fully empty (e.g. the user deleted their last MCP server), so
+// no real merge op exists to carry the removal via OwnedKeys. Without this the
+// dead key lingers in the destination forever.
+//
+// Safety (validated): the strategy is the adapter's exact, static
+// KeyMergeStrategy() — never inferred — so a JSONC opencode.json is never
+// merged with the strict-JSON path (which would clobber it). A dest that no
+// longer exists on disk is skipped (no empty "{}" file is created); the stale
+// state entry is dropped by PruneStaleState instead.
+func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope adapter.Scope, project, userHome string, rendered []adapter.FileOp) []adapter.FileOp {
+	strat := a.KeyMergeStrategy()
+	if strat == "" {
+		return nil // adapter doesn't merge keys
+	}
+	// Portable dest paths the agent DID render a key-merge op for this run.
+	renderedPaths := map[string]bool{}
+	for _, op := range rendered {
+		if isKeyMerge(op.MergeStrategy) {
+			renderedPaths[paths.HomeRelative(userHome, op.Path)] = true
+		}
+	}
+
+	// Group owned pointers by their portable dest path from state.Keys.
+	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	ownedByPath := map[string][]string{}
+	var order []string
+	for k := range s.Keys {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(k, prefix)
+		// rest = "<portablePath>:<pointer>"; the pointer is a JSON pointer
+		// starting with '/', so the ":/" boundary is unambiguous even when
+		// the path itself contains characters like ':' (a Windows drive).
+		i := strings.Index(rest, ":/")
+		if i < 0 {
+			continue
+		}
+		path, ptr := rest[:i], rest[i+1:]
+		if renderedPaths[path] {
+			continue // a real merge op already handles removal here
+		}
+		if _, seen := ownedByPath[path]; !seen {
+			order = append(order, path)
+		}
+		ownedByPath[path] = append(ownedByPath[path], ptr)
+	}
+
+	var cleanup []adapter.FileOp
+	for _, path := range order {
+		abs := paths.FromHomeRelative(userHome, path)
+		// If the dest was already deleted, there's nothing to clean — skip so
+		// we don't create an empty "{}" file. PruneStaleState drops the entry.
+		if _, err := os.Stat(abs); err != nil {
+			continue
+		}
+		cleanup = append(cleanup, adapter.FileOp{
+			Action:        "write",
+			Path:          abs,
+			Content:       []byte("{}"),
+			Mode:          0o644,
+			MergeStrategy: strat,
+			OwnedKeys:     ownedByPath[path],
+		})
+	}
+	return cleanup
 }
 
 // Apply commits a RenderPlan by constructing one Writer per agent and

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -24,6 +24,13 @@ type AgentResult struct {
 	Skips []adapter.Skip
 }
 
+// isKeyMerge reports whether a MergeStrategy accumulates JSON pointers into a
+// shared file (rather than replacing the whole file). Such ops must never be
+// deduped by path — one agent emits several of them to the same destination.
+func isKeyMerge(strategy string) bool {
+	return strategy == "merge-json-keys" || strategy == "merge-jsonc-keys"
+}
+
 // Total returns the total number of FileOps across all agents.
 func (p RenderPlan) Total() int {
 	n := 0
@@ -97,10 +104,15 @@ func PreviewCollisions(
 			if op.Action != "" && op.Action != "write" {
 				continue
 			}
-			if seen[op.Path] {
-				continue
+			// Mirror Apply's dedup: only whole-file replace writes are
+			// collapsed by path. Key-merge ops all run; the writer's
+			// per-path backedUp guard prevents a duplicate collision report.
+			if !isKeyMerge(op.MergeStrategy) {
+				if seen[op.Path] {
+					continue
+				}
+				seen[op.Path] = true
 			}
-			seen[op.Path] = true
 			// We don't have the post-merge finalBytes here without
 			// re-running the adapter. For preview purposes a conservative
 			// "is something there that doesn't look exactly like our op"
@@ -173,7 +185,14 @@ func Apply(
 		}
 		var deduped []adapter.FileOp
 		for _, op := range res.Ops {
-			if op.Action == "write" {
+			// Only whole-file replace writes are deduped (e.g. a shared
+			// SKILL.md written identically by claude and opencode). Key-merge
+			// ops are NOT deduped: a single agent emits separate
+			// merge-json-keys ops to one file (claude writes mcpServers,
+			// hooks, AND lspServers to settings.json), and each must run —
+			// the adapter re-reads and merges per op. Deduping them by path
+			// silently dropped every merge op after the first.
+			if op.Action == "write" && !isKeyMerge(op.MergeStrategy) {
 				if seen[op.Path] {
 					continue
 				}

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -39,9 +39,10 @@ func (p RenderPlan) Total() int {
 // s may be nil; when non-nil, OwnedKeys is populated on merge-json-keys ops
 // from state.Keys so the apply pipeline knows which JSON-pointer paths it owns.
 //
-// home is required so OwnedKeys lookups match the HOME-relative form
-// state stores.
-func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets, home string) (RenderPlan, error) {
+// userHome (the user's $HOME, paths.HomeDir) is required so OwnedKeys
+// lookups match the HOME-relative form state stores. It is NOT the agentsync
+// home — dest files live under $HOME, not under ~/.agentsync.
+func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets, userHome string) (RenderPlan, error) {
 	out := RenderPlan{PerAgent: map[string]AgentResult{}}
 	for _, name := range agents {
 		a := reg.Lookup(name)
@@ -55,7 +56,7 @@ func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adap
 		if s != nil {
 			for i, op := range ops {
 				if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
-					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path, home)
+					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path, userHome)
 				}
 			}
 		}
@@ -77,6 +78,7 @@ func PreviewCollisions(
 	reg *adapter.Registry,
 	st *state.Targets,
 	home string,
+	userHome string,
 	scope adapter.Scope,
 	project string,
 ) []CollisionReport {
@@ -90,7 +92,7 @@ func PreviewCollisions(
 		if !ok {
 			continue
 		}
-		w := NewPreviewWriter(st, home, scope, project, name)
+		w := NewPreviewWriter(st, home, userHome, scope, project, name)
 		for _, op := range res.Ops {
 			if op.Action != "" && op.Action != "write" {
 				continue
@@ -114,9 +116,9 @@ func PreviewCollisions(
 
 // ownedKeysFor returns the JSON-pointer strings owned by agentsync for a given
 // agent+scope+project+path combination, as recorded in state.Keys.
-func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path, home string) []string {
+func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path, userHome string) []string {
 	prefix := fmt.Sprintf("%s:%s:%s:%s:", agent, scope.String(),
-		paths.HomeRelative(home, project), paths.HomeRelative(home, path))
+		paths.HomeRelative(userHome, project), paths.HomeRelative(userHome, path))
 	var out []string
 	for k := range s.Keys {
 		if strings.HasPrefix(k, prefix) {
@@ -146,6 +148,7 @@ func Apply(
 	reg *adapter.Registry,
 	st *state.Targets,
 	home string,
+	userHome string,
 	scope adapter.Scope,
 	project string,
 ) ([]CollisionReport, error) {
@@ -178,7 +181,7 @@ func Apply(
 			}
 			deduped = append(deduped, op)
 		}
-		w := NewWriter(st, home, scope, project, name)
+		w := NewWriter(st, home, userHome, scope, project, name)
 		if err := a.Apply(deduped, w); err != nil {
 			allReports = append(allReports, w.Reports()...)
 			return allReports, fmt.Errorf("apply %s: %w", name, err)

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -180,9 +180,15 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 			continue
 		}
 		rest := strings.TrimPrefix(k, prefix)
-		// rest = "<portablePath>:<pointer>"; the pointer is a JSON pointer
-		// starting with '/', so the ":/" boundary is unambiguous even when
-		// the path itself contains characters like ':' (a Windows drive).
+		// rest = "<portablePath>:<pointer>". The pointer is a JSON pointer
+		// that always starts with '/', so the ":/" sequence marks the
+		// boundary. This is reliable for the realistic path shapes: portable
+		// "${HOME}/..." paths and POSIX absolute paths contain no ':', and
+		// Windows absolute paths use '\' (so a drive is "C:\", not "C:/").
+		// In the pathological case where a path or pointer-key still contains
+		// a literal ":/", a mis-split yields a path that fails the os.Stat
+		// existence check below and is harmlessly skipped (the orphan simply
+		// isn't cleaned that run) — it never deletes the wrong data.
 		i := strings.Index(rest, ":/")
 		if i < 0 {
 			continue

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -230,9 +230,12 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 // write path adapters are permitted to use.
 //
 // Returns the union of CollisionReports across all agents so the caller
-// can surface them. If any adapter returns an error, applies completed
-// so far are NOT rolled back (each underlying iox.AtomicWrite is atomic
-// per-file, but the plan as a whole is not transactional).
+// can surface them, plus the set of destination paths actually written this
+// run (so the apply-error rescue can record state for exactly those files and
+// no others). If any adapter returns an error, applies completed so far are
+// NOT rolled back (each underlying iox.AtomicWrite is atomic per-file, but the
+// plan as a whole is not transactional); the reports and written-set returned
+// reflect the work done before the failure.
 //
 // Deduplication: when two adapters emit a "write" op for the same path
 // (e.g. a shared skill file written by both claude and opencode), the
@@ -246,13 +249,14 @@ func Apply(
 	userHome string,
 	scope adapter.Scope,
 	project string,
-) ([]CollisionReport, error) {
+) ([]CollisionReport, map[string]bool, error) {
+	written := map[string]bool{}
 	if st == nil {
 		// Defensive: a nil state would make every write look like a
 		// foreign collision and produce duplicate backups. Callers that
 		// don't yet have a state object should construct an empty one
 		// (state.New) rather than passing nil.
-		return nil, fmt.Errorf("render.Apply: nil state")
+		return nil, written, fmt.Errorf("render.Apply: nil state")
 	}
 
 	var allReports []CollisionReport
@@ -264,7 +268,7 @@ func Apply(
 		}
 		a := reg.Lookup(name)
 		if a == nil {
-			return allReports, fmt.Errorf("adapter %q not registered at apply", name)
+			return allReports, written, fmt.Errorf("adapter %q not registered at apply", name)
 		}
 		var deduped []adapter.FileOp
 		for _, op := range res.Ops {
@@ -284,11 +288,14 @@ func Apply(
 			deduped = append(deduped, op)
 		}
 		w := NewWriter(st, home, userHome, scope, project, name)
-		if err := a.Apply(deduped, w); err != nil {
-			allReports = append(allReports, w.Reports()...)
-			return allReports, fmt.Errorf("apply %s: %w", name, err)
-		}
+		err := a.Apply(deduped, w)
 		allReports = append(allReports, w.Reports()...)
+		for path := range w.Wrote() {
+			written[path] = true
+		}
+		if err != nil {
+			return allReports, written, fmt.Errorf("apply %s: %w", name, err)
+		}
 	}
-	return allReports, nil
+	return allReports, written, nil
 }

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -83,7 +83,7 @@ func TestPipeline_DedupesIdenticalWritesAcrossAdapters(t *testing.T) {
 		},
 	}
 
-	if _, err := render.Apply(plan, reg, state.New(), t.TempDir(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
+	if _, _, err := render.Apply(plan, reg, state.New(), t.TempDir(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -83,7 +83,7 @@ func TestPipeline_DedupesIdenticalWritesAcrossAdapters(t *testing.T) {
 		},
 	}
 
-	if _, err := render.Apply(plan, reg, state.New(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
+	if _, err := render.Apply(plan, reg, state.New(), t.TempDir(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -23,14 +23,15 @@ import (
 // ~/.agentsync/ leaves its state entry behind forever; it shows up as
 // `Orphan` in `status` and `targets.json` grows unbounded over time.
 //
-// The home argument is used to normalize op.Path to its HOME-relative
-// form so state-key lookups match keys written by RecordOpsState (which
-// stores HOME-relative paths for cross-machine portability).
-func PruneStaleState(s *state.Targets, home, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) {
+// The userHome argument (the user's $HOME, paths.HomeDir) is used to
+// normalize op.Path to its HOME-relative form so state-key lookups match
+// keys written by RecordOpsState. It must NOT be the agentsync home — dest
+// files live under $HOME, not under ~/.agentsync.
+func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) {
 	if s == nil {
 		return
 	}
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(home, project))
+	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
 
 	// Build the set of paths and per-path pointer sets that this agent's
 	// current plan still produces. Paths are normalized to HOME-relative
@@ -41,7 +42,7 @@ func PruneStaleState(s *state.Targets, home, agent string, scope adapter.Scope, 
 		if op.Action != "" && op.Action != "write" {
 			continue
 		}
-		portable := paths.HomeRelative(home, op.Path)
+		portable := paths.HomeRelative(userHome, op.Path)
 		switch op.MergeStrategy {
 		case "merge-json-keys", "merge-jsonc-keys":
 			ptrs, ok := currentKeys[portable]
@@ -100,19 +101,20 @@ func PruneStaleState(s *state.Targets, home, agent string, scope adapter.Scope, 
 // Caller is expected to call this AFTER a successful Apply.
 //
 // Both op.Path and project are normalized to HOME-relative form via
-// paths.HomeRelative before being embedded in the state-map keys, so the
-// resulting targets.json is portable across machines whose $HOME differs
-// (e.g. /Users/alice/ vs /home/alice/ after a chezmoi sync). Without
-// this, every key prefix would shift on the new machine and every
-// native file would reclassify as ForeignCollision.
-func RecordOpsState(s *state.Targets, home, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
+// paths.HomeRelative (against userHome, the user's $HOME) before being
+// embedded in the state-map keys, so the resulting targets.json is portable
+// across machines whose $HOME differs (e.g. /Users/alice/ vs /home/alice/
+// after a chezmoi sync). userHome must NOT be the agentsync home: dest files
+// live under $HOME, not under ~/.agentsync, so using the agentsync home as
+// the base leaves every key machine-absolute and unportable.
+func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
 	now := time.Now().UTC()
-	portableProject := paths.HomeRelative(home, project)
+	portableProject := paths.HomeRelative(userHome, project)
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
 			continue
 		}
-		portablePath := paths.HomeRelative(home, op.Path)
+		portablePath := paths.HomeRelative(userHome, op.Path)
 		switch op.MergeStrategy {
 		case "merge-json-keys", "merge-jsonc-keys":
 			// Re-read final on-disk content and record per pointer.

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -75,11 +75,14 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 			continue
 		}
 		rest := strings.TrimPrefix(key, prefix)
-		// rest = "<path>:<pointer>"; find the LAST ':' isn't safe because
-		// pointers can contain ':'. Use strings.Index since we know the
-		// path part can also contain ':'. Match against currentKeys instead:
-		// look for any path in currentKeys that is a prefix of rest with a
-		// trailing ':<ptr>'.
+		// rest = "<path>:<pointer>", and BOTH path and pointer can contain
+		// ':' (e.g. a Windows "C:"-drive dest path), so the split point is
+		// ambiguous. Test every currentKeys path whose "path:" prefixes rest
+		// and keep the key if ANY of them owns the remaining pointer. We must
+		// NOT stop at the first prefix match: when one path is a colon-
+		// delimited string-prefix of another, the first candidate (map order
+		// is random) may be the wrong one, and breaking there would prune a
+		// live key.
 		matched := false
 		for path, ptrs := range currentKeys {
 			if !strings.HasPrefix(rest, path+":") {
@@ -88,8 +91,8 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 			ptr := strings.TrimPrefix(rest, path+":")
 			if _, ok := ptrs[ptr]; ok {
 				matched = true
+				break
 			}
-			break
 		}
 		if !matched {
 			delete(s.Keys, key)

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -170,6 +170,33 @@ func TestState_PortableAcrossHomes(t *testing.T) {
 	}
 }
 
+// TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey is the regression for
+// the prune bug where the Keys loop broke after the FIRST path whose
+// "path:" prefixed the key, even when that path's pointer set didn't match.
+// When one dest path is a colon-delimited string-prefix of another (e.g. a
+// Windows "C:"-drive path, or any path containing ':'), the wrong candidate
+// could be picked first (map order is random) and a live key pruned —
+// dropping ownership and forcing a needless foreign-collision backup next
+// apply. Looped to defeat map-iteration randomness: the old code failed
+// ~half the time, the fix passes every time.
+func TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey(t *testing.T) {
+	ops := []adapter.FileOp{
+		{Action: "write", Path: "a", MergeStrategy: "merge-json-keys", Content: []byte(`{"x":1}`)},
+		{Action: "write", Path: "a:b", MergeStrategy: "merge-json-keys", Content: []byte(`{"realptr":1}`)},
+	}
+	const liveKey = "claude:user::a:b:/realptr"
+	for i := 0; i < 64; i++ {
+		s := state.New()
+		s.Keys[liveKey] = state.KeyEntry{SHA256: "deadbeef"}
+		s.Keys["claude:user::a:/x"] = state.KeyEntry{SHA256: "feed"}
+		// userHome "" so HomeRelative leaves the colon-bearing paths intact.
+		render.PruneStaleState(s, "", "claude", adapter.ScopeUser, "", ops)
+		if _, ok := s.Keys[liveKey]; !ok {
+			t.Fatalf("iteration %d: live key %q wrongly pruned (ambiguous path prefix)", i, liveKey)
+		}
+	}
+}
+
 func TestRecordState_SkipsDeleteOps(t *testing.T) {
 	s := state.New()
 	err := render.RecordOpsState(s, "/tmp", "claude", adapter.ScopeUser, "", []adapter.FileOp{{

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -131,45 +132,42 @@ func TestPruneStaleState_DropsRemovedKeys(t *testing.T) {
 // works on either machine.
 func TestState_PortableAcrossHomes(t *testing.T) {
 	s := state.New()
-	// Machine A wrote state under /Users/alice/.
-	macHome := "/Users/alice"
-	macPath := "/Users/alice/.claude.json"
-	if err := writeKey(s, macHome, "claude", adapter.ScopeUser, "", macPath); err != nil {
+	// Machine A wrote state under its $HOME. We drive the REAL
+	// RecordOpsState path (not a hand-faked key) so this test would have
+	// caught the bug where the normalization base was the agentsync home
+	// rather than the user's $HOME and the key stayed machine-absolute.
+	macHome := t.TempDir() // stand-in for /Users/alice
+	macPath := filepath.Join(macHome, ".claude.json")
+	if err := os.WriteFile(macPath, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Machine B reads the same state under /home/alice/.
-	linuxHome := "/home/alice"
-	linuxPath := "/home/alice/.claude.json"
+	if err := render.RecordOpsState(s, macHome, "claude", adapter.ScopeUser, "", []adapter.FileOp{
+		{Action: "write", Path: macPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	gotKey := "claude:user::${HOME}/.claude.json"
 	if _, ok := s.Files[gotKey]; !ok {
-		t.Fatalf("expected portable key %q; have %v", gotKey, s.Files)
+		t.Fatalf("RecordOpsState did not produce a portable key %q; have %v", gotKey, s.Files)
 	}
-	// Now PruneStaleState on machine B with the same logical op should
-	// recognise the entry as still-present (not stale).
+	// The machine-absolute path must NOT appear anywhere in the keys.
+	for k := range s.Files {
+		if strings.Contains(k, macHome) {
+			t.Fatalf("state key embeds machine-absolute path %q: %q", macHome, k)
+		}
+	}
+
+	// Machine B reads the same state under a DIFFERENT $HOME. PruneStaleState
+	// with the same logical op must recognise the entry as still-present.
+	linuxHome := t.TempDir() // stand-in for /home/alice
+	linuxPath := filepath.Join(linuxHome, ".claude.json")
 	render.PruneStaleState(s, linuxHome, "claude", adapter.ScopeUser, "", []adapter.FileOp{
 		{Action: "write", Path: linuxPath},
 	})
 	if _, ok := s.Files[gotKey]; !ok {
 		t.Fatalf("portable key pruned on machine B; have %v", s.Files)
 	}
-}
-
-// writeKey is a tiny test helper that calls RecordOpsState with a single
-// file op so the test stays focused on the key shape, not the
-// per-op-type record path.
-func writeKey(s *state.Targets, home, agent string, sc adapter.Scope, project, path string) error {
-	tmp, _ := os.CreateTemp("", "agentsync-state-test-*")
-	tmpPath := tmp.Name()
-	_ = tmp.Close()
-	defer func() { _ = os.Remove(tmpPath) }()
-	_ = os.WriteFile(tmpPath, []byte("hello"), 0o644)
-	// Manually format the portable key — we can't call RecordOpsState
-	// because it reads the file at op.Path post-apply, and we want to
-	// pin the key shape, not the I/O.
-	s.Files[agent+":"+sc.String()+":"+project+":${HOME}/"+filepath.Base(path)] = state.FileEntry{
-		SHA256: "deadbeef",
-	}
-	return nil
 }
 
 func TestRecordState_SkipsDeleteOps(t *testing.T) {

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -85,6 +85,7 @@ type Writer struct {
 
 	backupRoot string          // <home>/.state/backups/<ts>; created lazily
 	backedUp   map[string]bool // path → already-backed-up this run
+	wrote      map[string]bool // path → destination actually written this run
 	reports    []CollisionReport
 	// dryRun, when true, skips both the destination write AND the backup
 	// write. The reports slice is still populated so callers can preview
@@ -130,6 +131,7 @@ func NewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, pr
 		agent:      agent,
 		backupRoot: filepath.Join(home, ".state", "backups", ts),
 		backedUp:   map[string]bool{},
+		wrote:      map[string]bool{},
 	}
 }
 
@@ -146,6 +148,12 @@ func NewPreviewWriter(st *state.Targets, home, userHome string, scope adapter.Sc
 // Safe to call after Apply completes.
 func (w *Writer) Reports() []CollisionReport { return w.reports }
 
+// Wrote returns the set of destination paths this writer actually wrote.
+// Used by the apply-error rescue to record state ONLY for files agentsync
+// committed this run — a pre-existing foreign file at an op that was never
+// attempted must not be recorded as owned (that would suppress its backup).
+func (w *Writer) Wrote() map[string]bool { return w.wrote }
+
 // Write satisfies adapter.DestWriter. finalBytes is the post-merge content
 // for merge ops, or op.Content for replace ops.
 func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
@@ -156,7 +164,11 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 	if mode == 0 {
 		mode = 0o644
 	}
-	return iox.AtomicWrite(op.Path, finalBytes, mode)
+	if err := iox.AtomicWrite(op.Path, finalBytes, mode); err != nil {
+		return err
+	}
+	w.wrote[op.Path] = true
+	return nil
 }
 
 // Delete satisfies adapter.DestWriter. Idempotent on missing files.

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -32,11 +32,18 @@ import (
 // iox.AtomicWrite call outside the allowed packages, so a future
 // contributor cannot silently bypass this guard.
 type Writer struct {
-	state   *state.Targets
-	home    string
-	scope   adapter.Scope
-	project string
-	agent   string
+	state *state.Targets
+	// home is the agentsync home (~/.agentsync); it anchors the backup
+	// root only. userHome is the user's $HOME (paths.HomeDir) and is the
+	// base for HomeRelative state-key normalization — dest files like
+	// ~/.claude.json live under userHome, NOT under the agentsync home, so
+	// using home here would never normalize them (the cross-machine
+	// portability no-op fixed in this change).
+	home     string
+	userHome string
+	scope    adapter.Scope
+	project  string
+	agent    string
 
 	backupRoot string          // <home>/.state/backups/<ts>; created lazily
 	backedUp   map[string]bool // path → already-backed-up this run
@@ -65,12 +72,15 @@ func (r CollisionReport) String() string {
 }
 
 // NewWriter constructs a Writer for one (agent, scope, project) tuple.
-// The render layer creates one writer per agent during Apply.
-func NewWriter(st *state.Targets, home string, scope adapter.Scope, project, agent string) *Writer {
+// The render layer creates one writer per agent during Apply. home is the
+// agentsync home (backup root); userHome is the user's $HOME (state-key
+// normalization base).
+func NewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, project, agent string) *Writer {
 	ts := time.Now().UTC().Format("20060102T150405Z")
 	return &Writer{
 		state:      st,
 		home:       home,
+		userHome:   userHome,
 		scope:      scope,
 		project:    project,
 		agent:      agent,
@@ -82,8 +92,8 @@ func NewWriter(st *state.Targets, home string, scope adapter.Scope, project, age
 // NewPreviewWriter constructs a Writer that records foreign-collision
 // reports without performing any disk writes. Used by `apply --dry-run` to
 // surface the same backup-and-overwrite events a real apply would produce.
-func NewPreviewWriter(st *state.Targets, home string, scope adapter.Scope, project, agent string) *Writer {
-	w := NewWriter(st, home, scope, project, agent)
+func NewPreviewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, project, agent string) *Writer {
+	w := NewWriter(st, home, userHome, scope, project, agent)
 	w.dryRun = true
 	return w
 }
@@ -129,7 +139,7 @@ func (w *Writer) maybeBackup(op adapter.FileOp, finalBytes []byte) error {
 
 func (w *Writer) maybeBackupFileOp(op adapter.FileOp, finalBytes []byte) error {
 	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
-		paths.HomeRelative(w.home, w.project), paths.HomeRelative(w.home, op.Path))
+		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
 	if _, owned := w.state.Files[stateKey]; owned {
 		return nil
 	}
@@ -169,8 +179,8 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 	}
 
 	var backupPath string
-	portableProject := paths.HomeRelative(w.home, w.project)
-	portablePath := paths.HomeRelative(w.home, op.Path)
+	portableProject := paths.HomeRelative(w.userHome, w.project)
+	portablePath := paths.HomeRelative(w.userHome, op.Path)
 	for _, ptr := range CollectPointers(ours, "") {
 		stateKey := fmt.Sprintf("%s:%s:%s:%s:%s", w.agent, w.scope.String(), portableProject, portablePath, ptr)
 		if _, owned := w.state.Keys[stateKey]; owned {
@@ -204,7 +214,7 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 // back up the whole file once if state has no entries claiming the path.
 func (w *Writer) maybeBackupFileOpForJSONCFallback(op adapter.FileOp) error {
 	stateKeyPrefix := fmt.Sprintf("%s:%s:%s:%s:", w.agent, w.scope.String(),
-		paths.HomeRelative(w.home, w.project), paths.HomeRelative(w.home, op.Path))
+		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
 	for k := range w.state.Keys {
 		if strings.HasPrefix(k, stateKeyPrefix) {
 			return nil // state owns at least one pointer here; trust the merge

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,43 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// DefaultBackupKeep is how many backup-timestamp dirs apply retains.
+const DefaultBackupKeep = 20
+
+// PruneBackups removes all but the most recent `keep` timestamp directories
+// under <home>/.state/backups. Each backup is a verbatim copy of a
+// pre-existing native config file (which may contain secrets), so they must
+// not accumulate unbounded — a disk-bloat and credential-lingering concern.
+// The dir names are zero-padded, fixed-width timestamps, so lexical sort is
+// chronological. Best-effort: a removal error for one dir doesn't abort.
+func PruneBackups(home string, keep int) error {
+	if keep < 0 {
+		return nil
+	}
+	root := filepath.Join(home, ".state", "backups")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	if len(dirs) <= keep {
+		return nil
+	}
+	sort.Strings(dirs) // ascending → oldest first
+	for _, d := range dirs[:len(dirs)-keep] {
+		_ = os.RemoveAll(filepath.Join(root, d))
+	}
+	return nil
+}
 
 // Writer is THE funnel for native-destination writes. Every adapter's
 // Apply method receives one of these and routes its writes through it

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -76,7 +76,13 @@ func (r CollisionReport) String() string {
 // agentsync home (backup root); userHome is the user's $HOME (state-key
 // normalization base).
 func NewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, project, agent string) *Writer {
-	ts := time.Now().UTC().Format("20060102T150405Z")
+	// Include the nanosecond offset so two applies in the same wall-clock
+	// second (e.g. a user-scope apply immediately followed by a project-scope
+	// one, or a retried apply) don't share a backup root and silently clobber
+	// each other's pre-existing-file copies. The global lock serializes
+	// applies, so successive runs always land on distinct nanoseconds.
+	now := time.Now().UTC()
+	ts := fmt.Sprintf("%s-%09d", now.Format("20060102T150405Z"), now.Nanosecond())
 	return &Writer{
 		state:      st,
 		home:       home,

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -82,7 +82,7 @@ func TestWriter_FileLevelBackup(t *testing.T) {
 	_ = os.WriteFile(dest, original, 0o644)
 
 	st := state.New()
-	w := render.NewWriter(st, home, adapter.ScopeUser, "", "claude")
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	op := adapter.FileOp{
 		Action:   "write",
 		Path:     dest,
@@ -133,7 +133,7 @@ func TestWriter_KeyLevelBackup(t *testing.T) {
 	_ = os.WriteFile(dest, original, 0o644)
 
 	st := state.New()
-	w := render.NewWriter(st, home, adapter.ScopeUser, "", "claude")
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	ours := []byte(`{"mcpServers":{"github":{"command":"npx","args":["-y","@m/server-github"]}}}`)
 	op := adapter.FileOp{
 		Action:        "write",
@@ -181,9 +181,12 @@ func TestWriter_NoCollisionWhenAlreadyOwned(t *testing.T) {
 	_ = os.WriteFile(dest, []byte("ours-v1"), 0o644)
 
 	st := state.New()
-	st.Files["claude:user::"+dest] = state.FileEntry{SHA256: "anything"}
+	// State keys are HOME-relative against the user's $HOME (here tmp), so an
+	// owned dest under tmp is recorded as "${HOME}/<rel>".
+	rel, _ := filepath.Rel(tmp, dest)
+	st.Files["claude:user::${HOME}/"+filepath.ToSlash(rel)] = state.FileEntry{SHA256: "anything"}
 
-	w := render.NewWriter(st, home, adapter.ScopeUser, "", "claude")
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	op := adapter.FileOp{Action: "write", Path: dest, Content: []byte("ours-v2"), Mode: 0o644}
 	if err := w.Write(op, op.Content); err != nil {
 		t.Fatal(err)
@@ -208,7 +211,7 @@ func TestWriter_NoCollisionWhenContentMatches(t *testing.T) {
 	_ = os.WriteFile(dest, content, 0o644)
 
 	st := state.New()
-	w := render.NewWriter(st, home, adapter.ScopeUser, "", "claude")
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	if err := w.Write(adapter.FileOp{Action: "write", Path: dest, Content: content}, content); err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +230,7 @@ func TestWriter_DeleteSkipsBackup(t *testing.T) {
 	_ = os.WriteFile(dest, []byte("bye"), 0o644)
 
 	st := state.New()
-	w := render.NewWriter(st, home, adapter.ScopeUser, "", "claude")
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	if err := w.Delete(adapter.FileOp{Action: "delete", Path: dest}); err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +269,7 @@ func TestRenderApply_FullPathBacksUpAcrossAgents(t *testing.T) {
 		},
 	}
 	st := state.New()
-	reports, err := render.Apply(plan, reg, st, home, adapter.ScopeUser, "")
+	reports, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -242,6 +242,51 @@ func TestWriter_DeleteSkipsBackup(t *testing.T) {
 	}
 }
 
+// TestRenderApply_MultipleMergeOpsSamePathAllApplied is the regression for
+// the dedup bug: render.Apply skipped any second Action=="write" op for a
+// path already seen, but that swept up merge-json-keys ops too. The claude
+// adapter emits separate merge ops to settings.json for MCP, hooks, and LSP;
+// deduping by path silently dropped hooks and LSP. Merge ops to the same
+// path must ALL run (the adapter re-reads and merges each), so only
+// whole-file replace writes may be deduped.
+func TestRenderApply_MultipleMergeOpsSamePathAllApplied(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+	dest := filepath.Join(tmp, ".claude", "settings.json")
+	_ = os.MkdirAll(filepath.Dir(dest), 0o755)
+
+	reg := adapter.NewRegistry()
+	_ = reg.Register(&fakeJSONApply{name: "claude"})
+
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude": {Ops: []adapter.FileOp{
+				{Action: "write", Path: dest, Content: []byte(`{"mcpServers":{"a":1}}`), MergeStrategy: "merge-json-keys", Mode: 0o644},
+				{Action: "write", Path: dest, Content: []byte(`{"hooks":{"PreToolUse":"echo"}}`), MergeStrategy: "merge-json-keys", Mode: 0o644},
+				{Action: "write", Path: dest, Content: []byte(`{"lspServers":{"go":{"command":"gopls"}}}`), MergeStrategy: "merge-json-keys", Mode: 0o644},
+			}},
+		},
+	}
+	if _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse settings.json: %v\n%s", err, data)
+	}
+	for _, key := range []string{"mcpServers", "hooks", "lspServers"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("merge op for %q was dropped; settings.json = %s", key, data)
+		}
+	}
+}
+
 // TestRenderApply_FullPathBacksUpAcrossAgents exercises the integrated
 // path: render.Apply constructs one writer per agent, each agent's
 // Apply routes through it, and the union of reports is returned.

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -270,7 +270,7 @@ func TestRenderApply_MultipleMergeOpsSamePathAllApplied(t *testing.T) {
 			}},
 		},
 	}
-	if _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
+	if _, _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
@@ -316,7 +316,7 @@ func TestRenderApply_FullPathBacksUpAcrossAgents(t *testing.T) {
 		},
 	}
 	st := state.New()
-	reports, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, "")
+	reports, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -33,6 +33,8 @@ func (f *fakeJSONApply) Ingest(_ adapter.Scope, _ string) (source.Canonical, err
 	return source.Canonical{}, nil
 }
 
+func (f *fakeJSONApply) KeyMergeStrategy() string { return "merge-json-keys" }
+
 // Apply mirrors the production adapter pattern: for replace ops, hand
 // op.Content to the writer; for merge ops, do the merge first and pass
 // the result.

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -361,3 +361,37 @@ func TestPruneBackups_KeepsNewest(t *testing.T) {
 		t.Fatalf("missing backups dir should be a no-op: %v", err)
 	}
 }
+
+// TestWriter_JSONCFallbackBacksUpWholeFile covers maybeBackupFileOpForJSONCFallback
+// (previously 0% covered): a merge op whose destination is JSONC (comments
+// make strict json.Unmarshal fail) and which state does not own must be
+// backed up whole-file before the merge writes.
+func TestWriter_JSONCFallbackBacksUpWholeFile(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+	dest := filepath.Join(tmp, "opencode.json")
+	original := []byte("// my hand-written config\n{\"mcp\":{\"github\":{\"command\":\"old\"}}}\n")
+	_ = os.WriteFile(dest, original, 0o644)
+
+	st := state.New() // nothing owned → must back up
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "opencode")
+	op := adapter.FileOp{
+		Action:        "write",
+		Path:          dest,
+		Content:       []byte(`{"mcp":{"github":{"command":"new"}}}`),
+		MergeStrategy: "merge-json-keys",
+		Mode:          0o644,
+	}
+	if err := w.Write(op, []byte(`{"mcp":{"github":{"command":"new"}}}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	reports := w.Reports()
+	if len(reports) != 1 || reports[0].Pointer != "" {
+		t.Fatalf("expected one whole-file (no-pointer) backup; got %+v", reports)
+	}
+	got, _ := os.ReadFile(reports[0].BackupTo)
+	if !strings.Contains(string(got), "old") {
+		t.Fatalf("JSONC-fallback backup missing original content: %s", got)
+	}
+}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -327,3 +327,37 @@ func TestRenderApply_FullPathBacksUpAcrossAgents(t *testing.T) {
 		t.Fatalf("backup not under <home>/.state/backups: %s", reports[0].BackupTo)
 	}
 }
+
+// TestPruneBackups_KeepsNewest verifies bounded backup retention: the most
+// recent `keep` timestamp dirs survive, older ones are removed.
+func TestPruneBackups_KeepsNewest(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".state", "backups")
+	names := []string{
+		"20260101T000001Z-000000001",
+		"20260101T000002Z-000000001",
+		"20260101T000003Z-000000001",
+		"20260101T000004Z-000000001",
+	}
+	for _, n := range names {
+		if err := os.MkdirAll(filepath.Join(root, n), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := render.PruneBackups(home, 2); err != nil {
+		t.Fatal(err)
+	}
+	left, _ := os.ReadDir(root)
+	if len(left) != 2 {
+		t.Fatalf("want 2 backups kept, got %d", len(left))
+	}
+	for _, e := range left {
+		if e.Name() < "20260101T000003Z" {
+			t.Fatalf("pruned the wrong (newer) dir; kept %s", e.Name())
+		}
+	}
+	// Missing backups root is a no-op, not an error.
+	if err := render.PruneBackups(t.TempDir(), 2); err != nil {
+		t.Fatalf("missing backups dir should be a no-op: %v", err)
+	}
+}

--- a/internal/secrets/age.go
+++ b/internal/secrets/age.go
@@ -14,7 +14,7 @@ import (
 )
 
 // AgeBackend reads an age-encrypted TOML file (secrets.age), decrypts it using
-// the identity file specified in opensync.toml [secrets], parses as TOML, and
+// the identity file specified in agentsync.toml [secrets], parses as TOML, and
 // resolves dotted keys. Cleartext is held in memory only and never written to
 // durable storage.
 type AgeBackend struct {

--- a/internal/secrets/age.go
+++ b/internal/secrets/age.go
@@ -62,7 +62,11 @@ func (b *AgeBackend) load() error {
 	if err := toml.Unmarshal(raw, &top); err != nil {
 		return fmt.Errorf("parse decrypted as TOML: %w", err)
 	}
-	b.cache = flatten("", top)
+	cache, err := flatten("", top)
+	if err != nil {
+		return fmt.Errorf("parse decrypted secrets: %w", err)
+	}
+	b.cache = cache
 	return nil
 }
 
@@ -81,7 +85,12 @@ func (b *AgeBackend) Resolve(dottedKey string) (string, error) {
 // flatten recursively converts a nested map[string]any into a flat
 // map[string]string with dotted keys, e.g. {"github": {"token": "x"}} ->
 // {"github.token": "x"}.
-func flatten(prefix string, m map[string]any) map[string]string {
+//
+// Non-string leaf values (numbers, bools, arrays, datetimes) are rejected
+// rather than coerced via fmt.Sprint: a TOML `token = 0123` would otherwise
+// resolve to "123" (or "83" for octal) and an array to Go's "[a b]" syntax,
+// substituting a silently-wrong credential into the user's agent config.
+func flatten(prefix string, m map[string]any) (map[string]string, error) {
 	out := map[string]string{}
 	for k, v := range m {
 		key := k
@@ -90,16 +99,20 @@ func flatten(prefix string, m map[string]any) map[string]string {
 		}
 		switch vv := v.(type) {
 		case map[string]any:
-			for kk, vvv := range flatten(key, vv) {
+			sub, err := flatten(key, vv)
+			if err != nil {
+				return nil, err
+			}
+			for kk, vvv := range sub {
 				out[kk] = vvv
 			}
 		case string:
 			out[key] = vv
 		default:
-			out[key] = fmt.Sprint(vv)
+			return nil, fmt.Errorf("secret %q has a non-string value (%T); secret values must be quoted strings", key, vv)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // Encrypt writes plaintext as-is, encrypted to the given age X25519

--- a/internal/secrets/age_test.go
+++ b/internal/secrets/age_test.go
@@ -3,6 +3,7 @@ package secrets_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"filippo.io/age"
@@ -38,6 +39,34 @@ api_key = "lin_xyz"
 	}
 	if v, err := b.Resolve("linear.api_key"); err != nil || v != "lin_xyz" {
 		t.Fatalf("linear.api_key = %q (err: %v)", v, err)
+	}
+}
+
+// TestAgeBackend_NonStringValueRejected is the regression for the bug where
+// flatten coerced non-string TOML leaves via fmt.Sprint: a numeric secret
+// like `token = 0123` silently resolved to "123" instead of erroring, so a
+// mistyped (unquoted) credential landed wrong in the agent config with no
+// diagnostic. Now load() fails loudly.
+func TestAgeBackend_NonStringValueRejected(t *testing.T) {
+	tmp := t.TempDir()
+	id, _ := age.GenerateX25519Identity()
+	idPath := filepath.Join(tmp, "id.txt")
+	if err := os.WriteFile(idPath, []byte(id.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agePath := filepath.Join(tmp, "secrets.age")
+	// token is an unquoted integer — a common mistake.
+	if err := secrets_pkg.Encrypt([]byte("[github]\ntoken = 1234\n"), id.Recipient().String(), agePath); err != nil {
+		t.Fatal(err)
+	}
+
+	b := secrets_pkg.NewAgeBackend(agePath, idPath)
+	_, err := b.Resolve("github.token")
+	if err == nil {
+		t.Fatal("expected error resolving a non-string secret value; got nil")
+	}
+	if !strings.Contains(err.Error(), "non-string") {
+		t.Fatalf("error should explain the non-string value; got: %v", err)
 	}
 }
 

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/source"
@@ -81,6 +82,79 @@ func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
 			out[k] = v
 		}
 	}
+	return out
+}
+
+// UnresolvedSecretRefs returns the sorted, de-duplicated set of ${secret:KEY}
+// reference keys in c that sec cannot resolve. Callers that print content
+// derived from a destination file written by a prior apply (notably
+// `agentsync diff`) use this to fail closed: if a secret reference cannot be
+// resolved now, the cleartext value substituted into that on-disk file on the
+// last apply cannot be redacted, so the safe action is to refuse rather than
+// leak it to stdout / logs / screenshots.
+//
+// ${env:…} references are intentionally excluded — the env backend is always
+// available, and an unresolved env ref is not a credential-leak risk.
+//
+// The walked field set mirrors CollectResolved / SubstituteCanonical.
+func UnresolvedSecretRefs(c *source.Canonical, sec Resolver) []string {
+	if c == nil {
+		return nil
+	}
+	missing := map[string]bool{}
+	scan := func(s string) {
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			if len(m) < 3 || m[1] != "secret" {
+				continue
+			}
+			key := m[2]
+			if _, err := sec.Resolve(key); err != nil {
+				missing[key] = true
+			}
+		}
+	}
+	for _, srv := range c.MCPServers {
+		scan(srv.Server.Command)
+		scan(srv.Server.URL)
+		for _, a := range srv.Server.Args {
+			scan(a)
+		}
+		for _, v := range srv.Server.Env {
+			scan(v)
+		}
+		for _, v := range srv.Server.Headers {
+			scan(v)
+		}
+	}
+	for _, h := range c.Hooks {
+		scan(h.Command)
+	}
+	for _, ls := range c.LSPServers {
+		scan(ls.Spec.Command)
+		scan(ls.Spec.URL)
+		for _, a := range ls.Spec.Args {
+			scan(a)
+		}
+		for _, v := range ls.Spec.Env {
+			scan(v)
+		}
+		for _, v := range ls.Spec.Headers {
+			scan(v)
+		}
+	}
+	if c.Project != nil {
+		for _, k := range UnresolvedSecretRefs(c.Project, sec) {
+			missing[k] = true
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(missing))
+	for k := range missing {
+		out = append(out, k)
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/secrets/mask_test.go
+++ b/internal/secrets/mask_test.go
@@ -82,3 +82,43 @@ func TestCollectResolved_SkipsUnresolved(t *testing.T) {
 		t.Fatalf("expected no entries for unresolvable refs, got %v", got)
 	}
 }
+
+// TestUnresolvedSecretRefs_FlagsUnresolvable is the regression for the
+// diff-leak: CollectResolved silently skips ${secret:…} refs the backend
+// cannot resolve (age key locked/absent), so the cleartext value already on
+// disk would print unredacted. UnresolvedSecretRefs surfaces those keys so
+// `diff` can fail closed instead of leaking. ${env:…} refs are intentionally
+// ignored — the env backend is always available and is not a leak risk.
+func TestUnresolvedSecretRefs_FlagsUnresolvable(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "github", Server: source.MCPServerSpec{
+				Env: map[string]string{
+					"GITHUB_TOKEN": "${secret:github.token}",
+					"HOST":         "${env:MY_HOST}",
+				},
+			}},
+		},
+		Hooks: []source.Hook{{Command: "echo ${secret:other.key}"}},
+	}
+	// Backend resolves github.token but NOT other.key (mimics a partially
+	// available backend / locked identity for some keys).
+	sec := mapBackend{"github.token": "ghp_x"}
+	got := secrets.UnresolvedSecretRefs(&c, sec)
+	if len(got) != 1 || got[0] != "other.key" {
+		t.Fatalf("want [other.key], got %v", got)
+	}
+}
+
+// TestUnresolvedSecretRefs_NoneWhenAllResolve confirms the common case does
+// not trip the fail-closed guard: every ${secret:…} resolves, and ${env:…}
+// refs are ignored entirely.
+func TestUnresolvedSecretRefs_NoneWhenAllResolve(t *testing.T) {
+	c := source.Canonical{
+		Hooks: []source.Hook{{Command: "echo ${secret:a} ${env:B}"}},
+	}
+	sec := mapBackend{"a": "secret-a"}
+	if got := secrets.UnresolvedSecretRefs(&c, sec); len(got) != 0 {
+		t.Fatalf("want none, got %v", got)
+	}
+}

--- a/internal/secrets/secretpaths.go
+++ b/internal/secrets/secretpaths.go
@@ -1,0 +1,68 @@
+package secrets
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// DefaultAgeFile is the encrypted-secrets location relative to the agentsync
+// home, used when [secrets].file is unset (it is optional in the init
+// template). apply, verify, diff, doctor, and the `secrets` subcommands MUST
+// resolve the age file the same way — otherwise a user who omits `file` can
+// `secrets set` / `secrets get` successfully (those default the path) yet have
+// apply fail to find the same file.
+const DefaultAgeFile = "secrets/secrets.age"
+
+// ResolveAgeFile returns the absolute path to the encrypted secrets file.
+// An empty cfg.File falls back to DefaultAgeFile. ${env:HOME} and a leading
+// ~ are expanded via userHome; relative paths are joined under agentsyncHome.
+func ResolveAgeFile(cfg source.SecretsConfig, agentsyncHome, userHome string) string {
+	f := cfg.File
+	if f == "" {
+		f = DefaultAgeFile
+	}
+	return resolveSecretPath(f, agentsyncHome, userHome)
+}
+
+// ResolveIdentityFile returns the absolute path to the age identity (private
+// key) file, expanding ${env:HOME} / leading ~ via userHome and joining
+// relative paths under agentsyncHome. An empty identity_file returns "".
+//
+// The init template ships identity_file = "${env:HOME}/.config/agentsync/age.key";
+// without this expansion AgeBackend.load would os.ReadFile the literal
+// "${env:HOME}/..." string and fail at apply time even though doctor/verify
+// (which expanded it for their stat check) reported the config healthy.
+func ResolveIdentityFile(cfg source.SecretsConfig, agentsyncHome, userHome string) string {
+	if cfg.IdentityFile == "" {
+		return ""
+	}
+	return resolveSecretPath(cfg.IdentityFile, agentsyncHome, userHome)
+}
+
+func resolveSecretPath(p, agentsyncHome, userHome string) string {
+	p = expandHome(p, userHome)
+	if p == "" || filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(agentsyncHome, p)
+}
+
+// expandHome replaces every ${env:HOME} occurrence and a leading ~ with
+// userHome. userHome should be paths.HomeDir(...) so it honours
+// AGENTSYNC_TARGET_ROOT (test redirection) the same way the rest of agentsync
+// resolves "home".
+func expandHome(p, userHome string) string {
+	if userHome == "" {
+		return p
+	}
+	p = strings.ReplaceAll(p, "${env:HOME}", userHome)
+	switch {
+	case p == "~":
+		return userHome
+	case strings.HasPrefix(p, "~/") || strings.HasPrefix(p, `~\`):
+		return filepath.Join(userHome, p[2:])
+	}
+	return p
+}

--- a/internal/secrets/secretpaths_test.go
+++ b/internal/secrets/secretpaths_test.go
@@ -1,0 +1,67 @@
+package secrets
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+func TestResolveAgeFile(t *testing.T) {
+	const ah = "/home/alice/.agentsync"
+	const uh = "/home/alice"
+	cases := []struct {
+		name string
+		file string
+		want string
+	}{
+		{"empty falls back to default", "", filepath.Join(ah, "secrets/secrets.age")},
+		{"relative joins under agentsync home", "secrets/x.age", filepath.Join(ah, "secrets/x.age")},
+		{"absolute stays absolute", "/etc/x.age", "/etc/x.age"},
+		{"env-home expands to user home", "${env:HOME}/vault/x.age", filepath.Join(uh, "vault/x.age")},
+		{"tilde expands to user home", "~/vault/x.age", filepath.Join(uh, "vault/x.age")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveAgeFile(source.SecretsConfig{File: tc.file}, ah, uh)
+			if got != tc.want {
+				t.Fatalf("ResolveAgeFile(%q) = %q, want %q", tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveIdentityFile(t *testing.T) {
+	const ah = "/home/alice/.agentsync"
+	const uh = "/home/alice"
+	cases := []struct {
+		name     string
+		identity string
+		want     string
+	}{
+		{"empty returns empty", "", ""},
+		{"env-home identity (the init-template shape)", "${env:HOME}/.config/agentsync/age.key", filepath.Join(uh, ".config/agentsync/age.key")},
+		{"absolute stays absolute", "/keys/age.key", "/keys/age.key"},
+		{"relative joins under agentsync home", "keys/age.key", filepath.Join(ah, "keys/age.key")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveIdentityFile(source.SecretsConfig{IdentityFile: tc.identity}, ah, uh)
+			if got != tc.want {
+				t.Fatalf("ResolveIdentityFile(%q) = %q, want %q", tc.identity, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveAgeFile_EnvHomeHonoursRedirect proves ${env:HOME} expands to the
+// passed userHome (which production wires to paths.HomeDir, honouring
+// AGENTSYNC_TARGET_ROOT) rather than the raw $HOME env var — the previous
+// expandEnvHome used os.Getenv("HOME") directly and so could not be
+// redirected under test or a relocated home.
+func TestResolveAgeFile_EnvHomeHonoursRedirect(t *testing.T) {
+	got := ResolveAgeFile(source.SecretsConfig{File: "${env:HOME}/x.age"}, "/irrelevant", "/redirected/home")
+	if got != "/redirected/home/x.age" {
+		t.Fatalf("got %q, want /redirected/home/x.age", got)
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,5 +1,5 @@
 // Package secrets resolves ${secret:foo.bar} and ${env:FOO} references at
-// apply-time. The active backend is selected from opensync.toml [secrets]
+// apply-time. The active backend is selected from agentsync.toml [secrets]
 // `backend` field (env|age).
 package secrets
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -6,7 +6,6 @@ package secrets
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -80,16 +79,18 @@ func (NopResolver) Resolve(key string) (string, error) {
 // SelectBackend returns the appropriate Resolver for the given SecretsConfig.
 // For "age" backend it returns an AgeBackend; for "env" or empty it returns EnvBackend.
 //
-// Relative paths in cfg.File are resolved against homeDir using filepath.Join
-// so that Windows backslash separators work the same as POSIX.
-func SelectBackend(cfg source.SecretsConfig, homeDir string) Resolver {
+// agentsyncHome anchors relative cfg.File / identity_file paths; userHome
+// (paths.HomeDir) expands ${env:HOME} and a leading ~. Both the age file
+// (defaulted via ResolveAgeFile) and the identity file (expanded via
+// ResolveIdentityFile) are resolved here so apply/verify/diff agree with the
+// `secrets` subcommands on which files to read.
+func SelectBackend(cfg source.SecretsConfig, agentsyncHome, userHome string) Resolver {
 	switch strings.ToLower(cfg.Backend) {
 	case "age":
-		ageFile := cfg.File
-		if ageFile != "" && !filepath.IsAbs(ageFile) {
-			ageFile = filepath.Join(homeDir, ageFile)
-		}
-		return NewAgeBackend(ageFile, cfg.IdentityFile)
+		return NewAgeBackend(
+			ResolveAgeFile(cfg, agentsyncHome, userHome),
+			ResolveIdentityFile(cfg, agentsyncHome, userHome),
+		)
 	case "env":
 		return EnvBackend{}
 	default:

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -99,7 +99,7 @@ func TestSelectBackend_RelativeFilePathUsesFilepathJoin(t *testing.T) {
 		File:         filepath.Join("secrets", "secrets.age"),
 		IdentityFile: filepath.Join(tmp, "key"),
 	}
-	r := secrets.SelectBackend(cfg, tmp)
+	r := secrets.SelectBackend(cfg, tmp, tmp)
 	// The resolver is an *AgeBackend; calling Resolve forces it to read AgeFile.
 	// We don't care that decryption fails (the file doesn't exist) — we care
 	// that the error references a path joined with the OS separator, not "/".

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -223,7 +223,10 @@ func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection,
 		skillPaths = discovered
 	}
 	for _, sk := range skillPaths {
-		abs := resolveComponentPathFS(sk, pluginCacheDir)
+		abs, err := resolveComponentPathFS(sk, pluginCacheDir)
+		if err != nil {
+			return pr, err
+		}
 		skill, err := loadSkillEntryFS(fs, abs)
 		if err != nil {
 			return pr, fmt.Errorf("load skill %q: %w", sk, err)
@@ -235,7 +238,10 @@ func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection,
 
 	// Commands: each entry is a path to a <name>.md file.
 	for _, cmd := range rawToStringSlice(manifest.Commands) {
-		abs := resolveComponentPathFS(cmd, pluginCacheDir)
+		abs, err := resolveComponentPathFS(cmd, pluginCacheDir)
+		if err != nil {
+			return pr, err
+		}
 		entry, err := loadMarkdownEntryFS(fs, abs)
 		if err != nil {
 			return pr, fmt.Errorf("load command %q: %w", cmd, err)
@@ -247,7 +253,10 @@ func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection,
 
 	// Subagents: each entry is a path to a <name>.md file.
 	for _, ag := range rawToStringSlice(manifest.Agents) {
-		abs := resolveComponentPathFS(ag, pluginCacheDir)
+		abs, err := resolveComponentPathFS(ag, pluginCacheDir)
+		if err != nil {
+			return pr, err
+		}
 		entry, err := loadMarkdownEntryFS(fs, abs)
 		if err != nil {
 			return pr, fmt.Errorf("load agent %q: %w", ag, err)
@@ -268,15 +277,52 @@ func readPluginProjection(fs afero.Fs, pluginCacheDir string) (PluginProjection,
 //  1. ${CLAUDE_PLUGIN_ROOT} substitution if present.
 //  2. Absolute paths returned as-is.
 //  3. Relative paths joined to pluginCacheDir.
-func resolveComponentPathFS(s, pluginCacheDir string) string {
+func resolveComponentPathFS(s, pluginCacheDir string) (string, error) {
 	const placeholder = "${CLAUDE_PLUGIN_ROOT}"
-	if strings.Contains(s, placeholder) {
-		return strings.ReplaceAll(s, placeholder, pluginCacheDir)
+	var resolved string
+	switch {
+	case strings.Contains(s, placeholder):
+		resolved = strings.ReplaceAll(s, placeholder, pluginCacheDir)
+	case filepath.IsAbs(s):
+		resolved = s
+	default:
+		resolved = filepath.Join(pluginCacheDir, s)
 	}
-	if filepath.IsAbs(s) {
-		return s
+	// The manifest contents are untrusted even though the cache itself was
+	// fetched safely: a hostile plugin.json listing "skills":["/etc/passwd"]
+	// or "../../secret" would otherwise be read and projected into the
+	// user's agent config. Refuse any path that escapes the plugin cache.
+	if !pathWithin(pluginCacheDir, resolved) {
+		return "", fmt.Errorf("plugin component path %q escapes plugin cache %q", resolved, pluginCacheDir)
 	}
-	return filepath.Join(pluginCacheDir, s)
+	return resolved, nil
+}
+
+// pathWithin reports whether child is the same path as parent or sits inside
+// it, after making both absolute and Clean. Used to bound manifest-listed
+// component paths to the plugin cache.
+func pathWithin(parent, child string) bool {
+	ap, err := filepath.Abs(parent)
+	if err != nil {
+		return false
+	}
+	ac, err := filepath.Abs(child)
+	if err != nil {
+		return false
+	}
+	ap = filepath.Clean(ap)
+	ac = filepath.Clean(ac)
+	if ap == ac {
+		return true
+	}
+	rel, err := filepath.Rel(ap, ac)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return false
+	}
+	return true
 }
 
 // rawToStringSlice coerces a json.RawMessage that holds either a JSON string

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -298,6 +298,21 @@ func resolveComponentPathFS(s, pluginCacheDir string) (string, error) {
 	return resolved, nil
 }
 
+// validateComponentName rejects a skill/subagent/command name that would
+// escape its destination directory once joined into a path. Component names
+// become path segments at render time (e.g. filepath.Join(SkillsDir, name,
+// "SKILL.md")), so a name from a hostile plugin manifest's frontmatter like
+// "../../evil" must never reach the writer.
+func validateComponentName(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("%s has an empty name", kind)
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") || strings.ContainsRune(name, 0) {
+		return fmt.Errorf("%s name %q contains a path separator or traversal component", kind, name)
+	}
+	return nil
+}
+
 // pathWithin reports whether child is the same path as parent or sits inside
 // it, after making both absolute and Clean. Used to bound manifest-listed
 // component paths to the plugin cache.
@@ -384,6 +399,9 @@ func loadSkillEntryFS(fs afero.Fs, path string) (*Skill, error) {
 	if name == "" {
 		name = filepath.Base(path)
 	}
+	if err := validateComponentName("skill", name); err != nil {
+		return nil, err
+	}
 	return &Skill{Name: name, Frontmatter: fm, Body: body}, nil
 }
 
@@ -408,6 +426,9 @@ func loadMarkdownEntryFS(fs afero.Fs, path string) (*markdownEntryFS, error) {
 	}
 	if name == "" {
 		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+	if err := validateComponentName("component", name); err != nil {
+		return nil, err
 	}
 	return &markdownEntryFS{name: name, fm: fm, body: body}, nil
 }

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -294,6 +294,34 @@ version = "1"
 	}
 }
 
+// TestLoad_RejectsTraversalComponentName is the regression for a plugin
+// component whose frontmatter name contains a path-traversal segment. The
+// name becomes a path segment at render time (filepath.Join(SkillsDir, name,
+// "SKILL.md")), so "../../evil" would write the SKILL.md outside the managed
+// skills dir. The loader must reject it.
+func TestLoad_RejectsTraversalComponentName(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	home := "/h"
+	cache := "/h/.state/cache/plugins"
+	_ = afero.WriteFile(fs, filepath.Join(home, "plugins", "x.toml"), []byte(`
+[plugin]
+id = "x@m"
+version = "1"
+`), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(cache, "x", ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"x","skills":["s"]}`), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(cache, "x", "s", "SKILL.md"),
+		[]byte("---\nname: ../../evil\n---\nbody\n"), 0o644)
+
+	_, err := source.LoadWithCache(fs, home, cache)
+	if err == nil {
+		t.Fatal("expected error for a component name with a traversal segment")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Fatalf("error should name the bad component name; got: %v", err)
+	}
+}
+
 // TestLoad_PluginManifestSHAMismatchRefuses is the regression for the
 // finding that ManifestSHA was recorded at install but never verified
 // at load. A user installs a plugin, the cache gets tampered with

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -2,6 +2,7 @@ package source_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -265,6 +266,31 @@ version = "1"
 	}
 	if !found {
 		t.Fatalf("plugin's MCP not surfaced via projection: %+v", c.MCPServers)
+	}
+}
+
+// TestLoad_RejectsEscapingComponentPath is the regression for the
+// manifest-path traversal on the loader projection path: a hostile
+// plugin.json listing a skills/commands/agents path outside the plugin
+// cache must be refused rather than read and projected.
+func TestLoad_RejectsEscapingComponentPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	home := "/h"
+	cache := "/h/.state/cache/plugins"
+	_ = afero.WriteFile(fs, filepath.Join(home, "plugins", "x.toml"), []byte(`
+[plugin]
+id = "x@m"
+version = "1"
+`), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(cache, "x", ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"x","skills":["../../../../etc/passwd"]}`),
+		0o644)
+	_, err := source.LoadWithCache(fs, home, cache)
+	if err == nil {
+		t.Fatal("expected error for plugin.json skill path escaping the cache")
+	}
+	if !strings.Contains(err.Error(), "escapes plugin cache") {
+		t.Fatalf("error should explain the escape; got: %v", err)
 	}
 }
 

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -1,0 +1,44 @@
+package source
+
+import (
+	"regexp"
+	"strings"
+)
+
+var memoryImportRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
+
+// maxMemoryImportDepth bounds recursive fragment expansion as a belt against
+// pathological nesting (cycles are already broken by the visiting set).
+const maxMemoryImportDepth = 16
+
+// ExpandMemoryImports replaces `@import ./fragments/<name>` directives in body
+// with the named fragment's content, RECURSIVELY — a fragment may itself
+// `@import` another. A single non-recursive pass (the previous behavior) left
+// nested directives as literal `@import` lines in the rendered CLAUDE.md /
+// AGENTS.md. Cycles are broken (a fragment already being expanded is left as a
+// literal directive), recursion is depth-bounded, and unknown fragments are
+// left as literal directives so the user notices.
+func ExpandMemoryImports(body string, fragments map[string]string) string {
+	return expandMemoryImports(body, fragments, map[string]bool{}, 0)
+}
+
+func expandMemoryImports(body string, fragments map[string]string, visiting map[string]bool, depth int) string {
+	if depth >= maxMemoryImportDepth {
+		return body
+	}
+	return memoryImportRe.ReplaceAllStringFunc(body, func(line string) string {
+		m := memoryImportRe.FindStringSubmatch(line)
+		if len(m) < 2 {
+			return line
+		}
+		name := m[1]
+		frag, ok := fragments[name]
+		if !ok || visiting[name] {
+			return line
+		}
+		visiting[name] = true
+		expanded := expandMemoryImports(frag, fragments, visiting, depth+1)
+		delete(visiting, name)
+		return strings.TrimRight(expanded, "\n")
+	})
+}

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -1,0 +1,49 @@
+package source_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestExpandMemoryImports_Recursive is the regression for the single-pass
+// expander: a fragment that itself @imports another left the nested directive
+// as a literal line in the rendered memory file.
+func TestExpandMemoryImports_Recursive(t *testing.T) {
+	body := "Top\n@import ./fragments/a.md\n"
+	frags := map[string]string{
+		"a.md": "Content A\n@import ./fragments/b.md",
+		"b.md": "Content B",
+	}
+	got := source.ExpandMemoryImports(body, frags)
+	if !strings.Contains(got, "Content A") || !strings.Contains(got, "Content B") {
+		t.Fatalf("nested fragment not expanded: %q", got)
+	}
+	if strings.Contains(got, "@import") {
+		t.Fatalf("literal @import directive leaked into output: %q", got)
+	}
+}
+
+// TestExpandMemoryImports_Cycle ensures a fragment cycle terminates and does
+// not stack-overflow; the cyclic directive is left literal.
+func TestExpandMemoryImports_Cycle(t *testing.T) {
+	body := "@import ./fragments/a.md\n"
+	frags := map[string]string{
+		"a.md": "A\n@import ./fragments/b.md",
+		"b.md": "B\n@import ./fragments/a.md",
+	}
+	got := source.ExpandMemoryImports(body, frags) // must not hang/overflow
+	if !strings.Contains(got, "A") || !strings.Contains(got, "B") {
+		t.Fatalf("cycle expansion dropped content: %q", got)
+	}
+}
+
+// TestExpandMemoryImports_UnknownFragmentLeftLiteral keeps a directive for a
+// missing fragment so the user notices.
+func TestExpandMemoryImports_UnknownFragmentLeftLiteral(t *testing.T) {
+	got := source.ExpandMemoryImports("@import ./fragments/missing.md\n", map[string]string{})
+	if !strings.Contains(got, "@import ./fragments/missing.md") {
+		t.Fatalf("unknown fragment directive should be preserved: %q", got)
+	}
+}

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -16,6 +16,24 @@ import (
 	"github.com/spxrogers/agentsync/internal/iox"
 )
 
+// ReadMCP reads mcp/<id>.toml from home. ok is false when the file does not
+// exist. Used by reconcile write-back to preserve source-only fields
+// (agents/enabled) that the rendered destination spec doesn't carry.
+func ReadMCP(home, id string) (m MCPServer, ok bool, err error) {
+	data, rerr := os.ReadFile(filepath.Join(home, "mcp", id+".toml"))
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return MCPServer{}, false, nil
+		}
+		return MCPServer{}, false, fmt.Errorf("read mcp %s: %w", id, rerr)
+	}
+	if uerr := toml.Unmarshal(data, &m); uerr != nil {
+		return MCPServer{}, false, fmt.Errorf("parse mcp %s: %w", id, uerr)
+	}
+	m.ID = id
+	return m, true, nil
+}
+
 // WriteMCP writes mcp/<id>.toml from m into home. Overwrites atomically.
 func WriteMCP(home, id string, m MCPServer) error {
 	body, err := toml.Marshal(m)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -23,6 +23,18 @@ func Load(path string) (*Targets, error) {
 	if err := json.Unmarshal(data, &t); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
+	// A file that is valid JSON but empty-shaped (`null`, `{}`, or any doc
+	// with no schema_version AND no entries) is almost certainly corruption
+	// (an interrupted external edit, a zeroed disk block, a truncate-clobber)
+	// — agentsync itself always writes schema_version. Loading it as a
+	// pristine empty state would make the next apply treat every managed
+	// destination as unowned and back them all up as foreign collisions.
+	// A legacy v0 file with real entries is still accepted (migrate handles it).
+	if t.SchemaVersion == 0 && len(t.Files) == 0 && len(t.Keys) == 0 &&
+		len(t.Marketplaces) == 0 && len(t.Plugins) == 0 {
+		return nil, fmt.Errorf("state file %s is empty or corrupt (no schema_version and no entries); "+
+			"remove it to reinitialize (agentsync will re-adopt destinations on the next apply)", path)
+	}
 	if err := migrate(&t); err != nil {
 		return nil, fmt.Errorf("migrate %s: %w", path, err)
 	}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
+// TestStore_RejectsEmptyShapedFile is the regression for the silent state
+// reset: a targets.json that is valid JSON but empty-shaped (`null` / `{}`)
+// — producible by an interrupted external edit or a truncate-clobber — used
+// to load as a pristine empty state, making the next apply back up every
+// managed destination as a foreign collision. It must now fail loudly.
+func TestStore_RejectsEmptyShapedFile(t *testing.T) {
+	for _, content := range []string{"null", "{}", "  {}\n", `{"schema_version":0}`} {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "targets.json")
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := state.Load(p); err == nil {
+			t.Fatalf("Load(%q) should fail as corrupt/empty; got nil", content)
+		}
+	}
+
+	// A legacy v0 file WITH entries must still load (migrate handles it).
+	dir := t.TempDir()
+	p := filepath.Join(dir, "targets.json")
+	if err := os.WriteFile(p, []byte(`{"files":{"claude:user::x":{"sha256":"a"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.Load(p); err != nil {
+		t.Fatalf("legacy v0 file with entries should load; got %v", err)
+	}
+}
+
 func TestStore_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "targets.json")


### PR DESCRIPTION
## Summary

Targets `main` directly — #19 and #20 (the latter via #22, after GitHub auto-closed #20 on the stacked-branch deletion) are already merged. Multi-wave hardening: #20's audit, two follow-up passes, a **3-round fresh-review loop**, a final polish pass, and a **post-evaluation security pass**. **~39 fixes**, each RED-test-first then GREEN. Full hermetic gate (`vet`, `build`, `test -race ./...`, e2e, bdd, smoke) green via podman.

**Launch verdict: shippable.** The sole launch-blocker (init not gitignoring `.state/` plaintext backups) is fixed, a regression sweep found none, and the non-blocking polish items are now resolved.

## Evaluation follow-up (latest push, `2f777a5`)

Three findings from a stacked-PR evaluation of #19→#20→#21, each TDD'd with a regression test:

- **A — npm HTTPS gap (security):** `enforceSecureScheme` only checked the git URL/repo, so an npm **registry** (and the **tarball URL** it resolves) could be plain `http://` even with the insecure-override unset. Now both are scheme-checked — the registry in `enforceSecureScheme`, the resolved tarball in `NPMFetcher.Fetch` before download. Refactored the per-URL logic into `checkURLScheme` with a **loopback carve-out** (http/git to `127.0.0.1`/`localhost`/`::1` has no MITM surface — covers local mirrors and the httptest fixtures).
- **D — `diff` secret leak (security):** `CollectResolved` silently skips `${secret:…}` refs it can't resolve, so with the age identity locked/absent `diff` would print a destination file still holding the cleartext value. `diff` now **fails closed** (clear, key-naming error) via the new `secrets.UnresolvedSecretRefs`. `${env:…}` refs are unaffected.
- **C — partial-apply data loss:** `saveBestEffortState` recorded any op whose dest merely existed (`os.Stat`). Since `render.Apply` stops at the first failing op, a pre-existing **foreign** file at a never-attempted op was marked owned and its foreign-collision backup suppressed on the next apply (silent data loss). `Writer` now tracks the paths it actually **wrote**; `render.Apply` returns that set; the rescue records only those (the partial-failure rescue for files that *did* land still works).

## Polish pass

- **docs:** renamed all stale `opensync` references → `agentsync` across `docs/superpowers/plans/*.md` and `docs/research/*.md` (command examples, `opensync.toml` paths, prose). `LAUNCH_CHECKLIST.md`'s two refs left intact (they intentionally describe the rename). (`5780716`)
- **test coverage:** added import round-trip tests for skill/hook/lsp/memory (only MCP/subagent/command were covered). (`dd1efd7`)
- **orphan-cleanup `:/` split:** confirmed safe for realistic paths (POSIX has no `:`; Windows uses `\`) and self-healing otherwise; documented. (`5d4681a`)

## Loop round 3

`.gitignore` launch-blocker (protect `.state/` credential backups); bounded backup retention; first-run hints (`secrets`/`status`/`diff`); data-safety test-hardening (`saveBestEffortState`, JSONC-fallback backup). Regression sweep: **no regressions**.

## Loop round 2

Removing the **last** MCP/hook/LSP now auto-cleans the dest (exact per-adapter merge strategy, no JSONC clobber); `null`/`{}` state silent-reset rejected; memory `@import` recursion + project memory-import path traversal; apply scope announced; backup-ts collision; **goreleaser v2 blocker**.

## Loop round 1

reconcile `--auto-writeback` data loss + dropped `agents`/`enabled` + mutually-exclusive flags; OpenCode dropped MCP `headers`; plugin component-name traversal; `LICENSE`+`SECURITY.md`; `verify` false-green; help text; doc drift.

## Earlier waves (condensed)

secrets path/`${env:HOME}`; state-key portability (was a no-op); `update --apply` plugin brick; `render.Apply` dropping hooks/LSP merge ops; `agent disable --purge` shared-file deletion + global locks; plugin path containment; npm/relative/git symlink rejection; tarball cap; `diff`/`status` plugin projection; non-string secrets; `PruneStaleState` prefix-match.

## Open (your call / env-limited)
- `LAUNCH_CHECKLIST.md` ships at the repo root with open `[ ]` items — left in place (a deliberate artifact); unship/move if you'd rather it not be public.
- Ran here via podman: full hermetic gate (`test-release` entrypoint — vet, build, `test -race ./...`, e2e, bdd, smoke) **green**. Still pending on a maintainer machine: `goreleaser check`/snapshot and golangci-lint (not in the test image; the local lint binary predates go1.26). CI's `lint` + `goreleaser-snapshot` jobs cover both.

## Test plan
- [x] full hermetic gate (vet, build, `test -race ./...` x16 pkgs, e2e, bdd, smoke) green via podman
- [ ] `goreleaser check` + golangci-lint on a maintainer machine (or via CI)
- [ ] Manual smoke: `init` → `.gitignore` has `/.state/`; remove last MCP server → apply → gone, foreign key survives

https://claude.ai/code/session_011R6axhTSMvavTbizwPK7uH

