### PR TITLE
feat(import): support bulk import via shortened selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   `import <agent>` captures the agent's full native config, `<agent>:<component>`
   captures every entry of a component, and the original `<agent>:<component>:<name>`
   still captures one item. Empty scopes report a notice and exit cleanly.
+  `import --dry-run` previews which source files an import would write without
+  touching `~/.agentsync/`.
 - **Safety primitives** — two-phase atomic writes, an apply lock, first-apply
   foreign-collision backups, symlinked-destination refusal, and a schema-versioned
   state file with portable (`${HOME}`-relative) keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 - **CLI**: `init`, `agent`, `doctor`, `verify`, `apply`, `status`, `diff`,
   `reconcile`, `import`, `mcp`, `plugin`, `marketplace`, `update`, `secrets`,
   `explain`.
+- **Bulk import** — the `import` selector now widens as parts are dropped:
+  `import <agent>` captures the agent's full native config, `<agent>:<component>`
+  captures every entry of a component, and the original `<agent>:<component>:<name>`
+  still captures one item. Empty scopes report a notice and exit cleanly.
 - **Safety primitives** — two-phase atomic writes, an apply lock, first-apply
   foreign-collision backups, symlinked-destination refusal, and a schema-versioned
   state file with portable (`${HOME}`-relative) keys.

--- a/docs/superpowers/specs/2026-05-04-agentsync-design.md
+++ b/docs/superpowers/specs/2026-05-04-agentsync-design.md
@@ -389,7 +389,7 @@ agentsync import <selector>          # capture native edits into source
 agentsync explain <plugin> [--json]
 ```
 
-**Selector grammar** for `import` (and future per-item commands): `<agent>:<component>:<name>` — e.g. `claude:mcp:github`, `opencode:agent:reviewer`.
+**Selector grammar** for `import` (and future per-item commands): `<agent>[:<component>[:<name>]]` — e.g. `claude:mcp:github`, `opencode:agent:reviewer`. Dropping the name imports every entry of that component; dropping the component too imports the agent's full native config in one pass.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -149,14 +149,21 @@ retyping them.
 # See what's on disk vs. what agentsync would write.
 agentsync status
 
-# Pull a specific native item into your canonical source.
-# Selector grammar: <agent>:<component>:<name>
-agentsync import claude:mcp:github
+# Pull native config into your canonical source.
+# Selector grammar: <agent>[:<component>[:<name>]] — drop parts to widen scope.
+agentsync import claude                 # the agent's full native config
+agentsync import claude:mcp             # every MCP server
+agentsync import claude:mcp:github      # a single MCP server
 agentsync import opencode:mcp:linear
 
 # Now it's in ~/.agentsync/ — apply to fan it out to your other agents.
 agentsync apply
 ```
+
+Dropping the name imports every entry of a component; dropping the component
+too imports everything the agent has (MCP, skills, subagents, commands, hooks,
+LSP, and memory) in one pass. A bulk import that finds nothing for a component
+reports it and exits cleanly rather than erroring.
 
 On a populated machine, the **first** apply will see pre-existing native files it
 didn't write and treat them as `foreign-collision`: it backs each one up to
@@ -435,7 +442,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `status` | Summarize drift/pending across agents. | `--scope --project` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
-| `import <agent>:<component>:<name>` | Capture a native edit into source. | |
+| `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. | |
 | `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
 
 Global: `-v/--verbose` for verbose logging on any command.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,6 +151,7 @@ agentsync status
 
 # Pull native config into your canonical source.
 # Selector grammar: <agent>[:<component>[:<name>]] — drop parts to widen scope.
+agentsync import claude --dry-run       # preview what a full import would write
 agentsync import claude                 # the agent's full native config
 agentsync import claude:mcp             # every MCP server
 agentsync import claude:mcp:github      # a single MCP server
@@ -163,7 +164,8 @@ agentsync apply
 Dropping the name imports every entry of a component; dropping the component
 too imports everything the agent has (MCP, skills, subagents, commands, hooks,
 LSP, and memory) in one pass. A bulk import that finds nothing for a component
-reports it and exits cleanly rather than erroring.
+reports it and exits cleanly rather than erroring. Add `--dry-run` to list the
+source files an import would write without touching `~/.agentsync/`.
 
 On a populated machine, the **first** apply will see pre-existing native files it
 didn't write and treat them as `foreign-collision`: it backs each one up to
