### PR TITLE
Modernize Go pin + golangci-lint; drop GOTOOLCHAIN hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches: [main]
 
-# Single source of truth for the Go toolchain. go.mod's `go` directive
-# specifies the language version; `toolchain` specifies the actual build
-# toolchain. setup-go reads the `go` directive and Go itself honours the
-# toolchain directive at runtime.
+# Single source of truth for the Go version: go.mod's `go` directive.
+# setup-go reads it via go-version-file below.
 env:
   GO_VERSION_FILE: go.mod
 
@@ -47,24 +45,17 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # GOTOOLCHAIN=local pins the analyser to whatever Go setup-go installed
-    # (the language version from go.mod's `go` directive). Without this,
-    # Go's auto-toolchain logic upgrades to the `toolchain` directive at
-    # runtime and golangci-lint then panics analysing stdlib it wasn't
-    # compiled against.
-    env:
-      GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
-          # Pin to a v2 we've validated against this config locally. Bump
-          # deliberately when upgrading; "latest" can change config syntax
-          # under us. Action @v8 is the first that supports binary v2.
-          version: v2.5.0
+          # Pin a known-good golangci-lint. Its release binary must be built
+          # with a Go >= our go.mod version, or it can't parse our export
+          # data; v2.12.2 ships built with Go 1.26. Bump deliberately.
+          version: v2.12.2
 
   goreleaser-snapshot:
     name: goreleaser-snapshot (cross-build matrix)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   timeout: 3m
   tests: true
-  go: "1.24"
+  go: "1.26"
 
 linters:
   default: none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,5 +67,7 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 
 - `just build` / `just test-fast`; full gate `just test-release` (hermetic container).
 - FS-touching tests refuse to run on host without `AGENTSYNC_TEST_IN_CONTAINER=1`.
-- `golangci-lint` 2.5.0 panics on Go ≥ 1.26 host toolchains; run lint as
-  `GOTOOLCHAIN=go1.25.10 golangci-lint run ./...` until the linter is upgraded.
+- Lint with `just lint` (`golangci-lint run ./...`); CI pins **golangci-lint
+  v2.12.2**, whose release binary is built with Go 1.26, so it parses our export
+  data natively — no `GOTOOLCHAIN` override needed. A local install built with
+  Go < 1.26 will refuse to run against this module; install v2.12.2 to match CI.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/spxrogers/agentsync
 
-go 1.24.0
-
-toolchain go1.26.2
+go 1.26.2
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
## Why

The `lint` CI job carried a `GOTOOLCHAIN=local` workaround: the pinned **golangci-lint v2.5.0** (built with go1.25.1) panicked parsing **go1.26.2** export data. The `go.mod` also kept a wide `go 1.24.0` / `toolchain go1.26.2` gap that made the version story confusing (and prompted the "is this even normal?" question).

Rather than keep papering over a stale linter, this collapses and upgrades.

## What changed

| File | Before | After |
|---|---|---|
| `go.mod` | `go 1.24.0` + `toolchain go1.26.2` | single `go 1.26.2` |
| `.golangci.yml` | `run.go: "1.24"` | `run.go: "1.26"` |
| `.github/workflows/ci.yml` | `GOTOOLCHAIN: local`, golangci-lint `v2.5.0`, action `@v8` | hack removed, `v2.12.2`, action `@v9` |

- **Single source of truth for Go version.** A `toolchain` line that merely matches the `go` line is a no-op (effective toolchain = `max(go, toolchain)`); it only does anything when *higher*. Floor and build version are now one line.
- **golangci-lint v2.12.2** release binaries are built with Go 1.26 (verified `GO_VERSION: '1.26'` in their release workflow), so they parse our export data natively — no `GOTOOLCHAIN` override needed.
- **action `@v9`**: only breaking change vs v8 is the Node20→Node24 runtime bump (GitHub-forced); the rest is additive.
- Removed the now-stale go/toolchain explainer comments.

## Verification (locally, under go1.26.2)

- `go vet ./...` — clean
- `go mod tidy` — no-op (go.mod/go.sum unchanged; no `toolchain` line returns)
- `golangci-lint v2.12.2 config verify` — exit 0, **no config migration needed** (already `version: "2"`)
- `golangci-lint v2.12.2 run ./...` — exit 0, **0 issues across all packages**, no export-data panic

## Out of scope

`docs/superpowers/plans/*.md` reference older Go versions but are historical planning records, not active build config — intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)