### PR TITLE
Harden the import bulk-selector feature (#30) after a fresh review loop

### DIFF
--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -23,3 +23,21 @@ func TestGetPointerValue_DecodesRFC6901(t *testing.T) {
 		t.Fatalf("did not decode ~1: nil for /mcpServers/a~1b")
 	}
 }
+
+// TestHashAtPointer_AbsentVsNull verifies the import seed distinguishes an
+// ABSENT pointer (return "" so the seed loop skips it, matching
+// render.RecordOpsState) from a present-but-null value (which hashes). Before
+// the fix, an absent pointer hashed sha256("null") and got seeded as a phantom.
+func TestHashAtPointer_AbsentVsNull(t *testing.T) {
+	m := map[string]any{"mcpServers": map[string]any{"github": map[string]any{"command": "x"}}}
+	if h := hashAtPointer(m, "/mcpServers/github"); h == "" {
+		t.Fatal("present pointer must hash non-empty")
+	}
+	if h := hashAtPointer(m, "/mcpServers/absent"); h != "" {
+		t.Fatalf("absent pointer must return the empty sentinel, got %q", h)
+	}
+	mn := map[string]any{"k": nil}
+	if h := hashAtPointer(mn, "/k"); h == "" {
+		t.Fatal("present-null must hash, not be treated as absent")
+	}
+}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -183,17 +183,19 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// filter, so MCP/LSP/hook capture still routes through capture.Capture
 	// (secret re-referencing + source-only field preservation) — see the
 	// importer bodies. Text components write directly via source.Write*.
+	var imp importedSet
 	var importErr error
 	switch component {
 	case "":
-		importErr = importAllComponents(cmd, home, agentName, c, dryRun)
+		imp, importErr = importAllComponents(cmd, home, agentName, c, dryRun)
 	default:
-		n, err := importComponent(cmd, home, c, component, name, dryRun)
+		ids, err := importComponent(cmd, home, c, component, name, dryRun)
 		importErr = err
+		imp.add(component, ids)
 		// A bulk component import (no name) that matched nothing is not an
 		// error — report it and exit cleanly. A named import that matched
 		// nothing already returned a "not found" error above.
-		if err == nil && n == 0 && name == "" {
+		if err == nil && len(ids) == 0 && name == "" {
 			fmt.Fprintf(cmd.OutOrStdout(), "no %s found in %s native config\n", component, agentName)
 		}
 	}
@@ -216,9 +218,10 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// Run this even when importErr != nil: a bulk/full-agent import can fail
 	// partway after already writing earlier components to the canonical, and
 	// those writes MUST be seeded or the next apply foreign-collides and
-	// overwrites the file they were just imported from. Re-rendering the
-	// (partially-updated) canonical seeds exactly what was written.
-	if seedErr := seedStateFromCurrentDest(home, agentName, reg); seedErr != nil {
+	// overwrites the file they were just imported from. Seeding is scoped to
+	// imp (the items actually imported), so a partial failure seeds exactly what
+	// was written and an un-imported sibling's state is never re-stamped.
+	if seedErr := seedStateFromCurrentDest(home, agentName, reg, imp); seedErr != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "warning: import state seed failed: %v\n", seedErr)
 	}
 
@@ -302,7 +305,7 @@ func unimportedDestPointers(home, agentName string, reg *adapter.Registry) []str
 // This makes the next \`apply\` non-destructive — the destination is
 // already known to agentsync, so any future divergence is real drift, not a
 // first-run foreign-collision.
-func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) error {
+func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry, imp importedSet) error {
 	statePath := filepath.Join(home, ".state", "targets.json")
 	// State keys are HOME-relative against the user's $HOME (paths.HomeDir),
 	// matching render.RecordOpsState — NOT the agentsync home, or apply
@@ -313,9 +316,12 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 		return err
 	}
 
-	// Build a fresh canonical from disk and render only this agent. Lenient: a
-	// strict plugin conflict must not block seeding (which would leave the
-	// just-imported dest exposed to a ForeignCollision overwrite on next apply).
+	// Build a fresh canonical from disk and render ONLY the items this import
+	// actually captured (imp). Lenient: a strict plugin conflict must not block
+	// seeding (which would leave the just-imported dest exposed to a
+	// ForeignCollision overwrite on next apply). Rendering the imported SUBSET —
+	// not the whole canonical — is what scopes the seed: an un-imported sibling
+	// isn't in the subset, so its state (and any drift it carries) is untouched.
 	pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
 	c, err := marketplace.LoadProjectedLenient(loaderFsForState(), home, pluginCacheRoot, nil)
 	if err != nil {
@@ -325,7 +331,8 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 	if a == nil {
 		return fmt.Errorf("adapter %q not registered", agentName)
 	}
-	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	sub := filterCanonicalTo(c, imp)
+	ops, _, err := a.Render(secrets.ForRender(sub), adapter.ScopeUser, "")
 	if err != nil {
 		return err
 	}
@@ -387,6 +394,44 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 	return state.Save(statePath, st)
 }
 
