### PR TITLE
Refactor: one secret boundary + one dest→source capture path (#24)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,16 @@ linters:
         # (canonical source, agentsync's own state, plugin TOMLs).
         - pattern: '^iox\.AtomicWrite$'
           msg: "use render.Writer / adapter.DestWriter for native-destination writes; iox.AtomicWrite is reserved for canonical-source / state / plugin-cache writes"
+        # secrets.Resolved.Canonical() is the render-only egress for the resolved
+        # apply model. Unwrapping a Resolved to a writable source.Canonical and
+        # persisting it would reintroduce the cleartext-secret-into-source leak
+        # the type split exists to prevent. Only the adapter Render entry points
+        # (and the secrets package's own tests) may call it; the exclusions list
+        # below whitelists them. The type wall makes passing a Resolved DIRECTLY
+        # to a source writer a compile error; this rule fences the one accessor
+        # that could otherwise launder it.
+        - pattern: '^secrets\.Resolved\.Canonical$'
+          msg: "do not unwrap secrets.Resolved to source.Canonical outside an adapter's Render; persisting it would leak resolved cleartext into ~/.agentsync. Render from the Resolved; capture writes the templated source.Canonical."
   exclusions:
     rules:
       # main.go can use os.UserHomeDir if needed.
@@ -70,6 +80,17 @@ linters:
       # iox.AtomicWrite — that's its whole job.
       - path: '(^|/)internal/adapter/testwriter\.go$'
         linters: [forbidigo]
+      # secrets.Resolved.Canonical() is the intended render egress: the two
+      # adapter Render entry points unwrap the resolved model to project it into
+      # destination FileOps. Scope this exclusion to THAT rule (via text) so the
+      # adapters still can't call iox.AtomicWrite directly.
+      - path: '(^|/)internal/adapter/(claude|opencode)/render\.go$'
+        linters: [forbidigo]
+        text: 'unwrap secrets\.Resolved'
+      # The secrets package's own tests assert on Resolved.Canonical() output.
+      - path: '(^|/)internal/secrets/.*_test\.go$'
+        linters: [forbidigo]
+        text: 'unwrap secrets\.Resolved'
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,34 +60,40 @@ linters:
       # foreign-collision backup. If you need to add a path here, the bar
       # is "this write does NOT target a file the user could plausibly
       # have hand-managed before agentsync was installed."
+      #
+      # Each is text-scoped to the AtomicWrite rule so it does NOT also
+      # suppress the other forbidigo rules (notably secrets.Resolved.Canonical)
+      # in these files — a whole-file [forbidigo] exclusion would silently
+      # un-fence a future Resolved-unwrap-then-write in e.g. reconcile.go.
       - path: '(^|/)internal/iox/.*'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       - path: '(^|/)internal/render/writer\.go$'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       - path: '(^|/)internal/source/writer\.go$'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       - path: '(^|/)internal/state/store\.go$'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       # secrets/age.go writes secrets.age under ~/.agentsync/ via the
       # atomic path so a Ctrl-C during re-encrypt can't truncate the file.
       # Same canonical-source category, not a native destination.
       - path: '(^|/)internal/secrets/age\.go$'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       # CLI files writing to ~/.agentsync/* (canonical source).
       - path: '(^|/)internal/cli/(plugin|marketplace|agent|reconcile|update)\.go$'
         linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       # The PassThroughWriter test helper deliberately delegates to
       # iox.AtomicWrite — that's its whole job.
       - path: '(^|/)internal/adapter/testwriter\.go$'
         linters: [forbidigo]
-      # secrets.Resolved.Canonical() is the intended render egress: the two
-      # adapter Render entry points unwrap the resolved model to project it into
-      # destination FileOps. Scope this exclusion to THAT rule (via text) so the
-      # adapters still can't call iox.AtomicWrite directly.
-      - path: '(^|/)internal/adapter/(claude|opencode)/render\.go$'
-        linters: [forbidigo]
-        text: 'unwrap secrets\.Resolved'
+        text: 'iox\.AtomicWrite is reserved'
       # The secrets package's own tests assert on Resolved.Canonical() output.
+      # Test-only, not a leak vector that ships; text-scoped to the rule.
       - path: '(^|/)internal/secrets/.*_test\.go$'
         linters: [forbidigo]
         text: 'unwrap secrets\.Resolved'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+Project memory for Claude Code / agent sessions working on agentsync.
+
+## Secret-handling invariants (read before touching secrets / capture / source writers)
+
+agentsync resolves `${secret:…}` / `${env:…}` references into native agent
+config at apply time, and captures native edits back into the canonical source
+(`~/.agentsync/`). The dangerous bug class is **a resolved cleartext secret
+being persisted into the canonical source** (often a committed dotfiles repo).
+The architecture below makes that hard to do by accident. Do not weaken it.
+
+**1. One field list.** Every secret-bearing canonical field is enumerated in
+exactly one place: `walkSecretFields` in `internal/secrets/walk.go` (MCP/LSP
+`Command,URL,Args,Env,Headers`; Hook `Command`; recursive `Project`).
+`SubstituteCanonical`, `CollectResolved`, `UnresolvedSecretRefs`, and
+`ReReferenceCanonical` all delegate to it. **Add a new secret-bearing field ONLY
+there** — every operation then picks it up automatically. `TestNewSecretFieldGuard`
+(reflect-based) fails if a string-shaped field is added to those structs without
+being classified.
+
+**2. One dest→source path.** All write-backs go through `capture.Capture`
+(`internal/capture`). It re-references secrets (`secrets.ReReferenceCanonical`),
+preserves source-only fields the rendered dest never carries (MCP/LSP
+`agents`/`enabled`), and writes via `internal/source/writer.go`. `import` and
+`reconcile` write-back both call it. **Do not add a new dest→source write that
+bypasses it.**
+
+**3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
+`secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the
+only thing adapters render from. `source.Write*` / `capture.Capture` accept only
+the templated `source.Canonical`. So passing the resolved apply model directly
+to a source writer is a **compile error**.
+
+### How the leak is actually prevented (three tiers)
+
+- **Compile-enforced (load-bearing):** can't pass a `secrets.Resolved` directly
+  to `source.Write*` / `capture.Capture`. Proven by `internal/capture/leak_fixture.go`
+  + `TestResolvedIsNotWritableToSource`.
+- **Value-invariant (load-bearing):** `cloneForResolve` detaches the resolved
+  copy (no aliasing back to the caller's templated canonical), and the walker
+  only visits MCP/LSP/Hook fields — so text components (skill/subagent/command/
+  memory) and `reconcile.writeBackFileItem` physically cannot carry a substituted
+  secret.
+- **Lint fence (defense-in-depth):** a `forbidigo` rule forbids
+  `secrets.Resolved.Canonical` outside the two adapter Render egress sites
+  (line-scoped `//nolint`). Keep `iox.AtomicWrite` exclusions text-scoped so they
+  never also exempt the `Canonical` rule.
+
+### Accepted residual — WATCH OUT FOR THIS
+
+The lint fence is a static matcher, so **interface dispatch, struct embedding,
+and reflection defeat it**, and `source.Write*` is itself not fenced. A
+*deliberate* two-step laundering — defeat the fence to obtain a writable
+`source.Canonical`, then call a source writer (which does not re-reference) —
+would leak. No innocent mistake produces this, and `capture.Capture` always
+re-references, so real flows are safe. **If you ever find yourself unwrapping a
+`secrets.Resolved` (via `.Canonical()` or any indirection) outside an adapter's
+`Render`, stop — you almost certainly want `capture.Capture`.** Fencing the whole
+`source.Write*` API was considered and declined (it fights the legitimate
+templated-write path and is bypassable one level down).
+
+See also: `internal/secrets/resolved.go`, `internal/source/writer.go` package
+doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
+
+## Build / test / lint
+
+- `just build` / `just test-fast`; full gate `just test-release` (hermetic container).
+- FS-touching tests refuse to run on host without `AGENTSYNC_TEST_IN_CONTAINER=1`.
+- `golangci-lint` 2.5.0 panics on Go ≥ 1.26 host toolchains; run lint as
+  `GOTOOLCHAIN=go1.25.10 golangci-lint run ./...` until the linter is upgraded.

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -4,6 +4,7 @@
 package adapter
 
 import (
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -63,7 +64,11 @@ type Adapter interface {
 	Name() string
 	Capabilities() Capability
 	Detect() (bool, error)
-	Render(c source.Canonical, scope Scope, project string) ([]FileOp, []Skip, error)
+	// Render projects the resolved canonical (secrets already substituted to
+	// cleartext, or wrapped templated for a preview) into destination FileOps.
+	// It accepts only secrets.Resolved — never a raw source.Canonical — so the
+	// render egress is type-distinct from the dest->source write path.
+	Render(r secrets.Resolved, scope Scope, project string) ([]FileOp, []Skip, error)
 	Ingest(scope Scope, project string) (source.Canonical, error)
 	// KeyMergeStrategy returns this adapter's single JSON-key-merge strategy
 	// ("merge-json-keys" for claude, "merge-jsonc-keys" for opencode), or ""

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -27,7 +28,7 @@ func TestIngest_RoundTripsMCPAndSkills(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestIngest_RoundTripsSubagentsAndCommands(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestIngest_RoundTripsHooksAndLSP(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 		Memory: source.Memory{Body: "# Agent Memory\n\nRemember: always be helpful.\n"},
 	}
 	a := claude.New(claude.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}

--- a/internal/adapter/claude/lsp.go
+++ b/internal/adapter/claude/lsp.go
@@ -17,6 +17,12 @@ func (a *Adapter) renderLSP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 	lspMap := map[string]any{}
 	var ownedKeys []string
 	for _, lsp := range c.LSPServers {
+		if lsp.Spec.Enabled != nil && !*lsp.Spec.Enabled {
+			continue
+		}
+		if !agentTargeted("claude", lsp.Spec.Agents) {
+			continue
+		}
 		spec := map[string]any{}
 		if lsp.Spec.Command != "" {
 			spec["command"] = lsp.Spec.Command
@@ -35,6 +41,9 @@ func (a *Adapter) renderLSP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 		}
 		lspMap[lsp.ID] = spec
 		ownedKeys = append(ownedKeys, "/lspServers/"+lsp.ID)
+	}
+	if len(lspMap) == 0 {
+		return nil, nil
 	}
 	obj := map[string]any{"lspServers": lspMap}
 	body, err := json.MarshalIndent(obj, "", "  ")

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// Render produces the full set of FileOps for a given canonical model.
+// Render produces the full set of FileOps for a given resolved canonical model.
 // Pure function: returns the same output for the same input (disk reads are
 // treated as fixed inputs for the purposes of the merge-json-keys strategy).
-func (a *Adapter) Render(c source.Canonical, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	c := r.Canonical()
 	paths := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 
 	var ops []adapter.FileOp

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -13,7 +13,7 @@ import (
 // Pure function: returns the same output for the same input (disk reads are
 // treated as fixed inputs for the purposes of the merge-json-keys strategy).
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
-	c := r.Canonical()
+	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	paths := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 
 	var ops []adapter.FileOp

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -26,7 +27,7 @@ func TestRender_MCP_UserScope(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, skips, err := a.Render(c, adapter.ScopeUser, "")
+	ops, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +71,7 @@ func TestRender_MCP_AgentsAllowlist(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +93,7 @@ func TestRender_Memory(t *testing.T) {
 		},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestRender_Skills(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found *adapter.FileOp
 	for i, op := range ops {
 		if strings.Contains(op.Path, "/skills/review/SKILL.md") {
@@ -148,7 +149,7 @@ func TestRender_LSP_WritesSettingsJSON(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +196,7 @@ func TestRender_LSP_WritesSettingsJSON(t *testing.T) {
 func TestRender_LSP_EmptyProducesNoOp(t *testing.T) {
 	c := source.Canonical{}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +215,7 @@ func TestRender_Hooks_WritesSettingsJSON(t *testing.T) {
 		},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +262,7 @@ func TestRender_Hooks_WritesSettingsJSON(t *testing.T) {
 func TestRender_Hooks_EmptyProducesNoOp(t *testing.T) {
 	c := source.Canonical{}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +282,7 @@ func TestRender_Commands(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +312,7 @@ func TestRender_Subagents(t *testing.T) {
 		}},
 	}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/adapter/noop/noop.go
+++ b/internal/adapter/noop/noop.go
@@ -5,6 +5,7 @@ package noop
 
 import (
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -17,7 +18,7 @@ func New(name string) *Adapter { return &Adapter{AdapterName: name} }
 func (a *Adapter) Name() string                     { return a.AdapterName }
 func (a *Adapter) Capabilities() adapter.Capability { return 0 }
 func (a *Adapter) Detect() (bool, error)            { return true, nil }
-func (a *Adapter) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
+func (a *Adapter) Render(secrets.Resolved, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
 	return nil, nil, nil
 }
 

--- a/internal/adapter/noop/noop_test.go
+++ b/internal/adapter/noop/noop_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/noop"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -14,7 +15,7 @@ func TestNoop_Implements(t *testing.T) {
 
 func TestNoop_Render(t *testing.T) {
 	a := noop.New("test")
-	ops, skips, err := a.Render(source.Canonical{}, adapter.ScopeUser, "")
+	ops, skips, err := a.Render(secrets.ForRender(source.Canonical{}), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/adapter/opencode/ingest_test.go
+++ b/internal/adapter/opencode/ingest_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/opencode"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -23,7 +24,7 @@ func TestIngest_RoundTripsMCP(t *testing.T) {
 		}},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestIngest_RoundTripsMCPHeaders(t *testing.T) {
 		}},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 		Memory: source.Memory{Body: "# Memory\n\nAlways be helpful.\n"},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -126,7 +127,7 @@ func TestIngest_RoundTripsSubagentsAndCommands(t *testing.T) {
 		}},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestIngest_JSONC_WithComments(t *testing.T) {
 		}},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: tmp})
-	ops, _, err := a.Render(in, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -11,7 +11,7 @@ import (
 
 // Render converts the resolved canonical into FileOps for OpenCode.
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
-	c := r.Canonical()
+	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var ops []adapter.FileOp
 	var skips []adapter.Skip

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// Render converts canonical source into FileOps for OpenCode.
-func (a *Adapter) Render(c source.Canonical, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+// Render converts the resolved canonical into FileOps for OpenCode.
+func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	c := r.Canonical()
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var ops []adapter.FileOp
 	var skips []adapter.Skip

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/opencode"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -24,7 +25,7 @@ func TestRender_MCP(t *testing.T) {
 		},
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found bool
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "opencode.json") {
@@ -57,7 +58,7 @@ func TestRender_MCP_PreservesHeaders(t *testing.T) {
 		},
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	for _, op := range ops {
 		if !strings.HasSuffix(op.Path, "opencode.json") {
 			continue
@@ -83,7 +84,7 @@ func TestRender_MCP_SkipsDisabled(t *testing.T) {
 		},
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "opencode.json") {
 			t.Fatal("should not emit op for disabled server")
@@ -99,7 +100,7 @@ func TestRender_MCP_SkipsOtherAgents(t *testing.T) {
 		},
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "opencode.json") {
 			t.Fatal("should not emit op for claude-only server")
@@ -116,7 +117,7 @@ func TestRender_Memory(t *testing.T) {
 		Memory: source.Memory{Body: "# Agent memory\n\nThis is the memory.\n"},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found bool
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "AGENTS.md") {
@@ -137,7 +138,7 @@ func TestRender_Memory(t *testing.T) {
 func TestRender_Memory_Empty(t *testing.T) {
 	c := source.Canonical{}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "AGENTS.md") {
 			t.Fatal("should not emit AGENTS.md op when memory is empty")
@@ -153,7 +154,7 @@ func TestRender_Memory_FragmentExpansion(t *testing.T) {
 		},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "AGENTS.md") {
 			if strings.Contains(string(op.Content), "@import") {
@@ -177,7 +178,7 @@ func TestRender_Skill(t *testing.T) {
 		Body:        "Skill body.\n",
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found bool
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "SKILL.md") && strings.Contains(op.Path, "my-skill") {
@@ -211,7 +212,7 @@ func TestRender_Subagent_FrontmatterMunge(t *testing.T) {
 		Body: "Review code.\n",
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, skips, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, skips, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	// verify file content
 	var op *adapter.FileOp
 	for i, o := range ops {
@@ -255,7 +256,7 @@ func TestRender_Subagent_PreservesDescriptionAndModel(t *testing.T) {
 		Body: "Help with things.\n",
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found bool
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "/agents/helper.md") {
@@ -289,7 +290,7 @@ func TestRender_Command_FrontmatterMunge(t *testing.T) {
 		Body: "Summarize the given file.\n",
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, skips, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, skips, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var op *adapter.FileOp
 	for i, o := range ops {
 		if strings.HasSuffix(o.Path, "/commands/summarize.md") {
@@ -330,7 +331,7 @@ func TestRender_Command_BodyPreserved(t *testing.T) {
 		Body:        "Run the linter on $ARGUMENTS.\n",
 	}}}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	ops, _, _ := a.Render(c, adapter.ScopeUser, "")
+	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	var found bool
 	for _, op := range ops {
 		if strings.HasSuffix(op.Path, "/commands/lint.md") {
@@ -355,7 +356,7 @@ func TestRender_HooksAndLSP_Skipped(t *testing.T) {
 		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
 	}
 	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
-	_, skips, err := a.Render(c, adapter.ScopeUser, "")
+	_, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -15,7 +16,7 @@ func (stub) Capabilities() adapter.Capability { return 0 }
 
 func (stub) Detect() (bool, error) { return false, nil }
 
-func (stub) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
+func (stub) Render(secrets.Resolved, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
 	return nil, nil, nil
 }
 

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -50,8 +50,13 @@ type Result struct {
 //     server's exposure or clear its enablement;
 //  3. writes through internal/source/writer.go (never iox.AtomicWrite directly).
 //
-// When the current source can't be loaded (first import, nothing to reference),
-// steps 1–2 are skipped and the ingested values are written as-is.
+// When the current source fails to load, re-reference + field-preservation are
+// skipped and the ingested values are written as-is. Note source.Load returns
+// no error for an empty/absent home, so this is rare; the ordinary "nothing to
+// reference" case (an item with no existing source counterpart, e.g. adopting a
+// foreign dest item) still runs steps 1–2 as no-ops. Such an item carries no
+// secret WE substituted (apply only substitutes from a source ${secret:…}), so
+// writing it verbatim is correct, not a leak.
 func Capture(home string, ingested *source.Canonical, opts Opts) (Result, error) {
 	var res Result
 	if ingested == nil {

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -1,0 +1,121 @@
+// Package capture owns the single dest->source write-back path. apply
+// substitutes ${secret:…} into a destination as cleartext and may drop
+// source-only fields the rendered dest never carries; any flow that reads a
+// destination back into the canonical source (import, reconcile write-back, a
+// future "adopt") must invert both, in exactly one place, or it reintroduces a
+// recurring class of bugs (cleartext-secret persistence, source-only field
+// drift, backup bypass).
+//
+// Capture is that place. It re-references secrets, preserves source-only
+// fields, and routes every write through internal/source/writer.go.
+package capture
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// Opts tunes a Capture call.
+type Opts struct {
+	// Warn receives a human-readable warning when a ${secret:…} reference in
+	// the current source cannot be resolved (backend unavailable / locked), so
+	// re-referencing may have left cleartext in the written-back file. nil
+	// discards it. This is the guard that keeps a secret from silently landing
+	// in ~/.agentsync.
+	Warn io.Writer
+}
+
+// Result reports what Capture wrote.
+type Result struct {
+	// Written lists the source-relative paths written, in write order.
+	Written []string
+}
+
+// Capture persists ingested — a canonical reconstructed from a destination —
+// back into the canonical source at home. It is the single dest->source path;
+// both import and reconcile build a single-item canonical and call it.
+//
+// For every component present in ingested it, in one place:
+//  1. re-references resolved secrets back to ${secret:…} against the current
+//     source (secrets.ReReferenceCanonical), so a live credential apply wrote
+//     into the destination is never persisted into ~/.agentsync;
+//  2. preserves source-only fields the rendered destination never carries
+//     (MCP/LSP agents + enabled), so write-back can't silently broaden a
+//     server's exposure or clear its enablement;
+//  3. writes through internal/source/writer.go (never iox.AtomicWrite directly).
+//
+// When the current source can't be loaded (first import, nothing to reference),
+// steps 1–2 are skipped and the ingested values are written as-is.
+func Capture(home string, ingested *source.Canonical, opts Opts) (Result, error) {
+	var res Result
+	if ingested == nil {
+		return res, nil
+	}
+
+	cur, cerr := source.Load(afero.NewOsFs(), home)
+	var sec secrets.Resolver
+	if cerr == nil {
+		userHome := paths.HomeDir(paths.OSEnv{})
+		sec = secrets.SelectBackend(cur.Config.Secrets, home, userHome)
+		secrets.ReReferenceCanonical(ingested, &cur, sec, secrets.EnvBackend{})
+	}
+
+	for _, m := range ingested.MCPServers {
+		if cerr == nil {
+			if existing, ok, rerr := source.ReadMCP(home, m.ID); rerr == nil && ok {
+				m.Server.Agents = existing.Server.Agents
+				m.Server.Enabled = existing.Server.Enabled
+			}
+		}
+		if err := source.WriteMCP(home, m.ID, m); err != nil {
+			return res, fmt.Errorf("write mcp %s: %w", m.ID, err)
+		}
+		res.Written = append(res.Written, "mcp/"+m.ID+".toml")
+	}
+
+	for _, ls := range ingested.LSPServers {
+		if cerr == nil {
+			if existing, ok, rerr := source.ReadLSP(home, ls.ID); rerr == nil && ok {
+				ls.Spec.Agents = existing.Spec.Agents
+				ls.Spec.Enabled = existing.Spec.Enabled
+			}
+		}
+		if err := source.WriteLSP(home, ls); err != nil {
+			return res, fmt.Errorf("write lsp %s: %w", ls.ID, err)
+		}
+		res.Written = append(res.Written, "lsp/"+ls.ID+".toml")
+	}
+
+	// Hooks have no per-entry source-only fields; write all entries for each
+	// event as a unit (matching WriteHooks' file-per-event shape).
+	byEvent := map[string][]source.Hook{}
+	var eventOrder []string
+	for _, h := range ingested.Hooks {
+		if _, seen := byEvent[h.Event]; !seen {
+			eventOrder = append(eventOrder, h.Event)
+		}
+		byEvent[h.Event] = append(byEvent[h.Event], h)
+	}
+	for _, event := range eventOrder {
+		if err := source.WriteHooks(home, event, byEvent[event]); err != nil {
+			return res, fmt.Errorf("write hooks/%s: %w", event, err)
+		}
+		res.Written = append(res.Written, "hooks/"+event+".toml")
+	}
+
+	if cerr == nil && opts.Warn != nil {
+		if missing := secrets.UnresolvedSecretRefs(&cur, sec); len(missing) > 0 {
+			fmt.Fprintf(opts.Warn,
+				"warning: could not re-reference secret(s) %s (secrets backend unavailable); "+
+					"the written-back source file may contain cleartext — review it before committing\n",
+				strings.Join(missing, ", "))
+		}
+	}
+	return res, nil
+}

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -1,0 +1,91 @@
+package capture_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/capture"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCapture_ReReferencesAndPreserves drives Capture directly (no CLI) to prove
+// the boundary both re-references a resolved secret AND preserves the
+// source-only fields (agents + enabled) the rendered destination never carries.
+func TestCapture_ReReferencesAndPreserves(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "live-secret-value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	// Existing source: templated secret + source-only fields.
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\n"+
+		"type = \"stdio\"\n"+
+		"command = \"npx\"\n"+
+		"agents = [\"claude\"]\n"+
+		"enabled = false\n"+
+		"[server.env]\n"+
+		"GH = \"${secret:TOK}\"\n")
+
+	// Ingested-from-dest: secret resolved to cleartext, source-only fields absent.
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID: "srv",
+		Server: source.MCPServerSpec{
+			Type:    "stdio",
+			Command: "npx",
+			Env:     map[string]string{"GH": "live-secret-value"},
+		},
+	}}}
+
+	res, err := capture.Capture(home, ingested, capture.Opts{})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(res.Written) != 1 || res.Written[0] != "mcp/srv.toml" {
+		t.Fatalf("unexpected Result.Written: %v", res.Written)
+	}
+
+	got, ok, err := source.ReadMCP(home, "srv")
+	if err != nil || !ok {
+		t.Fatalf("read back: ok=%v err=%v", ok, err)
+	}
+	if got.Server.Env["GH"] != "${secret:TOK}" {
+		t.Errorf("secret not re-referenced: GH=%q", got.Server.Env["GH"])
+	}
+	if len(got.Server.Agents) != 1 || got.Server.Agents[0] != "claude" {
+		t.Errorf("source-only agents not preserved: %v", got.Server.Agents)
+	}
+	if got.Server.Enabled == nil || *got.Server.Enabled {
+		t.Errorf("source-only enabled not preserved: %v", got.Server.Enabled)
+	}
+}
+
+// TestCapture_FirstImportNoSource exercises the path where no canonical source
+// exists yet (first import): there is nothing to re-reference against, so the
+// ingested values are written verbatim and Capture must not error.
+func TestCapture_FirstImportNoSource(t *testing.T) {
+	home := t.TempDir()
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "npx"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("capture (first import): %v", err)
+	}
+	got, ok, err := source.ReadMCP(home, "srv")
+	if err != nil || !ok {
+		t.Fatalf("read back: ok=%v err=%v", ok, err)
+	}
+	if got.Server.Command != "npx" {
+		t.Errorf("first-import write-as-is failed: command=%q", got.Server.Command)
+	}
+}

--- a/internal/capture/leak_compile_test.go
+++ b/internal/capture/leak_compile_test.go
@@ -1,0 +1,33 @@
+package capture_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestResolvedIsNotWritableToSource is the Part C guard: it compiles
+// leak_fixture.go (which tries to hand a secrets.Resolved to source.WriteMCP and
+// to Capture) under -tags=leakfixture and asserts the build FAILS with a type
+// error. A green build here would mean the resolved apply model became
+// assignable to the dest->source write path again — the leak class the type
+// split exists to forbid. This makes the guarantee a compile error, not a
+// code-review catch.
+func TestResolvedIsNotWritableToSource(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH; cannot run the negative-compile fixture")
+	}
+	cmd := exec.Command("go", "build", "-tags=leakfixture", "./internal/capture/")
+	cmd.Dir = "../.." // repo root, relative to internal/capture
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("leak_fixture.go compiled, but a secrets.Resolved MUST NOT be assignable "+
+			"to source.WriteMCP / Capture; the type wall has a hole.\nbuild output:\n%s", out)
+	}
+	// Confirm the failure is the expected type mismatch, not an unrelated build
+	// break (missing dep, syntax error elsewhere, etc.).
+	got := string(out)
+	if !strings.Contains(got, "secrets.Resolved") {
+		t.Fatalf("expected a type error mentioning secrets.Resolved; got:\n%s", got)
+	}
+}

--- a/internal/capture/leak_fixture.go
+++ b/internal/capture/leak_fixture.go
@@ -1,0 +1,22 @@
+//go:build leakfixture
+
+// This file is compiled ONLY under -tags=leakfixture, exclusively by
+// TestResolvedIsNotWritableToSource. It is the executable proof of the Part C
+// type wall: each statement below MUST fail to compile, because a
+// secrets.Resolved (the resolved apply model) is deliberately not assignable to
+// anything on the dest->source write path. If this file ever compiles, the wall
+// has a hole and a future capture path could leak resolved cleartext into
+// ~/.agentsync — exactly the leak the refactor makes unrepresentable.
+package capture
+
+import (
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+func leakFixture(home string, r secrets.Resolved) {
+	// A source writer takes the templated source.MCPServer — never a Resolved.
+	_ = source.WriteMCP(home, "x", r)
+	// Capture takes the templated *source.Canonical — never a Resolved.
+	_, _ = Capture(home, r, Opts{})
+}

--- a/internal/capture/main_test.go
+++ b/internal/capture/main_test.go
@@ -1,0 +1,15 @@
+package capture_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// TestMain enforces the hermeticity contract: these tests write to disk
+// (temp ~/.agentsync trees), so they run only inside the hermetic container.
+func TestMain(m *testing.M) {
+	testenv.MustRunInContainer()
+	os.Exit(m.Run())
+}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -83,11 +83,14 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		fmt.Fprintln(cmd.ErrOrStderr(), "scope: user")
 	}
 
-	// Resolve ${secret:...} and ${env:...} references before rendering.
+	// Resolve ${secret:...} and ${env:...} references before rendering. The
+	// result is a secrets.Resolved — the only thing adapters render from — and
+	// c is left templated for the report / agent enumeration below.
 	userHome := paths.HomeDir(paths.OSEnv{})
 	secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
 	envBackend := secrets.EnvBackend{}
-	if err := secrets.SubstituteCanonical(&c, secBackend, envBackend); err != nil {
+	resolved, err := secrets.SubstituteCanonical(c, secBackend, envBackend)
+	if err != nil {
 		return err
 	}
 
@@ -125,7 +128,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	}
 
 	if dryRun {
-		plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
+		plan, err := render.Plan(resolved, reg, agents, sc, projectRoot, s, userHome)
 		if err != nil {
 			return err
 		}
@@ -173,7 +176,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// Real apply: render + write. The writer constructed inside
 	// render.Apply enforces the foreign-collision backup invariant on
 	// every destination write — there is no separate guard pass.
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
+	plan, err := render.Plan(resolved, reg, agents, sc, projectRoot, s, userHome)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/capture_leak_test.go
+++ b/internal/cli/capture_leak_test.go
@@ -58,6 +58,13 @@ func writeSource(t *testing.T, home, rel, content string) string {
 // canonical source must end up with the ${secret:…} placeholder restored and no
 // cleartext written. One missing field in the walker would surface here as a
 // leak in exactly that row.
+// Project-overlay secret fields are covered at the unit level
+// (secrets.TestReReferenceCanonical_ProjectOverlay + the walker-visitation
+// test), not here: no dest->source capture path carries a Project overlay —
+// import is user-scope (adapter.ScopeUser) and Capture writes top-level
+// source files (mcp/<id>.toml, lsp/<id>.toml, hooks/<event>.toml), never a
+// project overlay. So the overlay leak surface lives entirely in the walker /
+// ReReferenceCanonical, which the secrets unit tests exercise directly.
 func TestCapture_ImportNoSecretLeak(t *testing.T) {
 	cases := []struct {
 		name     string // sub-test name

--- a/internal/cli/capture_leak_test.go
+++ b/internal/cli/capture_leak_test.go
@@ -254,15 +254,17 @@ func TestCapture_PreservesSourceOnlyFields(t *testing.T) {
 		{
 			name:   "mcp",
 			srcRel: "mcp/srv.toml",
+			// enabled = true keeps the server rendering (so import can find it)
+			// while still exercising preservation of the explicit enabled flag.
 			srcBody: "[server]\ntype = \"stdio\"\ncommand = \"npx\"\n" +
-				"agents = [\"claude\"]\n",
+				"agents = [\"claude\"]\nenabled = true\n",
 			selector: "claude:mcp:srv",
 		},
 		{
 			name:   "lsp",
 			srcRel: "lsp/srv.toml",
 			srcBody: "[server]\ncommand = \"gopls\"\n" +
-				"agents = [\"claude\"]\n",
+				"agents = [\"claude\"]\nenabled = true\n",
 			selector: "claude:lsp:srv",
 		},
 	} {
@@ -281,6 +283,9 @@ func TestCapture_PreservesSourceOnlyFields(t *testing.T) {
 			}
 			if !strings.Contains(string(got), "agents") || !strings.Contains(string(got), "claude") {
 				t.Fatalf("capture dropped the source-only agents allowlist for %s (broadens exposure):\n%s", tc.name, got)
+			}
+			if !strings.Contains(string(got), "enabled") {
+				t.Fatalf("capture dropped the source-only enabled flag for %s:\n%s", tc.name, got)
 			}
 		})
 	}

--- a/internal/cli/capture_leak_test.go
+++ b/internal/cli/capture_leak_test.go
@@ -1,0 +1,287 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cleartext is the resolved value of ${secret:LEAK_TOK}. After apply it is
+// substituted into the destination; it must NEVER survive a dest->source
+// capture (import / reconcile write-back) into ~/.agentsync.
+const cleartext = "ghp_LEAKVALUE_DO_NOT_PERSIST"
+
+// setupCaptureHome initialises a fresh ~/.agentsync with the claude agent and
+// the env secrets backend, and returns the agentsync home + the env map runCLI
+// needs (AGENTSYNC_TARGET_ROOT redirection + the secret value in the env).
+func setupCaptureHome(t *testing.T) (home string, env map[string]string) {
+	t.Helper()
+	tmp := t.TempDir()
+	env = map[string]string{
+		"AGENTSYNC_TARGET_ROOT": tmp,
+		"LEAK_TOK":              cleartext,
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	home = filepath.Join(tmp, ".agentsync")
+	tomlPath := filepath.Join(home, "agentsync.toml")
+	cfg, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tomlPath, append(cfg, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home, env
+}
+
+func writeSource(t *testing.T, home, rel, content string) string {
+	t.Helper()
+	p := filepath.Join(home, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestCapture_ImportNoSecretLeak is the table-driven leak guard: for every
+// secret-bearing field of every capturable component, apply substitutes the
+// secret to cleartext into the destination, import reads it back, and the
+// canonical source must end up with the ${secret:…} placeholder restored and no
+// cleartext written. One missing field in the walker would surface here as a
+// leak in exactly that row.
+func TestCapture_ImportNoSecretLeak(t *testing.T) {
+	cases := []struct {
+		name     string // sub-test name
+		srcRel   string // source file (relative to ~/.agentsync)
+		srcBody  string
+		selector string // import selector
+		// fields the walker must restore; each is a ${secret:…} substring the
+		// re-referenced source file must contain.
+		wantRefs []string
+	}{
+		{
+			name:   "mcp_stdio_command_args_env",
+			srcRel: "mcp/stdio.toml",
+			srcBody: "" +
+				"[server]\n" +
+				"type = \"stdio\"\n" +
+				"command = \"${secret:LEAK_TOK}\"\n" +
+				"args = [\"${secret:LEAK_TOK}\", \"plain-arg\"]\n" +
+				"[server.env]\n" +
+				"GH_TOKEN = \"${secret:LEAK_TOK}\"\n",
+			selector: "claude:mcp:stdio",
+			wantRefs: []string{"${secret:LEAK_TOK}"},
+		},
+		{
+			name:   "mcp_http_url_headers_env",
+			srcRel: "mcp/http.toml",
+			srcBody: "" +
+				"[server]\n" +
+				"type = \"http\"\n" +
+				"url = \"${secret:LEAK_TOK}\"\n" +
+				"[server.headers]\n" +
+				"Authorization = \"Bearer ${secret:LEAK_TOK}\"\n" +
+				"[server.env]\n" +
+				"API_KEY = \"${secret:LEAK_TOK}\"\n",
+			selector: "claude:mcp:http",
+			wantRefs: []string{"${secret:LEAK_TOK}"},
+		},
+		{
+			name:   "lsp_stdio_command_args_env",
+			srcRel: "lsp/stdiolsp.toml",
+			srcBody: "" +
+				"[server]\n" +
+				"command = \"${secret:LEAK_TOK}\"\n" +
+				"args = [\"--key\", \"${secret:LEAK_TOK}\"]\n" +
+				"[server.env]\n" +
+				"LSP_KEY = \"${secret:LEAK_TOK}\"\n",
+			selector: "claude:lsp:stdiolsp",
+			wantRefs: []string{"${secret:LEAK_TOK}"},
+		},
+		{
+			name:   "lsp_http_url_headers",
+			srcRel: "lsp/httplsp.toml",
+			srcBody: "" +
+				"[server]\n" +
+				"url = \"${secret:LEAK_TOK}\"\n" +
+				"[server.headers]\n" +
+				"Authorization = \"Bearer ${secret:LEAK_TOK}\"\n",
+			selector: "claude:lsp:httplsp",
+			wantRefs: []string{"${secret:LEAK_TOK}"},
+		},
+		{
+			name:   "hook_command",
+			srcRel: "hooks/PreToolUse.toml",
+			srcBody: "" +
+				"[[hook]]\n" +
+				"type = \"command\"\n" +
+				"command = \"audit ${secret:LEAK_TOK}\"\n",
+			selector: "claude:hook:PreToolUse",
+			wantRefs: []string{"${secret:LEAK_TOK}"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, env := setupCaptureHome(t)
+			srcPath := writeSource(t, home, tc.srcRel, tc.srcBody)
+
+			if _, err := runCLI(t, env, "apply"); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			// Precondition: apply really did substitute the cleartext into a dest.
+			if !destContains(t, home, cleartext) {
+				t.Fatalf("precondition failed: apply did not substitute the secret into any destination")
+			}
+
+			if _, err := runCLI(t, env, "import", tc.selector); err != nil {
+				t.Fatalf("import %s: %v", tc.selector, err)
+			}
+
+			got, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(got), cleartext) {
+				t.Fatalf("import leaked cleartext into source %s:\n%s", tc.srcRel, got)
+			}
+			for _, ref := range tc.wantRefs {
+				if !strings.Contains(string(got), ref) {
+					t.Fatalf("import did not restore %q in source %s:\n%s", ref, tc.srcRel, got)
+				}
+			}
+		})
+	}
+}
+
+// destContains reports whether any rendered destination file under the target
+// root holds substr. The target root is the parent of ~/.agentsync.
+func destContains(t *testing.T, home, substr string) bool {
+	t.Helper()
+	root := filepath.Dir(home)
+	found := false
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		// Skip the canonical source tree; we want DESTINATION files only.
+		if strings.HasPrefix(path, home+string(os.PathSeparator)) {
+			return nil
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr == nil && strings.Contains(string(data), substr) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// TestCapture_ReconcileNoSecretLeak exercises the OTHER capture path: reconcile
+// [w]rite-back reconstructs an MCP spec from the cleartext destination and must
+// re-reference every secret-bearing field before persisting source. The user
+// edits an unrelated, non-secret field (command) to create the drift that makes
+// write-back fire; the secret fields (args/env) must come back as placeholders.
+func TestCapture_ReconcileNoSecretLeak(t *testing.T) {
+	home, env := setupCaptureHome(t)
+	srcPath := writeSource(t, home, "mcp/srv.toml", ""+
+		"[server]\n"+
+		"type = \"stdio\"\n"+
+		"command = \"mybin\"\n"+ // non-secret, editable
+		"args = [\"--token\", \"${secret:LEAK_TOK}\"]\n"+
+		"[server.env]\n"+
+		"GH_TOKEN = \"${secret:LEAK_TOK}\"\n")
+
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	destPath := filepath.Join(filepath.Dir(home), ".claude.json")
+	dest, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(dest), cleartext) {
+		t.Fatalf("precondition: apply did not substitute the secret into %s:\n%s", destPath, dest)
+	}
+	edited := strings.Replace(string(dest), `"mybin"`, `"mybin2"`, 1)
+	if edited == string(dest) {
+		t.Fatalf("precondition: could not edit the non-secret command field:\n%s", dest)
+	}
+	if err := os.WriteFile(destPath, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), cleartext) {
+		t.Fatalf("reconcile write-back leaked cleartext into source:\n%s", got)
+	}
+	if !strings.Contains(string(got), "${secret:LEAK_TOK}") {
+		t.Fatalf("reconcile write-back did not restore the placeholder:\n%s", got)
+	}
+	if !strings.Contains(string(got), "mybin2") {
+		t.Fatalf("reconcile write-back dropped the genuine non-secret edit (command):\n%s", got)
+	}
+}
+
+// TestCapture_PreservesSourceOnlyFields proves capture preserves the
+// source-only targeting fields (agents) that the rendered destination never
+// carries, for BOTH MCP and LSP — resetting them would silently broaden a
+// server's exposure.
+func TestCapture_PreservesSourceOnlyFields(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		srcRel   string
+		srcBody  string
+		selector string
+	}{
+		{
+			name:   "mcp",
+			srcRel: "mcp/srv.toml",
+			srcBody: "[server]\ntype = \"stdio\"\ncommand = \"npx\"\n" +
+				"agents = [\"claude\"]\n",
+			selector: "claude:mcp:srv",
+		},
+		{
+			name:   "lsp",
+			srcRel: "lsp/srv.toml",
+			srcBody: "[server]\ncommand = \"gopls\"\n" +
+				"agents = [\"claude\"]\n",
+			selector: "claude:lsp:srv",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, env := setupCaptureHome(t)
+			srcPath := writeSource(t, home, tc.srcRel, tc.srcBody)
+			if _, err := runCLI(t, env, "apply"); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			if _, err := runCLI(t, env, "import", tc.selector); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+			got, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(got), "agents") || !strings.Contains(string(got), "claude") {
+				t.Fatalf("capture dropped the source-only agents allowlist for %s (broadens exposure):\n%s", tc.name, got)
+			}
+		})
+	}
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -81,7 +81,11 @@ func newDiffCmd() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
 				return nil
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
+			// diff renders the TEMPLATED canonical (it masks the destination's
+			// resolved cleartext separately, below); wrap as a render-only
+			// Resolved without substituting so it works even when the secrets
+			// backend is locked.
+			plan, err := render.Plan(secrets.ForRender(c), reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -73,7 +74,7 @@ func newExplainCmd() *cobra.Command {
 				return err
 			}
 
-			plan, err := render.Plan(filtered, reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
+			plan, err := render.Plan(secrets.ForRender(filtered), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -13,37 +13,12 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
-	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
-
-// reReferenceSecretsAgainstSource restores ${secret:…} placeholders in a
-// canonical reconstructed from a destination so import AND reconcile write-back
-// never persist a live credential into ~/.agentsync. It is a thin shim around
-// secrets.ReReferenceCanonical (the single boundary that owns the field-walk and
-// the field-positional restore) that supplies the current source as the
-// reference and surfaces a warning when the secrets backend can't resolve.
-func reReferenceSecretsAgainstSource(cmd *cobra.Command, home string, c *source.Canonical) {
-	cur, err := source.Load(loaderFsForState(), home)
-	if err != nil {
-		return // no source yet (first import) → nothing to re-reference
-	}
-	userHome := paths.HomeDir(paths.OSEnv{})
-	sec := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
-	env := secrets.EnvBackend{}
-
-	secrets.ReReferenceCanonical(c, &cur, sec, env)
-
-	if missing := secrets.UnresolvedSecretRefs(&cur, sec); len(missing) > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"warning: could not re-reference secret(s) %s (secrets backend unavailable); "+
-				"the written-back source file may contain cleartext — review it before committing\n",
-			strings.Join(missing, ", "))
-	}
-}
 
 // loaderFsForState returns an afero.Fs suitable for re-loading the
 // canonical repo when seeding state — the OS FS is correct here because
@@ -172,13 +147,11 @@ func importRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("selector %q is missing the item name; expected <agent>:<component>:<name>", sel)
 	}
 
-	// Re-reference secrets before writing back to source. The destination was
-	// written by a prior apply with ${secret:…} substituted to cleartext, so
-	// the ingested canonical holds live credentials. Convert any value that
-	// matches a known secret back to its placeholder so import doesn't persist
-	// a cleartext token into ~/.agentsync (often a committed dotfiles repo).
-	reReferenceSecretsAgainstSource(cmd, home, &c)
-
+	// MCP / LSP / hook capture routes through capture.Capture, which
+	// re-references secrets (the destination holds live cleartext substituted
+	// by a prior apply) and preserves source-only fields before writing source.
+	// The text components (skill/subagent/command/memory) carry no secrets and
+	// no source-only fields, so they write directly.
 	switch component {
 	case "mcp":
 		err = importMCP(cmd, home, c, name)
@@ -383,16 +356,9 @@ func parseSelector(sel string) (agentName, component, name string, err error) {
 func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string) error {
 	for _, m := range c.MCPServers {
 		if m.ID == name {
-			// Preserve source-only fields (agents allowlist, enabled) that the
-			// rendered destination never carries — otherwise import resets the
-			// agents allowlist to default-all (silently broadening the server's
-			// exposure) and clears enabled. reconcile write-back does the same.
-			if existing, ok, rerr := source.ReadMCP(home, m.ID); rerr == nil && ok {
-				m.Server.Agents = existing.Server.Agents
-				m.Server.Enabled = existing.Server.Enabled
-			}
-			if err := source.WriteMCP(home, m.ID, m); err != nil {
-				return fmt.Errorf("write mcp %s: %w", name, err)
+			single := source.Canonical{MCPServers: []source.MCPServer{m}}
+			if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "imported mcp/%s.toml\n", name)
 			return nil
@@ -451,8 +417,9 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 	if len(matched) == 0 {
 		return fmt.Errorf("hook event %q not found in native config", name)
 	}
-	if err := source.WriteHooks(home, name, matched); err != nil {
-		return fmt.Errorf("write hooks/%s: %w", name, err)
+	single := source.Canonical{Hooks: matched}
+	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "imported hooks/%s.toml (%d entries)\n", name, len(matched))
 	return nil
@@ -461,8 +428,9 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string) error {
 	for _, ls := range c.LSPServers {
 		if ls.ID == name {
-			if err := source.WriteLSP(home, ls); err != nil {
-				return fmt.Errorf("write lsp %s: %w", name, err)
+			single := source.Canonical{LSPServers: []source.LSPServer{ls}}
+			if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "imported lsp/%s.toml\n", name)
 			return nil

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -22,16 +22,10 @@ import (
 
 // reReferenceSecretsAgainstSource restores ${secret:…} placeholders in a
 // canonical reconstructed from a destination so import AND reconcile write-back
-// never persist a live credential into ~/.agentsync. apply substitutes secrets
-// to cleartext into the destination; both import and reconcile read that
-// destination back, so this puts the placeholders back before writing source.
-//
-// Matching is FIELD-POSITIONAL, not value-based: for each item present in the
-// current source, a field is restored to its templated form only if (a) the
-// source field actually referenced a secret and (b) the ingested value still
-// resolves to the same thing (the field is unchanged). A field the source did
-// NOT template (e.g. command = "npx") is never rewritten, even if its literal
-// happens to equal some secret's value — value-based masking would corrupt it.
+// never persist a live credential into ~/.agentsync. It is a thin shim around
+// secrets.ReReferenceCanonical (the single boundary that owns the field-walk and
+// the field-positional restore) that supplies the current source as the
+// reference and surfaces a warning when the secrets backend can't resolve.
 func reReferenceSecretsAgainstSource(cmd *cobra.Command, home string, c *source.Canonical) {
 	cur, err := source.Load(loaderFsForState(), home)
 	if err != nil {
@@ -41,98 +35,13 @@ func reReferenceSecretsAgainstSource(cmd *cobra.Command, home string, c *source.
 	sec := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
 	env := secrets.EnvBackend{}
 
-	// restore returns the source field's templated value when it referenced a
-	// secret and still resolves to the (unchanged) ingested value; otherwise it
-	// keeps the ingested value verbatim.
-	restore := func(srcVal, ingestedVal string) string {
-		if !strings.Contains(srcVal, "${secret:") {
-			return ingestedVal
-		}
-		if resolved, _, rerr := secrets.SubstituteRefs(srcVal, sec, env); rerr == nil && resolved == ingestedVal {
-			return srcVal
-		}
-		return ingestedVal
-	}
-
-	curMCP := make(map[string]source.MCPServerSpec, len(cur.MCPServers))
-	for _, m := range cur.MCPServers {
-		curMCP[m.ID] = m.Server
-	}
-	for i := range c.MCPServers {
-		src, ok := curMCP[c.MCPServers[i].ID]
-		if !ok {
-			continue
-		}
-		restoreServerFields(&c.MCPServers[i].Server, src.Command, src.URL, src.Args, src.Env, src.Headers, restore)
-	}
-
-	curLSP := make(map[string]source.LSPServerSpec, len(cur.LSPServers))
-	for _, l := range cur.LSPServers {
-		curLSP[l.ID] = l.Spec
-	}
-	for i := range c.LSPServers {
-		src, ok := curLSP[c.LSPServers[i].ID]
-		if !ok {
-			continue
-		}
-		sp := &c.LSPServers[i].Spec
-		restoreServerFields2(sp, src.Command, src.URL, src.Args, src.Env, src.Headers, restore)
-	}
-
-	// Hooks have no stable id; match by Event and restore a Command that the
-	// source templated and whose resolution equals the ingested command.
-	for i := range c.Hooks {
-		for _, h := range cur.Hooks {
-			if h.Event != c.Hooks[i].Event || !strings.Contains(h.Command, "${secret:") {
-				continue
-			}
-			if resolved, _, rerr := secrets.SubstituteRefs(h.Command, sec, env); rerr == nil && resolved == c.Hooks[i].Command {
-				c.Hooks[i].Command = h.Command
-				break
-			}
-		}
-	}
+	secrets.ReReferenceCanonical(c, &cur, sec, env)
 
 	if missing := secrets.UnresolvedSecretRefs(&cur, sec); len(missing) > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: could not re-reference secret(s) %s (secrets backend unavailable); "+
 				"the written-back source file may contain cleartext — review it before committing\n",
 			strings.Join(missing, ", "))
-	}
-}
-
-// restoreServerFields applies restore() field-positionally to an MCP spec.
-func restoreServerFields(dst *source.MCPServerSpec, srcCmd, srcURL string, srcArgs []string, srcEnv, srcHeaders map[string]string, restore func(string, string) string) {
-	dst.Command = restore(srcCmd, dst.Command)
-	dst.URL = restore(srcURL, dst.URL)
-	for j := range dst.Args {
-		if j < len(srcArgs) {
-			dst.Args[j] = restore(srcArgs[j], dst.Args[j])
-		}
-	}
-	for k, v := range dst.Env {
-		dst.Env[k] = restore(srcEnv[k], v)
-	}
-	for k, v := range dst.Headers {
-		dst.Headers[k] = restore(srcHeaders[k], v)
-	}
-}
-
-// restoreServerFields2 is restoreServerFields for an LSP spec (same field set,
-// distinct struct type).
-func restoreServerFields2(dst *source.LSPServerSpec, srcCmd, srcURL string, srcArgs []string, srcEnv, srcHeaders map[string]string, restore func(string, string) string) {
-	dst.Command = restore(srcCmd, dst.Command)
-	dst.URL = restore(srcURL, dst.URL)
-	for j := range dst.Args {
-		if j < len(srcArgs) {
-			dst.Args[j] = restore(srcArgs[j], dst.Args[j])
-		}
-	}
-	for k, v := range dst.Env {
-		dst.Env[k] = restore(srcEnv[k], v)
-	}
-	for k, v := range dst.Headers {
-		dst.Headers[k] = restore(srcHeaders[k], v)
 	}
 }
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -218,7 +219,7 @@ func unimportedDestPointers(home, agentName string, reg *adapter.Registry) []str
 	if a == nil {
 		return nil
 	}
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		return nil
 	}
@@ -281,7 +282,7 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 	if a == nil {
 		return fmt.Errorf("adapter %q not registered", agentName)
 	}
-	ops, _, err := a.Render(c, adapter.ScopeUser, "")
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
 	if err != nil {
 		return err
 	}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/paths"
@@ -463,22 +464,16 @@ func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 		if err := json.Unmarshal(specBytes, &spec); err != nil {
 			return fmt.Errorf("unmarshal mcp spec %s: %w", serverID, err)
 		}
-		// Preserve source-only fields (agents/enabled) that the rendered
-		// destination spec never carries — otherwise writing a dest edit
-		// back silently drops the user's targeting/enablement config.
-		if existing, ok, rerr := source.ReadMCP(home, serverID); rerr == nil && ok {
-			spec.Agents = existing.Server.Agents
-			spec.Enabled = existing.Server.Enabled
+		// The spec was reconstructed from the destination, where apply wrote any
+		// ${secret:…} as resolved cleartext and which never carries source-only
+		// fields (agents/enabled). capture.Capture re-references the secrets and
+		// preserves those fields before writing — the same single boundary import
+		// uses, so the two paths can't drift apart again.
+		single := source.Canonical{MCPServers: []source.MCPServer{{ID: serverID, Server: spec}}}
+		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return err
 		}
-		m := source.MCPServer{ID: serverID, Server: spec}
-		// The spec was reconstructed from the destination, where apply wrote
-		// any ${secret:…} as resolved cleartext. Re-reference known secrets
-		// back to their placeholder before persisting to source — otherwise
-		// write-back leaks the live token into ~/.agentsync (same hole that
-		// `import` guards against).
-		rc := source.Canonical{MCPServers: []source.MCPServer{m}}
-		reReferenceSecretsAgainstSource(cmd, home, &rc)
-		return source.WriteMCP(home, serverID, rc.MCPServers[0])
+		return nil
 	}
 	// Unsupported pointer shape (hooks, lsp, …). DO NOT silently no-op —
 	// the success message would be a lie.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -103,7 +104,9 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			agents = append(agents, name)
 		}
 	}
-	plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
+	// reconcile hashes the rendered TEMPLATED source for drift; wrap as a
+	// render-only Resolved without substituting (no backend needed).
+	plan, err := render.Plan(secrets.ForRender(c), reg, agents, sc, projectRoot, s, userHome)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/tailscale/hujson"
@@ -73,7 +74,9 @@ func newStatusCmd() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
 				return nil
 			}
-			plan, err := render.Plan(c, reg, agents, sc, projectRoot, s, userHome)
+			// status hashes the rendered TEMPLATED source for drift; wrap as a
+			// render-only Resolved without substituting (no backend needed).
+			plan, err := render.Plan(secrets.ForRender(c), reg, agents, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -195,8 +195,9 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 
 		secBackend := secrets.SelectBackend(c2.Config.Secrets, home, userHome)
 		envBackend := secrets.EnvBackend{}
-		if err := secrets.SubstituteCanonical(&c2, secBackend, envBackend); err != nil {
-			return fmt.Errorf("substitute secrets after update: %w", err)
+		resolved, serr := secrets.SubstituteCanonical(c2, secBackend, envBackend)
+		if serr != nil {
+			return fmt.Errorf("substitute secrets after update: %w", serr)
 		}
 
 		agents := []string{}
@@ -206,7 +207,7 @@ func updateRun(cmd *cobra.Command, doApply, _ bool, scopeFlag, projectFlag strin
 			}
 		}
 		reg := registryFactory()
-		plan, err := render.Plan(c2, reg, agents, sc, projectRoot, st, userHome)
+		plan, err := render.Plan(resolved, reg, agents, sc, projectRoot, st, userHome)
 		if err != nil {
 			return fmt.Errorf("plan after update: %w", err)
 		}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -49,7 +49,7 @@ func newVerifyCmd() *cobra.Command {
 			if os.Getenv("AGENTSYNC_ALLOW_OFFLINE_VERIFY") != "1" {
 				secBackend := secrets.SelectBackend(c.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
 				envBackend := secrets.EnvBackend{}
-				if err := secrets.SubstituteCanonical(&c, secBackend, envBackend); err != nil {
+				if _, err := secrets.SubstituteCanonical(c, secBackend, envBackend); err != nil {
 					return fmt.Errorf("verify ${secret:}/${env:} resolution: %w", err)
 				}
 			}

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
-	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
@@ -51,14 +51,14 @@ func (p RenderPlan) Total() int {
 // userHome (the user's $HOME, paths.HomeDir) is required so OwnedKeys
 // lookups match the HOME-relative form state stores. It is NOT the agentsync
 // home — dest files live under $HOME, not under ~/.agentsync.
-func Plan(c source.Canonical, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets, userHome string) (RenderPlan, error) {
+func Plan(r secrets.Resolved, reg *adapter.Registry, agents []string, scope adapter.Scope, project string, s *state.Targets, userHome string) (RenderPlan, error) {
 	out := RenderPlan{PerAgent: map[string]AgentResult{}}
 	for _, name := range agents {
 		a := reg.Lookup(name)
 		if a == nil {
 			return out, fmt.Errorf("adapter %q not registered", name)
 		}
-		ops, skips, err := a.Render(c, scope, project)
+		ops, skips, err := a.Render(r, scope, project)
 		if err != nil {
 			return out, fmt.Errorf("render %s: %w", name, err)
 		}

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/noop"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -19,7 +20,7 @@ type countingAdapter struct {
 	renderOps []adapter.FileOp
 }
 
-func (c *countingAdapter) Render(source.Canonical, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
+func (c *countingAdapter) Render(secrets.Resolved, adapter.Scope, string) ([]adapter.FileOp, []adapter.Skip, error) {
 	return c.renderOps, nil, nil
 }
 
@@ -33,7 +34,7 @@ func TestPipeline_PlanEmpty(t *testing.T) {
 	_ = reg.Register(noop.New("claude"))
 	_ = reg.Register(noop.New("opencode"))
 
-	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude", "opencode"}, adapter.ScopeUser, "", nil, "/tmp")
+	plan, err := render.Plan(secrets.ForRender(source.Canonical{}), reg, []string{"claude", "opencode"}, adapter.ScopeUser, "", nil, "/tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestPipeline_PlanEmpty(t *testing.T) {
 func TestPipeline_UnknownAgentError(t *testing.T) {
 	reg := adapter.NewRegistry()
 	_ = reg.Register(noop.New("claude"))
-	_, err := render.Plan(source.Canonical{}, reg, []string{"missing"}, adapter.ScopeUser, "", nil, "/tmp")
+	_, err := render.Plan(secrets.ForRender(source.Canonical{}), reg, []string{"missing"}, adapter.ScopeUser, "", nil, "/tmp")
 	if err == nil {
 		t.Fatal("expected error for unknown adapter")
 	}
@@ -122,7 +123,7 @@ func TestPipeline_OwnedKeysInjected(t *testing.T) {
 	key := "claude:user::${HOME}/.claude.json:/mcpServers/github"
 	s.Keys[key] = state.KeyEntry{SHA256: "abc123", AppliedAt: time.Now()}
 
-	plan, err := render.Plan(source.Canonical{}, reg, []string{"claude"}, adapter.ScopeUser, "", s, home)
+	plan, err := render.Plan(secrets.ForRender(source.Canonical{}), reg, []string{"claude"}, adapter.ScopeUser, "", s, home)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/render/sibling_section_test.go
+++ b/internal/render/sibling_section_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -16,7 +17,7 @@ import (
 // applyOnce runs the real plan→apply→prune→record cycle the apply command uses.
 func applyOnce(t *testing.T, reg *adapter.Registry, c source.Canonical, st *state.Targets, home, userHome string) {
 	t.Helper()
-	plan, err := render.Plan(c, reg, []string{"claude"}, adapter.ScopeUser, "", st, userHome)
+	plan, err := render.Plan(secrets.ForRender(c), reg, []string{"claude"}, adapter.ScopeUser, "", st, userHome)
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -25,7 +26,7 @@ type fakeJSONApply struct {
 func (f *fakeJSONApply) Name() string                     { return f.name }
 func (f *fakeJSONApply) Capabilities() adapter.Capability { return 0 }
 func (f *fakeJSONApply) Detect() (bool, error)            { return true, nil }
-func (f *fakeJSONApply) Render(_ source.Canonical, _ adapter.Scope, _ string) ([]adapter.FileOp, []adapter.Skip, error) {
+func (f *fakeJSONApply) Render(_ secrets.Resolved, _ adapter.Scope, _ string) ([]adapter.FileOp, []adapter.Skip, error) {
 	return nil, nil, nil
 }
 

--- a/internal/secrets/mask.go
+++ b/internal/secrets/mask.go
@@ -23,7 +23,9 @@ func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
 	if c == nil {
 		return out
 	}
-	collectString := func(s string) {
+	// walkSecretFields mutates in place; returning each value unchanged makes
+	// every assignment a no-op, so this stays a read-only redaction pass.
+	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
 		// Find every ${secret:foo} / ${env:NAME}; resolve each; record
 		// the mapping. We do not error on missing keys — this is a
 		// best-effort redaction.
@@ -58,41 +60,8 @@ func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
 				out[esc] = placeholder
 			}
 		}
-	}
-	for _, srv := range c.MCPServers {
-		collectString(srv.Server.Command)
-		collectString(srv.Server.URL)
-		for _, a := range srv.Server.Args {
-			collectString(a)
-		}
-		for _, v := range srv.Server.Env {
-			collectString(v)
-		}
-		for _, v := range srv.Server.Headers {
-			collectString(v)
-		}
-	}
-	for _, h := range c.Hooks {
-		collectString(h.Command)
-	}
-	for _, ls := range c.LSPServers {
-		collectString(ls.Spec.Command)
-		collectString(ls.Spec.URL)
-		for _, a := range ls.Spec.Args {
-			collectString(a)
-		}
-		for _, v := range ls.Spec.Env {
-			collectString(v)
-		}
-		for _, v := range ls.Spec.Headers {
-			collectString(v)
-		}
-	}
-	if c.Project != nil {
-		for k, v := range CollectResolved(c.Project, sec, env) {
-			out[k] = v
-		}
-	}
+		return s
+	})
 	return out
 }
 
@@ -107,13 +76,14 @@ func CollectResolved(c *source.Canonical, sec, env Resolver) map[string]string {
 // ${env:…} references are intentionally excluded — the env backend is always
 // available, and an unresolved env ref is not a credential-leak risk.
 //
-// The walked field set mirrors CollectResolved / SubstituteCanonical.
+// Walks the single walkSecretFields field set, shared with SubstituteCanonical,
+// CollectResolved, and ReReferenceCanonical.
 func UnresolvedSecretRefs(c *source.Canonical, sec Resolver) []string {
 	if c == nil {
 		return nil
 	}
 	missing := map[string]bool{}
-	scan := func(s string) {
+	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
 		for _, m := range re.FindAllStringSubmatch(s, -1) {
 			if len(m) < 3 || m[1] != "secret" {
 				continue
@@ -123,41 +93,8 @@ func UnresolvedSecretRefs(c *source.Canonical, sec Resolver) []string {
 				missing[key] = true
 			}
 		}
-	}
-	for _, srv := range c.MCPServers {
-		scan(srv.Server.Command)
-		scan(srv.Server.URL)
-		for _, a := range srv.Server.Args {
-			scan(a)
-		}
-		for _, v := range srv.Server.Env {
-			scan(v)
-		}
-		for _, v := range srv.Server.Headers {
-			scan(v)
-		}
-	}
-	for _, h := range c.Hooks {
-		scan(h.Command)
-	}
-	for _, ls := range c.LSPServers {
-		scan(ls.Spec.Command)
-		scan(ls.Spec.URL)
-		for _, a := range ls.Spec.Args {
-			scan(a)
-		}
-		for _, v := range ls.Spec.Env {
-			scan(v)
-		}
-		for _, v := range ls.Spec.Headers {
-			scan(v)
-		}
-	}
-	if c.Project != nil {
-		for _, k := range UnresolvedSecretRefs(c.Project, sec) {
-			missing[k] = true
-		}
-	}
+		return s
+	})
 	if len(missing) == 0 {
 		return nil
 	}

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -1,0 +1,75 @@
+package secrets
+
+import (
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// ReReferenceCanonical restores ${secret:…} placeholders in c — a canonical
+// reconstructed from a destination (or resolved by SubstituteCanonical) — using
+// against, the current templated source, as the reference. It is the inverse of
+// SubstituteCanonical and the single boundary through which a resolved /
+// ingested canonical is converted back toward the templated source form before
+// any write-back. apply substitutes ${secret:…} to cleartext into the
+// destination; capture reads that destination back, so without this re-reference
+// a live credential would be persisted into ~/.agentsync (often a committed
+// dotfiles repo).
+//
+// Matching is FIELD-POSITIONAL, not value-based: a field is restored to its
+// templated form only when (a) the corresponding source field actually
+// referenced a secret and (b) the ingested value still resolves to the same
+// thing (the field is unchanged). A field the source did NOT template (e.g.
+// command = "npx") is never rewritten, even if its literal happens to equal
+// some secret's value — value-based masking would corrupt it.
+//
+// Both c and against are walked through the one walkSecretFields enumeration, so
+// a new secret-bearing field is re-referenced automatically. Hooks have no
+// stable id, so they are matched by event + resolution (see rereferenceHook).
+func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, env Resolver) {
+	if c == nil || against == nil {
+		return
+	}
+	srcByLoc := make(map[secretFieldLoc]string)
+	walkSecretFields(against, func(loc secretFieldLoc, s string) string {
+		srcByLoc[loc] = s
+		return s
+	})
+	walkSecretFields(c, func(loc secretFieldLoc, ingested string) string {
+		if loc.kind == "hook" {
+			return rereferenceHook(against, loc.id, ingested, sec, env)
+		}
+		return restoreField(srcByLoc[loc], ingested, sec, env)
+	})
+}
+
+// restoreField returns the source field's templated value when it referenced a
+// secret and still resolves to the (unchanged) ingested value; otherwise it
+// keeps the ingested value verbatim. ${env:…} references are intentionally not
+// inverted — an env value is not a credential-at-rest concern the way a
+// ${secret:…} backend value is, and inverting it risks rewriting an unrelated
+// literal that happens to equal the env var's value.
+func restoreField(srcVal, ingested string, sec, env Resolver) string {
+	if !strings.Contains(srcVal, "${secret:") {
+		return ingested
+	}
+	if resolved, _, err := SubstituteRefs(srcVal, sec, env); err == nil && resolved == ingested {
+		return srcVal
+	}
+	return ingested
+}
+
+// rereferenceHook restores a hook command. Hooks have no stable id, so a
+// templated source command for the same event whose resolution equals the
+// ingested command is the match.
+func rereferenceHook(against *source.Canonical, event, ingested string, sec, env Resolver) string {
+	for _, h := range against.Hooks {
+		if h.Event != event || !strings.Contains(h.Command, "${secret:") {
+			continue
+		}
+		if resolved, _, err := SubstituteRefs(h.Command, sec, env); err == nil && resolved == ingested {
+			return h.Command
+		}
+	}
+	return ingested
+}

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -1,0 +1,91 @@
+package secrets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+type fakeResolver map[string]string
+
+func (f fakeResolver) Resolve(k string) (string, error) {
+	if v, ok := f[k]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("missing %q", k)
+}
+
+// TestReReferenceCanonical_FieldPositional covers the three behaviours the
+// capture boundary depends on:
+//   - a templated source field whose resolution matches the ingested value is
+//     restored to its ${secret:…} placeholder;
+//   - a non-secret source field whose literal happens to equal a secret value
+//     is left alone (over-mask regression — proves the match is field-positional,
+//     not value-based);
+//   - an ingested value that no longer resolves to the source template (a real
+//     dest edit) is kept verbatim rather than clobbered back to the placeholder.
+func TestReReferenceCanonical_FieldPositional(t *testing.T) {
+	sec := fakeResolver{"GH_TOKEN": "ghp_LIVE"}
+	env := fakeResolver{}
+
+	against := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "github",
+			Server: source.MCPServerSpec{
+				Type:    "stdio",
+				Command: "npx", // literal, never templated
+				// arg[1] is a NON-secret literal that happens to equal the secret value.
+				Args: []string{"--token", "ghp_LIVE"},
+				Env: map[string]string{
+					"GH_TOKEN": "${secret:GH_TOKEN}", // templated
+					"NOTE":     "${secret:GH_TOKEN}", // templated but edited in dest
+				},
+			},
+		}},
+		Hooks: []source.Hook{{
+			Event: "PreToolUse", Type: "command",
+			Command: "auth ${secret:GH_TOKEN}",
+		}},
+	}
+
+	// Ingested == what apply wrote to the dest (secrets resolved to cleartext),
+	// then read back. NOTE was hand-edited in the dest to a different value.
+	ingested := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "github",
+			Server: source.MCPServerSpec{
+				Type:    "stdio",
+				Command: "npx",
+				Args:    []string{"--token", "ghp_LIVE"},
+				Env: map[string]string{
+					"GH_TOKEN": "ghp_LIVE",
+					"NOTE":     "hand-edited",
+				},
+			},
+		}},
+		Hooks: []source.Hook{{
+			Event: "PreToolUse", Type: "command",
+			Command: "auth ghp_LIVE",
+		}},
+	}
+
+	ReReferenceCanonical(ingested, against, sec, env)
+
+	srv := ingested.MCPServers[0].Server
+	if srv.Env["GH_TOKEN"] != "${secret:GH_TOKEN}" {
+		t.Errorf("templated env field not re-referenced: got %q", srv.Env["GH_TOKEN"])
+	}
+	if srv.Env["NOTE"] != "hand-edited" {
+		t.Errorf("genuinely edited field was clobbered back to the placeholder: got %q", srv.Env["NOTE"])
+	}
+	if srv.Args[1] != "ghp_LIVE" {
+		t.Errorf("over-mask: a non-secret literal equal to a secret value was rewritten: got %q", srv.Args[1])
+	}
+	if srv.Command != "npx" {
+		t.Errorf("non-secret command rewritten: got %q", srv.Command)
+	}
+	if ingested.Hooks[0].Command != "auth ${secret:GH_TOKEN}" {
+		t.Errorf("hook command not re-referenced: got %q", ingested.Hooks[0].Command)
+	}
+}

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -89,3 +89,48 @@ func TestReReferenceCanonical_FieldPositional(t *testing.T) {
 		t.Errorf("hook command not re-referenced: got %q", ingested.Hooks[0].Command)
 	}
 }
+
+// TestReReferenceCanonical_ProjectOverlay proves the field-positional restore
+// recurses into the project overlay: a project-scope secret field is matched to
+// its project-scope source counterpart (the secretFieldLoc carries a scope
+// marker so a user-scope server of the same ID can't be mismatched against it).
+func TestReReferenceCanonical_ProjectOverlay(t *testing.T) {
+	sec := fakeResolver{"PTOK": "proj-secret"}
+	env := fakeResolver{}
+
+	against := &source.Canonical{
+		// Same ID at user scope, NOT templated — must not be matched against the
+		// project-scope field below.
+		MCPServers: []source.MCPServer{{
+			ID:     "psrv",
+			Server: source.MCPServerSpec{Env: map[string]string{"K": "user-literal"}},
+		}},
+		Project: &source.Canonical{
+			MCPServers: []source.MCPServer{{
+				ID:     "psrv",
+				Server: source.MCPServerSpec{Env: map[string]string{"K": "${secret:PTOK}"}},
+			}},
+		},
+	}
+	ingested := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID:     "psrv",
+			Server: source.MCPServerSpec{Env: map[string]string{"K": "user-literal"}},
+		}},
+		Project: &source.Canonical{
+			MCPServers: []source.MCPServer{{
+				ID:     "psrv",
+				Server: source.MCPServerSpec{Env: map[string]string{"K": "proj-secret"}},
+			}},
+		},
+	}
+
+	ReReferenceCanonical(ingested, against, sec, env)
+
+	if got := ingested.Project.MCPServers[0].Server.Env["K"]; got != "${secret:PTOK}" {
+		t.Errorf("project-overlay secret not re-referenced: got %q", got)
+	}
+	if got := ingested.MCPServers[0].Server.Env["K"]; got != "user-literal" {
+		t.Errorf("user-scope non-secret field corrupted by project-scope match: got %q", got)
+	}
+}

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -32,9 +32,17 @@ type Resolved struct {
 func ForRender(c source.Canonical) Resolved { return Resolved{c: c} }
 
 // Canonical returns the underlying model for the render layer to read. It is
-// the render-only egress: adapters consume it to produce destination FileOps.
-// It deliberately does not help the reverse direction — callers that persist to
-// source take a source.Canonical directly and so cannot be fed a Resolved.
+// the render-only egress: the adapter Render entry points consume it to project
+// the resolved model into destination FileOps.
+//
+// It returns a writable source.Canonical, so this accessor is the one seam that
+// could otherwise launder resolved cleartext back toward source. The type wall
+// makes passing a Resolved DIRECTLY to source.Write* / capture.Capture a compile
+// error; this accessor is additionally fenced by a forbidigo rule
+// (.golangci.yml) that forbids secrets.Resolved.Canonical outside the adapter
+// Render files, so non-render code can't unwrap-then-write. The dest->source
+// direction goes through ReReferenceCanonical + capture.Capture on a templated
+// source.Canonical, never through here.
 func (r Resolved) Canonical() source.Canonical { return r.c }
 
 // cloneForResolve copies c so SubstituteCanonical can resolve secrets into the

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -43,6 +43,17 @@ func ForRender(c source.Canonical) Resolved { return Resolved{c: c} }
 // Render files, so non-render code can't unwrap-then-write. The dest->source
 // direction goes through ReReferenceCanonical + capture.Capture on a templated
 // source.Canonical, never through here.
+//
+// ACCEPTED RESIDUAL (documented, intentional): the forbidigo fence is a static
+// matcher, so interface dispatch, struct embedding, and reflection can defeat
+// it; and source.Write* is itself not fenced. So a DELIBERATE two-step
+// laundering (defeat the fence to get a writable source.Canonical, then call a
+// source writer that skips re-referencing) remains possible. No innocent
+// mistake produces this, and capture.Capture always re-references, so every real
+// import/reconcile flow is safe. Fencing the whole source.Write* API was
+// declined (it fights the legitimate write path and is bypassable one level
+// down). If you find yourself unwrapping a Resolved outside an adapter Render,
+// stop — you almost certainly want capture.Capture instead.
 func (r Resolved) Canonical() source.Canonical { return r.c }
 
 // cloneForResolve copies c so SubstituteCanonical can resolve secrets into the

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -1,0 +1,94 @@
+package secrets
+
+import "github.com/spxrogers/agentsync/internal/source"
+
+// Resolved is a canonical model prepared for rendering to an agent destination.
+// It is a DISTINCT type — not assignable to source.Canonical and carrying no
+// exported field of that type — so the compiler forbids handing it to the
+// dest->source write path (capture.Capture and source.Write* accept only the
+// templated source.Canonical / its sub-structs). That makes the recurring leak
+// — resolved cleartext persisted back into ~/.agentsync — a compile error
+// rather than a code-review catch.
+//
+// Obtain one of two ways, both honest about what they contain:
+//
+//   - SubstituteCanonical: the apply/update path. Secrets are resolved to
+//     cleartext; the result MUST only flow forward (Render -> destination).
+//   - ForRender: the diff/status/reconcile/explain/import path. The canonical
+//     is wrapped as-is (still templated, or ingested-from-dest) because those
+//     callers render only to hash, preview, or enumerate — never to write real
+//     config — so resolution is irrelevant and must not be forced (it would
+//     fail when the secrets backend is locked).
+//
+// The single resolved->templated converter is ReReferenceCanonical; there is no
+// method that turns a Resolved back into a writable source.Canonical.
+type Resolved struct {
+	c source.Canonical
+}
+
+// ForRender wraps a templated (or ingested-from-destination) canonical as a
+// Resolved for rendering, WITHOUT resolving any ${secret:…}. Use it from paths
+// that render only to compute hashes / previews / owned pointers.
+func ForRender(c source.Canonical) Resolved { return Resolved{c: c} }
+
+// Canonical returns the underlying model for the render layer to read. It is
+// the render-only egress: adapters consume it to produce destination FileOps.
+// It deliberately does not help the reverse direction — callers that persist to
+// source take a source.Canonical directly and so cannot be fed a Resolved.
+func (r Resolved) Canonical() source.Canonical { return r.c }
+
+// cloneForResolve copies c so SubstituteCanonical can resolve secrets into the
+// copy while the caller's source.Canonical stays templated. Only the containers
+// the secret walk mutates (Args/Env/Headers slices+maps, the MCP/LSP/Hook
+// slices, and the Project overlay) are cloned; everything else is shared, since
+// substitution never touches it.
+func cloneForResolve(c source.Canonical) source.Canonical {
+	out := c
+	out.MCPServers = cloneMCPServers(c.MCPServers)
+	out.LSPServers = cloneLSPServers(c.LSPServers)
+	out.Hooks = append([]source.Hook(nil), c.Hooks...)
+	if c.Project != nil {
+		p := cloneForResolve(*c.Project)
+		out.Project = &p
+	}
+	return out
+}
+
+func cloneMCPServers(in []source.MCPServer) []source.MCPServer {
+	if in == nil {
+		return nil
+	}
+	out := make([]source.MCPServer, len(in))
+	for i, m := range in {
+		m.Server.Args = append([]string(nil), m.Server.Args...)
+		m.Server.Env = cloneStrMap(m.Server.Env)
+		m.Server.Headers = cloneStrMap(m.Server.Headers)
+		out[i] = m
+	}
+	return out
+}
+
+func cloneLSPServers(in []source.LSPServer) []source.LSPServer {
+	if in == nil {
+		return nil
+	}
+	out := make([]source.LSPServer, len(in))
+	for i, l := range in {
+		l.Spec.Args = append([]string(nil), l.Spec.Args...)
+		l.Spec.Env = cloneStrMap(l.Spec.Env)
+		l.Spec.Headers = cloneStrMap(l.Spec.Headers)
+		out[i] = l
+	}
+	return out
+}
+
+func cloneStrMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/secrets/substitute.go
+++ b/internal/secrets/substitute.go
@@ -7,23 +7,27 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// SubstituteCanonical walks every secret-bearing string field of the canonical
-// model (see walkSecretFields for the authoritative set) and resolves any
-// ${secret:...} / ${env:...} reference in-place, using sec as the secrets
-// backend and env as the environment resolver.
+// SubstituteCanonical resolves every secret-bearing string field of c (see
+// walkSecretFields for the authoritative set) — any ${secret:...} / ${env:...}
+// reference — and returns the result as a Resolved. The input c is left
+// untouched (it stays the templated source form); resolution happens on an
+// internal copy, so a resolved cleartext value can never alias back into the
+// caller's source.Canonical.
 //
-// If any reference cannot be resolved, it returns an error listing all
-// unresolved markers so the user knows exactly which secret is missing. Apply
-// is blocked — never silent about missing secrets.
-func SubstituteCanonical(c *source.Canonical, sec Resolver, env Resolver) error {
+// The Resolved return type is what makes the apply model render-only: it cannot
+// be handed to source.Write* or capture.Capture (compile error). If any
+// reference cannot be resolved, it returns an error listing all unresolved
+// markers — apply is blocked, never silent about a missing secret.
+func SubstituteCanonical(c source.Canonical, sec Resolver, env Resolver) (Resolved, error) {
+	cp := cloneForResolve(c)
 	var allUnresolved []string
-	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
+	walkSecretFields(&cp, func(_ secretFieldLoc, s string) string {
 		v, u, _ := SubstituteRefs(s, sec, env)
 		allUnresolved = append(allUnresolved, u...)
 		return v
 	})
 	if len(allUnresolved) > 0 {
-		return fmt.Errorf("unresolved secret references: %s", strings.Join(allUnresolved, ", "))
+		return Resolved{}, fmt.Errorf("unresolved secret references: %s", strings.Join(allUnresolved, ", "))
 	}
-	return nil
+	return Resolved{c: cp}, nil
 }

--- a/internal/secrets/substitute.go
+++ b/internal/secrets/substitute.go
@@ -7,94 +7,21 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// SubstituteCanonical walks all string-valued fields of the canonical model
-// that may contain ${secret:...} or ${env:...} references and resolves them
-// in-place. It uses sec as the secrets backend and env as the environment
-// resolver.
+// SubstituteCanonical walks every secret-bearing string field of the canonical
+// model (see walkSecretFields for the authoritative set) and resolves any
+// ${secret:...} / ${env:...} reference in-place, using sec as the secrets
+// backend and env as the environment resolver.
 //
 // If any reference cannot be resolved, it returns an error listing all
-// unresolved markers so the user knows exactly which secret is missing.
-// Apply is blocked — never silent about missing secrets.
+// unresolved markers so the user knows exactly which secret is missing. Apply
+// is blocked — never silent about missing secrets.
 func SubstituteCanonical(c *source.Canonical, sec Resolver, env Resolver) error {
 	var allUnresolved []string
-
-	// MCP servers: Command, Args, URL, Headers, Env
-	for i := range c.MCPServers {
-		srv := &c.MCPServers[i].Server
-		if v, u, err := SubstituteRefs(srv.Command, sec, env); err == nil {
-			srv.Command = v
-			allUnresolved = append(allUnresolved, u...)
-		}
-		if v, u, err := SubstituteRefs(srv.URL, sec, env); err == nil {
-			srv.URL = v
-			allUnresolved = append(allUnresolved, u...)
-		}
-		for j, a := range srv.Args {
-			if v, u, err := SubstituteRefs(a, sec, env); err == nil {
-				srv.Args[j] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-		for k, val := range srv.Env {
-			if v, u, err := SubstituteRefs(val, sec, env); err == nil {
-				srv.Env[k] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-		for k, val := range srv.Headers {
-			if v, u, err := SubstituteRefs(val, sec, env); err == nil {
-				srv.Headers[k] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-	}
-
-	// Hooks: Command
-	for i := range c.Hooks {
-		if v, u, err := SubstituteRefs(c.Hooks[i].Command, sec, env); err == nil {
-			c.Hooks[i].Command = v
-			allUnresolved = append(allUnresolved, u...)
-		}
-	}
-
-	// LSP servers: Command, URL, Args, Env, Headers
-	for i := range c.LSPServers {
-		sp := &c.LSPServers[i].Spec
-		if v, u, err := SubstituteRefs(sp.Command, sec, env); err == nil {
-			sp.Command = v
-			allUnresolved = append(allUnresolved, u...)
-		}
-		if v, u, err := SubstituteRefs(sp.URL, sec, env); err == nil {
-			sp.URL = v
-			allUnresolved = append(allUnresolved, u...)
-		}
-		for j, a := range sp.Args {
-			if v, u, err := SubstituteRefs(a, sec, env); err == nil {
-				sp.Args[j] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-		for k, val := range sp.Env {
-			if v, u, err := SubstituteRefs(val, sec, env); err == nil {
-				sp.Env[k] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-		for k, val := range sp.Headers {
-			if v, u, err := SubstituteRefs(val, sec, env); err == nil {
-				sp.Headers[k] = v
-				allUnresolved = append(allUnresolved, u...)
-			}
-		}
-	}
-
-	// Also substitute in project overlay if present.
-	if c.Project != nil {
-		if err := SubstituteCanonical(c.Project, sec, env); err != nil {
-			return err
-		}
-	}
-
+	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
+		v, u, _ := SubstituteRefs(s, sec, env)
+		allUnresolved = append(allUnresolved, u...)
+		return v
+	})
 	if len(allUnresolved) > 0 {
 		return fmt.Errorf("unresolved secret references: %s", strings.Join(allUnresolved, ", "))
 	}

--- a/internal/secrets/substitute_test.go
+++ b/internal/secrets/substitute_test.go
@@ -28,11 +28,12 @@ func TestSubstituteCanonical_MCPEnv(t *testing.T) {
 		},
 	}
 
-	if err := secrets.SubstituteCanonical(&c, sec, env); err != nil {
+	r, err := secrets.SubstituteCanonical(c, sec, env)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	srv := c.MCPServers[0].Server
+	srv := r.Canonical().MCPServers[0].Server
 	if srv.Env["GITHUB_TOKEN"] != "ghp_abc" {
 		t.Errorf("GITHUB_TOKEN = %q, want ghp_abc", srv.Env["GITHUB_TOKEN"])
 	}
@@ -58,7 +59,7 @@ func TestSubstituteCanonical_UnresolvedReturnsError(t *testing.T) {
 		},
 	}
 
-	err := secrets.SubstituteCanonical(&c, sec, env)
+	_, err := secrets.SubstituteCanonical(c, sec, env)
 	if err == nil {
 		t.Fatal("expected error for unresolved secret reference")
 	}
@@ -74,11 +75,12 @@ func TestSubstituteCanonical_HookCommand(t *testing.T) {
 		},
 	}
 
-	if err := secrets.SubstituteCanonical(&c, sec, env); err != nil {
+	r, err := secrets.SubstituteCanonical(c, sec, env)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if c.Hooks[0].Command != "sign --key=sk_live_xyz" {
-		t.Errorf("hook command = %q, want resolved", c.Hooks[0].Command)
+	if got := r.Canonical().Hooks[0].Command; got != "sign --key=sk_live_xyz" {
+		t.Errorf("hook command = %q, want resolved", got)
 	}
 }
 
@@ -93,10 +95,11 @@ func TestSubstituteCanonical_NoRefs(t *testing.T) {
 		},
 	}
 
-	if err := secrets.SubstituteCanonical(&c, sec, env); err != nil {
+	r, err := secrets.SubstituteCanonical(c, sec, env)
+	if err != nil {
 		t.Fatalf("unexpected error for canonical without refs: %v", err)
 	}
-	if c.MCPServers[0].Server.Env["FOO"] != "bar" {
+	if r.Canonical().MCPServers[0].Server.Env["FOO"] != "bar" {
 		t.Errorf("plain env mutated unexpectedly")
 	}
 }

--- a/internal/secrets/walk.go
+++ b/internal/secrets/walk.go
@@ -1,0 +1,85 @@
+package secrets
+
+import (
+	"strconv"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// secretFieldLoc identifies where a secret-bearing string lives in the
+// canonical model. A single-canonical walk (substitute / redact / unresolved
+// scan) ignores it; a paired walk (ReReferenceCanonical) uses it to find the
+// same field in a second canonical so a templated source value can be restored
+// field-positionally rather than by value.
+type secretFieldLoc struct {
+	scope string // "" (user scope) | "project" (overlay)
+	kind  string // "mcp" | "lsp" | "hook"
+	id    string // MCP/LSP server ID, or hook event
+	role  string // "command" | "url" | "arg" | "env" | "header"
+	sub   string // arg index, env/header map key, or hook index; "" otherwise
+}
+
+// walkSecretFields visits EVERY secret-bearing string field of c and replaces
+// each with fn's return value. This is the single authoritative enumeration of
+// the secret-bearing field set in the codebase:
+//
+//   - MCPServers[].Server: Command, URL, Args[], Env{}, Headers{}
+//   - Hooks[]:             Command
+//   - LSPServers[].Spec:   Command, URL, Args[], Env{}, Headers{}
+//   - Project (recursive overlay)
+//
+// Every secret operation — SubstituteCanonical, CollectResolved,
+// UnresolvedSecretRefs, ReReferenceCanonical — is a thin caller of this walker,
+// so a field added to source.MCPServerSpec / Hook / LSPServerSpec is picked up
+// by all of them automatically. Add new secret-bearing fields HERE and nowhere
+// else. The reflect-based guard in walk_test.go fails if a new string-shaped
+// field on those structs is introduced without being classified.
+//
+// fn must be pure with respect to the location: callers that only read (redact,
+// scan) return the value unchanged, making the assignment a no-op.
+func walkSecretFields(c *source.Canonical, fn func(loc secretFieldLoc, s string) string) {
+	walkSecretFieldsScoped(c, "", fn)
+}
+
+func walkSecretFieldsScoped(c *source.Canonical, scope string, fn func(loc secretFieldLoc, s string) string) {
+	if c == nil {
+		return
+	}
+	for i := range c.MCPServers {
+		id := c.MCPServers[i].ID
+		srv := &c.MCPServers[i].Server
+		srv.Command = fn(secretFieldLoc{scope, "mcp", id, "command", ""}, srv.Command)
+		srv.URL = fn(secretFieldLoc{scope, "mcp", id, "url", ""}, srv.URL)
+		for j := range srv.Args {
+			srv.Args[j] = fn(secretFieldLoc{scope, "mcp", id, "arg", strconv.Itoa(j)}, srv.Args[j])
+		}
+		for k, v := range srv.Env {
+			srv.Env[k] = fn(secretFieldLoc{scope, "mcp", id, "env", k}, v)
+		}
+		for k, v := range srv.Headers {
+			srv.Headers[k] = fn(secretFieldLoc{scope, "mcp", id, "header", k}, v)
+		}
+	}
+	for i := range c.Hooks {
+		h := &c.Hooks[i]
+		h.Command = fn(secretFieldLoc{scope, "hook", h.Event, "command", strconv.Itoa(i)}, h.Command)
+	}
+	for i := range c.LSPServers {
+		id := c.LSPServers[i].ID
+		sp := &c.LSPServers[i].Spec
+		sp.Command = fn(secretFieldLoc{scope, "lsp", id, "command", ""}, sp.Command)
+		sp.URL = fn(secretFieldLoc{scope, "lsp", id, "url", ""}, sp.URL)
+		for j := range sp.Args {
+			sp.Args[j] = fn(secretFieldLoc{scope, "lsp", id, "arg", strconv.Itoa(j)}, sp.Args[j])
+		}
+		for k, v := range sp.Env {
+			sp.Env[k] = fn(secretFieldLoc{scope, "lsp", id, "env", k}, v)
+		}
+		for k, v := range sp.Headers {
+			sp.Headers[k] = fn(secretFieldLoc{scope, "lsp", id, "header", k}, v)
+		}
+	}
+	if c.Project != nil {
+		walkSecretFieldsScoped(c.Project, "project", fn)
+	}
+}

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -120,12 +120,23 @@ func TestWalkerVisitsEveryCoveredField(t *testing.T) {
 				Headers: map[string]string{"H": "lsp-header"},
 			},
 		}},
+		// Project overlay: the walker must recurse into it so project-scope
+		// secret fields are covered too (apply substitutes them; capture
+		// re-references them). Sentinels below prove the recursion visits them.
+		Project: &source.Canonical{
+			MCPServers: []source.MCPServer{{
+				ID:     "psrv",
+				Server: source.MCPServerSpec{Command: "proj-command", Env: map[string]string{"P": "proj-env"}},
+			}},
+			Hooks: []source.Hook{{Event: "PostToolUse", Type: "command", Command: "proj-hook"}},
+		},
 	}
 	want := map[string]bool{
 		"mcp-command": false, "mcp-url": false, "mcp-arg0": false, "mcp-arg1": false,
 		"mcp-env": false, "mcp-header": false, "hook-command": false,
 		"lsp-command": false, "lsp-url": false, "lsp-arg0": false,
 		"lsp-env": false, "lsp-header": false,
+		"proj-command": false, "proj-env": false, "proj-hook": false,
 	}
 	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
 		if _, ok := want[s]; ok {

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -36,6 +36,7 @@ var walkerCovered = map[string]map[string]bool{
 		"Args":    true,
 		"Env":     true,
 		"Headers": true,
+		"Agents":  false, // source-only targeting allowlist, never a secret
 	},
 }
 

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -1,0 +1,150 @@
+package secrets
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// walkerCovered is the authoritative classification of the string-shaped
+// fields on the secret-bearing canonical structs: every such field is either
+// walked by walkSecretFields (true) or deliberately NOT a secret-bearing field
+// (false). TestNewSecretFieldGuard fails if a field exists on these structs
+// that is in neither column — forcing whoever adds it to decide, in one place,
+// whether secrets must traverse it. This is the guard that makes a new
+// secret-bearing field correct by construction instead of a silent leak.
+var walkerCovered = map[string]map[string]bool{
+	"MCPServerSpec": {
+		"Command": true,
+		"URL":     true,
+		"Args":    true,
+		"Env":     true,
+		"Headers": true,
+		"Type":    false, // enum discriminator, never a secret
+		"Agents":  false, // source-only targeting allowlist, never a secret
+	},
+	"Hook": {
+		"Command": true,
+		"Event":   false, // event name (e.g. PreToolUse)
+		"Matcher": false, // glob/regex, not a credential
+		"Type":    false, // always "command"
+	},
+	"LSPServerSpec": {
+		"Command": true,
+		"URL":     true,
+		"Args":    true,
+		"Env":     true,
+		"Headers": true,
+	},
+}
+
+// isStringShaped reports whether a struct field can carry a ${secret:…} /
+// ${env:…} reference: a string, a []string, or a map[string]string. Anything
+// else (bool, *bool, int) cannot hold a reference and is not the walker's
+// concern.
+func isStringShaped(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.String:
+		return true
+	case reflect.Slice:
+		return t.Elem().Kind() == reflect.String
+	case reflect.Map:
+		return t.Key().Kind() == reflect.String && t.Elem().Kind() == reflect.String
+	default:
+		return false
+	}
+}
+
+// TestNewSecretFieldGuard fails when a string-shaped field is added to a
+// secret-bearing struct without being classified in walkerCovered. It is the
+// "new field guard" required by the refactor: the walker, the classification
+// map, and the actual struct definitions cannot silently drift apart.
+func TestNewSecretFieldGuard(t *testing.T) {
+	structs := map[string]reflect.Type{
+		"MCPServerSpec": reflect.TypeOf(source.MCPServerSpec{}),
+		"Hook":          reflect.TypeOf(source.Hook{}),
+		"LSPServerSpec": reflect.TypeOf(source.LSPServerSpec{}),
+	}
+	for name, typ := range structs {
+		covered := walkerCovered[name]
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !isStringShaped(f.Type) {
+				continue
+			}
+			if _, ok := covered[f.Name]; !ok {
+				t.Errorf("%s.%s is string-shaped but unclassified: add it to walkSecretFields "+
+					"(and mark true) if it can hold a ${secret:…}/${env:…} reference, or mark it "+
+					"false in walkerCovered if it never carries a secret", name, f.Name)
+			}
+		}
+	}
+}
+
+// TestWalkerVisitsEveryCoveredField proves the walker actually traverses every
+// field classified as covered. Without this, the classification map could claim
+// coverage the walker never delivers (the exact leak the refactor prevents). It
+// plants a unique sentinel in each covered field, walks, and asserts each
+// sentinel was both visited and replaceable.
+func TestWalkerVisitsEveryCoveredField(t *testing.T) {
+	enabled := true
+	c := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "srv",
+			Server: source.MCPServerSpec{
+				Type:    "stdio",
+				Command: "mcp-command",
+				URL:     "mcp-url",
+				Args:    []string{"mcp-arg0", "mcp-arg1"},
+				Env:     map[string]string{"E": "mcp-env"},
+				Headers: map[string]string{"H": "mcp-header"},
+				Agents:  []string{"claude"},
+				Enabled: &enabled,
+			},
+		}},
+		Hooks: []source.Hook{{
+			Event:   "PreToolUse",
+			Matcher: "*",
+			Type:    "command",
+			Command: "hook-command",
+		}},
+		LSPServers: []source.LSPServer{{
+			ID: "lsp",
+			Spec: source.LSPServerSpec{
+				Command: "lsp-command",
+				URL:     "lsp-url",
+				Args:    []string{"lsp-arg0"},
+				Env:     map[string]string{"E": "lsp-env"},
+				Headers: map[string]string{"H": "lsp-header"},
+			},
+		}},
+	}
+	want := map[string]bool{
+		"mcp-command": false, "mcp-url": false, "mcp-arg0": false, "mcp-arg1": false,
+		"mcp-env": false, "mcp-header": false, "hook-command": false,
+		"lsp-command": false, "lsp-url": false, "lsp-arg0": false,
+		"lsp-env": false, "lsp-header": false,
+	}
+	walkSecretFields(c, func(_ secretFieldLoc, s string) string {
+		if _, ok := want[s]; ok {
+			want[s] = true
+		}
+		return s + "!" // mutate to prove the assignment path works for every field
+	})
+	for sentinel, visited := range want {
+		if !visited {
+			t.Errorf("walkSecretFields never visited the field carrying %q", sentinel)
+		}
+	}
+	// Non-secret string-shaped fields must NOT have been rewritten.
+	if c.MCPServers[0].Server.Type != "stdio" {
+		t.Errorf("walker rewrote MCP Type (non-secret): %q", c.MCPServers[0].Server.Type)
+	}
+	if got := c.MCPServers[0].Server.Agents; len(got) != 1 || got[0] != "claude" {
+		t.Errorf("walker rewrote MCP Agents (non-secret): %v", got)
+	}
+	if c.Hooks[0].Event != "PreToolUse" || c.Hooks[0].Matcher != "*" {
+		t.Errorf("walker rewrote hook Event/Matcher (non-secret)")
+	}
+}

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -141,6 +141,11 @@ type LSPServerSpec struct {
 	Env     map[string]string `toml:"env,omitempty"`
 	URL     string            `toml:"url,omitempty"`
 	Headers map[string]string `toml:"headers,omitempty"`
+	// Agents / Enabled mirror MCPServerSpec: they are source-only targeting
+	// fields that the rendered destination never carries, so capture must
+	// preserve them (via source.ReadLSP) rather than reset them from the dest.
+	Agents  []string `toml:"agents,omitempty"`  // ["*"] or ["claude",...]; empty = all
+	Enabled *bool    `toml:"enabled,omitempty"` // nil means default-on
 }
 
 // Memory mirrors memory/AGENTS.md and memory/fragments/.

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -34,6 +34,24 @@ func ReadMCP(home, id string) (m MCPServer, ok bool, err error) {
 	return m, true, nil
 }
 
+// ReadLSP reads lsp/<id>.toml from home. ok is false when the file does not
+// exist. Mirrors ReadMCP: used by capture to preserve source-only LSP fields
+// (agents/enabled) that the rendered destination spec doesn't carry.
+func ReadLSP(home, id string) (ls LSPServer, ok bool, err error) {
+	data, rerr := os.ReadFile(filepath.Join(home, "lsp", id+".toml"))
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return LSPServer{}, false, nil
+		}
+		return LSPServer{}, false, fmt.Errorf("read lsp %s: %w", id, rerr)
+	}
+	var lf lspFileOut
+	if uerr := toml.Unmarshal(data, &lf); uerr != nil {
+		return LSPServer{}, false, fmt.Errorf("parse lsp %s: %w", id, uerr)
+	}
+	return LSPServer{ID: id, Spec: lf.Server}, true, nil
+}
+
 // WriteMCP writes mcp/<id>.toml from m into home. Overwrites atomically.
 func WriteMCP(home, id string, m MCPServer) error {
 	body, err := toml.Marshal(m)

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -2,6 +2,18 @@
 // These are called by the reconcile command when the user selects [w]rite-back,
 // and by the import command to capture native edits.
 //
+// SECRET-SAFETY INVARIANT (read before adding a caller): these Write* helpers
+// take only the TEMPLATED source types (source.Canonical / its sub-structs) and
+// perform NO secret re-referencing. apply substitutes ${secret:…} to cleartext
+// into destinations, so any canonical reconstructed from a destination holds
+// live credentials. The ONLY sanctioned dest->source write path is
+// capture.Capture, which calls secrets.ReReferenceCanonical first. Do NOT pass
+// these helpers a value obtained by unwrapping secrets.Resolved.Canonical() — it
+// is the resolved (cleartext) apply model and would leak the secret into source.
+// This API is intentionally not lint-fenced (it is the legitimate templated
+// writer Capture is built on), so this discipline is the guard; see CLAUDE.md
+// "Secret-handling invariants" and internal/secrets/resolved.go.
+//
 // v1 trade-off: TOML comments in the original file are not preserved on
 // write-back. Comment-preserving mutation is deferred to v1.x.
 package source


### PR DESCRIPTION
Closes #24.

Collapses the federated secret handling and the duplicated dest→source "capture" logic into **one boundary and one capture path**, then makes the cleartext-leak class hard to reintroduce via the type system. Built as **A → B → C** plus review-driven hardening, forked from the merged #23 base.

## Part A — one secrets boundary (`internal/secrets`)
- Single `walkSecretFields` enumeration of the secret-bearing field set (MCP/LSP `Command,URL,Args,Env,Headers`; Hook `Command`; recursive `Project`). Previously walked independently in 4 places.
- `SubstituteCanonical`, `CollectResolved`, `UnresolvedSecretRefs` delegate to it.
- The field-positional dest→source re-reference moved out of `internal/cli` into `secrets.ReReferenceCanonical`.

## Part B — one dest→source capture path (`internal/capture`)
- `capture.Capture` is the single write-back: re-references secrets, preserves source-only fields the rendered dest never carries (MCP **and** LSP `agents`/`enabled`), routes all writes through `internal/source/writer.go`.
- `import` (mcp/lsp/hook) and `reconcile` write-back (mcp) both call it; `restoreServerFields`/`restoreServerFields2` and the cli-local re-reference are deleted.
- Added `source.ReadLSP`; gave `LSPServerSpec` `agents`/`enabled` for MCP/LSP parity (opt-in, nil → default-on, so no behavior change for existing configs).

## Part C — type-distinct resolved vs templated
- `secrets.Resolved` wraps `source.Canonical`, is **not assignable** to it, and is the only thing adapters render from.
- `SubstituteCanonical` returns `Resolved` (on an internal deep copy; the caller's `source.Canonical` stays templated); `secrets.ForRender` wraps templated/ingested canonicals for the render-only paths.
- `adapter.Render`/`render.Plan` accept `secrets.Resolved`; `source.Write*` and `capture.Capture` accept only the templated type.

## What prevents the leak — precise, three-tier framing
Reviewed across three rounds of fresh agents (full review + adversarial bypass testing). The accurate enforcement story:
- **Compile-enforced (load-bearing):** passing a `secrets.Resolved` **directly** to `source.Write*` / `capture.Capture` is a compile error. Proven by `leak_fixture.go` + `TestResolvedIsNotWritableToSource`.
- **Value-invariant (load-bearing):** `cloneForResolve` deep-copies exactly the containers the walker mutates (no aliasing back to the caller's templated canonical); `walkSecretFields` only visits MCP/LSP/Hook fields, so the text components (skill/subagent/command/memory) and `writeBackFileItem` physically can't carry a substituted `${secret:…}`.
- **Lint fence (defense-in-depth):** a `forbidigo` rule forbids `secrets.Resolved.Canonical` outside the two adapter render-egress sites (line-scoped `//nolint`). Two whole-file holes a reviewer found were closed: each `iox.AtomicWrite` exclusion is now text-scoped so it can't exempt the `Canonical` rule. Verified the fence now flags a `.Canonical()` added to `reconcile.go` or to the adapters off the egress line.

### Accepted residual (documented, intentional)
The only remaining leak path is **deliberate two-step laundering**: defeat the lint fence via interface dispatch / struct embedding / reflection (all inherently outside `forbidigo`'s static reach) to obtain a writable `source.Canonical`, then call `source.Write*` — which is intentionally **not** fenced (it is the legitimate templated-write API `Capture` is built on) and does not itself re-reference. No innocent mistake produces this, and `capture.Capture` always re-references, so every real import/reconcile flow stays safe. Fencing the whole `source.Write*` API was considered and declined (it fights the legitimate write path and is bypassable one level down) — kept as a documented residual.

This residual and the three invariants above are **codified in-tree** (not just here, so they don't rot with the PR description):
- new top-level **`CLAUDE.md`** — "Secret-handling invariants" (one field list, one dest→source path, the three-tier model, and the residual to watch for);
- **`internal/source/writer.go`** package doc — `SECRET-SAFETY INVARIANT` at the unfenced write API (never feed it a value unwrapped from `secrets.Resolved.Canonical()`);
- **`internal/secrets/resolved.go`** — `ACCEPTED RESIDUAL` note on `Resolved.Canonical()`.

## Scope notes
- **Design fork (confirmed with repo owner):** full strict split with dual constructors (`SubstituteCanonical` / `ForRender`), because diff/status/reconcile/explain/import render canonicals that are *not* the output of `SubstituteCanonical`.
- `agent disable --purge` is unchanged: a destination-*delete* path routed through the adapter `Apply`/merge writer, not a dest→source write.

## Test plan
- [x] **Table-driven leak test** across every secret-bearing field via **import AND reconcile** — restores `${secret:…}`, never writes cleartext (env backend).
- [x] **Project overlay** covered at unit level (`ReReferenceCanonical` + walker-visitation), documented in the leak test why no CLI path carries an overlay.
- [x] **"New field" guard** (reflect-based) over the secret-bearing structs.
- [x] **Field-preservation** for MCP and LSP `agents` **and** `enabled`.
- [x] **Over-mask regression** — a non-secret literal equal to a secret value is not rewritten.
- [x] **diff redaction** still covers raw + JSON-escaped, fails closed on unresolvable refs.
- [x] **Compile-fail fixture** proving a `Resolved` can't be passed to `source.WriteMCP`/`Capture`.

## Gate (verified locally)
- [x] `go build`, `golangci-lint` (0 issues, incl. the tightened `Resolved.Canonical` fence), `gofmt`/`gofumpt`, `go mod tidy`, `test-fast`
- [x] `go test -race ./internal/...` + `-tags=e2e` + `-tags=bdd`
- [x] No new `iox.AtomicWrite` callers outside the (text-scoped) forbidigo allowlist

> Toolchain note: `golangci-lint` 2.5.0 panics against host go1.26.2; runs clean under `GOTOOLCHAIN=go1.25.10`. The hermetic container (and CI's `setup-go` → go1.24.0 + `GOTOOLCHAIN=local`) use a matched toolchain.

https://claude.ai/code/session_01UwZDi5dov95jwiz7ZH4nEF