### PR TITLE
Multi-round hardening loop: kill bugs + launch readiness

### DIFF
--- a/internal/adapter/claude/apply.go
+++ b/internal/adapter/claude/apply.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 )
 
 // Apply executes ops against Claude's native destinations. All writes
@@ -37,8 +38,8 @@ func (a *Adapter) Apply(ops []adapter.FileOp, w adapter.DestWriter) error {
 func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy == "merge-json-keys" {
 		existing := readJSONFile(op.Path)
-		var ours map[string]any
-		if err := json.Unmarshal(op.Content, &ours); err != nil {
+		ours, err := jsonkeys.DecodeObject(op.Content)
+		if err != nil {
 			return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
 		}
 		merged, _, _ := MergeKeys(existing, ours, op.OwnedKeys)
@@ -56,9 +57,10 @@ func readJSONFile(path string) map[string]any {
 	if err != nil {
 		return map[string]any{}
 	}
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
-	if m == nil {
+	// Decode preserving json.Number so a foreign integer > 2^53 isn't rounded
+	// when the merged file is re-marshalled.
+	m, err := jsonkeys.DecodeObject(data)
+	if err != nil {
 		return map[string]any{}
 	}
 	return m

--- a/internal/adapter/claude/frontmatter.go
+++ b/internal/adapter/claude/frontmatter.go
@@ -12,6 +12,14 @@ import (
 // the input doesn't begin with "---\n", returns an empty map and the entire
 // input as body.
 func ParseFrontmatter(data []byte) (map[string]any, string, error) {
+	// Normalize CRLF → LF so a .md saved by a Windows editor ("---\r\n") is
+	// recognized as having frontmatter. Without this the literal "---\n" check
+	// fails, the whole file is treated as body, and description/model/mode
+	// silently vanish on ingest/import. agentsync re-renders bodies with LF,
+	// so the normalization is lossless in practice.
+	if bytes.IndexByte(data, '\r') >= 0 {
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	}
 	if !bytes.HasPrefix(data, []byte("---\n")) {
 		return map[string]any{}, string(data), nil
 	}

--- a/internal/adapter/claude/frontmatter_test.go
+++ b/internal/adapter/claude/frontmatter_test.go
@@ -61,3 +61,25 @@ func TestEncodeFrontmatter_Roundtrip(t *testing.T) {
 		t.Fatalf("body = %q", body2)
 	}
 }
+
+// TestParseFrontmatter_CRLF is the regression for skill/subagent/command .md
+// files saved by a Windows editor with CRLF line endings. The parser matched
+// only the literal "---\n" delimiter, so a "---\r\n" header was treated as no
+// frontmatter — the entire file became body and description/model/mode
+// silently vanished on ingest/import.
+func TestParseFrontmatter_CRLF(t *testing.T) {
+	input := []byte("---\r\nname: my-skill\r\ndescription: Does the thing\r\n---\r\nBody line one\r\n")
+	fm, body, err := claude.ParseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm["description"] != "Does the thing" {
+		t.Fatalf("description lost on CRLF input: %+v", fm)
+	}
+	if fm["name"] != "my-skill" {
+		t.Fatalf("name lost on CRLF input: %+v", fm)
+	}
+	if body == string(input) {
+		t.Fatalf("frontmatter not stripped; whole file returned as body: %q", body)
+	}
+}

--- a/internal/adapter/claude/largeint_test.go
+++ b/internal/adapter/claude/largeint_test.go
@@ -1,0 +1,38 @@
+package claude_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
+)
+
+// TestApply_PreservesForeignLargeInt is the regression for key-merge silently
+// rounding a foreign integer larger than 2^53: agentsync promises to preserve
+// foreign keys verbatim, but the merge unmarshalled the existing dest into
+// map[string]any with encoding/json's float64 default, so a user's
+// 1234567890123456789 became 1234567890123456800 on the next apply.
+func TestApply_PreservesForeignLargeInt(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, ".claude.json")
+	if err := os.WriteFile(dest, []byte(`{"foreignBig":1234567890123456789}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	op := adapter.FileOp{
+		Action:        "write",
+		Path:          dest,
+		MergeStrategy: "merge-json-keys",
+		Content:       []byte(`{"mcpServers":{"github":{"command":"npx"}}}`),
+	}
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	if err := a.Apply([]adapter.FileOp{op}, adapter.PassThroughWriter{}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dest)
+	if !strings.Contains(string(got), "1234567890123456789") {
+		t.Fatalf("foreign large int was rounded during merge:\n%s", got)
+	}
+}

--- a/internal/adapter/opencode/apply.go
+++ b/internal/adapter/opencode/apply.go
@@ -1,11 +1,11 @@
 package opencode
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 )
 
 // Apply routes every destination write through the supplied DestWriter
@@ -33,8 +33,8 @@ func (a *Adapter) Apply(ops []adapter.FileOp, w adapter.DestWriter) error {
 func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy == "merge-jsonc-keys" {
 		existing, _ := os.ReadFile(op.Path)
-		var ours map[string]any
-		if err := json.Unmarshal(op.Content, &ours); err != nil {
+		ours, err := jsonkeys.DecodeObject(op.Content)
+		if err != nil {
 			return fmt.Errorf("parse our payload: %w", err)
 		}
 		out, err := MergeJSONC(existing, ours, op.OwnedKeys)

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -42,6 +42,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 							Args:    asStrSlice(spec["args"]),
 							Env:     asStrMap(spec["env"]),
 							URL:     asStr(spec["url"]),
+							Headers: asStrMap(spec["headers"]),
 						}}
 						c.MCPServers = append(c.MCPServers, m)
 					}

--- a/internal/adapter/opencode/ingest_test.go
+++ b/internal/adapter/opencode/ingest_test.go
@@ -46,6 +46,43 @@ func TestIngest_RoundTripsMCP(t *testing.T) {
 	}
 }
 
+// TestIngest_RoundTripsMCPHeaders is the regression for OpenCode ingest
+// silently dropping a remote MCP server's auth headers. Render writes
+// spec["headers"]; ingest must read them back, or an `import`/reconcile
+// round-trip produces a server config missing its Authorization header,
+// which then 401s on the next apply.
+func TestIngest_RoundTripsMCPHeaders(t *testing.T) {
+	tmp := t.TempDir()
+	in := source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "remote",
+			Server: source.MCPServerSpec{
+				Type:    "http",
+				URL:     "https://mcp.example.com",
+				Headers: map[string]string{"Authorization": "Bearer xyz"},
+			},
+		}},
+	}
+	a := opencode.New(opencode.Options{TargetRoot: tmp})
+	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("MCP roundtrip lost: %+v", out.MCPServers)
+	}
+	if got := out.MCPServers[0].Server.Headers["Authorization"]; got != "Bearer xyz" {
+		t.Fatalf("auth header dropped on round-trip: got %q, headers=%+v", got, out.MCPServers[0].Server.Headers)
+	}
+}
+
 // TestIngest_RoundTripsMemory exercises: Render → Apply → Ingest for AGENTS.md.
 func TestIngest_RoundTripsMemory(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/adapter/opencode/settings.go
+++ b/internal/adapter/opencode/settings.go
@@ -35,12 +35,11 @@ func MergeJSONC(existing []byte, ours map[string]any, ownedPointers []string) ([
 		return nil, fmt.Errorf("parse jsonc: %w", err)
 	}
 	val.Standardize()
-	var existingMap map[string]any
-	if err := json.Unmarshal(val.Pack(), &existingMap); err != nil {
+	// Decode preserving json.Number so a foreign integer > 2^53 in the user's
+	// opencode.json isn't rounded when the merged file is re-marshalled.
+	existingMap, err := jsonkeys.DecodeObject(val.Pack())
+	if err != nil {
 		return nil, fmt.Errorf("standardize jsonc: %w", err)
-	}
-	if existingMap == nil {
-		existingMap = map[string]any{}
 	}
 	merged, _, _ := jsonkeys.MergeKeys(existingMap, ours, ownedPointers)
 	out, err := json.MarshalIndent(merged, "", "  ")

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -50,8 +50,8 @@ var v1Supported = map[string]bool{
 func newAgentCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "agent", Short: "manage which agents agentsync targets"}
 	cmd.AddCommand(
-		&cobra.Command{Use: "add <name>", Short: "register an agent (claude | opencode)", Args: cobra.ExactArgs(1), RunE: agentAddRun},
-		&cobra.Command{Use: "remove <name>", Short: "unregister an agent", Args: cobra.ExactArgs(1), RunE: agentRemoveRun},
+		&cobra.Command{Use: "add <name>", Short: "register an agent (claude | opencode)", Args: cobra.ExactArgs(1), RunE: lockedRun(agentAddRun)},
+		&cobra.Command{Use: "remove <name>", Short: "unregister an agent", Args: cobra.ExactArgs(1), RunE: lockedRun(agentRemoveRun)},
 		&cobra.Command{Use: "list", Short: "list registered agents", Args: cobra.NoArgs, RunE: agentListRun},
 		newAgentEnableCmd(),
 		newAgentDisableCmd(),
@@ -64,7 +64,7 @@ func newAgentEnableCmd() *cobra.Command {
 		Use:   "enable <name>",
 		Args:  cobra.ExactArgs(1),
 		Short: "enable a registered agent",
-		RunE:  agentEnableRun,
+		RunE:  lockedRun(agentEnableRun),
 	}
 }
 
@@ -74,9 +74,9 @@ func newAgentDisableCmd() *cobra.Command {
 		Use:   "disable <name>",
 		Args:  cobra.ExactArgs(1),
 		Short: "disable a registered agent (optionally purging its destination files)",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: lockedRun(func(cmd *cobra.Command, args []string) error {
 			return agentDisableRun(cmd, args, purge)
-		},
+		}),
 	}
 	cmd.Flags().BoolVar(&purge, "purge", false, "remove agent destination files that agentsync owns")
 	return cmd
@@ -293,13 +293,11 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 		return nil
 	}
 
-	// --purge mutates .state/targets.json and deletes destination files, so
-	// it must hold the global lock — otherwise a concurrent apply's
-	// read-modify-write of targets.json races this one and loses updates.
+	// The whole disable command (including this purge) already runs under the
+	// global lock via lockedRun, so call purge directly — re-acquiring here
+	// would deadlock on the re-entrant flock.
 	home := paths.AgentsyncHome(paths.OSEnv{})
-	return withGlobalLock(home, func() error {
-		return purgeAgentDests(cmd, name, home)
-	})
+	return purgeAgentDests(cmd, name, home)
 }
 
 // purgeAgentDests deletes the destination files owned solely by the named

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -103,6 +104,9 @@ func readAgentsyncTOML() (string, []byte, map[string]map[string]any, error) {
 	p := filepath.Join(home, "agentsync.toml")
 	raw, err := os.ReadFile(p)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return p, nil, nil, fmt.Errorf("no agentsync config at %s; run `agentsync init` first", p)
+		}
 		return p, nil, nil, fmt.Errorf("read %s: %w", p, err)
 	}
 	var cfg agentsyncCfg

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -318,59 +318,82 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 		return fmt.Errorf("load state: %w", err)
 	}
 
-	// Gather the portable ("${HOME}/...") dest paths owned by the agent
-	// being purged, and — separately — those still owned by ANY OTHER agent.
-	// The dest-path field is index 3 in both Files keys ("a:s:p:path") and
-	// Keys keys ("a:s:p:path:ptr").
 	prefix := name + ":"
-	purgedPaths := map[string]bool{}
-	otherPaths := map[string]bool{}
-	collect := func(key string, fields int) {
-		parts := strings.SplitN(key, ":", fields)
-		if len(parts) < 4 || parts[3] == "" {
-			return
-		}
-		if strings.HasPrefix(key, prefix) {
-			purgedPaths[parts[3]] = true
-		} else {
-			otherPaths[parts[3]] = true
-		}
-	}
-	for key := range s.Files {
-		collect(key, 4)
-	}
-	for key := range s.Keys {
-		collect(key, 5)
-	}
 
-	// Delete only paths NOT still owned by another agent. claude and
-	// opencode both render skills to ~/.claude/skills/<name>/SKILL.md, so
-	// after apply that path is owned by BOTH in state. Deleting it while
-	// purging one agent would destroy a file the other still needs — and
-	// Writer.Delete skips backup, so the loss is unrecoverable.
-	toDelete := map[string]bool{}
-	sharedKept := 0
-	for p := range purgedPaths {
-		if otherPaths[p] {
-			sharedKept++
+	// File-owned dests (whole-file replace ops, e.g. ~/.claude/skills/<n>/
+	// SKILL.md): the whole file is agentsync's, so a whole-file delete is
+	// correct — unless another agent still owns the same shared file. The
+	// dest path is field index 3 in a Files key ("agent:scope:project:path").
+	purgedFilePaths := map[string]bool{}
+	otherFilePaths := map[string]bool{}
+	for key := range s.Files {
+		parts := strings.SplitN(key, ":", 4)
+		if len(parts) < 4 || parts[3] == "" {
 			continue
 		}
-		toDelete[paths.FromHomeRelative(userHome, p)] = true
+		if strings.HasPrefix(key, prefix) {
+			purgedFilePaths[parts[3]] = true
+		} else {
+			otherFilePaths[parts[3]] = true
+		}
 	}
 
-	// Build delete ops and apply via the adapter. Purge is destructive
-	// by intent — we don't want collision-backups for files agentsync
-	// is being told to remove — but we still route through DestWriter
-	// because that's the only interface the adapter knows. The writer's
-	// Delete path skips backup deliberately (see DestWriter doc).
+	// Key-owned dests (merge-key pointers within a possibly-shared file, e.g.
+	// /mcpServers/<id> in ~/.claude.json): agentsync owns only those pointers,
+	// NOT the whole file. A whole-file delete here would destroy the user's
+	// foreign keys (other servers, top-level settings) with no backup. Collect
+	// this agent's owned pointers per path so we can remove ONLY them.
+	purgedKeyPtrs := map[string][]string{}
+	for key := range s.Keys {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		parts := strings.SplitN(key, ":", 5)
+		if len(parts) < 5 || parts[3] == "" {
+			continue
+		}
+		purgedKeyPtrs[parts[3]] = append(purgedKeyPtrs[parts[3]], parts[4])
+	}
+
 	reg := registryFactory()
 	a := reg.Lookup(name)
-	if a == nil {
-		// No adapter — just remove state entries.
-	} else {
+	deletedFiles := 0
+	prunedFiles := 0
+	sharedKept := 0
+	if a != nil {
 		var ops []adapter.FileOp
-		for path := range toDelete {
-			ops = append(ops, adapter.FileOp{Action: "delete", Path: path})
+		// Whole-file deletes for file-owned dests not shared with another
+		// agent. claude and opencode both render skills to the same path, so
+		// deleting a shared one while purging one agent would destroy a file
+		// the other still needs — Writer.Delete skips backup, so the loss is
+		// unrecoverable. Keep those.
+		for p := range purgedFilePaths {
+			if otherFilePaths[p] {
+				sharedKept++
+				continue
+			}
+			ops = append(ops, adapter.FileOp{Action: "delete", Path: paths.FromHomeRelative(userHome, p)})
+			deletedFiles++
+		}
+		// Pointer prunes for key-owned dests: an empty merge op carrying only
+		// this agent's owned pointers, so MergeKeys removes exactly those and
+		// preserves the user's (and any other agent's) keys in the shared file.
+		if strat := a.KeyMergeStrategy(); strat != "" {
+			for p, ptrs := range purgedKeyPtrs {
+				abs := paths.FromHomeRelative(userHome, p)
+				if _, err := os.Stat(abs); err != nil {
+					continue // already gone; nothing to prune
+				}
+				ops = append(ops, adapter.FileOp{
+					Action:        "write",
+					Path:          abs,
+					Content:       []byte("{}"),
+					Mode:          0o644,
+					MergeStrategy: strat,
+					OwnedKeys:     ptrs,
+				})
+				prunedFiles++
+			}
 		}
 		rw := render.NewWriter(s, home, userHome, adapter.ScopeUser, "", name)
 		if err := a.Apply(ops, rw); err != nil {
@@ -393,7 +416,7 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 		return fmt.Errorf("save state: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "purged %d destination path(s) for agent %s\n", len(toDelete), name)
+	fmt.Fprintf(cmd.OutOrStdout(), "purged agent %s: deleted %d file(s), pruned owned keys from %d shared file(s)\n", name, deletedFiles, prunedFiles)
 	if sharedKept > 0 {
 		fmt.Fprintf(cmd.OutOrStdout(), "  kept %d shared path(s) still owned by another agent\n", sharedKept)
 	}

--- a/internal/cli/agent_disable_test.go
+++ b/internal/cli/agent_disable_test.go
@@ -125,19 +125,27 @@ args    = ["-y", "@modelcontextprotocol/server-github"]
 		t.Fatalf("expected 'purged' in output; got: %s", out)
 	}
 
-	// .claude.json should be gone (it was the only owned file).
-	if _, err := os.Stat(claudePath); !os.IsNotExist(err) {
-		t.Fatalf(".claude.json should be removed after --purge; stat err: %v", err)
+	// .claude.json is a key-merge dest: agentsync owns only /mcpServers/github,
+	// not the whole file. Purge must PRUNE the owned pointer (so a user's
+	// foreign keys would survive), not delete the file. With no other content,
+	// the file remains as an empty object — but it must NOT be deleted, and the
+	// owned server must be gone.
+	after, statErr := os.ReadFile(claudePath)
+	if statErr != nil {
+		t.Fatalf(".claude.json must survive purge (key-merge dest, only pointers owned); read err: %v", statErr)
+	}
+	if strings.Contains(string(after), "github") {
+		t.Fatalf("owned mcpServers/github should have been pruned from .claude.json; got: %s", after)
 	}
 
 	// State should no longer have claude entries for Files/Keys.
-	// (We verify indirectly: a second purge should report 0 paths.)
+	// (We verify indirectly: a second purge should report nothing pruned.)
 	out2, err2 := runCLI(t, env, "agent", "disable", "claude", "--purge")
 	if err2 != nil {
 		t.Fatalf("second agent disable --purge: %v\n%s", err2, out2)
 	}
-	if !strings.Contains(out2, "0 destination path(s)") {
-		t.Fatalf("expected 0 paths on second purge; got: %s", out2)
+	if !strings.Contains(out2, "deleted 0 file(s), pruned owned keys from 0") {
+		t.Fatalf("expected nothing to purge on second run; got: %s", out2)
 	}
 }
 

--- a/internal/cli/agent_plugin_lock_test.go
+++ b/internal/cli/agent_plugin_lock_test.go
@@ -1,0 +1,40 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAgentAdd_AcquiresGlobalLock is the regression for the lost-update race:
+// `agent add/remove/enable/disable` did a read-modify-write of agentsync.toml
+// with no global lock, so a concurrent registration (or a racing apply reading
+// the file) could lose an update.
+func TestAgentAdd_AcquiresGlobalLock(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	assertCommandBlocksOnLock(t, env, tmp, "agent", "add", "claude")
+}
+
+// TestPluginDisable_AcquiresGlobalLock is the regression for plugin mutators
+// (install/upgrade/enable/disable/remove) racing `update`'s locked rewrite of
+// the same plugins/<id>.toml.
+func TestPluginDisable_AcquiresGlobalLock(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	pdir := filepath.Join(tmp, ".agentsync", "plugins")
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "demo.toml"),
+		[]byte("[plugin]\nid = \"demo\"\nversion = \"1.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertCommandBlocksOnLock(t, env, tmp, "plugin", "disable", "demo")
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/state"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -115,6 +116,16 @@ func checkStateDir(w io.Writer, home string) int {
 	}
 	_ = os.Remove(probe)
 	fmt.Fprintf(w, "  .state/    ok (writable)\n")
+
+	// Verify targets.json parses — the same load status/apply/diff/reconcile
+	// do. A corrupt state file makes every real command exit 1, so a readiness
+	// check that ignores it would falsely report healthy. A missing file is
+	// fine (state.Load returns an empty state on a fresh install).
+	if _, err := state.Load(filepath.Join(stateDir, "targets.json")); err != nil {
+		fmt.Fprintf(w, "  state file corrupt: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(w, "  state file ok\n")
 	return 0
 }
 

--- a/internal/cli/doctor_state_test.go
+++ b/internal/cli/doctor_state_test.go
@@ -1,0 +1,33 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDoctor_DetectsCorruptState is the regression for doctor's false-OK: a
+// corrupt .state/targets.json makes status/apply/diff/reconcile all exit 1,
+// but doctor only write-probed the .state/ directory and never loaded the
+// state file — so it printed "all checks passed" (exit 0). A readiness command
+// must not report healthy when every real command is broken.
+func TestDoctor_DetectsCorruptState(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	if err := os.WriteFile(statePath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "doctor"); err == nil {
+		t.Fatal("doctor reported healthy on a corrupt state file (should exit nonzero)")
+	}
+}

--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+// TestGetPointerValue_DecodesRFC6901 is the regression for status/diff
+// misclassifying drift on a managed item whose id contains '~' or '/'.
+// CollectPointers escapes those (~→~0, /→~1), but getPointerValue split the
+// pointer without decoding, so it looked up the literal "foo~0bar" key instead
+// of the real "foo~bar" key → nil source value → phantom drift forever. Every
+// other pointer getter (getJSONPointer, render.getPointerOK, jsonkeys
+// splitPointer) decodes; this one didn't.
+func TestGetPointerValue_DecodesRFC6901(t *testing.T) {
+	m := map[string]any{
+		"mcpServers": map[string]any{
+			"foo~bar": map[string]any{"command": "x"},
+			"a/b":     map[string]any{"command": "y"},
+		},
+	}
+	if got := getPointerValue(m, "/mcpServers/foo~0bar"); got == nil {
+		t.Fatalf("did not decode ~0: nil for /mcpServers/foo~0bar")
+	}
+	if got := getPointerValue(m, "/mcpServers/a~1b"); got == nil {
+		t.Fatalf("did not decode ~1: nil for /mcpServers/a~1b")
+	}
+}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -255,6 +255,13 @@ func importRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ingest %s: %w", agentName, err)
 	}
 
+	// Every component except memory addresses a named item; a two-part
+	// selector like "claude:mcp" would otherwise fall through to a misleading
+	// `mcp server "" not found` downstream. Fail with the expected grammar.
+	if component != "memory" && name == "" {
+		return fmt.Errorf("selector %q is missing the item name; expected <agent>:<component>:<name>", sel)
+	}
+
 	// Re-reference secrets before writing back to source. The destination was
 	// written by a prior apply with ${secret:…} substituted to cleartext, so
 	// the ingested canonical holds live credentials. Convert any value that

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -26,12 +26,19 @@ func loaderFsForState() afero.Fs { return afero.NewOsFs() }
 
 // jsonUnmarshalLoose is a thin wrapper that returns nil on empty input
 // (so callers can treat empty as "absent") and surfaces real parse errors.
+// It accepts JSONC (comments, trailing commas) via hujson so seeding state
+// from a hand-commented opencode.json doesn't mis-hash the dest as null —
+// matching the apply/ingest read path.
 func jsonUnmarshalLoose(data []byte, v *map[string]any) error {
 	if len(data) == 0 {
 		*v = map[string]any{}
 		return nil
 	}
-	return json.Unmarshal(data, v)
+	std, err := standardizeJSONC(data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(std, v)
 }
 
 // collectStateSeedPointers returns the JSON pointers we record state for

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -474,6 +474,14 @@ func parseSelector(sel string) (agentName, component, name string, err error) {
 func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string) error {
 	for _, m := range c.MCPServers {
 		if m.ID == name {
+			// Preserve source-only fields (agents allowlist, enabled) that the
+			// rendered destination never carries — otherwise import resets the
+			// agents allowlist to default-all (silently broadening the server's
+			// exposure) and clears enabled. reconcile write-back does the same.
+			if existing, ok, rerr := source.ReadMCP(home, m.ID); rerr == nil && ok {
+				m.Server.Agents = existing.Server.Agents
+				m.Server.Enabled = existing.Server.Enabled
+			}
 			if err := source.WriteMCP(home, m.ID, m); err != nil {
 				return fmt.Errorf("write mcp %s: %w", name, err)
 			}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -20,36 +20,118 @@ import (
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
-// reReferenceImportedSecrets converts any cleartext in the ingested canonical
-// that matches a known ${secret:…} value back to its placeholder, so import
-// never persists a live credential into ~/.agentsync. Best-effort: the map is
-// built from the current source's resolvable secrets; refs that can't be
-// resolved (backend unavailable) are warned about, since their cleartext can't
-// be detected and would land verbatim.
+// reReferenceImportedSecrets restores ${secret:…} placeholders in the ingested
+// canonical so import never persists a live credential into ~/.agentsync. apply
+// substitutes secrets to cleartext into the destination, and import ingests
+// that destination; this puts the placeholders back.
+//
+// Matching is FIELD-POSITIONAL, not value-based: for each item present in the
+// current source, a field is restored to its templated form only if (a) the
+// source field actually referenced a secret and (b) the ingested value still
+// resolves to the same thing (the field is unchanged). A field the source did
+// NOT template (e.g. command = "npx") is never rewritten, even if its literal
+// happens to equal some secret's value — value-based masking would corrupt it.
 func reReferenceImportedSecrets(cmd *cobra.Command, home string, c *source.Canonical) {
 	cur, err := source.Load(loaderFsForState(), home)
 	if err != nil {
 		return // no source yet (first import) → nothing to re-reference
 	}
 	userHome := paths.HomeDir(paths.OSEnv{})
-	secBackend := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
-	full := secrets.CollectResolved(&cur, secBackend, secrets.EnvBackend{})
-	redact := make(map[string]string, len(full))
-	for val, placeholder := range full {
-		// Only re-reference secret values; ${env:…} values are often
-		// low-entropy (paths, hostnames) and converting them risks
-		// over-matching unrelated text.
-		if strings.HasPrefix(placeholder, "${secret:") {
-			redact[val] = placeholder
+	sec := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
+	env := secrets.EnvBackend{}
+
+	// restore returns the source field's templated value when it referenced a
+	// secret and still resolves to the (unchanged) ingested value; otherwise it
+	// keeps the ingested value verbatim.
+	restore := func(srcVal, ingestedVal string) string {
+		if !strings.Contains(srcVal, "${secret:") {
+			return ingestedVal
+		}
+		if resolved, _, rerr := secrets.SubstituteRefs(srcVal, sec, env); rerr == nil && resolved == ingestedVal {
+			return srcVal
+		}
+		return ingestedVal
+	}
+
+	curMCP := make(map[string]source.MCPServerSpec, len(cur.MCPServers))
+	for _, m := range cur.MCPServers {
+		curMCP[m.ID] = m.Server
+	}
+	for i := range c.MCPServers {
+		src, ok := curMCP[c.MCPServers[i].ID]
+		if !ok {
+			continue
+		}
+		restoreServerFields(&c.MCPServers[i].Server, src.Command, src.URL, src.Args, src.Env, src.Headers, restore)
+	}
+
+	curLSP := make(map[string]source.LSPServerSpec, len(cur.LSPServers))
+	for _, l := range cur.LSPServers {
+		curLSP[l.ID] = l.Spec
+	}
+	for i := range c.LSPServers {
+		src, ok := curLSP[c.LSPServers[i].ID]
+		if !ok {
+			continue
+		}
+		sp := &c.LSPServers[i].Spec
+		restoreServerFields2(sp, src.Command, src.URL, src.Args, src.Env, src.Headers, restore)
+	}
+
+	// Hooks have no stable id; match by Event and restore a Command that the
+	// source templated and whose resolution equals the ingested command.
+	for i := range c.Hooks {
+		for _, h := range cur.Hooks {
+			if h.Event != c.Hooks[i].Event || !strings.Contains(h.Command, "${secret:") {
+				continue
+			}
+			if resolved, _, rerr := secrets.SubstituteRefs(h.Command, sec, env); rerr == nil && resolved == c.Hooks[i].Command {
+				c.Hooks[i].Command = h.Command
+				break
+			}
 		}
 	}
-	secrets.ReReferenceSecrets(c, redact)
 
-	if missing := secrets.UnresolvedSecretRefs(&cur, secBackend); len(missing) > 0 {
+	if missing := secrets.UnresolvedSecretRefs(&cur, sec); len(missing) > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: import could not re-reference secret(s) %s (secrets backend unavailable); "+
 				"the imported file may contain cleartext — review it before committing\n",
 			strings.Join(missing, ", "))
+	}
+}
+
+// restoreServerFields applies restore() field-positionally to an MCP spec.
+func restoreServerFields(dst *source.MCPServerSpec, srcCmd, srcURL string, srcArgs []string, srcEnv, srcHeaders map[string]string, restore func(string, string) string) {
+	dst.Command = restore(srcCmd, dst.Command)
+	dst.URL = restore(srcURL, dst.URL)
+	for j := range dst.Args {
+		if j < len(srcArgs) {
+			dst.Args[j] = restore(srcArgs[j], dst.Args[j])
+		}
+	}
+	for k, v := range dst.Env {
+		dst.Env[k] = restore(srcEnv[k], v)
+	}
+	for k, v := range dst.Headers {
+		dst.Headers[k] = restore(srcHeaders[k], v)
+	}
+}
+
+// restoreServerFields2 is restoreServerFields for an LSP spec (same field set,
+// distinct struct type).
+func restoreServerFields2(dst *source.LSPServerSpec, srcCmd, srcURL string, srcArgs []string, srcEnv, srcHeaders map[string]string, restore func(string, string) string) {
+	dst.Command = restore(srcCmd, dst.Command)
+	dst.URL = restore(srcURL, dst.URL)
+	for j := range dst.Args {
+		if j < len(srcArgs) {
+			dst.Args[j] = restore(srcArgs[j], dst.Args[j])
+		}
+	}
+	for k, v := range dst.Env {
+		dst.Env[k] = restore(srcEnv[k], v)
+	}
+	for k, v := range dst.Headers {
+		dst.Headers[k] = restore(srcHeaders[k], v)
 	}
 }
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -15,9 +15,43 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// reReferenceImportedSecrets converts any cleartext in the ingested canonical
+// that matches a known ${secret:…} value back to its placeholder, so import
+// never persists a live credential into ~/.agentsync. Best-effort: the map is
+// built from the current source's resolvable secrets; refs that can't be
+// resolved (backend unavailable) are warned about, since their cleartext can't
+// be detected and would land verbatim.
+func reReferenceImportedSecrets(cmd *cobra.Command, home string, c *source.Canonical) {
+	cur, err := source.Load(loaderFsForState(), home)
+	if err != nil {
+		return // no source yet (first import) → nothing to re-reference
+	}
+	userHome := paths.HomeDir(paths.OSEnv{})
+	secBackend := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
+	full := secrets.CollectResolved(&cur, secBackend, secrets.EnvBackend{})
+	redact := make(map[string]string, len(full))
+	for val, placeholder := range full {
+		// Only re-reference secret values; ${env:…} values are often
+		// low-entropy (paths, hostnames) and converting them risks
+		// over-matching unrelated text.
+		if strings.HasPrefix(placeholder, "${secret:") {
+			redact[val] = placeholder
+		}
+	}
+	secrets.ReReferenceSecrets(c, redact)
+
+	if missing := secrets.UnresolvedSecretRefs(&cur, secBackend); len(missing) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: import could not re-reference secret(s) %s (secrets backend unavailable); "+
+				"the imported file may contain cleartext — review it before committing\n",
+			strings.Join(missing, ", "))
+	}
+}
 
 // loaderFsForState returns an afero.Fs suitable for re-loading the
 // canonical repo when seeding state — the OS FS is correct here because
@@ -138,6 +172,13 @@ func importRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("ingest %s: %w", agentName, err)
 	}
+
+	// Re-reference secrets before writing back to source. The destination was
+	// written by a prior apply with ${secret:…} substituted to cleartext, so
+	// the ingested canonical holds live credentials. Convert any value that
+	// matches a known secret back to its placeholder so import doesn't persist
+	// a cleartext token into ~/.agentsync (often a committed dotfiles repo).
+	reReferenceImportedSecrets(cmd, home, &c)
 
 	switch component {
 	case "mcp":

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -20,10 +20,11 @@ import (
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
-// reReferenceImportedSecrets restores ${secret:…} placeholders in the ingested
-// canonical so import never persists a live credential into ~/.agentsync. apply
-// substitutes secrets to cleartext into the destination, and import ingests
-// that destination; this puts the placeholders back.
+// reReferenceSecretsAgainstSource restores ${secret:…} placeholders in a
+// canonical reconstructed from a destination so import AND reconcile write-back
+// never persist a live credential into ~/.agentsync. apply substitutes secrets
+// to cleartext into the destination; both import and reconcile read that
+// destination back, so this puts the placeholders back before writing source.
 //
 // Matching is FIELD-POSITIONAL, not value-based: for each item present in the
 // current source, a field is restored to its templated form only if (a) the
@@ -31,7 +32,7 @@ import (
 // resolves to the same thing (the field is unchanged). A field the source did
 // NOT template (e.g. command = "npx") is never rewritten, even if its literal
 // happens to equal some secret's value — value-based masking would corrupt it.
-func reReferenceImportedSecrets(cmd *cobra.Command, home string, c *source.Canonical) {
+func reReferenceSecretsAgainstSource(cmd *cobra.Command, home string, c *source.Canonical) {
 	cur, err := source.Load(loaderFsForState(), home)
 	if err != nil {
 		return // no source yet (first import) → nothing to re-reference
@@ -94,8 +95,8 @@ func reReferenceImportedSecrets(cmd *cobra.Command, home string, c *source.Canon
 
 	if missing := secrets.UnresolvedSecretRefs(&cur, sec); len(missing) > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(),
-			"warning: import could not re-reference secret(s) %s (secrets backend unavailable); "+
-				"the imported file may contain cleartext — review it before committing\n",
+			"warning: could not re-reference secret(s) %s (secrets backend unavailable); "+
+				"the written-back source file may contain cleartext — review it before committing\n",
 			strings.Join(missing, ", "))
 	}
 }
@@ -267,7 +268,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 	// the ingested canonical holds live credentials. Convert any value that
 	// matches a known secret back to its placeholder so import doesn't persist
 	// a cleartext token into ~/.agentsync (often a committed dotfiles repo).
-	reReferenceImportedSecrets(cmd, home, &c)
+	reReferenceSecretsAgainstSource(cmd, home, &c)
 
 	switch component {
 	case "mcp":

--- a/internal/cli/import_overmask_test.go
+++ b/internal/cli/import_overmask_test.go
@@ -1,0 +1,51 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestImport_DoesNotOverMaskNonSecretField is the regression for import
+// over-masking: a non-secret field whose literal value happens to equal a
+// secret's resolved value must NOT be rewritten to ${secret:…}. Here the
+// command is literally "npx" and a secret (TOK) also resolves to "npx";
+// import must keep command = "npx" and only re-reference the templated env.
+func TestImport_DoesNotOverMaskNonSecretField(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmp,
+		"TOK":                   "npx", // absurd, but proves field-positional scoping
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	tomlPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	cfg, _ := os.ReadFile(tomlPath)
+	_ = os.WriteFile(tomlPath, append(cfg, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644)
+
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcpPath), 0o755)
+	src := "[server]\ntype = \"stdio\"\ncommand = \"npx\"\n[server.env]\nTOK = \"${secret:TOK}\"\n"
+	_ = os.WriteFile(mcpPath, []byte(src), 0o644)
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := runCLI(t, env, "import", "claude:mcp:github"); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	got, _ := os.ReadFile(mcpPath)
+	gs := string(got)
+	if !strings.Contains(gs, "command = \"npx\"") && !strings.Contains(gs, "command = 'npx'") {
+		t.Fatalf("non-secret command field was over-masked:\n%s", gs)
+	}
+	if !strings.Contains(gs, "${secret:TOK}") {
+		t.Fatalf("templated env field should still be re-referenced:\n%s", gs)
+	}
+}

--- a/internal/cli/import_preserve_test.go
+++ b/internal/cli/import_preserve_test.go
@@ -1,0 +1,41 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestImport_PreservesSourceOnlyFields is the regression for import dropping
+// source-only MCP fields (agents/enabled) that the rendered destination never
+// carries. Reconstructing the server purely from the dest reset the agents
+// allowlist to default-all — silently BROADENING the server's exposure — and
+// cleared enabled. reconcile already preserves these; import must too.
+func TestImport_PreservesSourceOnlyFields(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcpPath), 0o755)
+	// A restrictive agents allowlist — a source-only field absent from the dest.
+	src := "[server]\ntype = \"stdio\"\ncommand = \"npx\"\nagents = [\"claude\"]\n"
+	_ = os.WriteFile(mcpPath, []byte(src), 0o644)
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := runCLI(t, env, "import", "claude:mcp:github"); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	got, _ := os.ReadFile(mcpPath)
+	if !strings.Contains(string(got), "claude") || !strings.Contains(string(got), "agents") {
+		t.Fatalf("import dropped the source-only agents allowlist (broadens exposure):\n%s", got)
+	}
+}

--- a/internal/cli/import_secret_test.go
+++ b/internal/cli/import_secret_test.go
@@ -1,0 +1,72 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestImport_ReReferencesSecretsNotCleartext is the regression for a
+// credential-persistence leak: `apply` substitutes ${secret:KEY} into the
+// destination as cleartext, and `import` ingests that destination. Writing the
+// ingested value verbatim back into ~/.agentsync/mcp/<id>.toml (a file users
+// commit to dotfiles repos) persisted the live secret in cleartext. Import must
+// re-reference known secret values back to their ${secret:KEY} placeholder.
+func TestImport_ReReferencesSecretsNotCleartext(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmp,
+		"GH_TOKEN":              "ghp_SUPERSECRET_DO_NOT_PERSIST",
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+
+	// Enable the env secrets backend.
+	tomlPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	cfg, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg = append(cfg, []byte("\n[secrets]\nbackend = \"env\"\n")...)
+	if err := os.WriteFile(tomlPath, cfg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Source MCP server that references the secret.
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := "[server]\ntype = \"stdio\"\ncommand = \"npx\"\n[server.env]\nGH_TOKEN = \"${secret:GH_TOKEN}\"\n"
+	if err := os.WriteFile(mcpPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	dest, _ := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+	if !strings.Contains(string(dest), "ghp_SUPERSECRET_DO_NOT_PERSIST") {
+		t.Fatalf("precondition failed: apply did not substitute the secret into the dest:\n%s", dest)
+	}
+
+	if _, err := runCLI(t, env, "import", "claude:mcp:github"); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	got, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "ghp_SUPERSECRET_DO_NOT_PERSIST") {
+		t.Fatalf("import persisted the cleartext secret into the source TOML:\n%s", got)
+	}
+	if !strings.Contains(string(got), "${secret:GH_TOKEN}") {
+		t.Fatalf("import did not re-reference the ${secret:GH_TOKEN} placeholder:\n%s", got)
+	}
+}

--- a/internal/cli/jsonc_read_test.go
+++ b/internal/cli/jsonc_read_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadJSONFile_ParsesJSONC is the regression for drift misclassification
+// on hand-commented opencode.json. Apply/Ingest accept JSONC via hujson, so a
+// user may legitimately add `//` comments; readJSONFile (used by status/diff/
+// reconcile to read the on-disk dest) used plain encoding/json, which rejects
+// JSONC. The parse failed → empty map → every owned merge-jsonc-keys pointer
+// classified as a phantom Conflict.
+func TestReadJSONFile_ParsesJSONC(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "opencode.json")
+	content := `{
+  // managed by agentsync
+  "mcp": {
+    "github": {"command": "npx"}, // trailing comma below too
+  },
+}`
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := readJSONFile(p)
+	mcp, ok := m["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("readJSONFile failed to parse JSONC: %v", m)
+	}
+	if _, ok := mcp["github"]; !ok {
+		t.Fatalf("github server missing after JSONC parse: %v", mcp)
+	}
+}
+
+// TestJSONUnmarshalLoose_ParsesJSONC covers the import-seed path, which used
+// the same plain encoding/json and would mis-seed state hashes (hashing null)
+// for a JSONC dest.
+func TestJSONUnmarshalLoose_ParsesJSONC(t *testing.T) {
+	var m map[string]any
+	content := []byte("{\n  \"a\": 1, // comment\n}")
+	if err := jsonUnmarshalLoose(content, &m); err != nil {
+		t.Fatalf("jsonUnmarshalLoose JSONC: %v", err)
+	}
+	if m["a"] == nil {
+		t.Fatalf("key a missing after JSONC loose-parse: %v", m)
+	}
+}

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/paths"
 )
 
 // lockTimeout is how long mutating CLI commands wait for the global lock
@@ -30,4 +32,20 @@ func withGlobalLock(home string, fn func() error) error {
 	}
 	defer func() { _ = lock.Release() }()
 	return fn()
+}
+
+// lockedRun wraps a cobra RunE so the command body executes under the global
+// lock. Used by the agent/plugin mutators that do a read-modify-write of
+// agentsync.toml or plugins/<id>.toml: without serialization, two concurrent
+// runs (or one racing a locked `apply`/`update`) lose an update — AtomicWrite
+// prevents a torn file but not a stale-read overwrite. The wrapped function
+// must NOT acquire the global lock itself (gofrs/flock would deadlock on the
+// re-entrant acquire from the same process).
+func lockedRun(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		home := paths.AgentsyncHome(paths.OSEnv{})
+		return withGlobalLock(home, func() error {
+			return fn(cmd, args)
+		})
+	}
 }

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -156,6 +156,9 @@ func newMarketplaceRemoveCmd() *cobra.Command {
 
 func marketplaceRemoveRun(cmd *cobra.Command, args []string) error {
 	name := args[0]
+	if err := validateCacheKey("marketplace", name); err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	tomlPath := filepath.Join(home, "marketplaces", name+".toml")

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -138,6 +138,9 @@ func newPluginUpgradeCmd() *cobra.Command {
 
 func pluginUpgradeRun(cmd *cobra.Command, args []string) error {
 	id := args[0]
+	if err := validateCacheKey("plugin", id); err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	// Read existing plugin toml.
@@ -211,6 +214,9 @@ func newPluginEnableCmd() *cobra.Command {
 
 func pluginEnableRun(cmd *cobra.Command, args []string) error {
 	id := args[0]
+	if err := validateCacheKey("plugin", id); err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	pluginPath := filepath.Join(home, "plugins", id+".toml")
 
@@ -246,6 +252,9 @@ func newPluginDisableCmd() *cobra.Command {
 
 func pluginDisableRun(cmd *cobra.Command, args []string) error {
 	id := args[0]
+	if err := validateCacheKey("plugin", id); err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	pluginPath := filepath.Join(home, "plugins", id+".toml")
 
@@ -279,6 +288,9 @@ func newPluginRemoveCmd() *cobra.Command {
 
 func pluginRemoveRun(cmd *cobra.Command, args []string) error {
 	id := args[0]
+	if err := validateCacheKey("plugin", id); err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	pluginPath := filepath.Join(home, "plugins", id+".toml")

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -54,7 +54,7 @@ func newPluginInstallCmd() *cobra.Command {
 		Use:   "install <id[@marketplace]>",
 		Short: "fetch a plugin and register it",
 		Args:  cobra.ExactArgs(1),
-		RunE:  pluginInstallRun,
+		RunE:  lockedRun(pluginInstallRun),
 	}
 }
 
@@ -132,7 +132,7 @@ func newPluginUpgradeCmd() *cobra.Command {
 		Use:   "upgrade <id>",
 		Short: "re-fetch a plugin and update its manifest sha",
 		Args:  cobra.ExactArgs(1),
-		RunE:  pluginUpgradeRun,
+		RunE:  lockedRun(pluginUpgradeRun),
 	}
 }
 
@@ -208,7 +208,7 @@ func newPluginEnableCmd() *cobra.Command {
 		Use:   "enable <id>",
 		Short: "enable a disabled plugin",
 		Args:  cobra.ExactArgs(1),
-		RunE:  pluginEnableRun,
+		RunE:  lockedRun(pluginEnableRun),
 	}
 }
 
@@ -246,7 +246,7 @@ func newPluginDisableCmd() *cobra.Command {
 		Use:   "disable <id>",
 		Short: "disable a plugin without removing it",
 		Args:  cobra.ExactArgs(1),
-		RunE:  pluginDisableRun,
+		RunE:  lockedRun(pluginDisableRun),
 	}
 }
 
@@ -282,7 +282,7 @@ func newPluginRemoveCmd() *cobra.Command {
 		Use:   "remove <id>",
 		Short: "remove a plugin and its cached files",
 		Args:  cobra.ExactArgs(1),
-		RunE:  pluginRemoveRun,
+		RunE:  lockedRun(pluginRemoveRun),
 	}
 }
 

--- a/internal/cli/purge_preserve_test.go
+++ b/internal/cli/purge_preserve_test.go
@@ -1,0 +1,66 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPurge_PreservesUserKeysInSharedFile is the regression for the
+// data-loss showstopper: `agent disable --purge` issued a whole-file delete
+// for every owned dest path, including key-merge files like ~/.claude.json
+// where agentsync owns only some pointers. That destroyed the user's foreign
+// keys (other MCP servers, top-level settings) with no backup. Purge must
+// prune only the owned pointers from a key-merge dest.
+func TestPurge_PreservesUserKeysInSharedFile(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcpPath), 0o755)
+	_ = os.WriteFile(mcpPath, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// The user hand-adds foreign content to the shared dest file.
+	dest := filepath.Join(tmp, ".claude.json")
+	raw, _ := os.ReadFile(dest)
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	m["userTopLevel"] = "keep-me"
+	if mcp, ok := m["mcpServers"].(map[string]any); ok {
+		mcp["userServer"] = map[string]any{"command": "mine"}
+	}
+	nb, _ := json.Marshal(m)
+	_ = os.WriteFile(dest, nb, 0o644)
+
+	if _, err := runCLI(t, env, "agent", "disable", "claude", "--purge"); err != nil {
+		t.Fatalf("disable --purge: %v", err)
+	}
+
+	after, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("dest file was deleted entirely (user data lost): %v", err)
+	}
+	var am map[string]any
+	if err := json.Unmarshal(after, &am); err != nil {
+		t.Fatalf("dest unreadable after purge: %v\n%s", err, after)
+	}
+	if am["userTopLevel"] != "keep-me" {
+		t.Fatalf("user top-level key destroyed by purge: %s", after)
+	}
+	mcp, _ := am["mcpServers"].(map[string]any)
+	if _, ok := mcp["userServer"]; !ok {
+		t.Fatalf("user's foreign MCP server destroyed by purge: %s", after)
+	}
+	if _, ok := mcp["github"]; ok {
+		t.Fatalf("agentsync-owned server should have been purged: %s", after)
+	}
+}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -237,7 +237,7 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 		switch action {
 		case 'w':
 			// write-back: persist destination value into the canonical source.
-			if err := writeBackItem(home, it); err != nil {
+			if err := writeBackItem(cmd, home, it); err != nil {
 				fmt.Fprintf(w, "  write-back error: %v\n", err)
 			} else {
 				fmt.Fprintf(w, "  write-back: %s\n", itemLabel(it))
@@ -419,9 +419,9 @@ func readChar(r *bufio.Reader) (byte, error) {
 // writeBackItem persists the current destination value for item it back into
 // the canonical source (~/.agentsync/). Only MCP-server items are fully
 // supported in v1; other item types fall back to a raw file copy.
-func writeBackItem(home string, it reconcileItem) error {
+func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 	if it.ptr != "" {
-		return writeBackKeyItem(home, it)
+		return writeBackKeyItem(cmd, home, it)
 	}
 	return writeBackFileItem(home, it)
 }
@@ -435,7 +435,7 @@ func writeBackItem(home string, it reconcileItem) error {
 // to: the prior code returned nil and printed "write-back: <label>", giving
 // the impression the hand-edit had been persisted when in fact it had not
 // — the next apply would then destroy the user's edit.
-func writeBackKeyItem(home string, it reconcileItem) error {
+func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 	dest := readJSONFile(it.op.Path)
 	// Expected ptr shape: /mcpServers/<serverID>/...
 	parts := strings.SplitN(strings.TrimPrefix(it.ptr, "/"), "/", 3)
@@ -471,7 +471,14 @@ func writeBackKeyItem(home string, it reconcileItem) error {
 			spec.Enabled = existing.Server.Enabled
 		}
 		m := source.MCPServer{ID: serverID, Server: spec}
-		return source.WriteMCP(home, serverID, m)
+		// The spec was reconstructed from the destination, where apply wrote
+		// any ${secret:…} as resolved cleartext. Re-reference known secrets
+		// back to their placeholder before persisting to source — otherwise
+		// write-back leaks the live token into ~/.agentsync (same hole that
+		// `import` guards against).
+		rc := source.Canonical{MCPServers: []source.MCPServer{m}}
+		reReferenceSecretsAgainstSource(cmd, home, &rc)
+		return source.WriteMCP(home, serverID, rc.MCPServers[0])
 	}
 	// Unsupported pointer shape (hooks, lsp, …). DO NOT silently no-op —
 	// the success message would be a lie.

--- a/internal/cli/reconcile_secret_test.go
+++ b/internal/cli/reconcile_secret_test.go
@@ -1,0 +1,57 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReconcileWriteBack_ReReferencesSecrets is the regression for the
+// reconcile [w]rite-back leak: apply substitutes ${secret:} into the dest as
+// cleartext; when the user edits the dest and reconcile writes it back, the MCP
+// spec was reconstructed from the cleartext dest and persisted to the source
+// TOML verbatim — leaking the live token into a file users commit. The import
+// path was hardened; reconcile write-back must re-reference too.
+func TestReconcileWriteBack_ReReferencesSecrets(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmp,
+		"GH_TOKEN":              "ghp_SUPERSECRET_DO_NOT_PERSIST",
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	tomlPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	cfg, _ := os.ReadFile(tomlPath)
+	_ = os.WriteFile(tomlPath, append(cfg, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644)
+
+	mcpPath := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcpPath), 0o755)
+	src := "[server]\ntype = \"stdio\"\ncommand = \"npx\"\n[server.env]\nGH_TOKEN = \"${secret:GH_TOKEN}\"\n"
+	_ = os.WriteFile(mcpPath, []byte(src), 0o644)
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// User hand-edits an UNRELATED field of the dest, creating drift.
+	destPath := filepath.Join(tmp, ".claude.json")
+	dest, _ := os.ReadFile(destPath)
+	edited := strings.Replace(string(dest), `"npx"`, `"npm"`, 1)
+	if edited == string(dest) {
+		t.Fatalf("precondition: could not edit dest command:\n%s", dest)
+	}
+	_ = os.WriteFile(destPath, []byte(edited), 0o644)
+
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, _ := os.ReadFile(mcpPath)
+	if strings.Contains(string(got), "ghp_SUPERSECRET_DO_NOT_PERSIST") {
+		t.Fatalf("reconcile write-back persisted the cleartext secret into source:\n%s", got)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -222,6 +222,12 @@ func getPointerValue(m map[string]any, ptr string) any {
 	parts := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
 	var cur any = m
 	for _, p := range parts {
+		// Decode RFC 6901 escapes so a managed id containing '~' or '/'
+		// (which CollectPointers escaped to ~0/~1) matches the real key.
+		// Without this, status/diff looked up the literal escaped key, found
+		// nothing, and reported phantom drift forever for that item.
+		p = strings.ReplaceAll(p, "~1", "/")
+		p = strings.ReplaceAll(p, "~0", "~")
 		mp, ok := cur.(map[string]any)
 		if !ok {
 			return nil

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -86,9 +86,14 @@ func newStatusCmd() *cobra.Command {
 				}
 				fmt.Fprintf(w, "[%s]\n", name)
 				seen := map[string]bool{}
-				// file-level: for each op, classify
+				// file-level: for each op, classify. Only key-merge ops are
+				// handled key-by-key below; every other strategy (including
+				// "replace", used by skills/subagents/commands/memory) is a
+				// whole-file op and must be classified here. Skipping on any
+				// non-empty MergeStrategy silently dropped all replace-strategy
+				// files, so status reported no drift for them.
 				for _, op := range res.Ops {
-					if op.MergeStrategy != "" {
+					if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
 						continue // covered key-by-key below
 					}
 					if seen[op.Path] {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/tailscale/hujson"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -179,13 +180,33 @@ func hashAnyValue(v any) string {
 	return hashContent(data)
 }
 
+// standardizeJSONC converts JSONC (comments, trailing commas) to plain JSON
+// bytes so encoding/json can parse it. It mirrors how the adapters read these
+// destination files (hujson.Parse + Standardize), keeping the drift/import
+// read paths in agreement with the apply write path.
+func standardizeJSONC(data []byte) ([]byte, error) {
+	v, err := hujson.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	v.Standardize()
+	return v.Pack(), nil
+}
+
 func readJSONFile(path string) map[string]any {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return map[string]any{}
 	}
-	var m map[string]any
-	_ = json.Unmarshal(data, &m)
+	m := map[string]any{}
+	// Accept JSONC: apply/ingest write and read these dests via hujson, so a
+	// user may legitimately have `//` comments or trailing commas in
+	// opencode.json. Reading them with plain encoding/json would fail and
+	// yield an empty map, making drift classification (status/diff/reconcile)
+	// report phantom conflicts for every owned pointer.
+	if std, serr := standardizeJSONC(data); serr == nil {
+		_ = json.Unmarshal(std, &m)
+	}
 	return m
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -46,6 +46,39 @@ func TestStatus_DriftAfterDirectEdit(t *testing.T) {
 	}
 }
 
+// TestStatus_DriftOnReplaceFile guards against the regression where status
+// only classified merge-json-keys ops (MCP/hooks/lsp) and silently dropped
+// every "replace"-strategy file (skills, subagents, commands, memory) — so a
+// hand-edited SKILL.md / CLAUDE.md / subagent showed no drift at all.
+func TestStatus_DriftOnReplaceFile(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	sk := filepath.Join(tmp, ".agentsync", "skills", "greet", "SKILL.md")
+	_ = os.MkdirAll(filepath.Dir(sk), 0o755)
+	_ = os.WriteFile(sk, []byte("---\nname: greet\ndescription: d\n---\nhi\n"), 0o644)
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	dst := filepath.Join(tmp, ".claude", "skills", "greet", "SKILL.md")
+	if err := os.WriteFile(dst, []byte("---\nname: greet\ndescription: d\n---\nHAND EDITED\n"), 0o644); err != nil {
+		t.Fatalf("edit dst: %v", err)
+	}
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "drift") {
+		t.Fatalf("status did not report drift on a replace-strategy skill file:\n%s", out)
+	}
+}
+
 func TestStatus_CleanAfterApply(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/traversal_remove_test.go
+++ b/internal/cli/traversal_remove_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newDiscardCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	return cmd
+}
+
+// TestPluginRemove_RejectsTraversal is the regression for an arbitrary-file
+// delete: `plugin remove` built filepath.Join(home, "plugins", id+".toml")
+// from the raw id and os.Remove'd it with no validation, so a traversal id
+// ("../../victim") deleted a file outside ~/.agentsync and exited 0. Only
+// `plugin install` validated the id.
+func TestPluginRemove_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	if err := os.MkdirAll(filepath.Join(home, "plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTSYNC_HOME", home)
+
+	victim := filepath.Join(base, "victim.toml")
+	if err := os.WriteFile(victim, []byte("precious"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pluginRemoveRun(newDiscardCmd(), []string{"../../victim"}); err == nil {
+		t.Fatal("expected pluginRemoveRun to reject a traversal id")
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatalf("victim file outside home was deleted via traversal: %v", err)
+	}
+}
+
+// TestMarketplaceRemove_RejectsTraversal is the same arbitrary-delete hole in
+// `marketplace remove`.
+func TestMarketplaceRemove_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	if err := os.MkdirAll(filepath.Join(home, "marketplaces"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTSYNC_HOME", home)
+
+	victim := filepath.Join(base, "victim.toml")
+	if err := os.WriteFile(victim, []byte("precious"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := marketplaceRemoveRun(newDiscardCmd(), []string{"../../victim"}); err == nil {
+		t.Fatal("expected marketplaceRemoveRun to reject a traversal name")
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatalf("victim file outside home was deleted via traversal: %v", err)
+	}
+}

--- a/internal/cli/ux_errors_test.go
+++ b/internal/cli/ux_errors_test.go
@@ -1,0 +1,40 @@
+package cli_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAgentList_MissingHome_FriendlyError covers P4: agent commands on an
+// uninitialized home printed a raw Go open error instead of pointing the user
+// at `agentsync init`.
+func TestAgentList_MissingHome_FriendlyError(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_HOME": filepath.Join(tmp, "nope")}
+	out, err := runCLI(t, env, "agent", "list")
+	if err == nil {
+		t.Fatalf("expected an error for a missing home; out=%s", out)
+	}
+	if !strings.Contains(out+err.Error(), "agentsync init") {
+		t.Fatalf("error should point at `agentsync init`; got out=%q err=%v", out, err)
+	}
+}
+
+// TestImport_TwoPartSelector_Rejected covers P5: a selector missing the item
+// name (e.g. "claude:mcp") must fail with the expected grammar, not a
+// misleading downstream "server \"\" not found".
+func TestImport_TwoPartSelector_Rejected(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	out, err := runCLI(t, env, "import", "claude:mcp")
+	if err == nil {
+		t.Fatalf("expected an error for a 2-part selector; out=%s", out)
+	}
+	if !strings.Contains(out+err.Error(), "missing the item name") {
+		t.Fatalf("expected a 'missing the item name' error; got out=%q err=%v", out, err)
+	}
+}

--- a/internal/jsonkeys/jsonkeys.go
+++ b/internal/jsonkeys/jsonkeys.go
@@ -21,16 +21,9 @@ func MergeKeys(existing, ours map[string]any, ownedPointers []string) (map[strin
 		merged = map[string]any{}
 	}
 
-	// Step 1: overlay ours onto merged
-	for k, v := range ours {
-		if ev, ok := merged[k].(map[string]any); ok {
-			if vv, ok := v.(map[string]any); ok {
-				merged[k] = mergeMaps(ev, vv)
-				continue
-			}
-		}
-		merged[k] = v
-	}
+	// Step 1: overlay ours onto merged, REPLACING at second-level (owned)
+	// granularity rather than deep-merging.
+	overlayOwned(merged, ours)
 
 	// Step 2: walk ownedPointers; if a pointer is no longer present in `ours`,
 	// delete it from merged. If still present, mark kept.
@@ -48,18 +41,27 @@ func MergeKeys(existing, ours map[string]any, ownedPointers []string) (map[strin
 	return merged, kept, removed
 }
 
-func mergeMaps(a, b map[string]any) map[string]any {
-	out := deepCopyMap(a)
-	for k, v := range b {
-		if existing, ok := out[k].(map[string]any); ok {
-			if vv, ok := v.(map[string]any); ok {
-				out[k] = mergeMaps(existing, vv)
-				continue
+// overlayOwned overlays ours onto merged at SECOND-LEVEL (owned) granularity:
+// agentsync owns a top-level section's child objects wholesale (e.g.
+// /mcpServers/<id>), so when both sides hold an object at a top-level key, each
+// child key from ours REPLACES the corresponding child in merged — it is not
+// deep-merged. This is what makes a removed inner field (a dropped env var, or
+// a stale `command` after a stdio→http switch) actually disappear, while still
+// preserving FOREIGN sibling children (ids the user added that ours doesn't
+// mention). A top-level key whose value is a scalar/array is replaced whole.
+// Values are deep-copied so merged shares no mutable structure with ours.
+func overlayOwned(merged, ours map[string]any) {
+	for k, v := range ours {
+		ovv, ok := v.(map[string]any)
+		mvv, mok := merged[k].(map[string]any)
+		if ok && mok {
+			for kk, vv := range ovv {
+				mvv[kk] = deepCopyValue(vv)
 			}
+			continue
 		}
-		out[k] = v
+		merged[k] = deepCopyValue(v)
 	}
-	return out
 }
 
 func deepCopyMap(m map[string]any) map[string]any {

--- a/internal/jsonkeys/jsonkeys.go
+++ b/internal/jsonkeys/jsonkeys.go
@@ -3,8 +3,32 @@
 package jsonkeys
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 )
+
+// DecodeObject unmarshals JSON object bytes into a map, preserving numbers as
+// json.Number rather than coercing to float64. The merge promises to preserve
+// FOREIGN keys verbatim, but float64 silently rounds any integer larger than
+// 2^53 (snowflake ids, nanosecond timestamps) on re-marshal. json.Number keeps
+// the literal digits and re-marshals exactly. nil/empty input yields an empty
+// map.
+func DecodeObject(data []byte) (map[string]any, error) {
+	m := map[string]any{}
+	if len(data) == 0 {
+		return m, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+	return m, nil
+}
 
 // MergeKeys merges ours into existing, removing ownedPointers that are no
 // longer in ours. Returns the merged map plus diagnostic lists.

--- a/internal/jsonkeys/jsonkeys.go
+++ b/internal/jsonkeys/jsonkeys.go
@@ -68,13 +68,28 @@ func deepCopyMap(m map[string]any) map[string]any {
 	}
 	out := make(map[string]any, len(m))
 	for k, v := range m {
-		if mm, ok := v.(map[string]any); ok {
-			out[k] = deepCopyMap(mm)
-		} else {
-			out[k] = v
-		}
+		out[k] = deepCopyValue(v)
 	}
 	return out
+}
+
+// deepCopyValue recursively copies maps and slices so the result shares no
+// mutable structure with the input. Scalars (string/float64/bool/nil) are
+// immutable and returned as-is. Without the []any case a merged result aliased
+// the input's arrays (and the objects inside them).
+func deepCopyValue(v any) any {
+	switch vv := v.(type) {
+	case map[string]any:
+		return deepCopyMap(vv)
+	case []any:
+		out := make([]any, len(vv))
+		for i, e := range vv {
+			out[i] = deepCopyValue(e)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 func pointerExists(m map[string]any, ptr string) bool {

--- a/internal/jsonkeys/jsonkeys_test.go
+++ b/internal/jsonkeys/jsonkeys_test.go
@@ -74,3 +74,27 @@ func TestMergeKeys_ForeignNotInOwnedListPreserved(t *testing.T) {
 		t.Fatalf("we owned old-mine but it wasn't in existing; nothing to remove. Got %v", removed)
 	}
 }
+
+// TestMergeKeys_DeepCopiesArrays guards against deepCopyMap aliasing nested
+// arrays (and the objects inside them) from the input `existing` map. Today no
+// caller mutates a merged array post-merge, but the aliasing is a latent
+// footgun: a future caller that did would silently corrupt the on-disk-derived
+// input. MergeKeys must return a fully independent copy.
+func TestMergeKeys_DeepCopiesArrays(t *testing.T) {
+	existing := map[string]any{
+		"hooks": []any{map[string]any{"cmd": "original"}},
+	}
+	merged, _, _ := jsonkeys.MergeKeys(existing, map[string]any{"other": float64(1)}, nil)
+
+	arr, ok := merged["hooks"].([]any)
+	if !ok || len(arr) != 1 {
+		t.Fatalf("hooks array not preserved through merge: %+v", merged["hooks"])
+	}
+	elem := arr[0].(map[string]any)
+	elem["cmd"] = "mutated"
+
+	origElem := existing["hooks"].([]any)[0].(map[string]any)
+	if origElem["cmd"] != "original" {
+		t.Fatalf("mutating the merged array corrupted the input `existing`: %v", origElem)
+	}
+}

--- a/internal/jsonkeys/jsonkeys_test.go
+++ b/internal/jsonkeys/jsonkeys_test.go
@@ -98,3 +98,33 @@ func TestMergeKeys_DeepCopiesArrays(t *testing.T) {
 		t.Fatalf("mutating the merged array corrupted the input `existing`: %v", origElem)
 	}
 }
+
+// TestMergeKeys_ReplacesOwnedObjectWholesale is the regression for stale inner
+// fields surviving removal. agentsync owns /mcpServers/<id> as a whole object,
+// so when `ours` drops an inner key (e.g. `env`, or `command` after a
+// stdio→http transport switch), MergeKeys must REPLACE the object — a
+// deep-merge stranded the removed field, leaving a stale (often secret-bearing)
+// value or an ambiguous command+url server on disk.
+func TestMergeKeys_ReplacesOwnedObjectWholesale(t *testing.T) {
+	existing := decode(`{"mcpServers": {"github": {"command": "npx", "env": {"TOKEN": "abc"}}}}`)
+	ours := decode(`{"mcpServers": {"github": {"command": "npx"}}}`)
+	owned := []string{"/mcpServers/github"}
+
+	merged, _, _ := jsonkeys.MergeKeys(existing, ours, owned)
+	gh := merged["mcpServers"].(map[string]any)["github"].(map[string]any)
+	if _, ok := gh["env"]; ok {
+		t.Fatalf("stale env survived owned-object replace: %+v", gh)
+	}
+
+	// Transport switch: command must vanish when ours has only url.
+	existing2 := decode(`{"mcpServers": {"srv": {"command": "npx", "type": "stdio"}}}`)
+	ours2 := decode(`{"mcpServers": {"srv": {"url": "https://x", "type": "http"}}}`)
+	merged2, _, _ := jsonkeys.MergeKeys(existing2, ours2, []string{"/mcpServers/srv"})
+	srv := merged2["mcpServers"].(map[string]any)["srv"].(map[string]any)
+	if _, ok := srv["command"]; ok {
+		t.Fatalf("stale command survived transport switch: %+v", srv)
+	}
+	if srv["url"] != "https://x" {
+		t.Fatalf("url not written on transport switch: %+v", srv)
+	}
+}

--- a/internal/marketplace/fetch_git.go
+++ b/internal/marketplace/fetch_git.go
@@ -179,6 +179,16 @@ func resolveRefName(ref string) plumbing.ReferenceName {
 // existed but wasn't a git repo.
 func extractSubdir(dir, subPath string) error {
 	fullSub := filepath.Join(dir, subPath)
+	// Containment guard: subPath comes straight from an untrusted
+	// marketplace.json `path` field. A traversal sequence ("../../etc")
+	// resolves OUTSIDE the clone after filepath.Join, which would let the
+	// copyDir below slurp arbitrary host files into the plugin cache — and
+	// from there into the user's agent config. Refuse anything that escapes
+	// the clone root. (The sibling npm/relative fetchers already bound their
+	// extraction; this closes the lone git-subdir hole.)
+	if !pathContains(dir, fullSub) {
+		return fmt.Errorf("subdir %q escapes the repository root (refusing path traversal)", subPath)
+	}
 	info, err := os.Stat(fullSub)
 	if err != nil {
 		return fmt.Errorf("subdir %s does not exist in clone: %w", subPath, err)

--- a/internal/marketplace/fetch_git_subdir_test.go
+++ b/internal/marketplace/fetch_git_subdir_test.go
@@ -1,0 +1,61 @@
+package marketplace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtractSubdir_RejectsTraversal is the regression for the git-subdir
+// path-traversal hole: a marketplace plugin entry can set `path` to a
+// traversal sequence ("../../etc"), which filepath.Join resolves OUTSIDE the
+// clone. Without a containment guard, copyDir would slurp arbitrary host
+// files into the plugin cache (then project them into agent config). The
+// extractor must refuse and leave the clone untouched.
+func TestExtractSubdir_RejectsTraversal(t *testing.T) {
+	parent := t.TempDir()
+	clone := filepath.Join(parent, "clone")
+	if err := os.MkdirAll(filepath.Join(clone, "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clone, "real", "ok.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sibling "secret" dir OUTSIDE the clone, holding a sensitive file.
+	secret := filepath.Join(parent, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secret, "id_rsa"), []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractSubdir(clone, "../secret"); err == nil {
+		t.Fatal("expected traversal subdir to be rejected, got nil error")
+	}
+
+	// The clone must not have been replaced with the external secret dir.
+	if _, err := os.Stat(filepath.Join(clone, "id_rsa")); err == nil {
+		t.Fatal("external file id_rsa was copied into the clone — traversal succeeded")
+	}
+}
+
+// TestExtractSubdir_HappyPath confirms the guard does not break a legitimate
+// in-tree subdirectory extraction.
+func TestExtractSubdir_HappyPath(t *testing.T) {
+	parent := t.TempDir()
+	clone := filepath.Join(parent, "clone")
+	if err := os.MkdirAll(filepath.Join(clone, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clone, "skills", "a.md"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractSubdir(clone, "skills"); err != nil {
+		t.Fatalf("legitimate subdir extraction failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(clone, "a.md")); err != nil {
+		t.Fatalf("subdir contents not promoted to clone root: %v", err)
+	}
+}

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -344,6 +344,9 @@ func loadSkillEntry(path string, readFile func(string) ([]byte, error)) (*source
 	if name == "" {
 		name = filepath.Base(path)
 	}
+	if err := validateProjectedName("skill", name); err != nil {
+		return nil, err
+	}
 
 	return &source.Skill{Name: name, Frontmatter: fm, Body: body}, nil
 }
@@ -374,8 +377,27 @@ func loadMarkdownEntry(path string, readFile func(string) ([]byte, error)) (*mar
 	if name == "" {
 		name = strings.TrimSuffix(filepath.Base(path), ".md")
 	}
+	if err := validateProjectedName("component", name); err != nil {
+		return nil, err
+	}
 
 	return &markdownEntry{name: name, fm: fm, body: body}, nil
+}
+
+// validateProjectedName rejects a skill/subagent/command name that would
+// escape its destination directory once joined into a path. Component names
+// become path segments at render time, so a name from a hostile plugin
+// manifest's frontmatter like "../../evil" must never reach a writer. This
+// mirrors the equivalent guard in the source loader's projection twin — the
+// runtime path — so the two projection implementations cannot diverge.
+func validateProjectedName(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("%s has an empty name", kind)
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") || strings.ContainsRune(name, 0) {
+		return fmt.Errorf("%s name %q contains a path separator or traversal component", kind, name)
+	}
+	return nil
 }
 
 // applyHooks interprets the hooks field (string | []string | map) and appends

--- a/internal/marketplace/projection_internal_test.go
+++ b/internal/marketplace/projection_internal_test.go
@@ -1,0 +1,33 @@
+package marketplace
+
+import "testing"
+
+// TestLoadComponentEntry_RejectsTraversalName closes the divergence between
+// the marketplace projection and the source loader twin: the loader validates
+// component names (a name becomes a path segment at render time, so a hostile
+// plugin frontmatter "name: ../../evil" is zip-slip-by-name), but the
+// marketplace projection's loaders did not. marketplace.Project has no
+// production caller today (the runtime path projects via the validating source
+// loader), but it is exported API and the two paths must not diverge.
+func TestLoadComponentEntry_RejectsTraversalName(t *testing.T) {
+	readFile := func(string) ([]byte, error) {
+		return []byte("---\nname: ../../evil\n---\nbody\n"), nil
+	}
+	if _, err := loadMarkdownEntry("cmd.md", readFile); err == nil {
+		t.Fatal("expected loadMarkdownEntry to reject a traversal name")
+	}
+	if _, err := loadSkillEntry("skills/x", readFile); err == nil {
+		t.Fatal("expected loadSkillEntry to reject a traversal name")
+	}
+}
+
+// TestLoadComponentEntry_AllowsNormalName confirms the guard does not reject a
+// legitimate component name.
+func TestLoadComponentEntry_AllowsNormalName(t *testing.T) {
+	readFile := func(string) ([]byte, error) {
+		return []byte("---\nname: code-review\n---\nbody\n"), nil
+	}
+	if _, err := loadMarkdownEntry("cmd.md", readFile); err != nil {
+		t.Fatalf("legitimate name rejected: %v", err)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -159,6 +159,13 @@ func Merge(base source.Canonical, m *Marker) source.Canonical {
 	// Memory imports: read project-relative files and append.
 	if len(m.Memory.Import) > 0 {
 		body := out.Memory.Body
+		// Resolve the root through any symlinks once so a symlinked tmp root
+		// (e.g. macOS /tmp -> /private/tmp) doesn't cause false rejections of
+		// legitimate in-root imports below.
+		resolvedRoot := m.Root
+		if rr, err := filepath.EvalSymlinks(m.Root); err == nil {
+			resolvedRoot = rr
+		}
 		for _, rel := range m.Memory.Import {
 			// Containment: a committed marker's import path must not escape
 			// the project root. Without this, `import = ["../../etc/passwd"]`
@@ -168,7 +175,16 @@ func Merge(base source.Canonical, m *Marker) source.Canonical {
 			if !importWithinRoot(m.Root, abs) {
 				continue
 			}
-			data, err := os.ReadFile(abs)
+			// Defense-in-depth: the lexical check above can't see a committed
+			// symlink under the root (leak.md -> /etc/passwd) — os.ReadFile
+			// would follow it off-root. Resolve symlinks and re-check against
+			// the resolved root before reading. Project markers come from
+			// cloned repos, so this path is attacker-influenced.
+			resolved, err := filepath.EvalSymlinks(abs)
+			if err != nil || !importWithinRoot(resolvedRoot, resolved) {
+				continue
+			}
+			data, err := os.ReadFile(resolved)
 			if err != nil {
 				continue
 			}

--- a/internal/project/symlink_import_test.go
+++ b/internal/project/symlink_import_test.go
@@ -1,0 +1,65 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/project"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestMerge_MemoryImport_RejectsSymlinkEscape is the regression for a
+// containment hole in project memory imports. importWithinRoot was purely
+// lexical, so a committed symlink under the project root (link -> /etc/passwd)
+// passed the check and os.ReadFile followed it off-root, splicing arbitrary
+// host-file content into the rendered memory. Project markers come from cloned
+// repos, so this is attacker-influenced.
+func TestMerge_MemoryImport_RejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	base := t.TempDir()
+	root := filepath.Join(base, "project")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Secret file OUTSIDE the project root.
+	secret := filepath.Join(base, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP-SECRET-HOST-DATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink INSIDE the root pointing at the outside secret.
+	link := filepath.Join(root, "leak.md")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	m := &project.Marker{
+		Root:   root,
+		Memory: project.ProjectMemorySection{Import: []string{"leak.md"}},
+	}
+	out := project.Merge(source.Canonical{}, m)
+	if strings.Contains(out.Memory.Body, "TOP-SECRET-HOST-DATA") {
+		t.Fatalf("symlinked import escaped the project root and leaked host data: %q", out.Memory.Body)
+	}
+}
+
+// TestMerge_MemoryImport_AllowsRegularFile confirms the guard still imports a
+// legitimate in-root file.
+func TestMerge_MemoryImport_AllowsRegularFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "extra.md"), []byte("project memory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &project.Marker{
+		Root:   root,
+		Memory: project.ProjectMemorySection{Import: []string{"extra.md"}},
+	}
+	out := project.Merge(source.Canonical{}, m)
+	if !strings.Contains(out.Memory.Body, "project memory") {
+		t.Fatalf("legitimate in-root import was dropped: %q", out.Memory.Body)
+	}
+}

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -64,7 +65,14 @@ func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adap
 		if s != nil {
 			for i, op := range ops {
 				if isKeyMerge(op.MergeStrategy) {
-					ops[i].OwnedKeys = ownedKeysFor(s, name, scope, project, op.Path, userHome)
+					owned := ownedKeysFor(s, name, scope, project, op.Path, userHome)
+					// Scope each op's OwnedKeys to the top-level sections THIS op
+					// writes. Several ops can target one file (claude writes
+					// mcpServers, hooks, AND lspServers to settings.json); without
+					// scoping, every op carried the union of owned pointers and
+					// MergeKeys' removal step deleted the OTHER ops' sections —
+					// last op wins, earlier sections wiped on the next apply.
+					ops[i].OwnedKeys = scopeOwnedToSections(owned, op.Content)
 				}
 			}
 			// Cleanup synthesis: when a key-merge section becomes empty in the
@@ -159,6 +167,43 @@ func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, 
 	return out
 }
 
+// scopeOwnedToSections filters owned JSON pointers down to those whose
+// top-level section is present in content (an op's rendered `ours`). Several
+// key-merge ops can target one file; each must only carry — and therefore only
+// be able to delete — pointers under the section(s) it actually writes. If
+// content can't be parsed we return none rather than all, so a malformed op
+// can never drive a cross-section deletion.
+func scopeOwnedToSections(owned []string, content []byte) []string {
+	if len(owned) == 0 {
+		return owned
+	}
+	var ours map[string]any
+	if err := json.Unmarshal(content, &ours); err != nil || ours == nil {
+		return nil
+	}
+	sections := make(map[string]struct{}, len(ours))
+	for k := range ours {
+		sections[escapeJSONPointer(k)] = struct{}{}
+	}
+	var out []string
+	for _, p := range owned {
+		if _, ok := sections[firstPointerSegment(p)]; ok {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// firstPointerSegment returns the first (escaped) path segment of a JSON
+// pointer, i.e. its top-level section: "/mcpServers/github" → "mcpServers".
+func firstPointerSegment(ptr string) string {
+	ptr = strings.TrimPrefix(ptr, "/")
+	if i := strings.IndexByte(ptr, '/'); i >= 0 {
+		return ptr[:i]
+	}
+	return ptr
+}
+
 // orphanCleanupOps synthesizes empty key-merge ops that remove keys the agent
 // owns in state but no longer renders this run — the case where a source
 // section went fully empty (e.g. the user deleted their last MCP server), so
@@ -175,11 +220,29 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 	if strat == "" {
 		return nil // adapter doesn't merge keys
 	}
-	// Portable dest paths the agent DID render a key-merge op for this run.
-	renderedPaths := map[string]bool{}
+	// Portable dest path → set of escaped top-level sections the agent rendered
+	// a key-merge op for this run. A section that still has a real op handles
+	// its own per-key removals via that op's (section-scoped) OwnedKeys; only a
+	// section with NO op this run is orphan-cleaned here. Tracking per-section
+	// (not per-path) is required now that OwnedKeys are section-scoped: removing
+	// a whole section leaves no op carrying its pointers, so the remaining
+	// sections' ops can no longer delete it.
+	renderedSections := map[string]map[string]struct{}{}
 	for _, op := range rendered {
-		if isKeyMerge(op.MergeStrategy) {
-			renderedPaths[paths.HomeRelative(userHome, op.Path)] = true
+		if !isKeyMerge(op.MergeStrategy) {
+			continue
+		}
+		pp := paths.HomeRelative(userHome, op.Path)
+		secs := renderedSections[pp]
+		if secs == nil {
+			secs = map[string]struct{}{}
+			renderedSections[pp] = secs
+		}
+		var ours map[string]any
+		if json.Unmarshal(op.Content, &ours) == nil {
+			for k := range ours {
+				secs[escapeJSONPointer(k)] = struct{}{}
+			}
 		}
 	}
 
@@ -206,8 +269,10 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 			continue
 		}
 		path, ptr := rest[:i], rest[i+1:]
-		if renderedPaths[path] {
-			continue // a real merge op already handles removal here
+		if secs, ok := renderedSections[path]; ok {
+			if _, sectionRendered := secs[firstPointerSegment(ptr)]; sectionRendered {
+				continue // a real op for this section handles its own removals
+			}
 		}
 		if _, seen := ownedByPath[path]; !seen {
 			order = append(order, path)

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -140,9 +140,21 @@ func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, 
 		paths.HomeRelative(userHome, project), paths.HomeRelative(userHome, path))
 	var out []string
 	for k := range s.Keys {
-		if strings.HasPrefix(k, prefix) {
-			out = append(out, strings.TrimPrefix(k, prefix))
+		if !strings.HasPrefix(k, prefix) {
+			continue
 		}
+		ptr := strings.TrimPrefix(k, prefix)
+		// The remainder must be a JSON pointer, which always begins with '/'.
+		// If it doesn't, this key belongs to a DIFFERENT dest path that merely
+		// shares a colon-delimited string prefix with `path` (e.g. dest "a" vs
+		// "a:b", realistic only for a Windows drive-letter path stored
+		// absolute). Claiming it would inject a foreign pointer into this op's
+		// OwnedKeys and corrupt ownership — the same colon-ambiguity class
+		// PruneStaleState and orphanCleanupOps already guard against.
+		if !strings.HasPrefix(ptr, "/") {
+			continue
+		}
+		out = append(out, ptr)
 	}
 	return out
 }

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"sort"
 
-	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -124,8 +123,8 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			row := PluginRow{
 				Plugin:   "(base)",
 				Agent:    agName,
-				MCP:      countMCPOps(res.Ops),
-				Commands: countCommandOps(res.Ops),
+				MCP:      countMCPServers(c, agName),
+				Commands: len(c.Commands),
 				Skips:    len(res.Skips),
 			}
 			row.Coverage = computeCoverage(row)
@@ -151,8 +150,8 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			row := PluginRow{
 				Plugin:   label,
 				Agent:    agName,
-				MCP:      countMCPOps(res.Ops),
-				Commands: countCommandOps(res.Ops),
+				MCP:      countMCPServers(c, agName),
+				Commands: len(c.Commands),
 				Skips:    len(res.Skips),
 			}
 			row.Coverage = computeCoverage(row)
@@ -173,29 +172,34 @@ func computeCoverage(row PluginRow) string {
 	return "none"
 }
 
-// countMCPOps counts write ops whose SourceID begins with "mcp" or that write
-// a file containing mcpServers (approximate heuristic).
-func countMCPOps(ops []adapter.FileOp) int {
-	// We count merge-json-keys ops (the claude adapter emits one for .claude.json
-	// which contains all MCP servers) — use the number of mcpServers in canonical
-	// as proxy.  Since we don't have the canonical here, count ops with
-	// MergeStrategy containing "json".
+// countMCPServers counts the canonical MCP servers that render for agent —
+// the actual server count, not the op count. The previous countMCPOps counted
+// merge-json-keys ops, which is always 1 for claude's single .claude.json
+// merge regardless of how many servers it holds, and wrongly also counted
+// hooks/lspServers ops (same strategy) as MCP.
+func countMCPServers(c source.Canonical, agent string) int {
 	n := 0
-	for _, op := range ops {
-		if op.MergeStrategy == "merge-json-keys" || op.MergeStrategy == "merge-jsonc-keys" {
+	for _, m := range c.MCPServers {
+		if m.Server.Enabled != nil && !*m.Server.Enabled {
+			continue
+		}
+		if targetsAgent(m.Server.Agents, agent) {
 			n++
 		}
 	}
 	return n
 }
 
-// countCommandOps counts write ops for slash commands.
-func countCommandOps(ops []adapter.FileOp) int {
-	n := 0
-	for _, op := range ops {
-		if op.Action == "write" && (op.MergeStrategy == "replace" || op.MergeStrategy == "") {
-			n++
+// targetsAgent reports whether an Agents allowlist includes agent. An empty
+// list or one containing "*" targets every agent.
+func targetsAgent(agents []string, agent string) bool {
+	if len(agents) == 0 {
+		return true
+	}
+	for _, a := range agents {
+		if a == "*" || a == agent {
+			return true
 		}
 	}
-	return n
+	return false
 }

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestBuildReport_NoPlugins(t *testing.T) {
-	c := source.Canonical{}
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github"}},
+	}
 	plan := render.RenderPlan{
 		PerAgent: map[string]render.AgentResult{
 			"claude": {
@@ -35,7 +37,7 @@ func TestBuildReport_NoPlugins(t *testing.T) {
 		t.Errorf("agent = %q, want claude", row.Agent)
 	}
 	if row.MCP != 1 {
-		t.Errorf("mcp = %d, want 1", row.MCP)
+		t.Errorf("mcp = %d, want 1 (one canonical MCP server)", row.MCP)
 	}
 	if row.Coverage != "full" {
 		t.Errorf("coverage = %q, want full", row.Coverage)
@@ -80,6 +82,8 @@ func TestBuildReport_WithPlugin(t *testing.T) {
 
 func TestBuildReport_PartialCoverage(t *testing.T) {
 	c := source.Canonical{
+		// One server renders (MCP>0) and one component is skipped → partial.
+		MCPServers: []source.MCPServer{{ID: "github"}},
 		Plugins: []source.Plugin{
 			{ID: "demo", Plugin: source.PluginSpec{ID: "demo@test-mp"}},
 		},
@@ -171,5 +175,35 @@ func TestTranslationReport_PrintJSON(t *testing.T) {
 	}
 	if len(out.Rows) != 1 {
 		t.Fatalf("expected 1 row in JSON, got %d", len(out.Rows))
+	}
+}
+
+// TestBuildReport_CountsItemsNotOps is the regression for the translation
+// report miscounting: it counted merge-json-keys OPS (always 1 for claude's
+// single .claude.json merge, and wrongly including hooks/lsp ops) as "mcp",
+// and counted every replace op (skills/subagents/memory) as "commands". The
+// counts must reflect actual canonical items.
+func TestBuildReport_CountsItemsNotOps(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github"}, {ID: "slack"}, {ID: "jira"}},
+		Memory:     source.Memory{Body: "# mem"},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude": {
+				Ops: []adapter.FileOp{
+					{Action: "write", Path: "/h/.claude.json", MergeStrategy: "merge-json-keys"},
+					{Action: "write", Path: "/h/.claude/CLAUDE.md", MergeStrategy: "replace"},
+				},
+			},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"claude"})
+	row := report.Rows[0]
+	if row.MCP != 3 {
+		t.Fatalf("MCP = %d, want 3 (server count, not op count)", row.MCP)
+	}
+	if row.Commands != 0 {
+		t.Fatalf("Commands = %d, want 0 (memory must not be counted as a command)", row.Commands)
 	}
 }

--- a/internal/render/sibling_section_test.go
+++ b/internal/render/sibling_section_test.go
@@ -1,0 +1,111 @@
+package render_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// applyOnce runs the real plan→apply→prune→record cycle the apply command uses.
+func applyOnce(t *testing.T, reg *adapter.Registry, c source.Canonical, st *state.Targets, home, userHome string) {
+	t.Helper()
+	plan, err := render.Plan(c, reg, []string{"claude"}, adapter.ScopeUser, "", st, userHome)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if _, _, err := render.Apply(plan, reg, st, home, userHome, adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for name, res := range plan.PerAgent {
+		render.PruneStaleState(st, userHome, name, adapter.ScopeUser, "", res.Ops)
+	}
+	for name, res := range plan.PerAgent {
+		if err := render.RecordOpsState(st, userHome, name, adapter.ScopeUser, "", res.Ops); err != nil {
+			t.Fatalf("RecordOpsState: %v", err)
+		}
+	}
+}
+
+func readSettings(t *testing.T, tmp string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	return m
+}
+
+// TestApply_MultiSectionSameFile_NoSiblingWipe is the regression for the
+// showstopper: claude writes hooks AND lspServers to settings.json as separate
+// key-merge ops. Each op received ALL owned pointers for the file, so on the
+// second apply the hooks op deleted the lsp pointer and vice versa — last op
+// wins, the other section is wiped.
+func TestApply_MultiSectionSameFile_NoSiblingWipe(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	reg := adapter.NewRegistry()
+	if err := reg.Register(claude.New(claude.Options{TargetRoot: tmp})); err != nil {
+		t.Fatal(err)
+	}
+	c := source.Canonical{
+		Hooks:      []source.Hook{{Event: "Stop", Type: "command", Command: "echo x"}},
+		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
+	}
+	st := state.New()
+	applyOnce(t, reg, c, st, home, tmp)
+	applyOnce(t, reg, c, st, home, tmp) // second apply is where the wipe happened
+
+	m := readSettings(t, tmp)
+	hooks, _ := m["hooks"].(map[string]any)
+	lsp, _ := m["lspServers"].(map[string]any)
+	if len(hooks) == 0 {
+		t.Fatalf("hooks section was wiped on re-apply: %+v", m)
+	}
+	if len(lsp) == 0 {
+		t.Fatalf("lspServers section was wiped on re-apply: %+v", m)
+	}
+}
+
+// TestApply_WholeSectionRemoval_StillCleansUp guards the removal case that the
+// per-op-section scoping must not regress: removing ALL hooks (while keeping
+// the lsp server) must still delete the orphaned hook from settings.json, even
+// though another section's op still writes that file.
+func TestApply_WholeSectionRemoval_StillCleansUp(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	reg := adapter.NewRegistry()
+	if err := reg.Register(claude.New(claude.Options{TargetRoot: tmp})); err != nil {
+		t.Fatal(err)
+	}
+	st := state.New()
+	withHooks := source.Canonical{
+		Hooks:      []source.Hook{{Event: "Stop", Type: "command", Command: "echo x"}},
+		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
+	}
+	applyOnce(t, reg, withHooks, st, home, tmp)
+
+	// Remove hooks entirely; keep the lsp server.
+	noHooks := source.Canonical{
+		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
+	}
+	applyOnce(t, reg, noHooks, st, home, tmp)
+
+	m := readSettings(t, tmp)
+	if hooks, _ := m["hooks"].(map[string]any); len(hooks) != 0 {
+		t.Fatalf("removed hook section was not cleaned up: %+v", m["hooks"])
+	}
+	if lsp, _ := m["lspServers"].(map[string]any); len(lsp) == 0 {
+		t.Fatalf("lspServers wrongly removed when only hooks were dropped: %+v", m)
+	}
+}

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -134,7 +134,19 @@ func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scop
 				return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
 			}
 			for _, ptr := range CollectPointers(ours, "") {
-				v := getPointer(final, ptr)
+				v, present := getPointerOK(final, ptr)
+				if !present {
+					// The pointer is not in the post-apply file. In a normal
+					// (full-success) apply every pointer in `ours` lands on
+					// disk, so absence means this op's merge never happened —
+					// the case where the apply-error rescue records several
+					// same-path ops but only some were written. Recording an
+					// absent pointer as owned (with a hash of null) would
+					// suppress its foreign-collision backup on a later apply
+					// and silently overwrite a value the user added in between.
+					// Skip it; only record what actually landed.
+					continue
+				}
 				hash := hashAny(v)
 				key := fmt.Sprintf("%s:%s:%s:%s:%s", agent, scope.String(), portableProject, portablePath, ptr)
 				s.Keys[key] = state.KeyEntry{
@@ -203,16 +215,29 @@ func replaceAll(s, from, to string) string {
 }
 
 func getPointer(m map[string]any, ptr string) any {
+	v, _ := getPointerOK(m, ptr)
+	return v
+}
+
+// getPointerOK is getPointer with an explicit presence signal so callers can
+// distinguish "pointer absent from the document" from "pointer present with a
+// null value" — getPointer returns nil for both. RecordOpsState relies on this
+// to avoid recording a pointer that never landed on disk.
+func getPointerOK(m map[string]any, ptr string) (any, bool) {
 	parts := splitPtr(ptr)
 	var cur any = m
 	for _, p := range parts {
 		mm, ok := cur.(map[string]any)
 		if !ok {
-			return nil
+			return nil, false
 		}
-		cur = mm[p]
+		v, present := mm[p]
+		if !present {
+			return nil, false
+		}
+		cur = v
 	}
-	return cur
+	return cur, true
 }
 
 func splitPtr(ptr string) []string {

--- a/internal/render/state_apply_internal_test.go
+++ b/internal/render/state_apply_internal_test.go
@@ -1,0 +1,50 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestRecordOpsState_SkipsAbsentMergePointers is the regression for the
+// partial-apply ownership-over-recording bug. When one agent emits several
+// merge-json-keys ops to the SAME destination and an early op succeeds while a
+// later one fails, the apply-error rescue (saveBestEffortState) records every
+// op whose PATH was written — including the failed op, since `wrote` is
+// per-path. RecordOpsState then re-read the file (holding only the succeeded
+// op's keys) and recorded the failed op's pointer as owned with a hash of
+// null. On the next apply that pointer is treated as owned, suppressing its
+// foreign-collision backup and silently overwriting a value the user created
+// in between. RecordOpsState must record only pointers actually present on
+// disk.
+func TestRecordOpsState_SkipsAbsentMergePointers(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "settings.json")
+	// On-disk reality after a partial apply: only op1's "a" landed.
+	if err := os.WriteFile(dest, []byte(`{"mcpServers":{"a":{"command":"x"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := []adapter.FileOp{
+		{Path: dest, MergeStrategy: "merge-json-keys", Content: []byte(`{"mcpServers":{"a":{"command":"x"}}}`)},
+		// op that "failed": its key "b" is NOT on disk.
+		{Path: dest, MergeStrategy: "merge-json-keys", Content: []byte(`{"mcpServers":{"b":{"command":"y"}}}`)},
+	}
+
+	s := state.New()
+	if err := RecordOpsState(s, "", "claude", adapter.ScopeUser, "", ops); err != nil {
+		t.Fatalf("RecordOpsState: %v", err)
+	}
+
+	wantOwned := "claude:user::" + dest + ":/mcpServers/a"
+	wantAbsent := "claude:user::" + dest + ":/mcpServers/b"
+	if _, ok := s.Keys[wantOwned]; !ok {
+		t.Fatalf("present pointer /mcpServers/a was not recorded as owned; keys=%v", s.Keys)
+	}
+	if _, ok := s.Keys[wantAbsent]; ok {
+		t.Fatalf("absent pointer /mcpServers/b was wrongly recorded as owned (would suppress a future backup); keys=%v", s.Keys)
+	}
+}

--- a/internal/render/writer_internal_test.go
+++ b/internal/render/writer_internal_test.go
@@ -4,7 +4,46 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// TestOwnedKeysFor_DisambiguatesColonPaths is the regression for the colon-
+// ambiguity bug PruneStaleState/orphanCleanupOps were hardened against but
+// ownedKeysFor was not: a state key whose dest path is a colon-delimited
+// string prefix of another path (realistic for a Windows drive path stored
+// absolute) must not be claimed as an owned pointer for the shorter path.
+// The remainder after the prefix is a JSON pointer, which always begins with
+// '/'. ownedKeysFor must reject any remainder that does not.
+func TestOwnedKeysFor_DisambiguatesColonPaths(t *testing.T) {
+	s := state.New()
+	// A real owned pointer for path "a".
+	s.Keys["claude:user::a:/legit"] = state.KeyEntry{SHA256: "x"}
+	// A pointer for the DIFFERENT path "a:b" — its key shares the "...:a:"
+	// prefix but the remainder ("b:/realptr") is not a pointer for "a".
+	s.Keys["claude:user::a:b:/realptr"] = state.KeyEntry{SHA256: "y"}
+
+	got := ownedKeysFor(s, "claude", adapter.ScopeUser, "", "a", "")
+
+	for _, k := range got {
+		if k == "b:/realptr" {
+			t.Fatalf("ownedKeysFor wrongly claimed a foreign path's pointer: %v", got)
+		}
+		if !strings.HasPrefix(k, "/") {
+			t.Fatalf("ownedKeysFor returned a non-pointer remainder %q: %v", k, got)
+		}
+	}
+	found := false
+	for _, k := range got {
+		if k == "/legit" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ownedKeysFor dropped the legitimate pointer /legit: %v", got)
+	}
+}
 
 // TestBackupPathFor_NeverEscapesRoot asserts that no src — including
 // adversarial inputs containing ".." or absolute paths — can place the

--- a/internal/secrets/age.go
+++ b/internal/secrets/age.go
@@ -104,9 +104,15 @@ func flatten(prefix string, m map[string]any) (map[string]string, error) {
 				return nil, err
 			}
 			for kk, vvv := range sub {
+				if _, dup := out[kk]; dup {
+					return nil, fmt.Errorf("secret key %q is defined more than once (e.g. both a quoted %q key and a nested table); use exactly one form", kk, kk)
+				}
 				out[kk] = vvv
 			}
 		case string:
+			if _, dup := out[key]; dup {
+				return nil, fmt.Errorf("secret key %q is defined more than once (e.g. both a quoted %q key and a nested table); use exactly one form", key, key)
+			}
 			out[key] = vv
 		default:
 			return nil, fmt.Errorf("secret %q has a non-string value (%T); secret values must be quoted strings", key, vv)

--- a/internal/secrets/age_internal_test.go
+++ b/internal/secrets/age_internal_test.go
@@ -1,0 +1,36 @@
+package secrets
+
+import "testing"
+
+// TestFlatten_RejectsAmbiguousDuplicateKey is the regression for a silent,
+// nondeterministic secret-resolution footgun: two distinct TOML constructs —
+// a quoted bare key literally named "github.token" and a nested [github]
+// table with a token field — both flatten to the dotted key "github.token".
+// The previous flatten kept whichever the random map iteration visited last,
+// so `${secret:github.token}` could resolve to a different value run to run.
+// flatten must reject the collision instead of silently picking one.
+func TestFlatten_RejectsAmbiguousDuplicateKey(t *testing.T) {
+	m := map[string]any{
+		"github.token": "A",
+		"github":       map[string]any{"token": "B"},
+	}
+	if _, err := flatten("", m); err == nil {
+		t.Fatal("expected an error for an ambiguous duplicate flattened key, got nil")
+	}
+}
+
+// TestFlatten_AllowsDistinctKeys confirms the collision guard does not reject
+// legitimate, distinct nested keys.
+func TestFlatten_AllowsDistinctKeys(t *testing.T) {
+	m := map[string]any{
+		"github": map[string]any{"token": "A", "user": "B"},
+		"openai": map[string]any{"key": "C"},
+	}
+	out, err := flatten("", m)
+	if err != nil {
+		t.Fatalf("unexpected error on distinct keys: %v", err)
+	}
+	if out["github.token"] != "A" || out["github.user"] != "B" || out["openai.key"] != "C" {
+		t.Fatalf("distinct keys flattened wrong: %+v", out)
+	}
+}

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -46,6 +47,16 @@ func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
 				continue
 			}
 			out[v] = placeholder
+			// Also register the JSON-escaped representation. A secret value
+			// containing a quote/backslash/control char (GCP JSON keys,
+			// escaped tokens) is stored JSON-escaped in destination files like
+			// .claude.json, and diff JSON-marshals it again before masking. A
+			// map keyed only on the raw value would never match the escaped
+			// on-disk form, leaking the cleartext to stdout. The longest-match
+			// ordering in MaskResolved handles raw-vs-escaped overlap.
+			if esc := jsonEscapeInner(v); esc != v {
+				out[esc] = placeholder
+			}
 		}
 	}
 	for _, srv := range c.MCPServers {
@@ -181,6 +192,18 @@ func MaskResolved(s string, resolved map[string]string) string {
 		s = strings.ReplaceAll(s, v, resolved[v])
 	}
 	return s
+}
+
+// jsonEscapeInner returns s as it would appear INSIDE a JSON string literal
+// (the json.Marshal output with the surrounding quotes stripped). For a value
+// with no special characters this equals s. Used so redaction also catches a
+// secret stored JSON-escaped in a destination file.
+func jsonEscapeInner(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil || len(b) < 2 {
+		return s
+	}
+	return string(b[1 : len(b)-1])
 }
 
 // sortByLengthDesc sorts s in place by descending length.

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -169,6 +169,56 @@ func UnresolvedSecretRefs(c *source.Canonical, sec Resolver) []string {
 	return out
 }
 
+// ReReferenceSecrets is the inverse of SubstituteCanonical for the import
+// path: it walks the same string fields and replaces any occurrence of a
+// resolved secret value with its ${secret:KEY} placeholder. `apply` substitutes
+// secrets into destination files as cleartext, and `import` ingests those
+// destinations — without this, importing would persist the live credential in
+// cleartext into the user's ~/.agentsync source files (commonly committed to a
+// dotfiles repo). redact maps resolved value → placeholder; build it from the
+// CURRENT source via CollectResolved, filtered to ${secret:…} placeholders so
+// low-entropy ${env:…} values aren't over-converted.
+func ReReferenceSecrets(c *source.Canonical, redact map[string]string) {
+	if c == nil || len(redact) == 0 {
+		return
+	}
+	mask := func(s string) string { return MaskResolved(s, redact) }
+	for i := range c.MCPServers {
+		srv := &c.MCPServers[i].Server
+		srv.Command = mask(srv.Command)
+		srv.URL = mask(srv.URL)
+		for j := range srv.Args {
+			srv.Args[j] = mask(srv.Args[j])
+		}
+		for k, v := range srv.Env {
+			srv.Env[k] = mask(v)
+		}
+		for k, v := range srv.Headers {
+			srv.Headers[k] = mask(v)
+		}
+	}
+	for i := range c.Hooks {
+		c.Hooks[i].Command = mask(c.Hooks[i].Command)
+	}
+	for i := range c.LSPServers {
+		sp := &c.LSPServers[i].Spec
+		sp.Command = mask(sp.Command)
+		sp.URL = mask(sp.URL)
+		for j := range sp.Args {
+			sp.Args[j] = mask(sp.Args[j])
+		}
+		for k, v := range sp.Env {
+			sp.Env[k] = mask(v)
+		}
+		for k, v := range sp.Headers {
+			sp.Headers[k] = mask(v)
+		}
+	}
+	if c.Project != nil {
+		ReReferenceSecrets(c.Project, redact)
+	}
+}
+
 // MaskResolved replaces every resolved value in b with its original
 // placeholder. Idempotent — a placeholder that appears in b stays as a
 // placeholder. Designed for redacting cleartext that may contain secrets

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -169,56 +169,6 @@ func UnresolvedSecretRefs(c *source.Canonical, sec Resolver) []string {
 	return out
 }
 
-// ReReferenceSecrets is the inverse of SubstituteCanonical for the import
-// path: it walks the same string fields and replaces any occurrence of a
-// resolved secret value with its ${secret:KEY} placeholder. `apply` substitutes
-// secrets into destination files as cleartext, and `import` ingests those
-// destinations — without this, importing would persist the live credential in
-// cleartext into the user's ~/.agentsync source files (commonly committed to a
-// dotfiles repo). redact maps resolved value → placeholder; build it from the
-// CURRENT source via CollectResolved, filtered to ${secret:…} placeholders so
-// low-entropy ${env:…} values aren't over-converted.
-func ReReferenceSecrets(c *source.Canonical, redact map[string]string) {
-	if c == nil || len(redact) == 0 {
-		return
-	}
-	mask := func(s string) string { return MaskResolved(s, redact) }
-	for i := range c.MCPServers {
-		srv := &c.MCPServers[i].Server
-		srv.Command = mask(srv.Command)
-		srv.URL = mask(srv.URL)
-		for j := range srv.Args {
-			srv.Args[j] = mask(srv.Args[j])
-		}
-		for k, v := range srv.Env {
-			srv.Env[k] = mask(v)
-		}
-		for k, v := range srv.Headers {
-			srv.Headers[k] = mask(v)
-		}
-	}
-	for i := range c.Hooks {
-		c.Hooks[i].Command = mask(c.Hooks[i].Command)
-	}
-	for i := range c.LSPServers {
-		sp := &c.LSPServers[i].Spec
-		sp.Command = mask(sp.Command)
-		sp.URL = mask(sp.URL)
-		for j := range sp.Args {
-			sp.Args[j] = mask(sp.Args[j])
-		}
-		for k, v := range sp.Env {
-			sp.Env[k] = mask(v)
-		}
-		for k, v := range sp.Headers {
-			sp.Headers[k] = mask(v)
-		}
-	}
-	if c.Project != nil {
-		ReReferenceSecrets(c.Project, redact)
-	}
-}
-
 // MaskResolved replaces every resolved value in b with its original
 // placeholder. Idempotent — a placeholder that appears in b stays as a
 // placeholder. Designed for redacting cleartext that may contain secrets

--- a/internal/secrets/mask_test.go
+++ b/internal/secrets/mask_test.go
@@ -1,12 +1,50 @@
 package secrets_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// TestCollectResolved_MasksJSONEscapedSecret is the regression for the diff
+// credential-leak when a secret value contains JSON-special characters (a
+// quote, backslash, or control char — common in GCP service-account JSON
+// keys, escaped tokens, base64 blobs). apply substitutes the RAW value into
+// .claude.json, where it is stored JSON-ESCAPED. diff reads it back and
+// JSON-marshals it before masking, so a redaction map keyed only on the raw
+// value never matches the escaped on-disk form and the cleartext leaks to
+// stdout. CollectResolved must register the JSON-escaped representation too.
+func TestCollectResolved_MasksJSONEscapedSecret(t *testing.T) {
+	raw := `tok"en\val` // contains a double-quote and a backslash
+	sec := mapBackend{"gcp.key": raw}
+	env := mapBackend{}
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "x",
+			Server: source.MCPServerSpec{
+				Env: map[string]string{"GCP_KEY": "${secret:gcp.key}"},
+			},
+		}},
+	}
+	redact := secrets.CollectResolved(&c, sec, env)
+
+	// Simulate what diff prints: the value as it sits in the on-disk JSON,
+	// i.e. json.Marshal of the raw value (quotes + escaping).
+	escaped, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	masked := secrets.MaskResolved(string(escaped), redact)
+	if strings.Contains(masked, `en\val`) {
+		t.Fatalf("JSON-escaped secret leaked through diff redaction: %s", masked)
+	}
+	if !strings.Contains(masked, "${secret:gcp.key}") {
+		t.Fatalf("placeholder missing after masking escaped form: %s", masked)
+	}
+}
 
 func TestCollectResolved_MCPEnv(t *testing.T) {
 	sec := mapBackend{"github.token": "ghp_SENTINEL_TOKEN_DO_NOT_LEAK"}

--- a/internal/source/frontmatter_crlf_test.go
+++ b/internal/source/frontmatter_crlf_test.go
@@ -1,0 +1,27 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestParseFrontmatter_CRLF is the regression for the source-package twin of
+// the frontmatter parser. The adapter twin (claude.ParseFrontmatter) was fixed
+// to accept CRLF, but source.ParseFrontmatter — used by source.Load and by
+// marketplace plugin projection (which parses externally-fetched .md files,
+// very plausibly CRLF) — still matched only "---\n", silently dropping all
+// frontmatter from a Windows-authored component.
+func TestParseFrontmatter_CRLF(t *testing.T) {
+	input := []byte("---\r\nname: my-skill\r\ndescription: Does the thing\r\n---\r\nBody line one\r\n")
+	fm, body, err := source.ParseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm["description"] != "Does the thing" || fm["name"] != "my-skill" {
+		t.Fatalf("frontmatter lost on CRLF input: %+v", fm)
+	}
+	if body == string(input) {
+		t.Fatalf("frontmatter not stripped; whole file returned as body: %q", body)
+	}
+}

--- a/internal/source/frontmatter_roundtrip_test.go
+++ b/internal/source/frontmatter_roundtrip_test.go
@@ -1,0 +1,46 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestWriteSubagent_PreservesListAndMapFrontmatter is the regression for the
+// import write-back corruption: renderFrontmatter emitted Go fmt syntax (%v)
+// for non-string values, so a subagent's `tools: [Read, Write]` list and any
+// nested map were serialized as "[Read Write]" / "map[a:1]" and re-parsed as a
+// single mangled string — corrupting the tool allowlist on `import
+// claude:agent:<name>`.
+func TestWriteSubagent_PreservesListAndMapFrontmatter(t *testing.T) {
+	home := t.TempDir()
+	sa := source.Subagent{
+		Name: "reviewer",
+		Frontmatter: map[string]any{
+			"description": "rev",
+			"tools":       []any{"Read", "Write"},
+			"nested":      map[string]any{"a": "one", "b": "two"},
+		},
+		Body: "body\n",
+	}
+	if err := source.WriteSubagent(home, sa); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, "agents", "reviewer.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fm, _, err := source.ParseFrontmatter(data)
+	if err != nil {
+		t.Fatalf("re-parse frontmatter: %v\nraw:\n%s", err, data)
+	}
+	tools, ok := fm["tools"].([]any)
+	if !ok || len(tools) != 2 {
+		t.Fatalf("tools list corrupted on write/read round-trip: %#v\nraw:\n%s", fm["tools"], data)
+	}
+	if _, ok := fm["nested"].(map[string]any); !ok {
+		t.Fatalf("nested map corrupted on write/read round-trip: %#v\nraw:\n%s", fm["nested"], data)
+	}
+}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -837,6 +837,14 @@ func loadLSP(fs afero.Fs, home string) ([]LSPServer, error) {
 // If the input doesn't begin with "---\n", returns an empty map and the
 // entire input as body.
 func ParseFrontmatter(data []byte) (map[string]any, string, error) {
+	// Normalize CRLF → LF so a component .md saved by a Windows editor
+	// ("---\r\n"), or shipped CRLF inside a fetched plugin, is recognized as
+	// having frontmatter. Without this the literal "---\n" check fails and the
+	// whole file becomes body, silently dropping description/model/mode.
+	// agentsync re-renders bodies with LF, so the normalization is lossless.
+	if bytes.IndexByte(data, '\r') >= 0 {
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	}
 	if !bytes.HasPrefix(data, []byte("---\n")) {
 		return map[string]any{}, string(data), nil
 	}

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"sigs.k8s.io/yaml"
 )
 
 // ReadMCP reads mcp/<id>.toml from home. ok is false when the file does not
@@ -153,36 +153,21 @@ func WriteMemory(home string, m Memory) error {
 
 // renderFrontmatter serialises a frontmatter map as a YAML block enclosed in
 // "---\n...\n---\n". If the map is empty or nil, returns "".
+//
+// It uses a real YAML marshaller (the same library ParseFrontmatter reads
+// with, and that claude.EncodeFrontmatter writes with). The previous homemade
+// emitter used Go's %v for non-string values, so a `tools: [Read, Write]` list
+// serialized as "[Read Write]" and a nested map as "map[a:1]" — both re-parsed
+// as a single mangled string, corrupting subagent tool allowlists and any
+// structured frontmatter on import write-back. sigs.k8s.io/yaml sorts map keys,
+// so output stays deterministic.
 func renderFrontmatter(fm map[string]any) string {
 	if len(fm) == 0 {
 		return ""
 	}
-	var sb strings.Builder
-	sb.WriteString("---\n")
-	// Deterministic order: sort keys.
-	keys := make([]string, 0, len(fm))
-	for k := range fm {
-		keys = append(keys, k)
+	y, err := yaml.Marshal(fm)
+	if err != nil {
+		return ""
 	}
-	sortStrings(keys)
-	for _, k := range keys {
-		v := fm[k]
-		switch vv := v.(type) {
-		case string:
-			sb.WriteString(fmt.Sprintf("%s: %q\n", k, vv))
-		default:
-			sb.WriteString(fmt.Sprintf("%s: %v\n", k, v))
-		}
-	}
-	sb.WriteString("---\n")
-	return sb.String()
-}
-
-// sortStrings is a minimal in-place sort for small slices (avoids importing sort).
-func sortStrings(ss []string) {
-	for i := 1; i < len(ss); i++ {
-		for j := i; j > 0 && ss[j-1] > ss[j]; j-- {
-			ss[j-1], ss[j] = ss[j], ss[j-1]
-		}
-	}
+	return "---\n" + string(y) + "---\n"
 }

--- a/test/bdd/features/02_agents.feature
+++ b/test/bdd/features/02_agents.feature
@@ -19,7 +19,7 @@ Feature: Agent registry
     And the output contains "claude"
     And the output contains "opencode"
 
-  Scenario: agent disable --purge removes destination files
+  Scenario: agent disable --purge prunes owned keys from a shared file
     Given I have added agent "claude"
     And I write the file ".agentsync/mcp/echo.toml" with:
       """
@@ -33,7 +33,11 @@ Feature: Agent registry
     And the file ".claude.json" exists
     When I run "agentsync agent disable claude --purge"
     Then the command succeeds
-    And the file ".claude.json" does not exist
+    # .claude.json is a key-merge dest: agentsync owns only /mcpServers/echo,
+    # not the whole file. Purge must prune the owned server (so a user's
+    # foreign keys would survive), never delete the shared file.
+    And the file ".claude.json" exists
+    And the file ".claude.json" does not contain "echo"
 
   Scenario: agent disable keeps the agent registered but disabled
     Given I have added agent "claude"


### PR DESCRIPTION
Running log of an adversarial **review → verify → fix** hardening loop driving toward launch readiness. Each round spawned a fresh team of parallel reviewers on non-overlapping areas; every finding was reproduced (RED test) or traced before a test-first fix landed as one focused commit. Newest round first.

Verification gate (green before every push): `just build`, `just lint`, `just fmt`, `just tidy`, `just test-fast` + full `go test -race ./internal/...` + e2e + BDD via the host container-bypass. (GitHub Actions minutes are exhausted for the month, so CI is validated locally — the committed tree builds & vets cleanly in isolation.)

> This branch also carries prior pre-launch hardening commits never merged to `main`, so they appear in the diff. Commits below are this loop's work.

## Round 5 — 3 fixes (2 showstoppers, 1 real-bug)
Areas: **Q** regression-hunt R4 · **R** data-loss red-team · **S** secret-leak red-team · **T** reconcile/update/bump flows.

| Sev | Fix | Commit |
|---|---|---|
| 🔴 showstopper | `agent disable --purge` whole-file-deleted key-merge dests (`.claude.json`), destroying the user's foreign keys with no backup. Now prunes only owned pointers. | `deb61d9` |
| 🔴 showstopper | `reconcile` write-back persisted resolved secret cleartext into source (same hole as import, which was fixed; reconcile wasn't). Now re-references field-positionally. | `1cd2918` |
| 🟠 real-bug | `import` dropped source-only `agents`/`enabled` → broadened a server's targeting. Now preserved (like reconcile). | `b5926fc` |

Regression-hunt (Q) on Round 4: **clean**. BDD scenario corrected (`78e5a69`) — it had mandated the purge data-loss behavior.

**Deferred / flagged (not changed):**
- 🟠 **T1 — `DetectSHADrift` is dead**: `update` never re-fetches plugin caches, so the re-uploaded-plugin tamper warning never fires. Correct fix needs a per-plugin read-only re-fetch during poll — a network-bearing restructure; deferred to a focused follow-up.
- latent: track-mode bumps use string `!=` (a rollback is reported/applied as a "downgrade bump") — defensible as "track latest"; `overlayOwned` would overwrite a foreign scalar/array at an owned top-level key without backup (no adapter produces that shape today).

## Round 4 — 8 fixes (1 showstopper, 5 real-bugs, 2 UX)
frontmatter writer YAML (was Go `%v`, corrupted lists/maps) · field-positional import re-reference · foreign large-int preservation (UseNumber) · RFC6901 pointer decode in status/diff · doctor false-OK on corrupt state · report counts items not ops · friendlier missing-home/import-selector errors. Commits `316b574` `f5437ea` `086c977` `ab7a018` `2da94a8` `12a3bd0` `d255761`. Regression-hunt on R3: clean. Flagged docs: README Cursor wording, Linux install URLs vs goreleaser asset names, LAUNCH_CHECKLIST staleness, `--auto-safe` (deferred feature).

## Round 3 — 4 fixes (1 security, 3 real-bugs)
import cleartext-secret persistence · status skipped replace-strategy drift · agent/plugin mutators unlocked (lost updates). Commits `04c7c0e` `5122131` `ec6f285`. Regression-hunt on R2: clean.

## Round 2 — 5 fixes (1 showstopper, 2 security)
multi-section sibling-wipe (design-validated) · owned-object deep-merge stranding fields · plugin/marketplace remove traversal · project symlink import · source-frontmatter CRLF twin. `181c465` `7d1c155` `13fd8fa` `7289cfb` `2bd8d71`.

## Round 1 — 10 fixes (2 security, 3 real-bugs, 3 latent, 2 nits/defensive)
git-subdir traversal · diff JSON-escaped secret leak · opencode ingest headers · JSONC drift reads · ownedKeysFor colon-ambiguity · partial-apply ownership · CRLF frontmatter · age dup-key · jsonkeys array aliasing · projection name validation. `b23c1e8`…`df4aaea`.

---
**Total: 33 fixes across 5 rounds** (4 showstoppers, 6 security, ~12 real-bugs, rest latent/nit/UX). Local gate + `-race` + e2e + BDD green.