+// filterCanonicalTo returns a copy of c containing only the components named in
+// imp — the items this import actually captured. Rendering THIS subset (rather
+// than the whole canonical) scopes state seeding to the imported items. A
+// reported-but-unwritten id simply won't be present in the re-loaded canonical,
+// so it self-corrects on a partial import. Config is intentionally omitted so no
+// settings op is emitted (settings are never imported).
+func filterCanonicalTo(c source.Canonical, imp importedSet) source.Canonical {
+	var sub source.Canonical
+	sub.MCPServers = filterByKey(c.MCPServers, imp.MCP, func(m source.MCPServer) string { return m.ID })
+	sub.LSPServers = filterByKey(c.LSPServers, imp.LSP, func(l source.LSPServer) string { return l.ID })
+	sub.Skills = filterByKey(c.Skills, imp.Skills, func(s source.Skill) string { return s.Name })
+	sub.Subagents = filterByKey(c.Subagents, imp.Subagents, func(s source.Subagent) string { return s.Name })
+	sub.Commands = filterByKey(c.Commands, imp.Commands, func(cm source.Command) string { return cm.Name })
+	sub.Hooks = filterByKey(c.Hooks, imp.HookEvents, func(h source.Hook) string { return h.Event })
+	if imp.Memory {
+		sub.Memory = c.Memory
+	}
+	return sub
+}
+
+// filterByKey returns the items whose key is in want (preserving order).
+func filterByKey[T any](items []T, want []string, key func(T) string) []T {
+	if len(want) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(want))
+	for _, w := range want {
+		set[w] = true
+	}
+	var out []T
+	for _, it := range items {
+		if set[key(it)] {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // parseSelector splits "agent[:component[:name]]" into its parts. A bare
 // "agent" (component == "") selects the whole config; "agent:component"
 // (name == "") selects every entry of that component.
@@ -429,12 +474,48 @@ func importVerb(dryRun bool) string {
 	return "imported"
 }
 
+// importedSet records which component identities an import actually captured,
+// so the state seeder can scope itself to exactly those items and not re-stamp
+// (and thereby mask drift on) un-imported siblings.
+type importedSet struct {
+	MCP        []string
+	LSP        []string
+	Skills     []string
+	Subagents  []string
+	Commands   []string
+	HookEvents []string
+	Memory     bool
+}
+
+// add routes a component's imported identities into the set.
+func (s *importedSet) add(component string, ids []string) {
+	switch component {
+	case "mcp":
+		s.MCP = append(s.MCP, ids...)
+	case "lsp":
+		s.LSP = append(s.LSP, ids...)
+	case "skill":
+		s.Skills = append(s.Skills, ids...)
+	case "agent", "subagent":
+		s.Subagents = append(s.Subagents, ids...)
+	case "command":
+		s.Commands = append(s.Commands, ids...)
+	case "hook":
+		s.HookEvents = append(s.HookEvents, ids...)
+	case "memory":
+		if len(ids) > 0 {
+			s.Memory = true
+		}
+	}
+}
+
 // importComponent imports one component class from c. When name is empty it
 // imports every entry of that component (the bulk form); when name is set it
 // imports just that entry and errors if it is absent. When dryRun is set it
-// writes nothing and only reports what it would write. It returns the number of
-// source items that were (or would be) written.
-func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string, dryRun bool) (int, error) {
+// writes nothing and only reports what it would write. It returns the identities
+// (server id, skill/subagent/command name, hook event) that were (or would be)
+// imported; len is the item count.
+func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string, dryRun bool) ([]string, error) {
 	switch component {
 	case "mcp":
 		return importMCP(cmd, home, c, name, dryRun)
@@ -451,30 +532,33 @@ func importComponent(cmd *cobra.Command, home string, c source.Canonical, compon
 	case "memory":
 		return importMemory(cmd, home, c, dryRun)
 	default:
-		return 0, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
+		return nil, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
 	}
 }
 
 // importAllComponents imports every importable component for the agent and
 // prints a one-line summary. Empty components are skipped silently; an agent
 // with nothing to import reports that and exits cleanly. dryRun is threaded
-// through so the preview writes nothing.
-func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical, dryRun bool) error {
+// through so the preview writes nothing. The returned set names everything
+// captured, so the caller can scope state seeding to it.
+func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical, dryRun bool) (importedSet, error) {
+	var imp importedSet
 	counts := map[string]int{}
 	total := 0
 	for _, comp := range importComponentOrder {
-		n, err := importComponent(cmd, home, c, comp, "", dryRun)
+		ids, err := importComponent(cmd, home, c, comp, "", dryRun)
 		if err != nil {
-			return err
+			return imp, err
 		}
-		if n > 0 {
-			counts[comp] = n
-			total += n
+		imp.add(comp, ids)
+		if len(ids) > 0 {
+			counts[comp] = len(ids)
+			total += len(ids)
 		}
 	}
 	if total == 0 {
 		fmt.Fprintf(cmd.OutOrStdout(), "no importable items found in %s native config\n", agentName)
-		return nil
+		return imp, nil
 	}
 	var parts []string
 	for _, comp := range importComponentOrder {
@@ -483,14 +567,14 @@ func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Ca
 		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s %d item(s) from %s: %s\n", importVerb(dryRun), total, agentName, strings.Join(parts, ", "))
-	return nil
+	return imp, nil
 }
 
 // importMCP captures the MCP server named name (or all of them when name is
 // empty). Capture.Capture batches the whole slice in one call, so it
 // re-references secrets and preserves source-only fields for every server.
 // When dryRun is set it reports the targets without writing.
-func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.MCPServer
 	for _, m := range c.MCPServers {
 		if name == "" || m.ID == name {
@@ -499,30 +583,32 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("mcp server %q not found in native config", name)
+			return nil, fmt.Errorf("mcp server %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	// Validate ids up front (before any write, and in dry-run) so the preview
 	// matches a real import and a bulk write is atomic on a bad id.
 	for _, m := range matched {
 		if err := source.ValidateComponentID("mcp", m.ID); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	if !dryRun {
 		single := source.Canonical{MCPServers: matched}
 		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
-	for _, m := range matched {
+	ids := make([]string, len(matched))
+	for i, m := range matched {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s mcp/%s.toml\n", importVerb(dryRun), m.ID)
+		ids[i] = m.ID
 	}
-	return len(matched), nil
+	return ids, nil
 }
 
-func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.Skill
 	for _, sk := range c.Skills {
 		if name == "" || sk.Name == name {
@@ -531,27 +617,29 @@ func importSkill(cmd *cobra.Command, home string, c source.Canonical, name strin
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("skill %q not found in native config", name)
+			return nil, fmt.Errorf("skill %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	for _, sk := range matched {
 		if err := source.ValidateComponentID("skill", sk.Name); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
+	names := make([]string, 0, len(matched))
 	for _, sk := range matched {
 		if !dryRun {
 			if err := source.WriteSkill(home, sk); err != nil {
-				return 0, fmt.Errorf("write skill %s: %w", sk.Name, err)
+				return nil, fmt.Errorf("write skill %s: %w", sk.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s skills/%s/SKILL.md\n", importVerb(dryRun), sk.Name)
+		names = append(names, sk.Name)
 	}
-	return len(matched), nil
+	return names, nil
 }
 
-func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.Subagent
 	for _, sa := range c.Subagents {
 		if name == "" || sa.Name == name {
@@ -560,27 +648,29 @@ func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name st
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("subagent %q not found in native config", name)
+			return nil, fmt.Errorf("subagent %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	for _, sa := range matched {
 		if err := source.ValidateComponentID("subagent", sa.Name); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
+	names := make([]string, 0, len(matched))
 	for _, sa := range matched {
 		if !dryRun {
 			if err := source.WriteSubagent(home, sa); err != nil {
-				return 0, fmt.Errorf("write subagent %s: %w", sa.Name, err)
+				return nil, fmt.Errorf("write subagent %s: %w", sa.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s agents/%s.md\n", importVerb(dryRun), sa.Name)
+		names = append(names, sa.Name)
 	}
-	return len(matched), nil
+	return names, nil
 }
 
-func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.Command
 	for _, cm := range c.Commands {
 		if name == "" || cm.Name == name {
@@ -589,31 +679,34 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("command %q not found in native config", name)
+			return nil, fmt.Errorf("command %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	for _, cm := range matched {
 		if err := source.ValidateComponentID("command", cm.Name); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
+	names := make([]string, 0, len(matched))
 	for _, cm := range matched {
 		if !dryRun {
 			if err := source.WriteCommand(home, cm); err != nil {
-				return 0, fmt.Errorf("write command %s: %w", cm.Name, err)
+				return nil, fmt.Errorf("write command %s: %w", cm.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s commands/%s.md\n", importVerb(dryRun), cm.Name)
+		names = append(names, cm.Name)
 	}
-	return len(matched), nil
+	return names, nil
 }
 
 // importHook captures hooks for the named event (or all events when name is
-// empty). name addresses an event, not an individual hook, so the count
-// returned is the number of hook entries written across all matched events.
-// When dryRun is set it reports the target event files without writing.
-func importHook(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+// empty). name addresses an event, not an individual hook. It returns the
+// DISTINCT events captured (one source file per event); the per-event line
+// still reports the entry count. When dryRun is set it reports the target event
+// files without writing.
+func importHook(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.Hook
 	for _, h := range c.Hooks {
 		if name == "" || h.Event == name {
@@ -622,19 +715,19 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("hook event %q not found in native config", name)
+			return nil, fmt.Errorf("hook event %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	for _, h := range matched {
 		if err := source.ValidateComponentID("hook event", h.Event); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	if !dryRun {
 		single := source.Canonical{Hooks: matched}
 		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	// One file per event; report each, preserving first-seen order.
@@ -649,10 +742,10 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 	for _, ev := range order {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s hooks/%s.toml (%d entries)\n", importVerb(dryRun), ev, perEvent[ev])
 	}
-	return len(matched), nil
+	return order, nil
 }
 
-func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) (int, error) {
+func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
 	var matched []source.LSPServer
 	for _, ls := range c.LSPServers {
 		if name == "" || ls.ID == name {
@@ -661,38 +754,42 @@ func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string,
 	}
 	if len(matched) == 0 {
 		if name != "" {
-			return 0, fmt.Errorf("lsp server %q not found in native config", name)
+			return nil, fmt.Errorf("lsp server %q not found in native config", name)
 		}
-		return 0, nil
+		return nil, nil
 	}
 	for _, ls := range matched {
 		if err := source.ValidateComponentID("lsp", ls.ID); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	if !dryRun {
 		single := source.Canonical{LSPServers: matched}
 		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
+	ids := make([]string, 0, len(matched))
 	for _, ls := range matched {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s lsp/%s.toml\n", importVerb(dryRun), ls.ID)
+		ids = append(ids, ls.ID)
 	}
-	return len(matched), nil
+	return ids, nil
 }
 
-func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bool) (int, error) {
+func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bool) ([]string, error) {
 	// Memory is a single block, not a named collection; nothing to write when
 	// the agent carries no memory (the common case during a full-agent import).
 	if strings.TrimSpace(c.Memory.Body) == "" {
-		return 0, nil
+		return nil, nil
 	}
 	if !dryRun {
 		if err := source.WriteMemory(home, c.Memory); err != nil {
-			return 0, fmt.Errorf("write memory: %w", err)
+			return nil, fmt.Errorf("write memory: %w", err)
 		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s memory/AGENTS.md\n", importVerb(dryRun))
-	return 1, nil
+	// A non-empty marker so importedSet.add flags memory was captured (it has no
+	// id; the seeder includes c.Memory when this is set).
+	return []string{"memory"}, nil
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -51,10 +51,16 @@ func collectStateSeedPointers(m map[string]any) []string {
 	return render.CollectPointers(m, "")
 }
 
-// hashAtPointer returns the SHA-256 of the JSON-marshaled value at ptr,
-// or the empty string if no value exists there.
+// hashAtPointer returns the SHA-256 of the JSON-marshaled value at ptr, or the
+// empty string when no value exists there. The empty sentinel (rather than
+// hashing a synthesized null) lets the seed loop SKIP an absent pointer, which
+// matches render.RecordOpsState skipping never-landed pointers — a present-null
+// value still hashes.
 func hashAtPointer(m map[string]any, ptr string) string {
-	v := getJSONPointer(m, ptr)
+	v, ok := getJSONPointer(m, ptr)
+	if !ok {
+		return ""
+	}
 	data, err := json.Marshal(v)
 	if err != nil {
 		return ""
@@ -63,13 +69,14 @@ func hashAtPointer(m map[string]any, ptr string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// getJSONPointer resolves a "/a/b/c" RFC 6901 pointer against m. Returns
-// nil if any segment is missing. We re-implement here rather than
-// exporting render.getPointer because keeping that helper unexported
-// preserves the current package boundary.
-func getJSONPointer(m map[string]any, ptr string) any {
+// getJSONPointer resolves a "/a/b/c" RFC 6901 pointer against m. The bool is
+// false when any segment is missing — distinct from a present value that
+// happens to be null. We re-implement here rather than exporting
+// render.getPointer because keeping that helper unexported preserves the
+// current package boundary.
+func getJSONPointer(m map[string]any, ptr string) (any, bool) {
 	if ptr == "" || ptr[0] != '/' {
-		return m
+		return m, true
 	}
 	parts := strings.Split(ptr[1:], "/")
 	for i, p := range parts {
@@ -82,11 +89,15 @@ func getJSONPointer(m map[string]any, ptr string) any {
 	for _, p := range parts {
 		mm, ok := cur.(map[string]any)
 		if !ok {
-			return nil
+			return nil, false
 		}
-		cur = mm[p]
+		v, exists := mm[p]
+		if !exists {
+			return nil, false
+		}
+		cur = v
 	}
-	return cur
+	return cur, true
 }
 
 // newImportCmd returns the "import" subcommand.
@@ -341,10 +352,17 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 				continue
 			}
 			for _, ptr := range collectStateSeedPointers(ours) {
+				h := hashAtPointer(existing, ptr)
+				if h == "" {
+					// Pointer absent on disk — skip rather than seed a phantom
+					// entry, matching render.RecordOpsState's skip of never-landed
+					// pointers (a present-null value hashes and is seeded).
+					continue
+				}
 				key := fmt.Sprintf("%s:%s:%s:%s:%s",
 					agentName, adapter.ScopeUser.String(), "", paths.HomeRelative(userHome, op.Path), ptr)
 				st.Keys[key] = state.KeyEntry{
-					SHA256:    hashAtPointer(existing, ptr),
+					SHA256:    h,
 					AppliedAt: now,
 					SourceID:  op.SourceID,
 				}
@@ -485,6 +503,13 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 		}
 		return 0, nil
 	}
+	// Validate ids up front (before any write, and in dry-run) so the preview
+	// matches a real import and a bulk write is atomic on a bad id.
+	for _, m := range matched {
+		if err := source.ValidateComponentID("mcp", m.ID); err != nil {
+			return 0, err
+		}
+	}
 	if !dryRun {
 		single := source.Canonical{MCPServers: matched}
 		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
@@ -511,6 +536,11 @@ func importSkill(cmd *cobra.Command, home string, c source.Canonical, name strin
 		return 0, nil
 	}
 	for _, sk := range matched {
+		if err := source.ValidateComponentID("skill", sk.Name); err != nil {
+			return 0, err
+		}
+	}
+	for _, sk := range matched {
 		if !dryRun {
 			if err := source.WriteSkill(home, sk); err != nil {
 				return 0, fmt.Errorf("write skill %s: %w", sk.Name, err)
@@ -535,6 +565,11 @@ func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name st
 		return 0, nil
 	}
 	for _, sa := range matched {
+		if err := source.ValidateComponentID("subagent", sa.Name); err != nil {
+			return 0, err
+		}
+	}
+	for _, sa := range matched {
 		if !dryRun {
 			if err := source.WriteSubagent(home, sa); err != nil {
 				return 0, fmt.Errorf("write subagent %s: %w", sa.Name, err)
@@ -557,6 +592,11 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 			return 0, fmt.Errorf("command %q not found in native config", name)
 		}
 		return 0, nil
+	}
+	for _, cm := range matched {
+		if err := source.ValidateComponentID("command", cm.Name); err != nil {
+			return 0, err
+		}
 	}
 	for _, cm := range matched {
 		if !dryRun {
@@ -585,6 +625,11 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 			return 0, fmt.Errorf("hook event %q not found in native config", name)
 		}
 		return 0, nil
+	}
+	for _, h := range matched {
+		if err := source.ValidateComponentID("hook event", h.Event); err != nil {
+			return 0, err
+		}
 	}
 	if !dryRun {
 		single := source.Canonical{Hooks: matched}
@@ -619,6 +664,11 @@ func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string,
 			return 0, fmt.Errorf("lsp server %q not found in native config", name)
 		}
 		return 0, nil
+	}
+	for _, ls := range matched {
+		if err := source.ValidateComponentID("lsp", ls.ID); err != nil {
+			return 0, err
+		}
 	}
 	if !dryRun {
 		single := source.Canonical{LSPServers: matched}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -172,29 +172,26 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// filter, so MCP/LSP/hook capture still routes through capture.Capture
 	// (secret re-referencing + source-only field preservation) — see the
 	// importer bodies. Text components write directly via source.Write*.
+	var importErr error
 	switch component {
 	case "":
-		if err := importAllComponents(cmd, home, agentName, c, dryRun); err != nil {
-			return err
-		}
+		importErr = importAllComponents(cmd, home, agentName, c, dryRun)
 	default:
 		n, err := importComponent(cmd, home, c, component, name, dryRun)
-		if err != nil {
-			return err
-		}
+		importErr = err
 		// A bulk component import (no name) that matched nothing is not an
 		// error — report it and exit cleanly. A named import that matched
 		// nothing already returned a "not found" error above.
-		if n == 0 && name == "" {
+		if err == nil && n == 0 && name == "" {
 			fmt.Fprintf(cmd.OutOrStdout(), "no %s found in %s native config\n", component, agentName)
 		}
 	}
 
 	// A dry-run wrote nothing, so there is no state to seed and the
 	// foreign-collision warning below would describe the pre-import world.
-	// Stop here with just the preview.
+	// Stop here with just the preview (surfacing any selector/not-found error).
 	if dryRun {
-		return nil
+		return importErr
 	}
 
 	// Seed state with the destination's current content hash so the next
@@ -204,8 +201,14 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// content — because the canonical→render pipeline may translate the
 	// content slightly (frontmatter normalization, etc.) and we want the
 	// next apply to compare against the file that exists today.
+	//
+	// Run this even when importErr != nil: a bulk/full-agent import can fail
+	// partway after already writing earlier components to the canonical, and
+	// those writes MUST be seeded or the next apply foreign-collides and
+	// overwrites the file they were just imported from. Re-rendering the
+	// (partially-updated) canonical seeds exactly what was written.
 	if seedErr := seedStateFromCurrentDest(home, agentName, reg); seedErr != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "warning: import succeeded but state seed failed: %v\n", seedErr)
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: import state seed failed: %v\n", seedErr)
 	}
 
 	// Warn if the destination file has additional pointers / files
@@ -220,7 +223,9 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		}
 		fmt.Fprintf(ew, "  Run `agentsync import %s` to capture the agent's full config, or accept the backup on next apply.\n", agentName)
 	}
-	return nil
+	// Surface a partial-import error after seeding so the command still exits
+	// non-zero, but the components that were written are now owned.
+	return importErr
 }
 
 // unimportedDestPointers returns a list of human-readable labels for
@@ -233,7 +238,10 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 // canonical claims, and diff against the actual on-disk contents.
 func unimportedDestPointers(home, agentName string, reg *adapter.Registry) []string {
 	pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
-	c, err := marketplace.LoadProjected(loaderFsForState(), home, pluginCacheRoot)
+	// Lenient: this is a post-import diagnostic re-render. A strict plugin
+	// conflict (unrelated to the import) must not abort it — matching the
+	// read-only commands (status/diff/explain).
+	c, err := marketplace.LoadProjectedLenient(loaderFsForState(), home, pluginCacheRoot, nil)
 	if err != nil {
 		return nil
 	}
@@ -294,9 +302,11 @@ func seedStateFromCurrentDest(home, agentName string, reg *adapter.Registry) err
 		return err
 	}
 
-	// Build a fresh canonical from disk and render only this agent.
+	// Build a fresh canonical from disk and render only this agent. Lenient: a
+	// strict plugin conflict must not block seeding (which would leave the
+	// just-imported dest exposed to a ForeignCollision overwrite on next apply).
 	pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
-	c, err := marketplace.LoadProjected(loaderFsForState(), home, pluginCacheRoot)
+	c, err := marketplace.LoadProjectedLenient(loaderFsForState(), home, pluginCacheRoot, nil)
 	if err != nil {
 		return err
 	}
@@ -377,6 +387,11 @@ func parseSelector(sel string) (agentName, component, name string, err error) {
 	// "claude:" is a typo, not a request to import the whole agent.
 	if len(parts) >= 2 && component == "" {
 		return "", "", "", fmt.Errorf("invalid selector %q: component must be non-empty", sel)
+	}
+	// "claude:mcp:" (trailing colon) is a typo, not a bulk request. Drop the
+	// colon for a bulk import (claude:mcp) or supply a name (claude:mcp:github).
+	if len(parts) == 3 && name == "" {
+		return "", "", "", fmt.Errorf("invalid selector %q: trailing colon with no name; use %q to import every %s, or supply a name", sel, agentName+":"+component, component)
 	}
 	return agentName, component, name, nil
 }

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -39,6 +39,52 @@ func TestImport_TrailingColonRejected(t *testing.T) {
 	}
 }
 
+// TestImport_DryRunRejectsInvalidID is the regression for a misleading preview:
+// --dry-run skipped the writers' validation, so it cheerfully previewed
+// "would import mcp/../escape.toml" for a traversal id that a real import
+// rejects. The preview must match what a real run accepts.
+func TestImport_DryRunRejectsInvalidID(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers":{"../escape":{"type":"stdio","command":"x"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "import", "claude:mcp:../escape", "--dry-run"); err == nil {
+		t.Fatal("dry-run should reject an invalid component id, not preview it")
+	}
+}
+
+// TestImport_RejectsColonInID rejects a native component id containing ':',
+// which would write an mcp/ns:gh.toml that is an illegal filename on Windows —
+// the canonical source is meant to be portable/committable across machines.
+func TestImport_RejectsColonInID(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers":{"ns:gh":{"type":"stdio","command":"x"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "import", "claude:mcp:ns:gh"); err == nil {
+		t.Fatal("a colon in a component id is not portable; import must reject it")
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", "ns:gh.toml")); err == nil {
+		t.Fatal("import wrote an unportable mcp/ns:gh.toml")
+	}
+}
+
 // TestImport_PartialFailureStillSeedsWritten is the regression for a partial
 // full-agent import: when a later component fails after an earlier one was
 // already written to the canonical source, the written component must still be

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -1,11 +1,79 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// mcpKeySHA returns the seeded state hash for /mcpServers/<id>, or "".
+func mcpKeySHA(t *testing.T, statePath, id string) string {
+	t.Helper()
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var st struct {
+		Keys map[string]struct {
+			SHA256 string `json:"sha256"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	for k, v := range st.Keys {
+		if strings.HasSuffix(k, "/mcpServers/"+id) {
+			return v.SHA256
+		}
+	}
+	return ""
+}
+
+// TestImport_DoesNotReseedUnimportedSibling is the regression for the
+// drift-masking bug: seedStateFromCurrentDest re-rendered the WHOLE canonical
+// and re-stamped every pointer, so importing one item silently re-seeded an
+// un-imported, drifted sibling at its drifted hash — turning its Drift into
+// Pending and causing the next apply to revert the user's edit with no backup.
+// Seeding must be scoped to only the items actually imported.
+func TestImport_DoesNotReseedUnimportedSibling(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	// Canonical owns foo; apply it so state is seeded for /mcpServers/foo.
+	if _, err := runCLI(t, env, "mcp", "add", "foo", "--command", "foo-orig"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	before := mcpKeySHA(t, statePath, "foo")
+	if before == "" {
+		t.Fatal("setup: foo not seeded after apply")
+	}
+
+	// Drift foo in the dest AND add a native bar to import.
+	claudeJSON := filepath.Join(tmp, ".claude.json")
+	if err := os.WriteFile(claudeJSON,
+		[]byte(`{"mcpServers":{"foo":{"type":"stdio","command":"DRIFTED"},"bar":{"type":"stdio","command":"bar-cmd"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Import ONLY bar — foo's drift must be preserved (its state untouched).
+	if _, err := runCLI(t, env, "import", "claude:mcp:bar"); err != nil {
+		t.Fatalf("import bar: %v", err)
+	}
+	if after := mcpKeySHA(t, statePath, "foo"); after != before {
+		t.Fatalf("importing bar re-seeded the un-imported sibling foo (masking its drift): before=%s after=%s", before, after)
+	}
+}
 
 // TestImport_InvalidSelector verifies that malformed selectors are rejected.
 func TestImport_InvalidSelector(t *testing.T) {

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -22,6 +22,73 @@ func TestImport_InvalidSelector(t *testing.T) {
 	}
 }
 
+// TestImport_TrailingColonRejected guards against a footgun: a trailing colon
+// (claude:mcp:) parsed to an empty name, which silently meant "bulk import all"
+// — surprising for a typo. It must be rejected like an empty component is.
+func TestImport_TrailingColonRejected(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "import", "claude:mcp:"); err == nil {
+		t.Fatal("expected trailing-colon selector to be rejected, not treated as bulk")
+	}
+}
+
+// TestImport_PartialFailureStillSeedsWritten is the regression for a partial
+// full-agent import: when a later component fails after an earlier one was
+// already written to the canonical source, the written component must still be
+// seeded into state — otherwise the next apply treats it as ForeignCollision
+// and overwrites the file the user just imported from.
+func TestImport_PartialFailureStillSeedsWritten(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	// Native config: an MCP server (imported first, cleanly).
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers":{"github":{"type":"stdio","command":"gh-mcp"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// ... and a skill (imported after mcp in the full-agent order).
+	skillDir := filepath.Join(tmp, ".claude", "skills", "deploy")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: deploy\n---\nDeploy stuff.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Force the skill write to fail: pre-create ~/.agentsync/skills/deploy as a
+	// FILE so WriteSkill's MkdirAll(skills/deploy) errors mid-import.
+	if err := os.MkdirAll(filepath.Join(tmp, ".agentsync", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".agentsync", "skills", "deploy"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Full-agent import: mcp succeeds (written to canonical), skill then fails.
+	if _, err := runCLI(t, env, "import", "claude"); err == nil {
+		t.Fatal("expected partial import to surface the skill write error")
+	}
+	// The mcp that WAS written must be seeded, or the next apply foreign-collides
+	// and overwrites .claude.json.
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	stData, _ := os.ReadFile(statePath)
+	if !strings.Contains(string(stData), "/mcpServers/github") {
+		t.Fatalf("partial import left the written mcp unseeded (foreign-collision hazard); state:\n%s", stData)
+	}
+}
+
 // TestImport_UnknownAgent verifies that an unknown agent returns an error.
 func TestImport_UnknownAgent(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// validateComponentID rejects a component id/name/event that would not produce
+// ValidateComponentID rejects a component id/name/event that would not produce
 // a clean file path under its source subdirectory. This is the single
 // dest->source write boundary, reached by `import` and `reconcile` write-back
 // with ids/keys taken from a NATIVE config — which may be foreign, synced, or
@@ -37,12 +37,15 @@ import (
 // path is an arbitrary-file-write (on write) / read (on read) primitive.
 // Mirrors the CLI's validateMCPID; here it guards every Write*/Read* so no
 // caller can bypass it.
-func validateComponentID(kind, id string) error {
+func ValidateComponentID(kind, id string) error {
 	if id == "" {
 		return fmt.Errorf("%s id is empty", kind)
 	}
-	if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") || filepath.IsAbs(id) {
-		return fmt.Errorf("%s id %q contains a path component", kind, id)
+	// Reject path separators, traversal, and absolute paths (write-anywhere
+	// guard), plus ':' — the id becomes a filename, and a colon is illegal on
+	// Windows, so allowing it would make the canonical source non-portable.
+	if strings.ContainsAny(id, `/\:`) || strings.Contains(id, "..") || filepath.IsAbs(id) {
+		return fmt.Errorf("%s id %q contains a path separator, '..', ':' or is absolute", kind, id)
 	}
 	return nil
 }
@@ -51,7 +54,7 @@ func validateComponentID(kind, id string) error {
 // exist. Used by reconcile write-back to preserve source-only fields
 // (agents/enabled) that the rendered destination spec doesn't carry.
 func ReadMCP(home, id string) (m MCPServer, ok bool, err error) {
-	if verr := validateComponentID("mcp", id); verr != nil {
+	if verr := ValidateComponentID("mcp", id); verr != nil {
 		return MCPServer{}, false, verr
 	}
 	data, rerr := os.ReadFile(filepath.Join(home, "mcp", id+".toml"))
@@ -72,7 +75,7 @@ func ReadMCP(home, id string) (m MCPServer, ok bool, err error) {
 // exist. Mirrors ReadMCP: used by capture to preserve source-only LSP fields
 // (agents/enabled) that the rendered destination spec doesn't carry.
 func ReadLSP(home, id string) (ls LSPServer, ok bool, err error) {
-	if verr := validateComponentID("lsp", id); verr != nil {
+	if verr := ValidateComponentID("lsp", id); verr != nil {
 		return LSPServer{}, false, verr
 	}
 	data, rerr := os.ReadFile(filepath.Join(home, "lsp", id+".toml"))
@@ -91,7 +94,7 @@ func ReadLSP(home, id string) (ls LSPServer, ok bool, err error) {
 
 // WriteMCP writes mcp/<id>.toml from m into home. Overwrites atomically.
 func WriteMCP(home, id string, m MCPServer) error {
-	if err := validateComponentID("mcp", id); err != nil {
+	if err := ValidateComponentID("mcp", id); err != nil {
 		return err
 	}
 	body, err := toml.Marshal(m)
@@ -103,7 +106,7 @@ func WriteMCP(home, id string, m MCPServer) error {
 
 // WritePlugin writes plugins/<id>.toml from p into home. Overwrites atomically.
 func WritePlugin(home, id string, p Plugin) error {
-	if err := validateComponentID("plugin", id); err != nil {
+	if err := ValidateComponentID("plugin", id); err != nil {
 		return err
 	}
 	body, err := toml.Marshal(p)
@@ -115,7 +118,7 @@ func WritePlugin(home, id string, p Plugin) error {
 
 // WriteMarketplace writes marketplaces/<name>.toml from m into home. Overwrites atomically.
 func WriteMarketplace(home, name string, m Marketplace) error {
-	if err := validateComponentID("marketplace", name); err != nil {
+	if err := ValidateComponentID("marketplace", name); err != nil {
 		return err
 	}
 	body, err := toml.Marshal(m)
@@ -127,7 +130,7 @@ func WriteMarketplace(home, name string, m Marketplace) error {
 
 // WriteSkill writes skills/<name>/SKILL.md from sk into home. Overwrites atomically.
 func WriteSkill(home string, sk Skill) error {
-	if err := validateComponentID("skill", sk.Name); err != nil {
+	if err := ValidateComponentID("skill", sk.Name); err != nil {
 		return err
 	}
 	dir := filepath.Join(home, "skills", sk.Name)
@@ -140,7 +143,7 @@ func WriteSkill(home string, sk Skill) error {
 
 // WriteSubagent writes agents/<name>.md from sa into home. Overwrites atomically.
 func WriteSubagent(home string, sa Subagent) error {
-	if err := validateComponentID("subagent", sa.Name); err != nil {
+	if err := ValidateComponentID("subagent", sa.Name); err != nil {
 		return err
 	}
 	dir := filepath.Join(home, "agents")
@@ -153,7 +156,7 @@ func WriteSubagent(home string, sa Subagent) error {
 
 // WriteCommand writes commands/<name>.md from cm into home. Overwrites atomically.
 func WriteCommand(home string, cm Command) error {
-	if err := validateComponentID("command", cm.Name); err != nil {
+	if err := ValidateComponentID("command", cm.Name); err != nil {
 		return err
 	}
 	dir := filepath.Join(home, "commands")
@@ -177,7 +180,7 @@ type hookEntryOut struct {
 
 // WriteHooks writes hooks/<event>.toml for the given event. Overwrites atomically.
 func WriteHooks(home, event string, hooks []Hook) error {
-	if err := validateComponentID("hook event", event); err != nil {
+	if err := ValidateComponentID("hook event", event); err != nil {
 		return err
 	}
 	dir := filepath.Join(home, "hooks")
@@ -206,7 +209,7 @@ type lspFileOut struct {
 
 // WriteLSP writes lsp/<id>.toml from ls into home. Overwrites atomically.
 func WriteLSP(home string, ls LSPServer) error {
-	if err := validateComponentID("lsp", ls.ID); err != nil {
+	if err := ValidateComponentID("lsp", ls.ID); err != nil {
 		return err
 	}
 	dir := filepath.Join(home, "lsp")


### PR DESCRIPTION
Adversarial **review → verify → fix → verify** loop over the `agentsync import` bulk-selector feature (#30). Three agents reviewed non-overlapping areas; every finding was verified before fixing (RED→GREEN), and the full local gate is green before each push. **3 commits.**

**Gate (green at HEAD):** `build / lint (0) / fmt / tidy / test-fast` + full `-race` internal suite + e2e (`-tags=e2e`) + bdd (`-tags=bdd`), all under `AGENTSYNC_TEST_IN_CONTAINER=1`.

---

## What the loop found & fixed

### `a269447` — scope state seeding to the items actually imported _(correctness; the deep one)_
`seedStateFromCurrentDest` re-rendered the **whole** canonical and re-stamped **every** pointer/file against the current dest. So importing one item also re-seeded **un-imported but already-owned siblings**, masking any drift they carried (**Drift → Pending**) — which made the next `apply` silently revert the user's hand-edit to that sibling **with no backup**. Pre-existing on the success path; the seed-on-error change below widened it to failed imports.

Each importer now reports the identities it captured (`importedSet`); the seeder re-loads the templated canonical, **filters it to that subset**, and renders only the subset — so its pointer set covers exactly the imported items and an un-imported sibling's state is never touched. Secret-safe (filtered from templated refs, rendered via `secrets.ForRender`; pointer names derive from ids, not values). A reported-but-unwritten id self-corrects (absent from the re-loaded canonical), so partial imports seed exactly what was written.

### `8708c69` — polish from the review _(low severity)_
- **dry-run honesty + atomicity:** importers validate component ids/names up front, so `--dry-run` rejects what a real import would reject and a bulk write fails before any partial write.
- **portability:** `source.ValidateComponentID` now also rejects `:` (an id becomes a filename; `:` is illegal on Windows) — guards every `Write*`/`Read*`.
- **absent-pointer seeding:** `getJSONPointer` distinguishes absent from present-null, so an absent pointer is skipped rather than seeded as a `sha256("null")` phantom (matches `RecordOpsState`).

### `dcf2048` — harden bulk/full-agent paths against partial-import overwrite _(correctness)_
- **Partial import left written files unseeded** → next `apply` saw them as ForeignCollision and backed-up+overwrote the file just imported from. `importRun` now seeds (and runs the unowned-pointer warning) best-effort even on a partial-import error, then surfaces the error.
- **Strict loader in seed/warn:** `seedStateFromCurrentDest`/`unimportedDestPointers` now use `LoadProjectedLenient`, so an unrelated strict plugin conflict can't abort seeding (which re-exposed the overwrite hazard).
- **Trailing-colon footgun:** `claude:mcp:` is rejected with guidance instead of silently meaning "bulk import all."

---

## Review outcome
- **Secret boundary — clean** (dedicated agent): bulk/full-agent capture still routes through `capture.Capture` (re-references secrets, field-positional keying); no cleartext to source or stdout.
- **Verification — clean** on the final scoped-seed fix: drift preserved across single / cross-component-bulk / same-component-bulk (incl. the subtle canonical-only sibling case), imported items still seeded (no foreign-collision regression), explicit re-import of a drifted item still clears its drift, byte-identical state keys across **both** the Claude and OpenCode adapters.

## Behavior note
A full-agent import summary now counts **hook events** (one source file per event) rather than individual hook entries — consistent with the per-event output lines.

https://claude.ai/code/session_01EUkxuEckF2D2cXRuc6vTiD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUkxuEckF2D2cXRuc6vTiD)_