### PR TITLE
docs: beta-release documentation set

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something agentsync did wrong or unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! A few details up front make this far faster to act on.
+        **Redact any secrets** before pasting config or output.
+  - type: input
+    id: version
+    attributes:
+      label: agentsync version
+      description: Output of `agentsync --version`.
+      placeholder: "agentsync v1.0.0 (commit abc1234, built …)"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other (note in description)
+    validations:
+      required: true
+  - type: dropdown
+    id: agents
+    attributes:
+      label: Which agent(s) are involved?
+      multiple: true
+      options:
+        - Claude Code
+        - OpenCode
+        - Codex CLI
+        - Cursor
+        - Not agent-specific
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands you ran, in order.
+      placeholder: |
+        1. agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
+        2. agentsync apply
+        3. ...
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config
+      description: The relevant snippet of your `~/.agentsync/` files. Redact secrets.
+      render: toml
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output / logs
+      description: Command output, ideally re-run with `-v/--verbose`. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/spxrogers/agentsync/security/advisories/new
+    about: Report security issues privately via a GitHub Security Advisory — please do NOT open a public issue. See SECURITY.md.
+  - name: Question or usage help
+    url: https://github.com/spxrogers/agentsync/blob/main/docs/user-guide.md
+    about: Start with the user guide; it covers install, the daily loop, secrets, and plugins.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest an enhancement or new capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        agentsync is personal-first and OSS-shareable — breadth isn't a goal, so
+        proposals that fit the existing model land fastest. Check the
+        [capability matrix](../blob/main/docs/capability-matrix.md) and
+        [known limits](../blob/main/README.md#known-limits-in-v1x) first; some
+        gaps are deliberate v1.x deferrals.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the pain, not just the proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like agentsync to do? CLI surface, config shape, behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - New agent adapter
+        - Existing adapter coverage (a skipped/projected component)
+        - MCP / plugins / marketplaces
+        - Secrets
+        - Drift / reconcile
+        - Project-local config
+        - CLI / UX
+        - Other (note in description)
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other approaches you weighed.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this change do, and why? Link any related issue. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / enhancement
+- [ ] Refactor (no behavior change)
+- [ ] Docs
+- [ ] Tests / CI / tooling
+
+## Test plan
+
+<!-- How did you verify this? Note any new tests. -->
+
+- [ ] `just test-release` is green (the release bar)
+- [ ] `just lint` is clean
+
+## Checklist
+
+- [ ] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
+- [ ] Tests added/updated for the behavior changed.
+- [ ] If this touches `internal/secrets`, `internal/capture`, or any
+      `source.Write*` path, I've re-read the secret-handling invariants in
+      `CLAUDE.md` / `SECURITY.md` and not weakened them.
+- [ ] Docs updated if behavior, CLI surface, or capability coverage changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to agentsync are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Until the first stable `1.0.0` tag, the project is in **beta**: the canonical
+source layout, CLI surface, and state schema are stabilizing but may still change.
+
+## [Unreleased]
+
+The v1.0 beta. Functional end-to-end (green under `just test-release`); remaining
+work before the `1.0.0` tag is distribution plumbing and a few documented
+trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
+
+### Added
+
+- **Canonical source model** in `~/.agentsync/` — hand-editable TOML + markdown
+  for agents, MCP servers, marketplaces, plugins, memory, and skills.
+- **Claude Code adapter** — full support for all seven components (MCP, memory,
+  skill, subagent, command, hook, LSP) with per-key merge into `~/.claude.json`
+  and `settings.json` that preserves foreign keys.
+- **OpenCode adapter** — MCP, memory, skills, subagents, and commands via JSONC
+  round-trip. Hooks and LSP are skipped with a warning.
+- **Bidirectional drift** — a 3-way classifier (9 cases) at file and JSON-pointer
+  granularity, surfaced via `status`/`diff` and resolved via an interactive
+  `reconcile` loop with bulk hotkeys and `--auto-*` flags.
+- **Marketplaces & plugins** — all five plugin sources (relative, github, url,
+  git-subdir, npm), `strict`-mode conflict policy, `${CLAUDE_PLUGIN_ROOT}`
+  substitution, per-component projection, translation report, manifest-SHA
+  pinning, and update modes.
+- **Project-local overlays** — `.agentsync.toml` walk-up discovery, overlay
+  merge, project-scope state tracking.
+- **age-encrypted secrets** — `${secret:…}`/`${env:…}` resolution at apply time,
+  `secrets {edit,get,set}`, redaction in `diff`. Resolved cleartext is never
+  captured back into the source (compile-, value-, and lint-enforced).
+- **CLI**: `init`, `agent`, `doctor`, `verify`, `apply`, `status`, `diff`,
+  `reconcile`, `import`, `mcp`, `plugin`, `marketplace`, `update`, `secrets`,
+  `explain`.
+- **Safety primitives** — two-phase atomic writes, an apply lock, first-apply
+  foreign-collision backups, symlinked-destination refusal, and a schema-versioned
+  state file with portable (`${HOME}`-relative) keys.
+- **Documentation set** — user guide, concepts, architecture, capability matrix,
+  and component map under [`docs/`](docs/).
+
+### Known limitations
+
+Documented v1.x trade-offs rather than bugs — see the
+[README](README.md#known-limits-in-v1x) and [capability matrix](docs/capability-matrix.md):
+Codex/Cursor adapters are no-ops (planned v1.1/v1.2); OpenCode hooks/LSP are
+skipped; TOML/JSONC comments are not preserved across write-back.
+
+[Unreleased]: https://github.com/spxrogers/agentsync/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,48 @@
 
 Project memory for Claude Code / agent sessions working on agentsync.
 
+## What this is
+
+agentsync is a single-machine Go CLI that centrally manages AI coding-agent
+configurations (Claude Code, OpenCode, and — planned — Codex CLI, Cursor). The
+user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
+committable to a dotfiles repo); `agentsync apply` renders it into each agent's
+native config. It's bidirectional: native edits are detected as drift and merged
+back via `reconcile`/`import`. Secrets are `${secret:…}`/`${env:…}` references
+resolved at apply time from an age-encrypted vault.
+
+**Read the docs before large changes:**
+- [`docs/concepts.md`](docs/concepts.md) — the three-state model + every term.
+- [`docs/architecture.md`](docs/architecture.md) — pipelines, drift classifier,
+  secret invariants, package layering.
+- [`docs/components.md`](docs/components.md) — package-by-package map.
+- [`docs/capability-matrix.md`](docs/capability-matrix.md) — per-agent support.
+- [`docs/superpowers/specs/2026-05-04-agentsync-design.md`](docs/superpowers/specs/2026-05-04-agentsync-design.md)
+  — the authoritative v1.0 design. Note: a few items in its §"CLI surface" were
+  aspirational and not wired in v1.0 (`apply --strict/--force/--agent` flags, an
+  `agentsync skill` command) — trust the code over the spec on the CLI surface.
+
+## Mental map of the code
+
+- **`internal/source`** — the canonical model (`source.Canonical`). The TOML
+  structs here *are* the schema; there is no separate IR. Loaders + `Write*` helpers.
+- **`internal/adapter`** (+ `claude`, `opencode`, `noop`) — the per-agent
+  `Adapter` interface. `Render` takes `secrets.Resolved` (not raw source);
+  `Apply` writes only through `DestWriter`.
+- **`internal/render`** — the apply pipeline (plan → classify → write → record
+  state → translation report).
+- **`internal/capture`** — the *single* dest→source write-back funnel.
+- **`internal/secrets`** — resolve / re-reference / mask. The leak guards live here.
+- **`internal/drift`** — the pure 3-way classifier (9 cases).
+- **`internal/marketplace`** — fetch + project plugins into components.
+- **`internal/{state,project,iox,jsonkeys,paths,log,testenv}`** — state file,
+  project overlay, atomic IO + lock, JSON-pointer merge, path resolution,
+  logging, test container guard.
+
+The registered command tree (`internal/cli/root.go`): `init`, `agent`, `apply`,
+`status`, `diff`, `reconcile`, `import`, `doctor`, `verify`, `mcp`, `plugin`,
+`marketplace`, `update`, `secrets`, `explain`.
+
 ## Secret-handling invariants (read before touching secrets / capture / source writers)
 
 agentsync resolves `${secret:…}` / `${env:…}` references into native agent
@@ -71,3 +113,39 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
   v2.12.2**, whose release binary is built with Go 1.26, so it parses our export
   data natively — no `GOTOOLCHAIN` override needed. A local install built with
   Go < 1.26 will refuse to run against this module; install v2.12.2 to match CI.
+- `just test` (full unit/integration in container), `just test-e2e`,
+  `just test-bdd`, `just test-live` (network, opt-in, not in the release gate).
+- Go version is `go.mod`'s `go` directive (currently **1.26.2**); CI reads it via
+  `go-version-file`. Bump in one place.
+
+## Code conventions
+
+- **Stdlib testing only** — no testify/gomega. Table-driven with a `name` field
+  and `t.Run`. `t.Helper()` in helpers that call `t.Fatal/Errorf`.
+- **Filesystem in tests** is always `afero.NewMemMapFs()` or `t.TempDir()`, never
+  `os.UserHomeDir()` — a `forbidigo` rule bans it in `_test.go` (use
+  `paths.HomeDir(env)`). FS-touching tests must run in the container; call
+  `testenv.RequireContainer(t)` / `MustRunInContainer()`.
+- **Errors** wrap with `fmt.Errorf("doing X: %w", err)`; match with `errors.Is/As`.
+  No `pkg/errors`.
+- **Imports** grouped stdlib / third-party / internal; gofumpt + goimports
+  formatting (`just fmt`).
+- **`time.Now()`** is forbidden in `internal/state` and `internal/render` (inject
+  a clock for testability) — enforced by `forbidigo`.
+- **Commits**: conventional commits with scope, e.g.
+  `feat(adapter): …`, `fix(secrets): …`, `test(drift): …`, `docs(readme): …`.
+
+## Adding things (where the invariants bite)
+
+- **New secret-bearing canonical field** → add it ONLY to `walkSecretFields`
+  (`internal/secrets/walk.go`). Every secret operation then picks it up; the
+  reflect-based `TestNewSecretFieldGuard` fails if you forget.
+- **New agent** → add `internal/adapter/<name>/` implementing the `Adapter`
+  interface and register it. `Render` must take `secrets.Resolved`; all writes
+  go through `DestWriter`. The canonical schema does not change.
+- **New dest→source write** → it must go through `capture.Capture`. Do not call
+  `source.Write*` directly from a write-back path (it does not re-reference
+  secrets). See the "Accepted residual" note above.
+- **New component field on the canonical model** → edit the structs in
+  `internal/source/schema.go`; teach each adapter's `Render`/`Ingest` and the
+  capability bitmask if it's a new component kind.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,26 @@ resolved at apply time from an age-encrypted vault.
   aspirational and not wired in v1.0 (`apply --strict/--force/--agent` flags, an
   `agentsync skill` command) — trust the code over the spec on the CLI surface.
 
+## Keep the docs in sync — non-negotiable
+
+Docs are part of the contract, not an afterthought. **No commit may change an
+interface, a contract, the canonical schema, the CLI surface, or load-bearing
+logic and leave the docs out of date.** If you change behavior, update the docs
+in the *same* commit. A reviewer should never have to wonder whether the prose
+or the code is the source of truth. Treat a stale doc as a bug.
+
+When you touch… | …also update in the same commit
+--- | ---
+the `Adapter` interface / `DestWriter` / render or capture contracts | `docs/architecture.md` (§3–§5), `docs/components.md`
+a CLI command, subcommand, or flag | `docs/user-guide.md` command reference, `README.md` quickstart
+agent/component coverage (a `Skip` goes native, a new adapter, a new component) | `docs/capability-matrix.md`, the matrices in `README.md` + `docs/user-guide.md`
+the canonical schema / `~/.agentsync/` layout | `docs/concepts.md`, `docs/architecture.md` (§2), the layout block in `docs/user-guide.md`
+the secret-handling invariants | the section below, `SECURITY.md`
+anything user-visible | `CHANGELOG.md` (under `[Unreleased]`)
+
+If a change makes a sentence in those docs false, the change is not done until
+the sentence is fixed.
+
 ## Mental map of the code
 
 - **`internal/source`** — the canonical model (`source.Canonical`). The TOML

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to agentsync
+
+Thanks for your interest! agentsync is **personal-first, OSS-shareable**: built
+well enough to share, not chasing breadth. Pull requests are welcome, but there's
+no support SLA — be patient, and prefer small, focused changes.
+
+If you're new to the codebase, read [`docs/concepts.md`](docs/concepts.md) then
+[`docs/architecture.md`](docs/architecture.md) first. The
+[component map](docs/components.md) tells you where things live.
+
+## Prerequisites
+
+- **Go** — the version in [`go.mod`](go.mod)'s `go` directive (currently 1.26.2).
+- **[`just`](https://github.com/casey/just)** — the task runner. `just` with no
+  args lists every recipe.
+- **podman** (preferred) or **docker** — the test suite runs in a hermetic
+  container (see below). Only the pure-unit and live cohorts run on the host.
+- **golangci-lint v2.12.2** — match CI exactly. Its release binary is built with
+  Go 1.26 so it can parse this module's export data; an older local build will
+  refuse to run.
+
+## Build
+
+```bash
+just build          # → ./bin/agentsync
+```
+
+## Test
+
+Every `just test*` recipe runs **inside a hermetic container** (podman first,
+docker fallback) — except the two explicit on-host opt-ins below. The repo is
+mounted read-only, the network is off, and each test's `HOME` is a fresh tmpdir,
+so the suite can never touch your real `~/.claude.json`, `~/.config/opencode/`,
+or `~/.agentsync/`.
+
+| Recipe | What it runs |
+|---|---|
+| `just test-fast` | Pure-unit packages on the host (no container, no FS). Fast iteration. |
+| `just test` | Unit + integration in the container. |
+| `just test-e2e` | Lifecycle end-to-end (build tag `e2e`). |
+| `just test-bdd` | Gherkin behaviour lock (build tag `bdd`). |
+| **`just test-release`** | **All layers in one container run. This is the bar — if it's green, the change is shippable.** |
+| `just test-live` | Network-dependent live cohort (build tag `live`); opt-in, **not** part of the release gate. |
+
+FS-touching tests refuse to run on the host. To run a single one outside the
+container during debugging:
+
+```bash
+AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run TestApply_FirstRun
+```
+
+## Lint & format
+
+```bash
+just lint           # golangci-lint run ./...
+just fmt            # gofmt -s + gofumpt
+just tidy           # go mod tidy
+```
+
+Test conventions enforced by lint (don't fight them):
+
+- Stdlib `testing` only — no testify/gomega. Table-driven with a `name` field.
+- Filesystem in tests is `afero.NewMemMapFs()` or `t.TempDir()` — never
+  `os.UserHomeDir()` (a `forbidigo` rule bans it in `_test.go`; use
+  `paths.HomeDir(env)`).
+- `time.Now()` is banned in `internal/state` and `internal/render` — inject a
+  clock for testability.
+
+## Security-critical invariants
+
+Before touching `internal/secrets`, `internal/capture`, or any `source.Write*`
+path, read the **Secret-handling invariants** section of
+[`CLAUDE.md`](CLAUDE.md) and [`SECURITY.md`](SECURITY.md). The core rule: a
+*resolved cleartext secret* must never be written back into the canonical source.
+The type system, a value invariant, and a lint fence all defend this — don't
+weaken them. New write-backs go through `capture.Capture`; new secret-bearing
+fields go only in `walkSecretFields`.
+
+## Commit messages
+
+Conventional commits with an explicit scope:
+
+```
+feat(adapter): project OpenCode subagent frontmatter
+fix(secrets): re-reference env vars on write-back
+test(drift): cover orphan-drifted at key granularity
+docs(readme): document age key backup
+```
+
+Keep commits focused and self-contained; include tests with the behaviour they
+cover.
+
+## Pull requests
+
+1. Branch from `main`.
+2. Make the change; add or update tests.
+3. Ensure **`just test-release`** is green and `just lint` is clean.
+4. Open the PR and fill in the template (what changed, why, test plan).
+
+For anything security-sensitive, **don't** open a public PR/issue first — use the
+private reporting path in [`SECURITY.md`](SECURITY.md).
+
+## Reporting bugs & requesting features
+
+Use the [issue templates](.github/ISSUE_TEMPLATE/). Bug reports are far easier to
+act on with `agentsync --version`, your OS, and the relevant snippet of your
+`~/.agentsync/` config (with secrets redacted).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
+<div align="center">
+
 # agentsync
 
-Centrally manage AI coding-agent configurations across Claude Code, OpenCode, Codex CLI, and Cursor.
+**One source of truth for every AI coding agent on your machine.**
+
+Define your MCP servers, memory, skills, and marketplace plugins once in
+`~/.agentsync/`. Run `agentsync apply`. They land — correctly translated — in
+Claude Code, OpenCode, and (soon) Codex CLI and Cursor.
+
+[Quickstart](#quickstart) · [Install](#install) · **[User guide](docs/user-guide.md)** · [Docs](docs/) · [Known limits](#known-limits-in-v1x)
+
+</div>
+
+> **Status: beta.** v1.0 ships Claude Code + OpenCode end-to-end. The tool is
+> functional and tested under `just test-release`; package-manager distribution
+> and a few documented trade-offs are still being finalized.
+
+---
+
+## What it does
+
+If you use more than one AI coding agent, you keep re-entering the same config in
+each one's native format, you forget to install a plugin everywhere, and your
+configs quietly drift apart. agentsync fixes the fan-out:
+
+- **Edit once, apply everywhere.** Add an MCP server or install a plugin a single
+  time; it's projected into each agent's native config — fully where the agent
+  has the concept, lossily-but-reported where it doesn't, skipped (never
+  silently) where it can't.
+- **Bidirectional, chezmoi-style.** When an agent edits its own config, agentsync
+  detects the drift and offers a merge: adopt the edit into your source, or
+  re-impose the source. Nothing is overwritten behind your back.
+- **Secrets stay secret.** Reference `${secret:github.token}`; agentsync resolves
+  it at apply time from an age-encrypted vault and **never** writes the cleartext
+  back into your (committable) source.
+
+New here? The **[User guide](docs/user-guide.md)** takes you 0→100.
 
 ## Quickstart
 
@@ -10,6 +45,28 @@ Centrally manage AI coding-agent configurations across Claude Code, OpenCode, Co
     agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
     agentsync apply --dry-run    # preview translation report before writing
     agentsync apply
+
+## Documentation
+
+| Doc | What it covers |
+| --- | --- |
+| **[User guide](docs/user-guide.md)** | Install → first sync → daily loop → secrets → plugins → project config. |
+| [Concepts & glossary](docs/concepts.md) | The three-state model, drift, reconcile — every term in one page. |
+| [Capability matrix](docs/capability-matrix.md) | Exactly what each agent supports, and what's lossy or deferred. |
+| [Architecture](docs/architecture.md) | The apply/capture pipelines, drift classifier, and secret invariants. |
+| [Component map](docs/components.md) | The codebase, package by package. |
+| [CONTRIBUTING](CONTRIBUTING.md) · [SECURITY](SECURITY.md) · [CHANGELOG](CHANGELOG.md) | Contributing, threat model, release history. |
+
+## Supported agents at a glance
+
+| Agent | Status | Component coverage |
+| --- | --- | --- |
+| **Claude Code** | ✓ full adapter | All seven components, incl. LSP. |
+| **OpenCode** | ✓ adapter | MCP, memory, skills, subagents, commands. Hooks + LSP skipped. |
+| **Codex CLI** | planned (v1.1) | No-op today; `agent add codex` rejected unless overridden. |
+| **Cursor** | planned (v1.2) | No-op today; will manage project-scope rules only. |
+
+Full ✓/◐/✗ breakdown per component: **[capability matrix](docs/capability-matrix.md)**.
 
 ## Install
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# agentsync documentation
+
+Start here. The docs are layered — read top-to-bottom to go from zero to fluent,
+or jump to whatever you need.
+
+| Doc | Read it when you want to… | Audience |
+|---|---|---|
+| **[User guide](user-guide.md)** | Install agentsync and go from 0→100: first sync, daily loop, secrets, plugins, project config. | Users |
+| **[Concepts & glossary](concepts.md)** | Understand the three-state model, drift, reconcile, and every term in one page. | Everyone |
+| **[Capability matrix](capability-matrix.md)** | Know exactly what each agent supports and what's lossy or deferred. | Users · contributors |
+| **[Architecture](architecture.md)** | See how the apply/capture pipelines, drift classifier, and secret invariants work. | Contributors |
+| **[Component map](components.md)** | Navigate the codebase package by package. | Contributors |
+
+**Repo-root docs:**
+
+- **[README](../README.md)** — quickstart, install, known limits, full env-var table.
+- **[CONTRIBUTING](../CONTRIBUTING.md)** — how to build, test, and submit changes.
+- **[SECURITY](../SECURITY.md)** — threat model and vulnerability reporting.
+- **[CLAUDE.md](../CLAUDE.md)** — project memory for AI agents working on the code.
+- **[CHANGELOG](../CHANGELOG.md)** — what changed, release by release.
+
+**Suggested reading order**
+
+1. New user → [User guide](user-guide.md) (skim [Concepts](concepts.md) when a term is unfamiliar).
+2. Evaluating fit → [Capability matrix](capability-matrix.md).
+3. Contributing → [Concepts](concepts.md) → [Architecture](architecture.md) → [Component map](components.md) → [CONTRIBUTING](../CONTRIBUTING.md).
+
+---
+
+### Internal design history
+
+`docs/superpowers/` (the original v1.0 design spec and milestone plans) and
+`docs/decisions/` (architecture decision records) are kept for provenance. The
+docs above supersede them for day-to-day use; the spec remains the authoritative
+record of *why* v1.0 is shaped the way it is.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,283 @@
+# Architecture
+
+How agentsync is put together: the data model, the apply/capture pipelines, the
+drift classifier, and the safety and secrets invariants that make it trustworthy
+enough to point at your real config and your real credentials.
+
+If you haven't yet, read [Concepts & glossary](concepts.md) first — this page
+assumes that vocabulary. For a package-by-package index, see the
+[component map](components.md).
+
+---
+
+## 1. The three-state model
+
+agentsync inherits chezmoi's three-state design. Every operation is a comparison
+between **Source** (what you committed), **Target** (what the source renders to,
+computed in memory), and **Destination** (what's on disk in each agent).
+
+```mermaid
+flowchart LR
+    subgraph S["Source — ~/.agentsync/"]
+        TOML["TOML + .md<br/>(hand-editable)"]
+    end
+    subgraph T["Target — in memory"]
+        OPS["per-agent FileOps<br/>+ Skips"]
+    end
+    subgraph D["Destination — on disk"]
+        NATIVE["~/.claude.json<br/>~/.config/opencode/…"]
+    end
+    TOML -- "render (resolve secrets + project)" --> OPS
+    OPS -- "write (atomic)" --> NATIVE
+    NATIVE -- "capture (ingest + re-reference)" --> TOML
+```
+
+Drift is a hash comparison against the **last-applied** hashes recorded in
+state: if the destination's hash no longer matches what agentsync last wrote, the
+file was edited outside agentsync.
+
+---
+
+## 2. The canonical model *is* the schema
+
+There is no separate internal IR. The Go structs in `internal/source` that parse
+the TOML/markdown in `~/.agentsync/` are the canonical model
+(`source.Canonical`), and adapters render directly from it. Adding a component
+field means changing those structs; adding an agent means adding an adapter that
+consumes them — the schema is the contract between the two.
+
+```
+source.Canonical
+├── Config          (agentsync.toml: agents, update defaults, secrets backend)
+├── MCPServers      (mcp/*.toml)
+├── Skills          (skills/*/SKILL.md)
+├── Subagents, Commands, Hooks, LSPServers
+├── Plugins, Marketplaces   (plugins/*.toml, marketplaces/*.toml)
+├── Memory          (memory/AGENTS.md + fragments/)
+└── Project         (.agentsync.toml overlay, when in project scope)
+```
+
+---
+
+## 3. The adapter contract
+
+Every agent integration implements one interface (`internal/adapter/adapter.go`):
+
+```go
+type Adapter interface {
+    Name() string
+    Capabilities() Capability       // bitmask: MCP, Memory, Skill, Subagent, Command, Hook, LSP
+    Detect() (bool, error)          // is this agent installed?
+    Render(r secrets.Resolved, scope Scope, project string) ([]FileOp, []Skip, error)
+    Ingest(scope Scope, project string) (source.Canonical, error)
+    KeyMergeStrategy() string       // "merge-json-keys" | "merge-jsonc-keys" | ""
+    Apply(ops []FileOp, w DestWriter) error
+}
+```
+
+Two design points worth internalizing:
+
+- **`Render` accepts only `secrets.Resolved`, never a raw `source.Canonical`.**
+  `Resolved` is a wrapper type produced by secret substitution; you cannot pass
+  the templated source model to `Render`, and you cannot pass the resolved
+  (cleartext) model to a source writer. This makes "leak a resolved secret back
+  into source" a *compile error*, not a code-review check.
+- **Every destination write goes through `DestWriter`.** Adapters never call
+  `iox.AtomicWrite`/`os.Remove` directly. `DestWriter` owns the
+  foreign-collision backup invariant (back up any pre-existing file agentsync
+  doesn't yet own, before overwriting). A `forbidigo` lint rule fails any direct
+  write outside the allowed packages, so a new adapter can't regress the backup
+  guarantee.
+
+`Capability` is a bitmask, so the OpenCode adapter simply omits `CapHook` and
+`CapLSP` and the pipeline reports those components as skipped.
+
+---
+
+## 4. The apply pipeline (Source ▶ Destination)
+
+`agentsync apply` is local-only and offline. It renders from the cache that
+`agentsync update` populated.
+
+```mermaid
+flowchart TD
+    A["cli: newApplyCmd"] --> B["source.Load(fs, home)"]
+    B --> P["project.Discover + Merge<br/>(if in project scope)"]
+    P --> C["marketplace.LoadProjected<br/>(plugins → components, from cache)"]
+    C --> SEC["secrets.SubstituteCanonical<br/>→ secrets.Resolved"]
+    SEC --> REN["render.Plan<br/>(each adapter.Render → FileOps + Skips)"]
+    REN --> CL["drift.Classify per file/key<br/>(H_src vs H_applied vs H_dest)"]
+    CL --> W["render.Apply via DestWriter<br/>(two-phase atomic write + backups)"]
+    W --> ST["state.Save targets.json<br/>(record new hashes)"]
+    W --> RPT["render.TranslationReport<br/>(✓ / ◐ / ✗ per plugin per agent)"]
+```
+
+Key stages:
+
+1. **Load** the canonical source (`internal/source`).
+2. **Overlay** the project marker if the apply is project-scoped (`internal/project`).
+3. **Project plugins** into components from the local cache (`internal/marketplace`).
+4. **Resolve secrets** — `${secret:…}`/`${env:…}` → `secrets.Resolved` (`internal/secrets`).
+5. **Plan** — each enabled adapter renders the resolved model into `FileOp`s and
+   `Skip`s (`internal/render`, `internal/adapter/*`).
+6. **Classify** each file/key with the 3-way drift classifier (`internal/drift`).
+7. **Write** through `DestWriter` with two-phase atomic writes and
+   foreign-collision backups (`internal/render`, `internal/iox`).
+8. **Record** new hashes in `targets.json` (`internal/state`) and print the
+   translation report.
+
+`--dry-run` runs steps 1–6 and prints the plan/report without writing.
+
+---
+
+## 5. The capture pipeline (Destination ▶ Source)
+
+The reverse path — used by `agentsync import` and reconcile's `[w]rite-back` —
+goes through exactly one function, `capture.Capture`:
+
+```mermaid
+flowchart LR
+    NATIVE["native config on disk"] --> ING["adapter.Ingest<br/>→ source.Canonical"]
+    ING --> CAP["capture.Capture"]
+    CAP --> RR["secrets.ReReferenceCanonical<br/>(cleartext → ${secret:…})"]
+    RR --> PRES["preserve source-only fields<br/>(agents, enabled)"]
+    PRES --> WR["source.Write* (templated only)"]
+    WR --> SRC["~/.agentsync/*.toml"]
+```
+
+`capture.Capture` is the single dest→source funnel. It **re-references** any
+resolved secret back to its `${secret:…}` form before writing, and it preserves
+source-only fields (like an MCP server's `agents`/`enabled` list) that the
+rendered destination never carried. No other code path writes destination data
+back into the source.
+
+---
+
+## 6. Drift — the 3-way classifier
+
+`internal/drift` is a pure function over three hashes. For every managed file or
+key:
+
+- `H_src` — computed now from the canonical source
+- `H_applied` — recorded last apply in `targets.json`
+- `H_dest` — current on-disk content (or nil)
+
+| `H_applied` vs `H_src` | `H_applied` vs `H_dest` | Class | `apply` behavior |
+|---|---|---|---|
+| = | = | **clean** | noop |
+| ≠ | = | **pending** | write `H_src` |
+| = | ≠ | **drift** | block; suggest reconcile |
+| ≠ | ≠, `H_dest = H_src` | **converged** | refresh state silently |
+| ≠ | ≠, all differ | **conflict** | block; require reconcile |
+| `H_applied` nil, `H_dest` nil | — | **new** | create |
+| `H_applied` nil, `H_dest` ≠ nil | — | **foreign-collision** | back up dest, then write |
+| `H_src` nil, `H_applied` ≠ nil | `H_dest = H_applied` | **orphan** | delete |
+| `H_src` nil, `H_applied` ≠ nil | `H_dest ≠ H_applied` | **orphan-drifted** | warn |
+
+`drift.SafeForAutoApply(class)` is what `reconcile --auto-safe` consults — it
+auto-resolves only the cases that can't lose work (`converged`, `pending`).
+
+**Granularity.** Structured files (JSON/JSONC/TOML) are tracked per **JSON
+pointer**, so agentsync can own `$.mcpServers.github` inside `~/.claude.json`
+without touching keys it didn't write. Those untouched keys are **foreign keys**
+— surfaced in `status` but never entering the classifier. If a structured file
+fails to parse, the algorithm degrades to file-level on the whole file.
+
+---
+
+## 7. Safety primitives
+
+All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
+
+1. **Two-phase atomic write** — write to `.state/staging/`, fsync, rename onto
+   the final path. A crash leaves either the old or the new file, never a partial.
+2. **File lock** — `gofrs/flock` on `.state/apply.lock` serializes concurrent
+   `apply`/`reconcile`. `apply --dry-run` is read-only and takes no lock.
+3. **`AGENTSYNC_TARGET_ROOT`** — every dest path resolves through one helper
+   (`internal/paths`), so tests redirect `$HOME` to a tmpdir. A `forbidigo` rule
+   bans `os.UserHomeDir()` in `_test.go`.
+4. **First-apply backups** — the `foreign-collision` case copies the pre-existing
+   destination into `.state/backups/<ts>/` before writing. Symlinked
+   destinations are refused by default.
+5. **Manifest-SHA pinning** — every plugin records the marketplace-published
+   manifest SHA, so a re-uploaded version is detected as drift rather than
+   silently consumed.
+
+---
+
+## 8. Secrets — how the leak is prevented
+
+The dangerous bug class is a *resolved cleartext secret being persisted back
+into the canonical source* (often a committed dotfiles repo). agentsync makes
+this hard to do by accident with three tiers of defense:
+
+- **Compile-enforced (load-bearing).** `secrets.SubstituteCanonical` returns
+  `secrets.Resolved`, a wrapper that is *not* assignable to `source.Canonical`.
+  Adapters' `Render` take `Resolved`; source writers and `capture.Capture` take
+  only the templated `source.Canonical`. Passing resolved data to a writer is a
+  compile error.
+- **Value-invariant (load-bearing).** Secret substitution clones the model
+  before resolving (no aliasing back to the caller's templated copy), and the
+  field walker only visits secret-bearing fields — so text components (memory,
+  skills, commands) physically cannot carry a substituted secret.
+- **Lint fence (defense-in-depth).** A `forbidigo` rule forbids unwrapping a
+  `Resolved` outside the two adapter `Render` egress sites.
+
+There is one **accepted residual**: a *deliberate* two-step laundering (defeat
+the lint fence to obtain a writable `source.Canonical`, then call a source writer
+directly) could leak. No innocent mistake produces it, and `capture.Capture`
+always re-references. The single field list lives in `walkSecretFields`
+(`internal/secrets/walk.go`); a reflection-based test fails if a new
+string-shaped secret-bearing field is added without classification.
+
+> If you ever find yourself unwrapping a `secrets.Resolved` outside an adapter's
+> `Render`, stop — you almost certainly want `capture.Capture`. The full set of
+> invariants is in [`CLAUDE.md`](../CLAUDE.md) and [`SECURITY.md`](../SECURITY.md).
+
+---
+
+## 9. Network boundary
+
+`agentsync update` is the **only** command that touches the network. It clones
+or fetches marketplaces (`go-git`, with a `git` shell-out fallback for sparse
+clones) and npm tarballs (registry HTTP, no `npm` binary required), writing them
+to `.state/cache/`. Everything else — including `apply` — reads only from that
+cache, which keeps `apply` fast, offline, and reproducible in CI.
+
+Untrusted-input hardening at this boundary: fetchers reject symlinks in
+tarballs, cap decompressed size (`AGENTSYNC_MAX_TARBALL_MB`), verify manifest
+SHAs, bound component paths to the plugin cache, and reject `http://`/`git://`
+sources unless `AGENTSYNC_ALLOW_INSECURE_URLS=1`.
+
+---
+
+## 10. Package layering
+
+```mermaid
+flowchart TD
+    CLI["internal/cli — cobra command tree"]
+    REN["internal/render — apply pipeline"]
+    CAP["internal/capture — dest▶source funnel"]
+    AD["internal/adapter (+ claude, opencode, noop)"]
+    SRC["internal/source — canonical model + loaders/writers"]
+    SEC["internal/secrets — resolve / re-reference / mask"]
+    MKT["internal/marketplace — fetch + project plugins"]
+    PRJ["internal/project — .agentsync.toml overlay"]
+    DRF["internal/drift — 3-way classifier (pure)"]
+    ST["internal/state — targets.json"]
+    INFRA["internal/iox · paths · jsonkeys · log"]
+
+    CLI --> REN & CAP & AD & SRC & SEC & MKT & PRJ & DRF & ST
+    REN --> AD & SEC & SRC & ST & DRF & INFRA
+    CAP --> SRC & SEC & INFRA
+    AD --> SRC & SEC & INFRA
+    MKT --> SRC
+    PRJ --> SRC
+    SRC --> INFRA
+    SEC --> SRC & INFRA
+    ST --> INFRA
+```
+
+`internal/drift`, `internal/iox`, `internal/jsonkeys`, `internal/paths`, and
+`internal/log` have no internal dependencies — they're the leaves. See the
+[component map](components.md) for what each package contains.

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -1,0 +1,89 @@
+# Capability matrix
+
+What works, what's lossy, and what's deferred — per agent, per component. This
+is the honest-expectations page for the beta. If a translation is lossy or
+skipped, agentsync says so at apply time in the [translation report](concepts.md#translation-report--coverage);
+nothing is dropped silently.
+
+**Legend**
+
+| Symbol | Meaning |
+|:--:|---|
+| ✓ | **native** — full fidelity; the agent has the concept directly |
+| ◐ | **projected** — translated with documented, reported loss |
+| ✗ | **skipped** — no honest translation; logged in the apply report |
+| — | not yet implemented (adapter is registered but no-op) |
+
+---
+
+## Agent status
+
+| Agent | Status in v1.0 / beta | Notes |
+|---|---|---|
+| **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. |
+| **OpenCode** | ✅ Adapter (some components projected/skipped) | MCP, memory, skills, subagents, commands. Hooks and LSP are skipped with a warning. |
+| **Codex CLI** | 🔜 Planned (v1.1) | Registered as a no-op. `agent add codex` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. |
+| **Cursor** | 🔜 Planned (v1.2) | Registered as a no-op. Will manage project-scope rules only (user rules live in Cursor's app-local storage). |
+
+---
+
+## Component × agent
+
+Component support across agents. Codex (v1.1) and Cursor (v1.2) columns describe
+the **planned** projection per the design spec; their adapters are no-ops today.
+
+| Component | Claude (v1.0) | OpenCode (v1.0) | Codex (v1.1) | Cursor (v1.2) |
+|---|:--:|:--:|:--:|:--:|
+| **MCP server** | ✓ `~/.claude.json` | ✓ `opencode.json` | ◐ `config.toml` | ◐ `mcp.json` |
+| **Memory** | ✓ `CLAUDE.md` | ✓ `AGENTS.md` | ◐ `~/.codex/AGENTS.md` | ◐ `AGENTS.md` |
+| **Skill** | ✓ `~/.claude/skills/X/SKILL.md` | ✓ shared `.claude/skills/` | ◐ `~/.agents/skills/` | ✗ no skills concept |
+| **Subagent** | ✓ `~/.claude/agents/X.md` | ◐ frontmatter munged | ◐ markdown → TOML | ✗ |
+| **Slash command** | ✓ `~/.claude/commands/X.md` | ◐ `argument-hint` dropped | ✗ no custom commands | ◐ → `.cursor/rules/*.mdc` |
+| **Hook** | ✓ JSON in settings | ✗ skip (JS/TS plugins) | ◐ `hooks.json`, 5/9 events | ◐ `hooks.json`, ~6/9 events |
+| **LSP server** | ✓ native | ✗ skip (deferred) | ✗ no LSP concept | ✗ deferred |
+
+> The ◐/✗ cells are *features*, not bugs: agentsync refuses to invent a
+> translation that would mislead you. Every ◐ and ✗ is printed in the apply
+> report and queryable with `agentsync explain <plugin> --json`.
+
+---
+
+## Why OpenCode skips hooks and LSP
+
+- **Hooks** — OpenCode hooks are JS/TS plugins that subscribe to events, not
+  declarative shell commands like Claude's. There is no mechanical translation;
+  generating a JS/TS shim is deferred past v1. Hand-author a small plugin if you
+  need a hook on OpenCode.
+- **LSP** — projection of LSP servers to non-Claude agents is deferred to v1.x.
+  Claude plugins that bundle LSP servers install correctly on Claude itself; on
+  other agents you'll see `lsp server X skipped` in the report.
+
+## Escape hatches
+
+You control fan-out explicitly:
+
+- `agents = ["claude", "opencode"]` on an MCP server or plugin entry → fan out
+  only to those agents.
+- `[plugin.overrides.<agent>]` with `component = "skip"` → drop one component
+  for one agent.
+
+---
+
+## Known limits (v1.x)
+
+These are documented trade-offs, not regressions. The authoritative list lives
+in the [README](../README.md#known-limits-in-v1x); the highlights:
+
+- **Comment preservation** — comments in `mcp/*.toml` and in `opencode.json` are
+  not preserved across a write-back/import round-trip in the rewritten section.
+- **Owned-key hand-edits** — if you hand-edit an agentsync-owned key in a shared
+  file, the next `apply` overwrites it with no backup (agentsync considers it its
+  own). Run `agentsync reconcile` first to capture the edit.
+- **Insecure sources** — `http://` and `git://` plugin/marketplace sources are
+  rejected by default (MITM protection); override with
+  `AGENTSYNC_ALLOW_INSECURE_URLS=1`.
+- **Symlinked destinations** are rejected by default; override with
+  `AGENTSYNC_ALLOW_SYMLINK_DEST=1`.
+- **Not on the roadmap**: Continue, Gemini CLI, Aider.
+
+See the [user guide](user-guide.md) to put this into practice.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,213 @@
+# Component map
+
+A package-by-package index of the codebase. Each entry lists the package's
+responsibility, its key exported symbols, and which internal packages it depends
+on. For *how the pieces fit together*, read the [architecture](architecture.md);
+this page is the directory.
+
+```
+cmd/agentsync/        # main(): inject version ldflags, call cli.Execute()
+internal/
+├── cli/              # cobra command tree (entry layer)
+├── source/           # the canonical model + loaders/writers   ← the schema
+├── secrets/          # ${secret:}/${env:} resolve · re-reference · mask
+├── project/          # .agentsync.toml overlay discovery + merge
+├── adapter/          # the per-agent Adapter interface + registry
+│   ├── claude/       #   full adapter (reference implementation)
+│   ├── opencode/     #   adapter (hooks/LSP skipped)
+│   └── noop/         #   placeholder for unimplemented agents
+├── render/           # the apply pipeline: plan · write · report
+├── capture/          # the single dest▶source write-back funnel
+├── drift/            # the 3-way classifier (pure, no IO)
+├── state/            # targets.json (last-applied hashes)
+├── marketplace/      # fetch marketplaces/plugins · project components
+├── iox/              # atomic write + file lock
+├── jsonkeys/         # per-key JSON-pointer merge (preserve foreign keys)
+├── paths/            # AGENTSYNC_HOME / TARGET_ROOT / HOME resolution
+├── log/              # slog setup
+└── testenv/          # hermetic-container test guard
+```
+
+---
+
+## Entry layer
+
+### `cmd/agentsync`
+The binary's `main`. Injects `Version`/`Commit`/`Date` via `-ldflags` and calls
+`cli.Execute()`. Nothing else lives here.
+
+### `internal/cli`
+Wires every cobra subcommand into the root tree and dispatches to handlers; this
+is the only package that depends on nearly all the others.
+- **Key:** `NewRoot() *cobra.Command`, `Execute() error`, `Version`/`Commit`/`Date`.
+- **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
+  `status`, `diff`, `reconcile`, `import`, `doctor`, `verify`,
+  `mcp {add,remove,list}`, `plugin {install,upgrade,enable,disable,remove,list}`,
+  `marketplace {add,remove,list}`, `update`, `secrets {edit,get,set}`, `explain`.
+- **Depends on:** adapter, source, state, secrets, paths, render, marketplace,
+  project, drift, log.
+- **Files:** `root.go` + one file per command group.
+
+---
+
+## Core model
+
+### `internal/source` — *the schema*
+Loads and represents `~/.agentsync/`. The TOML-tagged structs here *are* the
+canonical model that adapters render from; also provides write-back helpers and
+memory-fragment expansion.
+- **Key:** `Canonical` (the root model: `Config`, `MCPServers`, `Skills`,
+  `Subagents`, `Commands`, `Hooks`, `LSPServers`, `Plugins`, `Marketplaces`,
+  `Memory`, `Project`); `Load(fs, home)`; `ParseFrontmatter`; the `Write*`
+  family (`WriteMCP`, `WriteLSP`, `WritePlugin`, `WriteMarketplace`, `WriteSkill`,
+  `WriteSubagent`, `WriteCommand`, `WriteHooks`, `WriteMemory`); `ReadMCP`/`ReadLSP`
+  (carry source-only fields); `ExpandMemoryImports`.
+- **Depends on:** iox, jsonkeys.
+- **Files:** `schema.go`, `loader.go`, `writer.go`, `memory.go`.
+
+### `internal/secrets`
+Resolves `${secret:dotted.key}` and `${env:NAME}` at apply time; re-references
+cleartext back to `${secret:…}` for write-back; masks resolved values for display.
+The `Resolved` wrapper type is the load-bearing leak guard.
+- **Key:** `Resolver` (interface); `Resolved` (resolved-model wrapper);
+  `SubstituteCanonical` (→ `Resolved`); `ReReferenceCanonical`; `CollectResolved`;
+  `UnresolvedSecretRefs`; `MaskResolved`; `AgeBackend`/`EnvBackend`/`NopResolver`;
+  `SelectBackend`; and the single field list `walkSecretFields` (in `walk.go`).
+- **Depends on:** source, iox.
+- **Files:** `secrets.go`, `age.go`, `resolved.go`, `substitute.go`,
+  `rereference.go`, `mask.go`, `walk.go`, `secretpaths.go`.
+
+### `internal/project`
+Discovers a repo's `.agentsync.toml` marker by walking up from the cwd and merges
+its overlay (project MCP servers, plugin enable/disable, extra memory) onto the
+base canonical model.
+- **Key:** `MarkerFile` (`.agentsync.toml`); `Marker`; `Discover(cwd)`;
+  `Merge(base, m) source.Canonical`.
+- **Depends on:** source.
+- **Files:** `project.go`.
+
+---
+
+## Translation layer
+
+### `internal/adapter`
+Declares the per-agent `Adapter` contract and a registry; the `DestWriter`
+interface funnels all destination writes through the foreign-collision backup.
+- **Key:** `Adapter` (interface); `DestWriter` (interface); `Capability`
+  (bitmask: `CapMCP`, `CapMemory`, `CapSkill`, `CapSubagent`, `CapCommand`,
+  `CapHook`, `CapLSP`); `Scope` (`ScopeUser`/`ScopeProject`); `FileOp`; `Skip`;
+  `Registry` (`NewRegistry`, `Register`, `Lookup`, `Names`).
+- **Files:** `adapter.go`, `registry.go`.
+
+### `internal/adapter/claude`
+The reference adapter — all seven components including LSP, with per-key merge
+into shared JSON files (`~/.claude.json`, `settings.json`) that preserves foreign
+keys.
+- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `ParseFrontmatter`/
+  `EncodeFrontmatter`; `MergeKeys`.
+- **Depends on:** adapter, secrets, source, paths, iox, jsonkeys.
+- **Files:** `claude.go`, `render.go`, `ingest.go`, `apply.go`, `paths.go`,
+  `frontmatter.go`, `skill.go`, `command.go`, `subagent.go`, `hook.go`, `lsp.go`,
+  `memory.go`, `settings.go`.
+
+### `internal/adapter/opencode`
+The OpenCode adapter — MCP, memory, skills, subagents, commands via JSONC
+round-trip (`tailscale/hujson`). Omits `CapHook`/`CapLSP` (skipped with a warning).
+- **Key:** `New(Options) *Adapter`; the `Adapter` methods.
+- **Depends on:** adapter, secrets, source, paths, iox.
+- **Files:** `opencode.go`, `render.go`, `ingest.go`, `apply.go`, `paths.go`,
+  `skill.go`, `subagent.go`, `command.go`, `memory.go`, `settings.go`.
+
+### `internal/adapter/noop`
+Placeholder adapter for unimplemented agents (Codex, Cursor): detects true,
+renders nothing. `agent add` rejects these unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`.
+- **Depends on:** adapter, secrets, source. **Files:** `noop.go`.
+
+---
+
+## Pipeline & state
+
+### `internal/render`
+Orchestrates apply: canonical + registry → per-agent `FileOp`s/`Skip`s, runs
+collision detection and backups, records state, synthesizes cleanup ops for
+orphaned owned keys, and builds the translation report.
+- **Key:** `Plan`; `Apply`; `PreviewCollisions`; `Writer`
+  (`NewWriter`/`NewPreviewWriter`); `TranslationReport` (`PrintText`/`PrintJSON`);
+  `BuildReport`; `RecordOpsState`; `OrphanFiles`; `PruneStaleState`;
+  `BackupFile`/`PruneBackups`; `CollisionReport`.
+- **Depends on:** adapter, secrets, source, state, paths, iox, drift.
+- **Files:** `pipeline.go`, `writer.go`, `state_apply.go`, `report.go`.
+
+### `internal/capture`
+The single dest→source write-back path: re-references secrets, preserves
+source-only fields, writes via `source.Write*`. Used by `import` and reconcile.
+- **Key:** `Capture(home, ingested, opts) (Result, error)`; `Opts`; `Result`.
+- **Depends on:** source, secrets, paths, iox.
+- **Files:** `capture.go`, `leak_fixture.go` (compile-time leak guard).
+
+### `internal/drift`
+Pure 3-way classifier — no IO.
+- **Key:** `Class` (`Clean`, `Pending`, `Drift`, `Converged`, `Conflict`, `New`,
+  `ForeignCollision`, `Orphan`, `OrphanDrifted`); `Classify(hsrc, happlied, hdest)`;
+  `SafeForAutoApply(c)`.
+- **Files:** `classifier.go`.
+
+### `internal/state`
+Persists last-applied hashes and plugin/marketplace pins to
+`.state/targets.json`; schema-versioned with migrators.
+- **Key:** `SchemaVersion`; `Targets` (`Files`, `Keys`, `Marketplaces`,
+  `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`.
+- **Depends on:** iox. **Files:** `schema.go`, `store.go`, `migrate.go`.
+
+### `internal/marketplace`
+Models the Claude marketplace/plugin format, fetches sources, and projects plugin
+manifests into canonical components.
+- **Key:** `Marketplace`, `PluginEntry`, `Source`, `PluginManifest`;
+  `ProjectionResult`; `Project`/`ProjectWithReader`; `Fetcher` (interface) with
+  `GitFetcher`/`NPMFetcher`/`RelativeFetcher`; `LoadProjected`/
+  `LoadProjectedLenient`/`LoadProjectedExcluding`.
+- **Depends on:** source, log.
+- **Files:** `manifest.go`, `projection.go`, `loadprojected.go`, `fetcher.go`,
+  `fetch_git.go`, `fetch_npm.go`, `fetch_relative.go`, `update.go`.
+
+---
+
+## Infrastructure (leaf packages, no internal deps)
+
+### `internal/iox`
+Atomic file IO and locking.
+- **Key:** `AtomicWrite(dest, data, mode)`; `Lock`/`AcquireLock`/
+  `AcquireLockTimeout`; `ErrSymlinkDest`; `AllowSymlinkDestEnv`.
+- **Files:** `atomic.go`, `lock.go`.
+
+### `internal/jsonkeys`
+Per-key JSON-pointer merge that preserves foreign keys and uses `json.Number`
+(no float64 rounding).
+- **Key:** `DecodeObject`; `DecodeYAML`; `MergeKeys(existing, ours, ownedPointers)`.
+- **Files:** `jsonkeys.go`.
+
+### `internal/paths`
+Resolves `AGENTSYNC_HOME`, `AGENTSYNC_TARGET_ROOT`, and `$HOME`; converts between
+absolute and `${HOME}`-relative forms for portable state.
+- **Key:** `Env` (interface), `OSEnv`, `MapEnv`; `HomeDir`; `AgentsyncHome`;
+  `HomeRelative`/`FromHomeRelative`.
+- **Files:** `paths.go`.
+
+### `internal/log`
+slog setup. **Key:** `New(w, verbose) *slog.Logger`. **Files:** `log.go`.
+
+### `internal/testenv`
+Guards FS-touching tests so they only run in the hermetic container.
+- **Key:** `RequireContainer(t)`; `MustRunInContainer()`; `InContainer() bool`;
+  `EnvVar` (`AGENTSYNC_TEST_IN_CONTAINER`).
+- **Files:** `container.go`.
+
+---
+
+## Dependency direction at a glance
+
+`cli` sits on top of everything. `render`, `capture`, and the adapters depend on
+`source` + `secrets`. `source`/`secrets`/`state` depend only on the leaf infra
+packages (`iox`, `jsonkeys`, `paths`). `drift`, `iox`, `jsonkeys`, `paths`, and
+`log` depend on nothing internal — they're the foundation. See the rendered
+dependency graph in [architecture §10](architecture.md#10-package-layering).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,166 @@
+# Concepts & glossary
+
+agentsync borrows its mental model from [chezmoi](https://www.chezmoi.io/): you
+keep one **canonical source** of truth, you **apply** it to produce the real
+files agents read, and when something edits those files out from under you,
+agentsync detects the **drift** and helps you **reconcile** it.
+
+Read this page once and the rest of the docs — the [architecture](architecture.md),
+the [user guide](user-guide.md), and `agentsync --help` — will click into place.
+
+---
+
+## The three-state model
+
+Everything agentsync does is a comparison between three states of the same
+logical thing (an MCP server, a memory file, a plugin's slash command):
+
+| State | What it is | Where it lives |
+|---|---|---|
+| **Source** | What *you* committed — the intent. | `~/.agentsync/` (a git repo you own) |
+| **Target** | What the source *renders to* for a given agent, computed fresh in memory at apply time. | nowhere on disk — it's transient |
+| **Destination** | What is *actually on disk* in each agent's native config right now. | `~/.claude.json`, `~/.config/opencode/`, … |
+
+```
+   Source                Target                 Destination
+  ~/.agentsync/   render   (in-memory)   write    ~/.claude/…
+  hand-edited    ───────▶  per-agent    ───────▶  ~/.config/opencode/…
+  TOML + .md               FileOps                native config files
+       ▲                                                │
+       │                      capture                   │
+       └────────────────────────────────────────────────┘
+              (write native edits back into source)
+```
+
+The genius of the model is that **drift is just a hash comparison**:
+
+- **Drift** — the destination changed since agentsync last wrote it
+  (`hash(destination) ≠ hash(last-applied)`). Something edited the native file.
+- **Source change** — you edited the canonical source
+  (`hash(target) ≠ hash(last-applied)`). A normal pending change.
+- **Conflict** — *both* happened. agentsync stops and asks you to reconcile.
+
+---
+
+## Core terms
+
+### Canonical source (`~/.agentsync/`)
+The single directory you own and (optionally) commit to git. It holds small,
+hand-editable TOML files (one MCP server per file, one plugin per file) plus
+markdown for memory and skills. Override its location with `AGENTSYNC_HOME`.
+There is **no hidden internal representation** — the Go structs that parse these
+TOML files *are* the canonical model.
+
+### Adapter
+A per-agent translator. Each adapter knows how to **render** the canonical model
+into one agent's native config format and how to **ingest** that native config
+back into the canonical model. Claude and OpenCode are real adapters in v1.0;
+Codex and Cursor are registered but no-op (see the [capability matrix](capability-matrix.md)).
+Adding an agent means adding an adapter — the canonical schema never changes.
+
+### Apply / Render
+`agentsync apply` runs the **render** pipeline: load the source → resolve
+secrets → ask each enabled adapter to project the model into a set of file
+operations → write them atomically → record hashes in state. Apply is
+**local-only and offline** — it never hits the network.
+
+### Capture / Ingest / write-back
+The reverse direction. **Ingest** reads an agent's native config back into the
+canonical model; **capture** persists that back into `~/.agentsync/`. This is how
+`agentsync import` (pull a native edit into the source) and the reconcile
+`[w]rite-back` action work. All write-back funnels through one place
+(`internal/capture`) so secrets get re-referenced and never leak as cleartext.
+
+### Drift & the 3-way classifier
+For every managed item, agentsync holds three hashes — source (`H_src`),
+last-applied (`H_applied`, from state), and destination (`H_dest`) — and
+classifies the item into exactly one of nine cases:
+
+| Class | Meaning | What `apply` does |
+|---|---|---|
+| **clean** | all three agree | nothing |
+| **pending** | you changed the source | write the new source |
+| **drift** | the destination was edited | block; suggest `reconcile` |
+| **converged** | source and dest changed to the *same* value | refresh state silently |
+| **conflict** | source and dest changed to *different* values | block; require `reconcile` |
+| **new** | brand-new item, nothing on disk | create |
+| **foreign-collision** | a pre-existing file agentsync didn't write | back it up, then write |
+| **orphan** | removed from source, still on disk | delete |
+| **orphan-drifted** | removed from source, but the dest was also edited | warn; ask for explicit action |
+
+Granularity is **per-key** for structured files (JSON/JSONC/TOML, tracked by
+JSON pointer) and **per-file** for everything else. Keys agentsync never wrote
+are **foreign keys** — surfaced for awareness but never touched.
+
+### Reconcile
+The interactive merge UX for drift and conflicts. For each drifting item you
+choose `[w]rite-back` (adopt the dest edit into source), `[o]verride` (re-impose
+source), `[s]kip`, `[i]gnore` (add to `ignore.toml`), `[d]iff`, or `[q]uit`.
+Bulk hotkeys (`W`/`O`/`S`) and non-interactive flags (`--auto-writeback`,
+`--auto-override`, `--auto-safe`) exist for scripting.
+
+### Scope & the project marker
+Config applies at **user** scope (the whole machine) or **project** scope (one
+repo). A repo opts in by dropping a `.agentsync.toml` marker at its root;
+agentsync walks up from the current directory to find it. The marker can add
+project-only MCP servers, disable plugins, and merge extra memory.
+
+### Secrets: `${secret:…}` and `${env:…}`
+The canonical source never stores cleartext credentials. You write
+`${secret:github.token}` or `${env:HOME}`; agentsync **resolves** these at apply
+time — `${secret:…}` from an age-encrypted file, `${env:…}` from the
+environment. The public **recipient** key is safe to commit; the private
+**identity** key is per-machine and never backed up for you.
+
+> A central invariant: a *resolved* cleartext secret must never be written back
+> into the canonical source. The type system enforces this — see
+> [architecture](architecture.md#secrets-how-the-leak-is-prevented) and `CLAUDE.md`.
+
+### State (`~/.agentsync/.state/`)
+Gitignored bookkeeping: `targets.json` (the last-applied hashes that make drift
+detection possible), the apply lock, the two-phase write staging dir, first-apply
+backups, and the marketplace/plugin cache. Keys are stored `${HOME}`-relative so
+state is portable across machines.
+
+### Marketplace / Plugin / Projection
+A **marketplace** is a registry of plugins (Claude's marketplace format). A
+**plugin** is a bag of components — MCP servers, skills, subagents, commands,
+hooks, LSP servers. **Projection** translates each component independently into
+each target agent, which is where fan-out happens: install once, land on every
+enabled agent that supports the component.
+
+### Translation report & coverage
+Every `apply`, `verify`, and `explain` ends with a report showing, per plugin
+per agent, what landed:
+
+- **✓ native** — full fidelity; the agent has the concept directly.
+- **◐ projected** — lossy but defensible translation, explicitly reported.
+- **✗ skipped** — no honest translation exists; logged so it's never silent.
+
+### Update (the only networked verb)
+`agentsync update` is the *only* command that touches the network: it polls
+marketplaces, refreshes the cache, and recomputes version pins. `apply` then
+runs entirely from cache. This split keeps `apply` fast, reproducible, and
+offline-safe.
+
+---
+
+## How the verbs relate
+
+```
+   you edit ~/.agentsync/                      an agent edits its own config
+            │                                              │
+            ▼                                              ▼
+   agentsync apply  ──writes──▶  native config  ──drift──▶  agentsync status
+   (source ▶ dest)                                          agentsync diff
+                                                                  │
+                                                                  ▼
+                                              agentsync reconcile / import
+                                                  (dest ▶ source capture)
+
+   agentsync update  ──network──▶  refresh marketplace cache & pins
+                                   (then apply renders from cache, offline)
+```
+
+Next: see the [architecture](architecture.md) for how these are implemented, or
+jump straight to the [user guide](user-guide.md) to get hands-on.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,477 @@
+<div align="center">
+
+# agentsync — User Guide
+
+**One source of truth for every AI coding agent on your machine.**
+
+Define your MCP servers, memory, skills, and marketplace plugins *once*.
+Run `agentsync apply`. Watch them land — correctly translated — in Claude Code,
+OpenCode, and (soon) Codex and Cursor.
+
+[Why agentsync](#why-agentsync) · [Install](#install) · [Your first sync](#your-first-sync-5-minutes) · [Already have configs?](#already-have-configs) · [The daily loop](#the-daily-loop) · [Building your config](#building-your-config) · [Command reference](#command-reference)
+
+</div>
+
+---
+
+## Why agentsync
+
+If you use more than one AI coding agent, you've felt this: you add an MCP server
+to Claude, then hand-copy it into OpenCode's JSON, then again into Codex's TOML.
+You install a plugin in one and forget it in the others. You hard-code a token
+into a config file and pray it never lands in git. Your `~/.claude.json` and your
+OpenCode config slowly drift apart, and you have no idea which one is "right."
+
+agentsync fixes the fan-out. You keep **one canonical config** in `~/.agentsync/`
+— small, hand-editable TOML and markdown files you can commit to a dotfiles repo
+— and agentsync projects it into each agent's *native* format. Add a server
+once; it lands everywhere. Install a plugin once; every agent that understands
+its components gets them. Reference a secret as `${secret:github.token}`; it's
+resolved at apply time and **never** written back as cleartext.
+
+And because agents edit their own configs, agentsync is **bidirectional**: it
+notices when a native file drifts from what it last wrote and offers a
+chezmoi-style merge — adopt the edit into your source, or re-impose the source.
+Nothing is overwritten behind your back, and nothing is lost.
+
+> **The promise:** edit in one place, apply once, trust the result — with your
+> secrets safe and your drift visible.
+
+---
+
+## The 60-second mental model
+
+Three states, one comparison. (Full version in [Concepts](concepts.md).)
+
+```
+   ~/.agentsync/            apply            ~/.claude.json
+   (your source)   ───────────────────▶     ~/.config/opencode/…
+   TOML + markdown     render + translate    (what agents read)
+        ▲                                            │
+        └──────────── reconcile / import ────────────┘
+                  (capture native edits back)
+```
+
+- **Source** — what you committed in `~/.agentsync/`.
+- **`apply`** — renders the source and writes each agent's native config.
+- **Drift** — an agent (or you) edited a native file; `status`/`diff` show it.
+- **`reconcile`** — merge that edit back into source, or override it.
+
+That's the whole tool. Everything below is detail.
+
+---
+
+## Install
+
+> **Beta note:** the package-manager channels below are wired up and publish
+> starting with the first tagged release. Until then, **build from source.**
+
+**From source (works today):**
+
+```bash
+go install github.com/spxrogers/agentsync/cmd/agentsync@latest
+# or: git clone … && go build ./cmd/agentsync
+```
+
+**macOS — Homebrew**
+
+```bash
+brew tap spxrogers/tap
+brew install agentsync
+```
+
+**Windows — Scoop / Chocolatey**
+
+```bash
+scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
+scoop install agentsync
+# or:
+choco install agentsync
+```
+
+**Linux** — `.deb`/`.rpm` on the [Releases page](https://github.com/spxrogers/agentsync/releases),
+or `yay -S agentsync-bin` (AUR).
+
+Verify:
+
+```bash
+agentsync --version
+```
+
+---
+
+## Your first sync (5 minutes)
+
+This is the greenfield path — start clean, end with an MCP server live in two
+agents.
+
+```bash
+# 1. Create ~/.agentsync/ and its layout.
+agentsync init
+
+# 2. Register the agents you use.
+agentsync agent add claude
+agentsync agent add opencode
+
+# 3. Add an MCP server once — it will fan out to both agents.
+agentsync mcp add github \
+  --command npx \
+  --args "-y,@modelcontextprotocol/server-github"
+
+# 4. Preview before writing anything. Always safe; never touches disk.
+agentsync apply --dry-run
+
+# 5. Apply for real.
+agentsync apply
+```
+
+Confirm it landed in both native configs:
+
+```bash
+jq '.mcpServers.github' ~/.claude.json
+jq '.mcp.github'        ~/.config/opencode/opencode.json
+```
+
+> **`apply --dry-run` is your friend.** It prints the full
+> [translation report](#multi-agent-fan-out) — what lands natively (✓), what's
+> projected with loss (◐), and what's skipped (✗) — without writing a byte. Run
+> it before every real apply until you trust the output.
+
+---
+
+## Already have configs?
+
+Most people don't start clean — you arrive with servers and plugins already
+configured in Claude or OpenCode. Bring them under management instead of
+retyping them.
+
+```bash
+# See what's on disk vs. what agentsync would write.
+agentsync status
+
+# Pull a specific native item into your canonical source.
+# Selector grammar: <agent>:<component>:<name>
+agentsync import claude:mcp:github
+agentsync import opencode:mcp:linear
+
+# Now it's in ~/.agentsync/ — apply to fan it out to your other agents.
+agentsync apply
+```
+
+On a populated machine, the **first** apply will see pre-existing native files it
+didn't write and treat them as `foreign-collision`: it backs each one up to
+`~/.agentsync/.state/backups/<timestamp>/` *before* writing. Nothing is lost.
+Preview which files will be backed up with `agentsync apply --dry-run` first.
+
+---
+
+## The daily loop
+
+Four commands cover day-to-day use:
+
+| Command | When you run it |
+|---|---|
+| `agentsync apply` | After editing your source — push changes to agents. |
+| `agentsync status` | "What's out of sync?" — a summary across all agents. |
+| `agentsync diff` | "Show me exactly what changed." Secrets are redacted. |
+| `agentsync reconcile` | An agent edited its config — merge or override the drift. |
+
+A typical session after an agent edited a file out from under you:
+
+```bash
+agentsync status              # spot the drift
+agentsync diff claude         # inspect it (resolved secrets are masked)
+agentsync reconcile           # interactively resolve
+```
+
+Inside `reconcile`, for each drifting item:
+
+```
+~/.claude/settings.json#$.permissions.bash[2]   (drift)
+  source:      "Bash(git push:*)"
+  destination: "Bash(git push:*) Bash(npm publish:*)"
+
+  [w]rite-back   [o]verride   [s]kip   [i]gnore   [d]iff   [q]uit
+```
+
+- **`w`** adopt the destination edit into your source (and `W` for all).
+- **`o`** re-impose the source, discarding the edit (`O` for all).
+- **`i`** stop tracking this path (adds it to `~/.agentsync/ignore.toml`).
+- **`s`/`q`** skip / quit.
+
+Scripting it? `--auto-writeback`, `--auto-override`, or `--auto-safe` (which only
+auto-resolves changes that can't lose work).
+
+---
+
+## Building your config
+
+`~/.agentsync/` is just files. Use the CLI or edit them in `$EDITOR` — both are
+first-class. Layout:
+
+```
+~/.agentsync/
+├── agentsync.toml            # agents, update defaults, secrets backend
+├── mcp/<server>.toml         # one MCP server per file
+├── marketplaces/<name>.toml  # one marketplace per file
+├── plugins/<id>.toml         # one plugin enablement per file
+├── memory/AGENTS.md          # canonical memory (+ fragments/*.md)
+├── skills/<name>/SKILL.md    # standalone skills
+└── secrets/secrets.age       # age-encrypted secrets
+```
+
+### Agents
+
+```bash
+agentsync agent add claude        # register
+agentsync agent list              # see registry + enabled state
+agentsync agent disable opencode  # stop applying to it (keeps source)
+agentsync agent disable opencode --purge   # also remove what it wrote
+```
+
+> `agent add codex` / `agent add cursor` are rejected in beta — their adapters
+> are no-ops (Codex is v1.1, Cursor v1.2). See the [capability matrix](capability-matrix.md).
+
+### MCP servers
+
+```bash
+# stdio transport
+agentsync mcp add github \
+  --command npx \
+  --args "-y,@modelcontextprotocol/server-github" \
+  --env "GITHUB_TOKEN=\${secret:github.token}"
+
+# http/sse transport
+agentsync mcp add linear --type http --url https://mcp.linear.app/sse
+
+# limit fan-out to specific agents
+agentsync mcp add company-api --command npx --args "-y,@company/mcp" \
+  --agents "claude,opencode"
+
+agentsync mcp list
+agentsync mcp remove github
+```
+
+By default a server fans out to **all enabled agents** (`--agents "*"`). The
+`mcp/<name>.toml` file it writes is small and editable by hand.
+
+### Memory
+
+Your canonical memory lives in `memory/AGENTS.md` and renders to each agent's
+native file (`CLAUDE.md` for Claude, `AGENTS.md` for OpenCode). Compose it from
+reusable fragments:
+
+```markdown
+<!-- ~/.agentsync/memory/AGENTS.md -->
+# Coding conventions
+
+@import ./fragments/style.md
+@import ./fragments/security-rules.md
+```
+
+### Marketplaces & plugins — the fan-out payoff
+
+This is where agentsync earns its keep. Add a marketplace, install a plugin once,
+and every enabled agent gets the components it understands:
+
+```bash
+agentsync marketplace add github:anthropics/claude-plugins-official
+agentsync plugin install atlassian@anthropic
+
+agentsync update           # fetch from the network (the only networked verb)
+agentsync apply            # render from cache → all agents
+```
+
+A plugin is a bag of components (MCP servers, skills, subagents, commands, hooks,
+LSP servers). Each is translated independently per agent — fully, lossily, or
+skipped — and the report tells you exactly which:
+
+```
+plugin: atlassian@anthropic
+  claude    ✓ full    (1 mcp, 5 commands)
+  opencode  ◐ partial (1 mcp; 5 commands → projected)
+```
+
+Inspect any plugin's coverage without applying:
+
+```bash
+agentsync explain atlassian@anthropic
+agentsync explain atlassian@anthropic --json
+```
+
+Control fan-out per plugin with `agents = [...]` or per-component
+`[plugin.overrides.<agent>]` in the plugin's TOML file.
+
+### Secrets
+
+Never put a credential in a config file. Reference it:
+
+```toml
+# in mcp/github.toml
+[server.env]
+GITHUB_TOKEN = "${secret:github.token}"
+```
+
+Store the value in the age-encrypted vault — three ways:
+
+```bash
+agentsync secrets set github.token --stdin    # from stdin (best for scripts / 1Password CLI)
+agentsync secrets set github.token            # interactive prompt, echo off
+agentsync secrets edit                        # open the whole vault in $EDITOR
+agentsync secrets get github.token            # read one back (to verify)
+```
+
+`${secret:…}` is resolved at apply time and written into native config; `${env:…}`
+pulls from the environment. The resolved value is **never** captured back into
+your source — `agentsync diff` even redacts it so a piped diff can't leak it.
+
+> ### ⚠ Back up your age key
+> Secrets are encrypted to an age **recipient** (public key — safe to commit).
+> Decryption needs the **identity** file (private key), which is per-machine.
+> **agentsync does not back it up for you.** Lose it and you lose access to every
+> encrypted secret. Stash it in a 1Password Secure Note or your machine-setup repo.
+
+### Project-local config
+
+A repo can carry its own overlay. Drop a `.agentsync.toml` at its root; agentsync
+finds it by walking up from your current directory.
+
+```toml
+# myrepo/.agentsync.toml
+agents = ["claude", "opencode"]   # subset for this project
+
+[[mcp]]
+id      = "company-api"
+type    = "stdio"
+command = "npx"
+args    = ["-y", "@company/mcp"]
+
+[plugins]
+disabled = ["screenshot"]         # turn off a user-level plugin here
+```
+
+Apply from inside the repo and the overlay merges onto your user config:
+
+```bash
+cd ~/code/myrepo
+agentsync apply               # auto-detects project scope
+ls .claude/settings.json      # project-scope config landed
+```
+
+Force a scope explicitly with `--scope user|project` or `--project <path>`.
+
+---
+
+## Updating from the network
+
+`update` is the **only** command that touches the network. It polls
+marketplaces, refreshes the local cache, and recomputes version pins — without
+touching any agent config. `apply` then renders from that cache, so it's always
+fast, offline, and reproducible.
+
+```bash
+agentsync update                  # refresh cache + show pending plugin bumps
+agentsync update --apply          # refresh, then apply
+agentsync update --apply --auto-safe   # same, auto-resolving only safe changes
+```
+
+Want nightly refreshes? agentsync ships no daemon — wire
+`agentsync update --apply --auto-safe` into your own cron / launchd / systemd /
+Task Scheduler.
+
+---
+
+## Multi-agent fan-out
+
+Not every agent supports every component, and agentsync never pretends
+otherwise. Each component is marked **✓ native**, **◐ projected** (lossy, but
+reported), or **✗ skipped** (no honest translation) per agent.
+
+| Component | Claude | OpenCode | Codex (v1.1) | Cursor (v1.2) |
+|---|:--:|:--:|:--:|:--:|
+| MCP server | ✓ | ✓ | ◐ | ◐ |
+| Memory | ✓ | ✓ | ◐ | ◐ |
+| Skill | ✓ | ✓ | ◐ | ✗ |
+| Subagent | ✓ | ◐ | ◐ | ✗ |
+| Slash command | ✓ | ◐ | ✗ | ◐ |
+| Hook | ✓ | ✗ | ◐ | ◐ |
+| LSP server | ✓ | ✗ | ✗ | ✗ |
+
+Full detail, native paths, and the reasoning behind each ◐/✗ are in the
+[capability matrix](capability-matrix.md).
+
+---
+
+## Cross-machine sync
+
+agentsync is deliberately single-machine. To carry `~/.agentsync/` across
+machines, use [chezmoi](https://www.chezmoi.io/) (or any dotfile manager):
+
+```bash
+chezmoi add ~/.agentsync
+```
+
+The encrypted secrets file is safe to sync; the age identity (private key) is
+not — distribute that through your existing secret-sharing flow.
+
+---
+
+## Command reference
+
+Beta surface. `agentsync <command> --help` is always authoritative.
+
+| Command | Purpose | Key flags / args |
+|---|---|---|
+| `init [<git-url>]` | Create `~/.agentsync/`; optionally clone a bootstrap repo. | |
+| `doctor` | Diagnose setup: PATH, home/state writability, config schema, secrets backend. | |
+| `verify` | Validate config and surface every unresolved `${secret:}`/`${env:}` ref. | |
+| `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
+| `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
+| `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
+| `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
+| `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
+| `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
+| `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
+| `status` | Summarize drift/pending across agents. | `--scope --project` |
+| `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
+| `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
+| `import <agent>:<component>:<name>` | Capture a native edit into source. | |
+| `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
+
+Global: `-v/--verbose` for verbose logging on any command.
+
+---
+
+## Troubleshooting & environment overrides
+
+The [README](../README.md#troubleshooting) carries the full troubleshooting list
+and the complete environment-variable table. The ones you'll reach for most:
+
+| Env var | Purpose |
+|---|---|
+| `AGENTSYNC_HOME` | Override the `~/.agentsync/` location. |
+| `AGENTSYNC_ALLOW_SYMLINK_DEST=1` | Write through symlinked destinations (e.g. chezmoi-managed files). |
+| `AGENTSYNC_ALLOW_INSECURE_URLS=1` | Accept `http://`/`git://` plugin/marketplace sources. |
+| `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` | Let `verify` skip secret resolution (CI without an age key). |
+
+Quick hits:
+
+- **`${secret:foo}` not resolving?** `agentsync secrets get foo` to confirm the
+  key exists in the decrypted vault.
+- **`update` can't fetch a marketplace?** Sanity-check the URL with
+  `git ls-remote`.
+- **First apply backed up a pile of files?** Expected on a populated machine —
+  they're in `.state/backups/<ts>/`, nothing was lost.
+
+---
+
+## Where to go next
+
+- **[Concepts & glossary](concepts.md)** — the mental model in depth.
+- **[Architecture](architecture.md)** — how the pipeline and safety invariants work.
+- **[Capability matrix](capability-matrix.md)** — exactly what each agent supports.
+- **[Component map](components.md)** — the codebase, package by package.
+- **[SECURITY.md](../SECURITY.md)** — threat model and reporting.
+
+Found a rough edge during your first 100 minutes? That's exactly the beta
+feedback we want — [open an issue](https://github.com/spxrogers/agentsync/issues).


### PR DESCRIPTION
Add a layered docs set for the beta and round out OSS hygiene:

- docs/user-guide.md: 0→100 ramp (install, first sync, import path,
  daily loop, secrets, plugins, project config, command reference)
- docs/concepts.md: three-state model + glossary
- docs/architecture.md: apply/capture pipelines, drift classifier,
  secret invariants, package layering (with diagrams)
- docs/components.md: package-by-package map
- docs/capability-matrix.md: per-agent component support
- docs/README.md: docs index
- README.md: stronger value prop, docs index, capability summary
- CLAUDE.md: orientation + conventions + "adding things"
- CONTRIBUTING.md, CHANGELOG.md, issue/PR templates

https://claude.ai/code/session_01AKmMWNYjrsHix1eQsXd3yQ