@@ -442,7 +444,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `status` | Summarize drift/pending across agents. | `--scope --project` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
-| `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. | |
+| `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. | `--dry-run` |
 | `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
 
 Global: `-v/--verbose` for verbose logging on any command.

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -90,25 +90,29 @@ func getJSONPointer(m map[string]any, ptr string) any {
 }
 
 // newImportCmd returns the "import" subcommand.
-// Selector grammar: <agent>:<component>:<name>
-// e.g. claude:mcp:github  opencode:agent:reviewer
+// Selector grammar: <agent>[:<component>[:<name>]]
+// e.g. claude (full config), claude:mcp (all servers), claude:mcp:github (one).
 func newImportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "import <agent>:<component>:<name>",
+		Use:   "import <agent>[:<component>[:<name>]]",
 		Args:  cobra.ExactArgs(1),
-		Short: "capture a native config item back into the canonical source",
-		Long: `import reads the named item from the agent's native config and writes it
-back into ~/.agentsync/ as the canonical source of truth.
+		Short: "capture native config back into the canonical source",
+		Long: `import reads items from an agent's native config and writes them back
+into ~/.agentsync/ as the canonical source of truth.
 
-Selector format: <agent>:<component>:<name>
+Selector grammar: <agent>[:<component>[:<name>]]
   agent     - registered agent name (claude, opencode, codex, cursor)
   component - mcp | skill | agent | command | hook | lsp | memory
-  name      - item name (server id, skill name, subagent name, etc.)
+  name      - item name (server id, skill name, subagent name, hook event)
+
+Dropping the name imports every entry of that component; dropping the
+component too imports the agent's full native config in one pass.
 
 Examples:
-  agentsync import claude:mcp:github
-  agentsync import opencode:agent:reviewer
-  agentsync import claude:command:review`,
+  agentsync import claude                 # all importable components
+  agentsync import claude:mcp             # every MCP server
+  agentsync import claude:mcp:github      # a single MCP server
+  agentsync import opencode:agent:reviewer`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// import mutates ~/.agentsync/ AND .state/targets.json. It
 			// must hold the global lock so a concurrent apply on the
@@ -151,38 +155,30 @@ func importRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ingest %s: %w", agentName, err)
 	}
 
-	// Every component except memory addresses a named item; a two-part
-	// selector like "claude:mcp" would otherwise fall through to a misleading
-	// `mcp server "" not found` downstream. Fail with the expected grammar.
-	if component != "memory" && name == "" {
-		return fmt.Errorf("selector %q is missing the item name; expected <agent>:<component>:<name>", sel)
-	}
-
-	// MCP / LSP / hook capture routes through capture.Capture, which
-	// re-references secrets (the destination holds live cleartext substituted
-	// by a prior apply) and preserves source-only fields before writing source.
-	// The text components (skill/subagent/command/memory) carry no secrets and
-	// no source-only fields, so they write directly.
-	switch component {
-	case "mcp":
-		err = importMCP(cmd, home, c, name)
-	case "skill":
-		err = importSkill(cmd, home, c, name)
-	case "agent", "subagent":
-		err = importSubagent(cmd, home, c, name)
-	case "command":
-		err = importCommand(cmd, home, c, name)
-	case "hook":
-		err = importHook(cmd, home, c, name)
-	case "lsp":
-		err = importLSP(cmd, home, c, name)
-	case "memory":
-		err = importMemory(cmd, home, c)
+	// Three selector depths, narrowing from broad to specific:
+	//   <agent>                     -> every importable component
+	//   <agent>:<component>         -> every entry of that component
+	//   <agent>:<component>:<name>  -> a single named entry
+	// The bulk forms reuse the same per-component importers with an empty name
+	// filter, so MCP/LSP/hook capture still routes through capture.Capture
+	// (secret re-referencing + source-only field preservation) — see the
+	// importer bodies. Text components write directly via source.Write*.
+	switch {
+	case component == "":
+		if err := importAllComponents(cmd, home, agentName, c); err != nil {
+			return err
+		}
 	default:
-		return fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
-	}
-	if err != nil {
-		return err
+		n, err := importComponent(cmd, home, c, component, name)
+		if err != nil {
+			return err
+		}
+		// A bulk component import (no name) that matched nothing is not an
+		// error — report it and exit cleanly. A named import that matched
+		// nothing already returned a "not found" error above.
+		if n == 0 && name == "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "no %s found in %s native config\n", component, agentName)
+		}
 	}
 
 	// Seed state with the destination's current content hash so the next
@@ -206,7 +202,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 		for _, w := range warnings {
 			fmt.Fprintf(ew, "  %s\n", w)
 		}
-		fmt.Fprintln(ew, "  Run `agentsync import <agent>:<component>:<name>` for each, or accept the backup on next apply.")
+		fmt.Fprintf(ew, "  Run `agentsync import %s` to capture the agent's full config, or accept the backup on next apply.\n", agentName)
 	}
 	return nil
 }
@@ -347,113 +343,248 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 	return state.Save(statePath, st)
 }
 
-// parseSelector splits "agent:component:name" into its three parts.
+// parseSelector splits "agent[:component[:name]]" into its parts. A bare
+// "agent" (component == "") selects the whole config; "agent:component"
+// (name == "") selects every entry of that component.
 func parseSelector(sel string) (agentName, component, name string, err error) {
 	parts := strings.SplitN(sel, ":", 3)
-	if len(parts) < 2 {
-		return "", "", "", fmt.Errorf("invalid selector %q: expected <agent>:<component>:<name>", sel)
-	}
 	agentName = parts[0]
-	component = parts[1]
+	if len(parts) >= 2 {
+		component = parts[1]
+	}
 	if len(parts) == 3 {
 		name = parts[2]
 	}
-	if agentName == "" || component == "" {
-		return "", "", "", fmt.Errorf("invalid selector %q: agent and component must be non-empty", sel)
+	if agentName == "" {
+		return "", "", "", fmt.Errorf("invalid selector %q: agent must be non-empty; expected <agent>[:<component>[:<name>]]", sel)
+	}
+	// "claude:" is a typo, not a request to import the whole agent.
+	if len(parts) >= 2 && component == "" {
+		return "", "", "", fmt.Errorf("invalid selector %q: component must be non-empty", sel)
 	}
 	return agentName, component, name, nil
 }
 
-func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string) error {
+// importComponentOrder lists the importable components in the order a
+// full-agent import walks them (and the order they appear in the summary).
+// "subagent" is an accepted alias for "agent" in selectors but is not listed
+// here to avoid importing subagents twice.
+var importComponentOrder = []string{"mcp", "lsp", "skill", "agent", "command", "hook", "memory"}
+
+// importComponent imports one component class from c. When name is empty it
+// imports every entry of that component (the bulk form); when name is set it
+// imports just that entry and errors if it is absent. It returns the number of
+// source items written.
+func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string) (int, error) {
+	switch component {
+	case "mcp":
+		return importMCP(cmd, home, c, name)
+	case "skill":
+		return importSkill(cmd, home, c, name)
+	case "agent", "subagent":
+		return importSubagent(cmd, home, c, name)
+	case "command":
+		return importCommand(cmd, home, c, name)
+	case "hook":
+		return importHook(cmd, home, c, name)
+	case "lsp":
+		return importLSP(cmd, home, c, name)
+	case "memory":
+		return importMemory(cmd, home, c)
+	default:
+		return 0, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
+	}
+}
+
+// importAllComponents imports every importable component for the agent and
+// prints a one-line summary. Empty components are skipped silently; an agent
+// with nothing to import reports that and exits cleanly.
+func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical) error {
+	counts := map[string]int{}
+	total := 0
+	for _, comp := range importComponentOrder {
+		n, err := importComponent(cmd, home, c, comp, "")
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			counts[comp] = n
+			total += n
+		}
+	}
+	if total == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "no importable items found in %s native config\n", agentName)
+		return nil
+	}
+	var parts []string
+	for _, comp := range importComponentOrder {
+		if counts[comp] > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", counts[comp], comp))
+		}
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "imported %d item(s) from %s: %s\n", total, agentName, strings.Join(parts, ", "))
+	return nil
+}
+
+// importMCP captures the MCP server named name (or all of them when name is
+// empty). Capture.Capture batches the whole slice in one call, so it
+// re-references secrets and preserves source-only fields for every server.
+func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+	var matched []source.MCPServer
 	for _, m := range c.MCPServers {
-		if m.ID == name {
-			single := source.Canonical{MCPServers: []source.MCPServer{m}}
-			if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-				return err
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "imported mcp/%s.toml\n", name)
-			return nil
+		if name == "" || m.ID == name {
+			matched = append(matched, m)
 		}
 	}
-	return fmt.Errorf("mcp server %q not found in native config", name)
+	if len(matched) == 0 {
+		if name != "" {
+			return 0, fmt.Errorf("mcp server %q not found in native config", name)
+		}
+		return 0, nil
+	}
+	single := source.Canonical{MCPServers: matched}
+	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		return 0, err
+	}
+	for _, m := range matched {
+		fmt.Fprintf(cmd.OutOrStdout(), "imported mcp/%s.toml\n", m.ID)
+	}
+	return len(matched), nil
 }
 
-func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string) error {
+func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+	var matched []source.Skill
 	for _, sk := range c.Skills {
-		if sk.Name == name {
-			if err := source.WriteSkill(home, sk); err != nil {
-				return fmt.Errorf("write skill %s: %w", name, err)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "imported skills/%s/SKILL.md\n", name)
-			return nil
+		if name == "" || sk.Name == name {
+			matched = append(matched, sk)
 		}
 	}
-	return fmt.Errorf("skill %q not found in native config", name)
+	if len(matched) == 0 {
+		if name != "" {
+			return 0, fmt.Errorf("skill %q not found in native config", name)
+		}
+		return 0, nil
+	}
+	for _, sk := range matched {
+		if err := source.WriteSkill(home, sk); err != nil {
+			return 0, fmt.Errorf("write skill %s: %w", sk.Name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "imported skills/%s/SKILL.md\n", sk.Name)
+	}
+	return len(matched), nil
 }
 
-func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string) error {
+func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+	var matched []source.Subagent
 	for _, sa := range c.Subagents {
-		if sa.Name == name {
-			if err := source.WriteSubagent(home, sa); err != nil {
-				return fmt.Errorf("write subagent %s: %w", name, err)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "imported agents/%s.md\n", name)
-			return nil
+		if name == "" || sa.Name == name {
+			matched = append(matched, sa)
 		}
 	}
-	return fmt.Errorf("subagent %q not found in native config", name)
+	if len(matched) == 0 {
+		if name != "" {
+			return 0, fmt.Errorf("subagent %q not found in native config", name)
+		}
+		return 0, nil
+	}
+	for _, sa := range matched {
+		if err := source.WriteSubagent(home, sa); err != nil {
+			return 0, fmt.Errorf("write subagent %s: %w", sa.Name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "imported agents/%s.md\n", sa.Name)
+	}
+	return len(matched), nil
 }
 
-func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string) error {
+func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+	var matched []source.Command
 	for _, cm := range c.Commands {
-		if cm.Name == name {
-			if err := source.WriteCommand(home, cm); err != nil {
-				return fmt.Errorf("write command %s: %w", name, err)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "imported commands/%s.md\n", name)
-			return nil
+		if name == "" || cm.Name == name {
+			matched = append(matched, cm)
 		}
 	}
-	return fmt.Errorf("command %q not found in native config", name)
+	if len(matched) == 0 {
+		if name != "" {
+			return 0, fmt.Errorf("command %q not found in native config", name)
+		}
+		return 0, nil
+	}
+	for _, cm := range matched {
+		if err := source.WriteCommand(home, cm); err != nil {
+			return 0, fmt.Errorf("write command %s: %w", cm.Name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "imported commands/%s.md\n", cm.Name)
+	}
+	return len(matched), nil
 }
 
-func importHook(cmd *cobra.Command, home string, c source.Canonical, name string) error {
-	// Find hooks for the named event.
+// importHook captures hooks for the named event (or all events when name is
+// empty). name addresses an event, not an individual hook, so the count
+// returned is the number of hook entries written across all matched events.
+func importHook(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
 	var matched []source.Hook
 	for _, h := range c.Hooks {
-		if h.Event == name {
+		if name == "" || h.Event == name {
 			matched = append(matched, h)
 		}
 	}
 	if len(matched) == 0 {
-		return fmt.Errorf("hook event %q not found in native config", name)
+		if name != "" {
+			return 0, fmt.Errorf("hook event %q not found in native config", name)
+		}
+		return 0, nil
 	}
 	single := source.Canonical{Hooks: matched}
 	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-		return err
+		return 0, err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "imported hooks/%s.toml (%d entries)\n", name, len(matched))
-	return nil
+	// One file per event; report each, preserving first-seen order.
+	perEvent := map[string]int{}
+	var order []string
+	for _, h := range matched {
+		if _, seen := perEvent[h.Event]; !seen {
+			order = append(order, h.Event)
+		}
+		perEvent[h.Event]++
+	}
+	for _, ev := range order {
+		fmt.Fprintf(cmd.OutOrStdout(), "imported hooks/%s.toml (%d entries)\n", ev, perEvent[ev])
+	}
+	return len(matched), nil
 }
 
-func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string) error {
+func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+	var matched []source.LSPServer
 	for _, ls := range c.LSPServers {
-		if ls.ID == name {
-			single := source.Canonical{LSPServers: []source.LSPServer{ls}}
-			if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-				return err
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "imported lsp/%s.toml\n", name)
-			return nil
+		if name == "" || ls.ID == name {
+			matched = append(matched, ls)
 		}
 	}
-	return fmt.Errorf("lsp server %q not found in native config", name)
+	if len(matched) == 0 {
+		if name != "" {
+			return 0, fmt.Errorf("lsp server %q not found in native config", name)
+		}
+		return 0, nil
+	}
+	single := source.Canonical{LSPServers: matched}
+	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		return 0, err
+	}
+	for _, ls := range matched {
+		fmt.Fprintf(cmd.OutOrStdout(), "imported lsp/%s.toml\n", ls.ID)
+	}
+	return len(matched), nil
 }
 
-func importMemory(cmd *cobra.Command, home string, c source.Canonical) error {
+func importMemory(cmd *cobra.Command, home string, c source.Canonical) (int, error) {
+	// Memory is a single block, not a named collection; nothing to write when
+	// the agent carries no memory (the common case during a full-agent import).
+	if strings.TrimSpace(c.Memory.Body) == "" {
+		return 0, nil
+	}
 	if err := source.WriteMemory(home, c.Memory); err != nil {
-		return fmt.Errorf("write memory: %w", err)
+		return 0, fmt.Errorf("write memory: %w", err)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "imported memory/AGENTS.md\n")
-	return nil
+	return 1, nil
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -163,8 +163,8 @@ func importRun(cmd *cobra.Command, args []string) error {
 	// filter, so MCP/LSP/hook capture still routes through capture.Capture
 	// (secret re-referencing + source-only field preservation) — see the
 	// importer bodies. Text components write directly via source.Write*.
-	switch {
-	case component == "":
+	switch component {
+	case "":
 		if err := importAllComponents(cmd, home, agentName, c); err != nil {
 			return err
 		}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -93,6 +93,7 @@ func getJSONPointer(m map[string]any, ptr string) any {
 // Selector grammar: <agent>[:<component>[:<name>]]
 // e.g. claude (full config), claude:mcp (all servers), claude:mcp:github (one).
 func newImportCmd() *cobra.Command {
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "import <agent>[:<component>[:<name>]]",
 		Args:  cobra.ExactArgs(1),
@@ -106,28 +107,36 @@ Selector grammar: <agent>[:<component>[:<name>]]
   name      - item name (server id, skill name, subagent name, hook event)
 
 Dropping the name imports every entry of that component; dropping the
-component too imports the agent's full native config in one pass.
+component too imports the agent's full native config in one pass. Use
+--dry-run to preview which source files would be written, without writing.
 
 Examples:
   agentsync import claude                 # all importable components
   agentsync import claude:mcp             # every MCP server
   agentsync import claude:mcp:github      # a single MCP server
+  agentsync import claude --dry-run       # preview without writing
   agentsync import opencode:agent:reviewer`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// import mutates ~/.agentsync/ AND .state/targets.json. It
 			// must hold the global lock so a concurrent apply on the
 			// other terminal cannot interleave its own state.Save and
-			// destroy our seed entries (or vice versa).
+			// destroy our seed entries (or vice versa). --dry-run writes
+			// neither, so it is read-only and skips the lock — matching
+			// `apply --dry-run`.
+			if dryRun {
+				return importRun(cmd, args, true)
+			}
 			home := paths.AgentsyncHome(paths.OSEnv{})
 			return withGlobalLock(home, func() error {
-				return importRun(cmd, args)
+				return importRun(cmd, args, false)
 			})
 		},
 	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview which source files would be written, without writing")
 	return cmd
 }
 
-func importRun(cmd *cobra.Command, args []string) error {
+func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	sel := args[0]
 	agentName, component, name, err := parseSelector(sel)
 	if err != nil {
@@ -165,11 +174,11 @@ func importRun(cmd *cobra.Command, args []string) error {
 	// importer bodies. Text components write directly via source.Write*.
 	switch component {
 	case "":
-		if err := importAllComponents(cmd, home, agentName, c); err != nil {
+		if err := importAllComponents(cmd, home, agentName, c, dryRun); err != nil {
 			return err
 		}
 	default:
-		n, err := importComponent(cmd, home, c, component, name)
+		n, err := importComponent(cmd, home, c, component, name, dryRun)
 		if err != nil {
 			return err
 		}
@@ -179,6 +188,13 @@ func importRun(cmd *cobra.Command, args []string) error {
 		if n == 0 && name == "" {
 			fmt.Fprintf(cmd.OutOrStdout(), "no %s found in %s native config\n", component, agentName)
 		}
+	}
+
+	// A dry-run wrote nothing, so there is no state to seed and the
+	// foreign-collision warning below would describe the pre-import world.
+	// Stop here with just the preview.
+	if dryRun {
+		return nil
 	}
 
 	// Seed state with the destination's current content hash so the next
@@ -371,26 +387,36 @@ func parseSelector(sel string) (agentName, component, name string, err error) {
 // here to avoid importing subagents twice.
 var importComponentOrder = []string{"mcp", "lsp", "skill", "agent", "command", "hook", "memory"}
 
+// importVerb is the past/conditional verb used in per-item and summary lines so
+// a --dry-run preview reads "would import …" instead of "imported …".
+func importVerb(dryRun bool) string {
+	if dryRun {
+		return "would import"
+	}
+	return "imported"
+}
+
 // importComponent imports one component class from c. When name is empty it
 // imports every entry of that component (the bulk form); when name is set it
-// imports just that entry and errors if it is absent. It returns the number of
-// source items written.
-func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string) (int, error) {
+// imports just that entry and errors if it is absent. When dryRun is set it
+// writes nothing and only reports what it would write. It returns the number of
+// source items that were (or would be) written.
+func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string, dryRun bool) (int, error) {
 	switch component {
 	case "mcp":
-		return importMCP(cmd, home, c, name)
+		return importMCP(cmd, home, c, name, dryRun)
 	case "skill":
-		return importSkill(cmd, home, c, name)
+		return importSkill(cmd, home, c, name, dryRun)
 	case "agent", "subagent":
-		return importSubagent(cmd, home, c, name)
+		return importSubagent(cmd, home, c, name, dryRun)
 	case "command":
-		return importCommand(cmd, home, c, name)
+		return importCommand(cmd, home, c, name, dryRun)
 	case "hook":
-		return importHook(cmd, home, c, name)
+		return importHook(cmd, home, c, name, dryRun)
 	case "lsp":
-		return importLSP(cmd, home, c, name)
+		return importLSP(cmd, home, c, name, dryRun)
 	case "memory":
-		return importMemory(cmd, home, c)
+		return importMemory(cmd, home, c, dryRun)
 	default:
 		return 0, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
 	}
@@ -398,12 +424,13 @@ func importComponent(cmd *cobra.Command, home string, c source.Canonical, compon
 
 // importAllComponents imports every importable component for the agent and
 // prints a one-line summary. Empty components are skipped silently; an agent
-// with nothing to import reports that and exits cleanly.
-func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical) error {
+// with nothing to import reports that and exits cleanly. dryRun is threaded
+// through so the preview writes nothing.
+func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical, dryRun bool) error {
 	counts := map[string]int{}
 	total := 0
 	for _, comp := range importComponentOrder {
-		n, err := importComponent(cmd, home, c, comp, "")
+		n, err := importComponent(cmd, home, c, comp, "", dryRun)
 		if err != nil {
 			return err
 		}
@@ -422,14 +449,15 @@ func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Ca
 			parts = append(parts, fmt.Sprintf("%d %s", counts[comp], comp))
 		}
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "imported %d item(s) from %s: %s\n", total, agentName, strings.Join(parts, ", "))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s %d item(s) from %s: %s\n", importVerb(dryRun), total, agentName, strings.Join(parts, ", "))
 	return nil
 }
 
 // importMCP captures the MCP server named name (or all of them when name is
 // empty). Capture.Capture batches the whole slice in one call, so it
 // re-references secrets and preserves source-only fields for every server.
-func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+// When dryRun is set it reports the targets without writing.
+func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.MCPServer
 	for _, m := range c.MCPServers {
 		if name == "" || m.ID == name {
@@ -442,17 +470,19 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string)
 		}
 		return 0, nil
 	}
-	single := source.Canonical{MCPServers: matched}
-	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-		return 0, err
+	if !dryRun {
+		single := source.Canonical{MCPServers: matched}
+		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return 0, err
+		}
 	}
 	for _, m := range matched {
-		fmt.Fprintf(cmd.OutOrStdout(), "imported mcp/%s.toml\n", m.ID)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s mcp/%s.toml\n", importVerb(dryRun), m.ID)
 	}
 	return len(matched), nil
 }
 
-func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.Skill
 	for _, sk := range c.Skills {
 		if name == "" || sk.Name == name {
@@ -466,15 +496,17 @@ func importSkill(cmd *cobra.Command, home string, c source.Canonical, name strin
 		return 0, nil
 	}
 	for _, sk := range matched {
-		if err := source.WriteSkill(home, sk); err != nil {
-			return 0, fmt.Errorf("write skill %s: %w", sk.Name, err)
+		if !dryRun {
+			if err := source.WriteSkill(home, sk); err != nil {
+				return 0, fmt.Errorf("write skill %s: %w", sk.Name, err)
+			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "imported skills/%s/SKILL.md\n", sk.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s skills/%s/SKILL.md\n", importVerb(dryRun), sk.Name)
 	}
 	return len(matched), nil
 }
 
-func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.Subagent
 	for _, sa := range c.Subagents {
 		if name == "" || sa.Name == name {
@@ -488,15 +520,17 @@ func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name st
 		return 0, nil
 	}
 	for _, sa := range matched {
-		if err := source.WriteSubagent(home, sa); err != nil {
-			return 0, fmt.Errorf("write subagent %s: %w", sa.Name, err)
+		if !dryRun {
+			if err := source.WriteSubagent(home, sa); err != nil {
+				return 0, fmt.Errorf("write subagent %s: %w", sa.Name, err)
+			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "imported agents/%s.md\n", sa.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s agents/%s.md\n", importVerb(dryRun), sa.Name)
 	}
 	return len(matched), nil
 }
 
-func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.Command
 	for _, cm := range c.Commands {
 		if name == "" || cm.Name == name {
@@ -510,10 +544,12 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 		return 0, nil
 	}
 	for _, cm := range matched {
-		if err := source.WriteCommand(home, cm); err != nil {
-			return 0, fmt.Errorf("write command %s: %w", cm.Name, err)
+		if !dryRun {
+			if err := source.WriteCommand(home, cm); err != nil {
+				return 0, fmt.Errorf("write command %s: %w", cm.Name, err)
+			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "imported commands/%s.md\n", cm.Name)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s commands/%s.md\n", importVerb(dryRun), cm.Name)
 	}
 	return len(matched), nil
 }
@@ -521,7 +557,8 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 // importHook captures hooks for the named event (or all events when name is
 // empty). name addresses an event, not an individual hook, so the count
 // returned is the number of hook entries written across all matched events.
-func importHook(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+// When dryRun is set it reports the target event files without writing.
+func importHook(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.Hook
 	for _, h := range c.Hooks {
 		if name == "" || h.Event == name {
@@ -534,9 +571,11 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 		}
 		return 0, nil
 	}
-	single := source.Canonical{Hooks: matched}
-	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-		return 0, err
+	if !dryRun {
+		single := source.Canonical{Hooks: matched}
+		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return 0, err
+		}
 	}
 	// One file per event; report each, preserving first-seen order.
 	perEvent := map[string]int{}
@@ -548,12 +587,12 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 		perEvent[h.Event]++
 	}
 	for _, ev := range order {
-		fmt.Fprintf(cmd.OutOrStdout(), "imported hooks/%s.toml (%d entries)\n", ev, perEvent[ev])
+		fmt.Fprintf(cmd.OutOrStdout(), "%s hooks/%s.toml (%d entries)\n", importVerb(dryRun), ev, perEvent[ev])
 	}
 	return len(matched), nil
 }
 
-func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string) (int, error) {
+func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
 	var matched []source.LSPServer
 	for _, ls := range c.LSPServers {
 		if name == "" || ls.ID == name {
@@ -566,25 +605,29 @@ func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string)
 		}
 		return 0, nil
 	}
-	single := source.Canonical{LSPServers: matched}
-	if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-		return 0, err
+	if !dryRun {
+		single := source.Canonical{LSPServers: matched}
+		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return 0, err
+		}
 	}
 	for _, ls := range matched {
-		fmt.Fprintf(cmd.OutOrStdout(), "imported lsp/%s.toml\n", ls.ID)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s lsp/%s.toml\n", importVerb(dryRun), ls.ID)
 	}
 	return len(matched), nil
 }
 
-func importMemory(cmd *cobra.Command, home string, c source.Canonical) (int, error) {
+func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bool) (int, error) {
 	// Memory is a single block, not a named collection; nothing to write when
 	// the agent carries no memory (the common case during a full-agent import).
 	if strings.TrimSpace(c.Memory.Body) == "" {
 		return 0, nil
 	}
-	if err := source.WriteMemory(home, c.Memory); err != nil {
-		return 0, fmt.Errorf("write memory: %w", err)
+	if !dryRun {
+		if err := source.WriteMemory(home, c.Memory); err != nil {
+			return 0, fmt.Errorf("write memory: %w", err)
+		}
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "imported memory/AGENTS.md\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "%s memory/AGENTS.md\n", importVerb(dryRun))
 	return 1, nil
 }

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -502,6 +502,70 @@ func TestImport_FullAgentEmpty(t *testing.T) {
 	}
 }
 
+// TestImport_DryRunWritesNothing verifies --dry-run previews the target
+// without writing the source file or seeding state.
+func TestImport_DryRunWritesNothing(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers": {"github": {"type": "stdio", "command": "npx"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:mcp:github", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "would import mcp/github.toml") {
+		t.Fatalf("dry-run should preview the target; got: %s", out)
+	}
+	if strings.Contains(out, "imported mcp/github.toml") && !strings.Contains(out, "would import") {
+		t.Fatalf("dry-run must not claim a real import; got: %s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", "github.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("dry-run must not write the canonical source; stat err=%v", statErr)
+	}
+
+	// A real import afterwards still works (dry-run left no partial state).
+	if out, err := runCLI(t, env, "import", "claude:mcp:github"); err != nil {
+		t.Fatalf("real import after dry-run: %v\n%s", err, out)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", "github.toml")); statErr != nil {
+		t.Fatalf("real import after dry-run did not write source: %v", statErr)
+	}
+}
+
+// TestImport_DryRunFullAgent verifies --dry-run on the full-agent form
+// previews a summary and writes none of the components.
+func TestImport_DryRunFullAgent(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers": {"github": {"type": "stdio", "command": "npx"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "CLAUDE.md"), []byte("# Memory\nBe concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude", "--dry-run")
+	if err != nil {
+		t.Fatalf("import claude --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "would import") || !strings.Contains(out, "from claude") {
+		t.Fatalf("dry-run full-agent summary missing; got: %s", out)
+	}
+	for _, rel := range []string{
+		filepath.Join("mcp", "github.toml"),
+		filepath.Join("memory", "AGENTS.md"),
+	} {
+		if _, statErr := os.Stat(filepath.Join(tmp, ".agentsync", rel)); !os.IsNotExist(statErr) {
+			t.Fatalf("dry-run must not write %s; stat err=%v", rel, statErr)
+		}
+	}
+}
+
 // TestImport_UnknownComponent verifies that an unknown component errors.
 func TestImport_UnknownComponent(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -394,6 +394,114 @@ func TestImport_MemoryFromClaude(t *testing.T) {
 	}
 }
 
+// TestImport_AllMCPFromClaude verifies the bulk component form: import
+// claude:mcp (no name) captures every native MCP server in one pass.
+func TestImport_AllMCPFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	claudeJSON := filepath.Join(tmp, ".claude.json")
+	if err := os.WriteFile(claudeJSON, []byte(`{
+		"mcpServers": {
+			"github": {"type": "stdio", "command": "npx", "args": ["-y", "server-github"]},
+			"linear":  {"type": "stdio", "command": "npx", "args": ["-y", "server-linear"]}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:mcp")
+	if err != nil {
+		t.Fatalf("import claude:mcp: %v\n%s", err, out)
+	}
+	for _, want := range []string{"mcp/github.toml", "mcp/linear.toml"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("bulk import output missing %q; got: %s", want, out)
+		}
+	}
+	for _, id := range []string{"github", "linear"} {
+		if _, statErr := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", id+".toml")); statErr != nil {
+			t.Fatalf("canonical mcp/%s.toml not written: %v", id, statErr)
+		}
+	}
+}
+
+// TestImport_FullAgentFromClaude verifies the full-agent form: import claude
+// (no component) captures every importable component and prints a summary.
+func TestImport_FullAgentFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+
+	// Component dirs under .claude/.
+	agentsDir := filepath.Join(tmp, ".claude", "agents")
+	commandsDir := filepath.Join(tmp, ".claude", "commands")
+	skillDir := filepath.Join(tmp, ".claude", "skills", "deploy")
+	for _, d := range []string{agentsDir, commandsDir, skillDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// MCP via .claude.json.
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers": {"github": {"type": "stdio", "command": "npx"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Hooks + LSP via settings.json.
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "settings.json"), []byte(`{
+		"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}]},
+		"lspServers": {"gopls": {"command": "gopls"}}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "reviewer.md"),
+		[]byte("---\ndescription: \"Code reviewer\"\n---\nReview.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commandsDir, "review.md"), []byte("Do a review."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: deploy\ndescription: ship it\n---\nDeploy.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "CLAUDE.md"), []byte("# Memory\nBe concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude")
+	if err != nil {
+		t.Fatalf("import claude: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "imported") || !strings.Contains(out, "from claude") {
+		t.Fatalf("full-agent import missing summary line; got: %s", out)
+	}
+
+	// Every component should have landed in the canonical source.
+	wantFiles := []string{
+		filepath.Join("mcp", "github.toml"),
+		filepath.Join("lsp", "gopls.toml"),
+		filepath.Join("hooks", "PreToolUse.toml"),
+		filepath.Join("agents", "reviewer.md"),
+		filepath.Join("commands", "review.md"),
+		filepath.Join("skills", "deploy", "SKILL.md"),
+		filepath.Join("memory", "AGENTS.md"),
+	}
+	for _, rel := range wantFiles {
+		if _, statErr := os.Stat(filepath.Join(tmp, ".agentsync", rel)); statErr != nil {
+			t.Fatalf("full-agent import did not write %s: %v", rel, statErr)
+		}
+	}
+}
+
+// TestImport_FullAgentEmpty reports cleanly when there is nothing to import.
+func TestImport_FullAgentEmpty(t *testing.T) {
+	_, env := importTestEnv(t)
+	out, err := runCLI(t, env, "import", "claude")
+	if err != nil {
+		t.Fatalf("full-agent import of an empty config should not error; out=%s err=%v", out, err)
+	}
+	if !strings.Contains(out, "no importable items found") {
+		t.Fatalf("expected an empty-config notice; got: %s", out)
+	}
+}
+
 // TestImport_UnknownComponent verifies that an unknown component errors.
 func TestImport_UnknownComponent(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/ux_errors_test.go
+++ b/internal/cli/ux_errors_test.go
@@ -21,20 +21,39 @@ func TestAgentList_MissingHome_FriendlyError(t *testing.T) {
 	}
 }
 
-// TestImport_TwoPartSelector_Rejected covers P5: a selector missing the item
-// name (e.g. "claude:mcp") must fail with the expected grammar, not a
-// misleading downstream "server \"\" not found".
-func TestImport_TwoPartSelector_Rejected(t *testing.T) {
+// TestImport_TwoPartSelector_BulkComponent covers the bulk form: a selector
+// without an item name (e.g. "claude:mcp") imports every entry of that
+// component. With no native MCP servers present it reports a soft notice and
+// exits cleanly rather than erroring.
+func TestImport_TwoPartSelector_BulkComponent(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	if _, err := runCLI(t, env, "init"); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 	out, err := runCLI(t, env, "import", "claude:mcp")
-	if err == nil {
-		t.Fatalf("expected an error for a 2-part selector; out=%s", out)
+	if err != nil {
+		t.Fatalf("bulk component import should not error on an empty component; out=%s err=%v", out, err)
 	}
-	if !strings.Contains(out+err.Error(), "missing the item name") {
-		t.Fatalf("expected a 'missing the item name' error; got out=%q err=%v", out, err)
+	if !strings.Contains(out, "no mcp found") {
+		t.Fatalf("expected a 'no mcp found' notice; got out=%q", out)
+	}
+}
+
+// TestImport_TrailingColonSelector_Rejected keeps the typo guard: "claude:"
+// names an empty component and must fail rather than silently importing the
+// whole agent.
+func TestImport_TrailingColonSelector_Rejected(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	out, err := runCLI(t, env, "import", "claude:")
+	if err == nil {
+		t.Fatalf("expected an error for a trailing-colon selector; out=%s", out)
+	}
+	if !strings.Contains(out+err.Error(), "component must be non-empty") {
+		t.Fatalf("expected a 'component must be non-empty' error; got out=%q err=%v", out, err)
 	}
 }


### PR DESCRIPTION
## Summary

`agentsync import` was single-item only — you had to run it once per MCP server, skill, command, etc. This makes the selector widen as parts are dropped:

| Selector | Scope |
|---|---|
| `agentsync import claude` | the agent's **full** native config |
| `agentsync import claude:mcp` | **every** MCP server |
| `agentsync import claude:mcp:github` | a single server (unchanged) |

- Bulk MCP/LSP/hook capture still routes through `capture.Capture`, so secret re-referencing and source-only field preservation (`agents`/`enabled`) hold for **every** entry — no new dest→source path, no `secrets.Resolved` unwrapping. Honors the invariants in `CLAUDE.md`.
- Empty scopes report a notice and exit 0 (`no mcp found in claude native config`) rather than erroring. A named miss still errors with `not found`, as before.
- Full-agent import prints a one-line summary (`imported N item(s) from claude: 1 mcp, 1 command, …`) and skips empty components silently.
- The post-import foreign-collision warning now points at `agentsync import <agent>` to grab everything in one pass.
- `claude:` (trailing colon) is still rejected as a typo.

## Test plan

- [x] `go test ./...` green (`AGENTSYNC_TEST_IN_CONTAINER=1`)
- [x] New tests: bulk MCP (`claude:mcp`, 2 servers), full-agent (`claude`, all 7 components), empty full-agent notice, empty bulk-component notice, trailing-colon rejection
- [x] Existing single-item import + e2e/BDD selectors unchanged
- [x] `gofmt`/`go vet` clean (CI runs golangci-lint v2.12.2; local v2.5.0 refuses on the Go 1.26 module)

## Docs

Updated `docs/user-guide.md` (the "Already have configs?" walkthrough + command table), the design-spec selector grammar, and a `CHANGELOG.md` entry.

https://claude.ai/code/session_01EcTxu8CMWHfySJ1vp8Xgnv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcTxu8CMWHfySJ1vp8Xgnv)_