### PR TITLE
Hardening loop: kill bugs + launch readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`[updates] default_mode` is honored** — the config knob (written into the
+  generated `agentsync.toml` by `init`) was parsed but never consulted:
+  `update` hardcoded `track` for any plugin without an explicit `update` mode,
+  so a user who set `default_mode = "pinned"` still had default-mode plugins
+  auto-bumped. The canonical default now flows into bump computation.
 - **`reconcile` exits non-zero when a write-back fails** — a `[w]rite-back` that
   errored (e.g. an unsupported `/hooks/*` pointer) printed a `write-back error`
   line but `reconcile` still exited 0, so `reconcile --auto-writeback && deploy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,10 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   (`SKILL.md`, command/subagent markdown) with an unchanged `plugin.json` passed
   verification and was projected. The pin is now a `tree:v1:` hash over the
   whole plugin cache tree (excluding `.git/`), computed and verified by one
-  shared function. **Migration:** existing bare-hex pins are refused with a
-  re-pin instruction — run `agentsync update` (or `agentsync plugin upgrade
-  <id>`) to re-pin, or set `AGENTSYNC_ALLOW_PLUGIN_DRIFT=1` to bypass once.
+  shared function. **Migration:** existing pre-tree-hash (bare-hex) pins keep
+  verifying under the prior `plugin.json`-only scheme, so existing installs are
+  not broken; re-installing or `agentsync plugin upgrade <id>` rewrites the pin
+  as a tree hash that covers the bodies going forward.
 - **Nested memory fragments load** — `@import ./fragments/<name>` accepts a
   nested path (e.g. `sub/frag.md`), but fragments were read non-recursively and
   keyed by basename, so a nested fragment never loaded and its directive stayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`apply` is a true no-op when nothing changed** — the writer now skips the
+  atomic write when a destination already holds the exact bytes apply would
+  write, so a clean re-apply no longer churns file mtimes (which misled
+  mtime-watching tooling and made a no-op look like real work). `apply` reports
+  `up to date: N ops, no changes` instead of `applied: N ops` in that case.
+- **`verify` rejects a half-initialized home** — a home with component files but
+  no `agentsync.toml` (an authoring command run before `init`) reported a false
+  `ok: schema valid`; `verify` now requires the config marker.
+- **`agent add`/`disable` preserve section spacing** — regenerating the
+  `[agents]` block dropped the blank line before the next section, collapsing the
+  file's formatting over repeated edits; a single separator is now kept.
 - **Shared MCP/LSP write-back no longer silently last-writer-wins** — a server
   fanned out to multiple agents (`agents = ["*"]`) and edited *differently* in
   each native config produced two `reconcile` write-back items targeting one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **OpenCode MCP servers render in OpenCode's native schema** — the adapter
+  previously wrote `type` verbatim (`stdio`/`http`), `command` as a bare string
+  with a separate `args` array, and `env`, none of which match OpenCode's config
+  schema — so a rendered `opencode.json` could fail to load the server. MCP
+  servers now project to `type: "local"|"remote"`, `command` as a string array,
+  and `environment`, with ingest/reconcile inverting the translation through one
+  shared helper. (`reconcile` write-back of an OpenCode MCP edit previously also
+  crashed unmarshaling the array `command`.)
 - **Secret never leaks on a structural native edit (security)** — write-back
   (`import` / `reconcile`) re-referenced `${secret:…}` strictly by field
   position, so a native edit that shifted structure — prepending an MCP/LSP arg,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Nested memory fragments load** — `@import ./fragments/<name>` accepts a
+  nested path (e.g. `sub/frag.md`), but fragments were read non-recursively and
+  keyed by basename, so a nested fragment never loaded and its directive stayed
+  literal in the rendered memory. Fragments are now walked recursively and keyed
+  by their slash path under `memory/fragments/`.
 - **Cross-plugin MCP/LSP server collisions no longer silently clobber** — two
   plugins (or a plugin and your own config) declaring the same MCP/LSP server id
   with *different* content were unioned and rendered into an id-keyed map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`secrets edit` no longer panics on a blank `$EDITOR`** — the `$EDITOR`
+  word-split introduced above indexed an empty `strings.Fields` result, so a
+  whitespace-only `EDITOR` (e.g. `EDITOR="   "`) crashed with an index panic;
+  it now falls back to `vi`.
 - **`secrets edit` honors a `$EDITOR` with flags** — `EDITOR="code --wait"`
   (or `vim -u NONE`, `emacsclient -c`, …) was treated as a single executable
   path and failed; `$EDITOR` is now word-split. This is the command that steers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`reconcile` exits non-zero when a write-back fails** — a `[w]rite-back` that
+  errored (e.g. an unsupported `/hooks/*` pointer) printed a `write-back error`
+  line but `reconcile` still exited 0, so `reconcile --auto-writeback && deploy`
+  proceeded as if the dest edit had been captured (the next apply would then
+  clobber it). A failed write-back now exits non-zero.
 - **Plugin manifest pin covers component bodies (tree hash)** — the integrity
   pin recorded in `plugins/<id>.toml` previously hashed only
   `.claude-plugin/plugin.json`, so a tampered or re-uploaded component body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Foreign-collision backup covers explicit `null`** — a hand-authored
+  destination holding an explicit `null` at a JSON pointer agentsync is about to
+  write (e.g. `mcpServers.github = null` in `~/.claude.json`) is now backed up
+  before being overwritten, instead of being silently replaced. Previously an
+  absent pointer and a present-`null` pointer were indistinguishable to the
+  collision check.
 - **Marketplace slug never empty** — `marketplace add` derives its slug by
   sanitising *before* applying the `"marketplace"` fallback, and only adopts a
   declared `marketplace.json` name when it sanitises to something usable. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Shared MCP/LSP write-back no longer silently last-writer-wins** — a server
+  fanned out to multiple agents (`agents = ["*"]`) and edited *differently* in
+  each native config produced two `reconcile` write-back items targeting one
+  source file; the second silently clobbered the first and left the first agent
+  stuck in `conflict`. The run now detects the divergence, keeps the first
+  write, refuses the conflicting one with a clear message, and exits non-zero;
+  identical edits across agents still write cleanly.
 - **Deregistered agents no longer orphan native config silently** — after
   `agent remove` (or `agent disable` without `--purge`), the agent's rendered
   native config and state keys lingered with no diagnostic (`status`/`apply`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Plugin manifest pin covers component bodies (tree hash)** — the integrity
+  pin recorded in `plugins/<id>.toml` previously hashed only
+  `.claude-plugin/plugin.json`, so a tampered or re-uploaded component body
+  (`SKILL.md`, command/subagent markdown) with an unchanged `plugin.json` passed
+  verification and was projected. The pin is now a `tree:v1:` hash over the
+  whole plugin cache tree (excluding `.git/`), computed and verified by one
+  shared function. **Migration:** existing bare-hex pins are refused with a
+  re-pin instruction — run `agentsync update` (or `agentsync plugin upgrade
+  <id>`) to re-pin, or set `AGENTSYNC_ALLOW_PLUGIN_DRIFT=1` to bypass once.
 - **Nested memory fragments load** — `@import ./fragments/<name>` accepts a
   nested path (e.g. `sub/frag.md`), but fragments were read non-recursively and
   keyed by basename, so a nested fragment never loaded and its directive stayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   secret-bearing field to a value the vault no longer knows — leaving the live
   credential as cleartext in the canonical (committed) source. `capture.Capture`
   (`import`/`reconcile` write-back) now runs a fail-closed backstop: if a
-  resolved secret would still be written, or a `${secret:K}` the source
-  referenced has vanished from the captured server/hook, it refuses the
-  write-back and tells the user to update the vault or edit the source directly.
+  resolved secret would still be written, or a `${secret:K}` a captured server's
+  own field rotated away from, it refuses the write-back and tells the user to
+  update the vault or edit the source directly. The check is scoped to the
+  fields actually being written and to each field's own counterpart, so a
+  single-item `import`/reconcile isn't blocked by an unrelated server's secret,
+  and removing a credential field (no residual cleartext) is allowed.
 - **`secrets edit` no longer panics on a blank `$EDITOR`** — the `$EDITOR`
   word-split introduced above indexed an empty `strings.Fields` result, so a
   whitespace-only `EDITOR` (e.g. `EDITOR="   "`) crashed with an index panic;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,11 +90,13 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   credential as cleartext in the canonical (committed) source. `capture.Capture`
   (`import`/`reconcile` write-back) now runs a fail-closed backstop: if a
   resolved secret would still be written, or a `${secret:K}` a captured server's
-  own field rotated away from, it refuses the write-back and tells the user to
-  update the vault or edit the source directly. The check is scoped to the
-  fields actually being written and to each field's own counterpart, so a
-  single-item `import`/reconcile isn't blocked by an unrelated server's secret,
-  and removing a credential field (no residual cleartext) is allowed.
+  own field rotated/edited away from, it refuses the write-back and tells the
+  user to update the vault or edit the source directly. The check is per-field
+  and shape-aware: a single-item `import`/reconcile isn't blocked by an
+  unrelated server's secret; an unchanged literal that merely contains a secret
+  value, a trimmed-out secret, and a removed credential field (none leave
+  cleartext) are allowed; only a value moved into a field or a secret slot
+  rotated to cleartext is refused.
 - **`secrets edit` no longer panics on a blank `$EDITOR`** — the `$EDITOR`
   word-split introduced above indexed an empty `strings.Fields` result, so a
   whitespace-only `EDITOR` (e.g. `EDITOR="   "`) crashed with an index panic;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Cross-plugin MCP/LSP server collisions no longer silently clobber** — two
+  plugins (or a plugin and your own config) declaring the same MCP/LSP server id
+  with *different* content were unioned and rendered into an id-keyed map
+  last-wins, letting a later/untrusted plugin silently repoint a trusted
+  server's `command`/`url`/`headers`. Projection now refuses such a divergent
+  collision on mutating loads (apply/reconcile/import/update) and warns on
+  read-only ones (status/diff/explain); identical duplicates still dedup. (Skill/
+  command/subagent name collisions were already surfaced as a hard apply error.)
 - **Frontmatter parser accepts a closing fence at EOF / empty frontmatter** — a
   skill/subagent/command markdown file whose closing `---` sits at end-of-file
   with no trailing newline (common: editors strip it; frontmatter-only files),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Partial `import` seeds the items it already wrote** — when importing a whole
+  component (e.g. `import claude:command`) or a whole agent, a write that failed
+  partway left the *already-written* items unseeded in state, so the next
+  `apply` saw them as foreign-collision and backed up / overwrote the very file
+  they were just imported from. The written items are now seeded even on a
+  partial failure (and the command still exits non-zero).
 - **`[updates] default_mode` is honored** — the config knob (written into the
   generated `agentsync.toml` by `init`) was parsed but never consulted:
   `update` hardcoded `track` for any plugin without an explicit `update` mode,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Deregistered agents no longer orphan native config silently** — after
+  `agent remove` (or `agent disable` without `--purge`), the agent's rendered
+  native config and state keys lingered with no diagnostic (`status`/`apply`
+  only iterate enabled agents), and `disable --purge` was unreachable once the
+  agent was deregistered. `status` now surfaces an orphaned agent's leftover
+  state, and `agent disable <name> --purge` works for an already-removed agent
+  (purge reads state, so it doesn't need the agent registered). Removal stays
+  non-destructive by default.
 - **Write-back refuses to persist a moved or rotated secret (security)** — secret
   re-reference matches by value, so it could not restore a `${secret:…}`
   reference when the user *moved* a secret into a field whose source counterpart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Write-back refuses to persist a moved or rotated secret (security)** — secret
+  re-reference matches by value, so it could not restore a `${secret:…}`
+  reference when the user *moved* a secret into a field whose source counterpart
+  is a literal (e.g. inlining a token onto a `command`), or *rotated* a
+  secret-bearing field to a value the vault no longer knows — leaving the live
+  credential as cleartext in the canonical (committed) source. `capture.Capture`
+  (`import`/`reconcile` write-back) now runs a fail-closed backstop: if a
+  resolved secret would still be written, or a `${secret:K}` the source
+  referenced has vanished from the captured server/hook, it refuses the
+  write-back and tells the user to update the vault or edit the source directly.
 - **`secrets edit` no longer panics on a blank `$EDITOR`** — the `$EDITOR`
   word-split introduced above indexed an empty `strings.Fields` result, so a
   whitespace-only `EDITOR` (e.g. `EDITOR="   "`) crashed with an index panic;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Frontmatter parser accepts a closing fence at EOF / empty frontmatter** — a
+  skill/subagent/command markdown file whose closing `---` sits at end-of-file
+  with no trailing newline (common: editors strip it; frontmatter-only files),
+  or an empty `---`/`---` block, previously returned `unterminated frontmatter`.
+  In `source.Load` that aborted the entire load — bricking *every* command — and
+  in the Claude adapter's ingest it silently dropped the component. Both
+  `ParseFrontmatter` implementations now accept these shapes.
 - **OpenCode MCP servers render in OpenCode's native schema** — the adapter
   previously wrote `type` verbatim (`stdio`/`http`), `command` as a bare string
   with a separate `args` array, and `env`, none of which match OpenCode's config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`secrets edit` honors a `$EDITOR` with flags** — `EDITOR="code --wait"`
+  (or `vim -u NONE`, `emacsclient -c`, …) was treated as a single executable
+  path and failed; `$EDITOR` is now word-split. This is the command that steers
+  users away from the argv-leaking `set key=value` form, so its breakage
+  mattered.
+- **`secrets get`/`edit` match apply's vault contract** — `get` now errors on a
+  non-string leaf instead of printing a Go-formatted value apply would refuse,
+  and `edit` validates the saved buffer with the same `flatten` check apply uses
+  (string-only leaves, no quoted-key-vs-table collisions) so it can't encrypt a
+  vault that every later apply would reject. `secrets set --stdin` now trims a
+  single trailing newline (not all of them), preserving a secret that
+  legitimately ends in newlines.
 - **Partial `import` seeds the items it already wrote** — when importing a whole
   component (e.g. `import claude:command`) or a whole agent, a write that failed
   partway left the *already-written* items unseeded in state, so the next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 - **Documentation set** — user guide, concepts, architecture, capability matrix,
   and component map under [`docs/`](docs/).
 
+### Fixed
+
+- **Marketplace slug never empty** — `marketplace add` derives its slug by
+  sanitising *before* applying the `"marketplace"` fallback, and only adopts a
+  declared `marketplace.json` name when it sanitises to something usable. A
+  punctuation-only source or name (e.g. `...`) no longer authors
+  `marketplaces/.toml` and a stray `marketplaces/_` cache directory.
+- **Degenerate component ids rejected** — `mcp add .`, `mcp add " "`, and any
+  write of a component whose id is a bare `.` or all-whitespace now error
+  instead of authoring a confusing `mcp/..toml` / `mcp/ .toml` in the canonical
+  source. Enforced centrally in `source.ValidateComponentID` (covering MCP, LSP,
+  hook events, plugins, skills, subagents, commands) and mirrored in the CLI
+  `mcp add` gate.
+
 ### Known limitations
 
 Documented v1.x trade-offs rather than bugs — see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`agent disable --purge` validates the name; `doctor` names a half-init** —
+  `disable <bogus> --purge` reported a misleading "purged 0 files" success for
+  any string; it now rejects an unknown agent like the other subcommands (a
+  removed-but-valid agent still purges). `doctor` now flags a home missing
+  `agentsync.toml` instead of calling the schema "ok", matching `verify`.
 - **`apply` is a true no-op when nothing changed** — the writer now skips the
   atomic write when a destination already holds the exact bytes apply would
   write, so a clean re-apply no longer churns file mtimes (which misled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Secret never leaks on a structural native edit (security)** — write-back
+  (`import` / `reconcile`) re-referenced `${secret:…}` strictly by field
+  position, so a native edit that shifted structure — prepending an MCP/LSP arg,
+  renaming an env/header key, or renaming a server id — moved the resolved
+  cleartext to a location with no source counterpart and silently persisted the
+  live credential into `~/.agentsync` (often a committed dotfiles repo). A
+  value-based fallback now restores the placeholder for any source-referenced
+  secret whose cleartext survives the positional pass, while still leaving a
+  value that coincidentally equals a non-templated source literal untouched.
 - **Foreign-collision backup covers explicit `null`** — a hand-authored
   destination holding an explicit `null` at a JSON pointer agentsync is about to
   write (e.g. `mcpServers.github = null` in `~/.claude.json`) is now backed up

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,8 +150,13 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
   No `pkg/errors`.
 - **Imports** grouped stdlib / third-party / internal; gofumpt + goimports
   formatting (`just fmt`).
-- **`time.Now()`** is forbidden in `internal/state` and `internal/render` (inject
-  a clock for testability) — enforced by `forbidigo`.
+- **`time.Now()`** in `internal/render`/`internal/state` is confined to
+  informational metadata (state `AppliedAt`, backup-dir names) — it never feeds a
+  content hash or the drift classifier, so it calls `time.Now().UTC()` directly
+  rather than through an injected clock. Keep any new timestamp in these packages
+  out of hashed/compared content for the same reason. (There is no `forbidigo`
+  rule enforcing this, and `internal/cli` uses `time.Now().UTC()` freely for
+  fetch/import timestamps.)
 - **Commits**: conventional commits with scope, e.g.
   `feat(adapter): …`, `fix(secrets): …`, `test(drift): …`, `docs(readme): …`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,13 @@ being classified.
 preserves source-only fields the rendered dest never carries (MCP/LSP
 `agents`/`enabled`), and writes via `internal/source/writer.go`. `import` and
 `reconcile` write-back both call it. **Do not add a new dest→source write that
-bypasses it.**
+bypasses it.** After re-referencing, `capture.Capture` runs a **fail-closed
+backstop** (`secrets.ResidualSecretCleartext`): re-reference matches by value and
+cannot tell a *moved/rotated* secret from a deliberate literal edit, so if a live
+vault secret value would still be written verbatim, or a `${secret:K}` the source
+group referenced is now absent from the ingested group (rotated/edited away),
+Capture **refuses the whole write** rather than persist cleartext. It errs toward
+refusing; the user updates the vault or edits the canonical source directly.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,11 @@ can resolve secrets into native config files. Areas of particular interest:
   `agentsync diff`.
 - **Untrusted marketplaces / plugins**: a marketplace or plugin you add is
   treated as untrusted input. Fetchers reject symlinks (npm/relative/git),
-  cap decompressed tarball size, verify plugin manifest SHAs, and bound
-  manifest-listed component paths and names to the plugin cache.
+  cap decompressed tarball size, and bound manifest-listed component paths and
+  names to the plugin cache. Each installed plugin is pinned with a content
+  hash over its *entire* cache tree (every projected component body, not just
+  `plugin.json`), so a tampered or re-uploaded body is detected at apply rather
+  than silently consumed.
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,14 @@ source-only fields (like an MCP server's `agents`/`enabled` list) that the
 rendered destination never carried. No other code path writes destination data
 back into the source.
 
+Re-reference matches by value, so it cannot distinguish a *moved or rotated*
+secret from a deliberate non-secret edit. As a **fail-closed backstop**,
+`capture.Capture` re-scans the about-to-be-written model
+(`secrets.ResidualSecretCleartext`): if a live vault secret value would still be
+written verbatim, or a `${secret:K}` the source referenced has vanished from the
+captured group (rotated/edited away), it **refuses the write** rather than risk
+persisting cleartext — directing the user to update the vault or edit the source.
+
 ---
 
 ## 6. Drift — the 3-way classifier
@@ -225,6 +233,13 @@ this hard to do by accident with three tiers of defense:
   skills, commands) physically cannot carry a substituted secret.
 - **Lint fence (defense-in-depth).** A `forbidigo` rule forbids unwrapping a
   `Resolved` outside the two adapter `Render` egress sites.
+- **Capture fail-closed backstop (defense-in-depth).** The *dest→source*
+  direction can't be type-enforced (it legitimately writes a templated
+  `source.Canonical`), and re-reference matches by value — so a secret *moved*
+  into a literal-counterpart field or *rotated* to a vault-unknown value can
+  evade restoration. `capture.Capture` re-scans the about-to-be-written model
+  (`secrets.ResidualSecretCleartext`) and **refuses to write** if a resolved
+  secret would persist, rather than guess.
 
 There is one **accepted residual**: a *deliberate* two-step laundering (defeat
 the lint fence to obtain a writable `source.Canonical`, then call a source writer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,9 +199,12 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
 4. **First-apply backups** — the `foreign-collision` case copies the pre-existing
    destination into `.state/backups/<ts>/` before writing. Symlinked
    destinations are refused by default.
-5. **Manifest-SHA pinning** — every plugin records the marketplace-published
-   manifest SHA, so a re-uploaded version is detected as drift rather than
-   silently consumed.
+5. **Manifest-SHA pinning** — every plugin records a `tree:v1:` content hash
+   over its *entire* cache tree (every projected component body — skills,
+   command/subagent markdown — not just `plugin.json`, excluding `.git/`), so a
+   re-uploaded version *or* a tampered component body is detected as drift
+   rather than silently consumed. (An entry-only plugin with no cached bodies is
+   pinned over its marketplace entry.)
 
 ---
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -79,8 +79,9 @@ You control fan-out explicitly:
 
 - `agents = ["claude", "opencode"]` on an MCP server or plugin entry → fan out
   only to those agents.
-- `[plugin.overrides.<agent>]` with `component = "skip"` → drop one component
-  for one agent.
+
+(A per-component `[plugin.overrides.<agent>]` skip was specced but is **not
+wired in v1** — the projector does not consult it. Use the `agents` allowlist.)
 
 ---
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -58,6 +58,21 @@ the **planned** projection per the design spec; their adapters are no-ops today.
   Claude plugins that bundle LSP servers install correctly on Claude itself; on
   other agents you'll see `lsp server X skipped` in the report.
 
+## How OpenCode MCP servers are projected
+
+OpenCode's native MCP schema differs from the canonical model, so the adapter
+translates rather than copying fields verbatim:
+
+- **transport** — canonical `type = "stdio"` → OpenCode `"type": "local"`;
+  `"http"`/`"sse"` → `"type": "remote"`. OpenCode has no separate SSE transport,
+  so a `sse` server normalizes to `http` if it is later captured back via
+  `import`/`reconcile` (an apply-only flow is unaffected).
+- **command** — canonical `command` + `args` are flattened into OpenCode's single
+  `command` string array (`["npx", "-y", "pkg"]`), and split back on ingest.
+- **environment** — canonical `env` is written under OpenCode's `environment`
+  key (not `env`).
+- **remote** — `url` and `headers` carry through unchanged.
+
 ## Escape hatches
 
 You control fan-out explicitly:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -308,8 +308,9 @@ agentsync explain atlassian@anthropic
 agentsync explain atlassian@anthropic --json
 ```
 
-Control fan-out per plugin with `agents = [...]` or per-component
-`[plugin.overrides.<agent>]` in the plugin's TOML file.
+Control fan-out per plugin with `agents = [...]` in the plugin's TOML file. (A
+per-component `[plugin.overrides.<agent>]` table was specced but is **not wired
+in v1** — the projector does not consult it; use the `agents` allowlist.)
 
 ### Secrets
 

--- a/internal/adapter/claude/frontmatter.go
+++ b/internal/adapter/claude/frontmatter.go
@@ -26,18 +26,41 @@ func ParseFrontmatter(data []byte) (map[string]any, string, error) {
 		return map[string]any{}, string(data), nil
 	}
 	rest := data[len("---\n"):]
-	end := bytes.Index(rest, []byte("\n---\n"))
-	if end < 0 {
+	yml, body, ok := splitFrontmatterBody(rest)
+	if !ok {
 		return nil, "", fmt.Errorf("unterminated frontmatter")
 	}
-	yml := rest[:end]
-	body := rest[end+len("\n---\n"):]
-
+	// An empty frontmatter block ("---\n---\n…") is a valid empty mapping.
+	if len(bytes.TrimSpace(yml)) == 0 {
+		return map[string]any{}, string(body), nil
+	}
 	fm, err := jsonkeys.DecodeYAML(yml)
 	if err != nil {
 		return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
 	}
 	return fm, string(body), nil
+}
+
+// splitFrontmatterBody splits the bytes AFTER the opening "---\n" into YAML
+// frontmatter and body, accepting the closing "---" fence mid-file ("\n---\n"),
+// at end-of-file ("\n---", no trailing newline), or — for an empty mapping — as
+// the first line ("---\n…" or just "---"). ok is false only with no closing
+// fence. Mirrors source.splitFrontmatterBody; without it a component .md whose
+// fence sits at EOF was silently dropped on ingest.
+func splitFrontmatterBody(rest []byte) (yml, body []byte, ok bool) {
+	switch {
+	case bytes.HasPrefix(rest, []byte("---\n")):
+		return nil, rest[len("---\n"):], true
+	case bytes.Equal(rest, []byte("---")):
+		return nil, nil, true
+	}
+	if i := bytes.Index(rest, []byte("\n---\n")); i >= 0 {
+		return rest[:i], rest[i+len("\n---\n"):], true
+	}
+	if bytes.HasSuffix(rest, []byte("\n---")) {
+		return rest[:len(rest)-len("\n---")], nil, true
+	}
+	return nil, nil, false
 }
 
 // EncodeFrontmatter writes "---\n<yaml>\n---\n<body>" with the keys in fm.

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -36,14 +36,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 						if !ok {
 							continue
 						}
-						m := source.MCPServer{ID: id, Server: source.MCPServerSpec{
-							Type:    asStr(spec["type"]),
-							Command: asStr(spec["command"]),
-							Args:    asStrSlice(spec["args"]),
-							Env:     asStrMap(spec["env"]),
-							URL:     asStr(spec["url"]),
-							Headers: asStrMap(spec["headers"]),
-						}}
+						m := source.MCPServer{ID: id, Server: IngestMCPSpec(spec)}
 						c.MCPServers = append(c.MCPServers, m)
 					}
 				}
@@ -119,6 +112,60 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 }
 
 func asStr(v any) string { s, _ := v.(string); return s }
+
+// IngestMCPSpec translates one OpenCode-native MCP server spec — the value
+// under opencode.json `/mcp/<id>` — into the canonical MCPServerSpec. It is the
+// exact inverse of opencodeMCPSpec (Render). Exported so reconcile's key-level
+// write-back reconstructs an opencode MCP server through the SAME translation
+// the adapter uses, rather than assuming the dest shape matches the canonical
+// model (it doesn't: command is an array, env is `environment`, type is
+// local/remote).
+func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	command, args := opencodeIngestCommand(raw["command"])
+	return source.MCPServerSpec{
+		Type:    canonicalMCPType(asStr(raw["type"])),
+		Command: command,
+		Args:    args,
+		Env:     asStrMap(raw["environment"]),
+		URL:     asStr(raw["url"]),
+		Headers: asStrMap(raw["headers"]),
+	}
+}
+
+// canonicalMCPType maps OpenCode's transport ("local"/"remote") back to the
+// canonical model's stdio/http. OpenCode has no separate sse transport, so a
+// remote server normalises to "http" on write-back (an apply-only flow is
+// unaffected — render maps both http and sse to "remote"). An unrecognised
+// value is preserved verbatim.
+func canonicalMCPType(opencodeType string) string {
+	switch opencodeType {
+	case "local":
+		return "stdio"
+	case "remote":
+		return "http"
+	default:
+		return opencodeType
+	}
+}
+
+// opencodeIngestCommand splits OpenCode's command — a string array
+// [command, ...args] — into the canonical command + args. A bare string is
+// tolerated for hand-edited configs. A single-element array yields no args so
+// the value round-trips cleanly (render flattens command+nil-args back to it).
+func opencodeIngestCommand(v any) (command string, args []string) {
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	arr := asStrSlice(v)
+	switch len(arr) {
+	case 0:
+		return "", nil
+	case 1:
+		return arr[0], nil
+	default:
+		return arr[0], arr[1:]
+	}
+}
 
 func asStrSlice(v any) []string {
 	arr, ok := v.([]any)

--- a/internal/adapter/opencode/ingest_test.go
+++ b/internal/adapter/opencode/ingest_test.go
@@ -42,8 +42,40 @@ func TestIngest_RoundTripsMCP(t *testing.T) {
 	if srv.Command != "npx" {
 		t.Fatalf("command = %q, want npx", srv.Command)
 	}
+	// The command array [npx -y x] must split back into command + args so a
+	// reconcile write-back doesn't fold the flags into the command string.
+	if len(srv.Args) != 2 || srv.Args[0] != "-y" || srv.Args[1] != "x" {
+		t.Fatalf("args = %v, want [-y x]", srv.Args)
+	}
+	if srv.Type != "stdio" {
+		t.Fatalf("type = %q, want stdio (from OpenCode \"local\")", srv.Type)
+	}
 	if srv.Env["TOKEN"] != "abc" {
 		t.Fatalf("env token missing: %+v", srv.Env)
+	}
+}
+
+// TestRender_MCP_SSEMapsToRemote proves the canonical "sse" transport renders as
+// OpenCode "remote" (OpenCode has no separate sse transport).
+func TestRender_MCP_SSEMapsToRemote(t *testing.T) {
+	c := source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "stream",
+		Server: source.MCPServerSpec{Type: "sse", URL: "https://sse.example.com"},
+	}}}
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 || out.MCPServers[0].Server.URL != "https://sse.example.com" {
+		t.Fatalf("sse->remote round-trip lost the server: %+v", out.MCPServers)
 	}
 }
 

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -69,26 +69,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 		if !agentTargeted("opencode", m.Server.Agents) {
 			continue
 		}
-		spec := map[string]any{}
-		if m.Server.Type != "" {
-			spec["type"] = m.Server.Type
-		}
-		if m.Server.Command != "" {
-			spec["command"] = m.Server.Command
-		}
-		if len(m.Server.Args) > 0 {
-			spec["args"] = m.Server.Args
-		}
-		if len(m.Server.Env) > 0 {
-			spec["env"] = m.Server.Env
-		}
-		if m.Server.URL != "" {
-			spec["url"] = m.Server.URL
-		}
-		if len(m.Server.Headers) > 0 {
-			spec["headers"] = m.Server.Headers
-		}
-		mcp[m.ID] = spec
+		mcp[m.ID] = opencodeMCPSpec(m.Server)
 	}
 	if len(mcp) == 0 {
 		return nil, nil
@@ -106,6 +87,58 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 		SourceID:      "mcp/* (multiple)",
 		MergeStrategy: "merge-jsonc-keys",
 	}}, nil
+}
+
+// opencodeMCPSpec projects a canonical MCP server into OpenCode's native shape
+// (https://opencode.ai/config.json): `type` is "local" or "remote", a local
+// server's `command` is a string ARRAY ([command, ...args]), env vars live under
+// `environment` (not `env`), and a remote server carries `url`/`headers`. The
+// canonical model instead keeps command/args split and uses stdio/http/sse, so
+// translate. Ingest (canonicalMCPType / opencodeIngestCommand) inverts this.
+func opencodeMCPSpec(s source.MCPServerSpec) map[string]any {
+	spec := map[string]any{}
+	if isRemoteMCP(s) {
+		spec["type"] = "remote"
+		if s.URL != "" {
+			spec["url"] = s.URL
+		}
+		if len(s.Headers) > 0 {
+			spec["headers"] = s.Headers
+		}
+		return spec
+	}
+	spec["type"] = "local"
+	if cmd := commandArray(s); len(cmd) > 0 {
+		spec["command"] = cmd
+	}
+	if len(s.Env) > 0 {
+		spec["environment"] = s.Env
+	}
+	return spec
+}
+
+// isRemoteMCP decides whether a canonical server maps to OpenCode's "remote"
+// type. OpenCode collapses http and sse into a single "remote" transport; an
+// untyped server is classified by whether it carries a URL but no command.
+func isRemoteMCP(s source.MCPServerSpec) bool {
+	switch s.Type {
+	case "http", "sse":
+		return true
+	case "stdio":
+		return false
+	default:
+		return s.URL != "" && s.Command == ""
+	}
+}
+
+// commandArray flattens a canonical command + args into OpenCode's single
+// command string array.
+func commandArray(s source.MCPServerSpec) []string {
+	var cmd []string
+	if s.Command != "" {
+		cmd = append(cmd, s.Command)
+	}
+	return append(cmd, s.Args...)
 }
 
 func agentTargeted(name string, agents []string) bool {

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -21,6 +21,7 @@ func TestRender_MCP(t *testing.T) {
 		ID: "github",
 		Server: source.MCPServerSpec{
 			Type: "stdio", Command: "npx", Args: []string{"-y", "x"},
+			Env:    map[string]string{"TOKEN": "abc"},
 			Agents: []string{"opencode"}, Enabled: &enabled,
 		},
 	}}}
@@ -36,8 +37,21 @@ func TestRender_MCP(t *testing.T) {
 			var ours map[string]any
 			_ = json.Unmarshal(op.Content, &ours)
 			mcp := ours["mcp"].(map[string]any)["github"].(map[string]any)
-			if mcp["command"] != "npx" {
-				t.Fatalf("command = %v", mcp["command"])
+			// OpenCode's native schema: type local|remote, command as a string
+			// ARRAY ([command, ...args]), and `environment` (not `env`).
+			if mcp["type"] != "local" {
+				t.Fatalf("type = %v, want \"local\"", mcp["type"])
+			}
+			cmd, ok := mcp["command"].([]any)
+			if !ok || len(cmd) != 3 || cmd[0] != "npx" || cmd[1] != "-y" || cmd[2] != "x" {
+				t.Fatalf("command = %v, want [\"npx\",\"-y\",\"x\"] array", mcp["command"])
+			}
+			if _, hasEnv := mcp["env"]; hasEnv {
+				t.Fatalf("must use \"environment\", not \"env\": %v", mcp)
+			}
+			env, ok := mcp["environment"].(map[string]any)
+			if !ok || env["TOKEN"] != "abc" {
+				t.Fatalf("environment = %v, want {TOKEN: abc}", mcp["environment"])
 			}
 		}
 	}
@@ -66,6 +80,12 @@ func TestRender_MCP_PreservesHeaders(t *testing.T) {
 		var ours map[string]any
 		_ = json.Unmarshal(op.Content, &ours)
 		mcp := ours["mcp"].(map[string]any)["remote"].(map[string]any)
+		if mcp["type"] != "remote" {
+			t.Fatalf("type = %v, want \"remote\"", mcp["type"])
+		}
+		if mcp["url"] != "https://mcp.example.com" {
+			t.Fatalf("url = %v", mcp["url"])
+		}
 		h, ok := mcp["headers"].(map[string]any)
 		if !ok || h["Authorization"] != "Bearer tok" {
 			t.Fatalf("opencode MCP dropped headers: %v", mcp)

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -77,6 +77,21 @@ func Capture(home string, ingested *source.Canonical, opts Opts) (Result, error)
 	sec := secrets.SelectBackend(cur.Config.Secrets, home, userHome)
 	secrets.ReReferenceCanonical(ingested, &cur, sec, secrets.EnvBackend{})
 
+	// Fail-closed backstop: re-reference matches by value and cannot tell a
+	// moved/rotated secret from a deliberate literal edit, so it can leave a
+	// resolved credential as cleartext (a secret moved into a literal-counterpart
+	// field, or a rotated value the vault no longer knows). Rather than guess and
+	// risk persisting a live credential into ~/.agentsync, refuse the whole
+	// write-back and tell the user exactly which fields to resolve (update the
+	// vault, or edit the canonical source directly).
+	if leaks := secrets.ResidualSecretCleartext(ingested, &cur, sec, secrets.EnvBackend{}); len(leaks) > 0 {
+		return res, fmt.Errorf("refusing to write back: a resolved secret would be persisted as "+
+			"cleartext into ~/.agentsync at %s — re-reference could not restore the ${secret:…} "+
+			"reference (the value was moved or rotated). Update the vault (`agentsync secrets set`) "+
+			"and/or edit the canonical source directly, then retry; set AGENTSYNC_ALLOW_PLUGIN_DRIFT "+
+			"is NOT a bypass here", strings.Join(leaks, ", "))
+	}
+
 	for _, m := range ingested.MCPServers {
 		if existing, ok, rerr := source.ReadMCP(home, m.ID); rerr == nil && ok {
 			m.Server.Agents = existing.Server.Agents

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -235,6 +235,72 @@ func TestCapture_RemovingSecretFieldAllowed(t *testing.T) {
 	}
 }
 
+// TestCapture_TrimmedEmbeddedSecretAllowed is the regression for a false-refusal:
+// trimming a secret OUT of a still-present field (the field keeps non-secret
+// text) leaves no cleartext, so capture must allow it — the SLOT prong must
+// distinguish a trim (slot+context removed) from a rotation (slot holds a new
+// value).
+func TestCapture_TrimmedEmbeddedSecretAllowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("T", "real_token_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"serve --tok=${secret:T}\"\n")
+	// User dropped the --tok flag in the dest; nothing cleartext remains.
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "serve"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("trimming a secret out of a field (no cleartext) must be allowed: %v", err)
+	}
+}
+
+// TestCapture_UnchangedLiteralCollidingWithSecretAllowed is the regression for a
+// false-refusal: an UNCHANGED literal in one server that coincidentally contains
+// another server's secret value must not be refused (it was already in source;
+// re-reference deliberately leaves such literals byte-for-byte).
+func TestCapture_UnchangedLiteralCollidingWithSecretAllowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("T", "tok12345abc")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "a.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"a\"\n[server.env]\nK = \"${secret:T}\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "b.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"run --note=tok12345abc-extra\"\n")
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "b",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "run --note=tok12345abc-extra"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("unchanged literal that merely contains another secret's value must be allowed: %v", err)
+	}
+	if got, _, _ := source.ReadMCP(home, "b"); got.Server.Command != "run --note=tok12345abc-extra" {
+		t.Fatalf("literal must be left byte-for-byte, got: %q", got.Server.Command)
+	}
+}
+
+// TestCapture_RefusesEmbeddedRotation locks that the shape-aware SLOT still
+// catches a genuine rotation of an EMBEDDED secret to a vault-unknown value
+// (the leak it must keep refusing while allowing trims above).
+func TestCapture_RefusesEmbeddedRotation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("T", "old_token_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"serve --tok=${secret:T}\"\n")
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "serve --tok=ROTATED_UNVAULTED_TOKEN"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err == nil {
+		t.Fatal("rotating an embedded secret to a new value must be refused")
+	}
+	if raw, _ := os.ReadFile(filepath.Join(home, "mcp", "srv.toml")); strings.Contains(string(raw), "ROTATED_UNVAULTED_TOKEN") {
+		t.Fatalf("rotated cleartext must not be persisted:\n%s", raw)
+	}
+}
+
 // TestCapture_RejectsTraversalID is the regression for an arbitrary-file-write
 // primitive via import/capture: an ingested component id/event (taken from a
 // foreign / synced / project-supplied native config) was joined straight into a

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -189,6 +189,52 @@ func TestCapture_AllowsLegitWriteBacks(t *testing.T) {
 	}
 }
 
+// TestCapture_SingleItemNotRefusedByUnrelatedSecret is the regression for a
+// false-refusal: a single-item write-back (import claude:mcp:alpha) must NOT be
+// blocked because a DIFFERENT source server (beta) has a ${secret:} the leak
+// scan thinks is "missing" — only the items being written are relevant.
+func TestCapture_SingleItemNotRefusedByUnrelatedSecret(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AT", "alpha_secret_value")
+	t.Setenv("BT", "beta_secret_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "alpha.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"a\"\n[server.env]\nK = \"${secret:AT}\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "beta.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"b\"\n[server.env]\nK = \"${secret:BT}\"\n")
+	// Capture only alpha (unchanged secret value as apply wrote it).
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "alpha",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "a", Env: map[string]string{"K": "alpha_secret_value"}},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("single-item write-back must not be refused by an unrelated server's secret: %v", err)
+	}
+	got, _, _ := source.ReadMCP(home, "alpha")
+	if got.Server.Env["K"] != "${secret:AT}" {
+		t.Fatalf("alpha secret not re-referenced: %q", got.Server.Env["K"])
+	}
+}
+
+// TestCapture_RemovingSecretFieldAllowed is the regression for a false-refusal:
+// removing a secret-bearing field entirely (the server is now public) is safe —
+// there is no cleartext to persist — so capture must allow it, not refuse.
+func TestCapture_RemovingSecretFieldAllowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "live_secret_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"),
+		"[server]\ntype=\"stdio\"\ncommand=\"npx\"\n[server.env]\nAUTH = \"${secret:TOK}\"\n")
+	// Dest had the env removed (server no longer needs auth).
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "npx"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("removing a secret field (no residual cleartext) must be allowed: %v", err)
+	}
+}
+
 // TestCapture_RejectsTraversalID is the regression for an arbitrary-file-write
 // primitive via import/capture: an ingested component id/event (taken from a
 // foreign / synced / project-supplied native config) was joined straight into a

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -3,6 +3,7 @@ package capture_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/capture"
@@ -66,6 +67,50 @@ func TestCapture_ReReferencesAndPreserves(t *testing.T) {
 	}
 	if got.Server.Enabled == nil || *got.Server.Enabled {
 		t.Errorf("source-only enabled not preserved: %v", got.Server.Enabled)
+	}
+}
+
+// TestCapture_NoLeakOnStructuralEdit drives the full dest->source funnel for the
+// exact scenario that leaked: a user adds a flag to an MCP server's args in the
+// native UI (shifting the secret to a new index), then write-back is captured.
+// The positional re-reference misses the shifted index; the value-based fallback
+// must restore the ${secret:…} placeholder so the resolved credential is NEVER
+// persisted into ~/.agentsync.
+func TestCapture_NoLeakOnStructuralEdit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "ghp_live_credential_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\n"+
+		"type = \"stdio\"\n"+
+		"command = \"npx\"\n"+
+		"args = [\"--token\", \"${secret:TOK}\"]\n")
+
+	// Native edit prepended "--verbose"; the secret resolved to cleartext sits
+	// at the new index 2.
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID: "srv",
+		Server: source.MCPServerSpec{
+			Type:    "stdio",
+			Command: "npx",
+			Args:    []string{"--verbose", "--token", "ghp_live_credential_value"},
+		},
+	}}}
+
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, "mcp", "srv.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "ghp_live_credential_value") {
+		t.Fatalf("LEAK: resolved secret persisted into source:\n%s", raw)
+	}
+	got, _, _ := source.ReadMCP(home, "srv")
+	if len(got.Server.Args) != 3 || got.Server.Args[2] != "${secret:TOK}" {
+		t.Fatalf("shifted secret not re-referenced: %v", got.Server.Args)
 	}
 }
 

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -114,6 +114,81 @@ func TestCapture_NoLeakOnStructuralEdit(t *testing.T) {
 	}
 }
 
+// TestCapture_RefusesMovedSecretIntoLiteralField is the fail-closed backstop
+// for a secret MOVED onto a field whose source counterpart is a literal: source
+// command="run-server" (literal) + a secret in env; the user inlines the token
+// onto the command in the dest. Re-reference can't restore it (no templated
+// counterpart there), so capture must REFUSE rather than persist cleartext.
+func TestCapture_RefusesMovedSecretIntoLiteralField(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "ghp_live_credential_value")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\ntype = \"stdio\"\ncommand = \"run-server\"\n[server.env]\nAUTH = \"${secret:TOK}\"\n")
+
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "run-server --token=ghp_live_credential_value"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err == nil {
+		t.Fatal("capture must REFUSE a secret moved into a literal-counterpart field, got nil")
+	}
+	// And it must NOT have written the cleartext.
+	if raw, _ := os.ReadFile(filepath.Join(home, "mcp", "srv.toml")); strings.Contains(string(raw), "ghp_live_credential_value") {
+		t.Fatalf("LEAK: cleartext persisted despite refusal:\n%s", raw)
+	}
+}
+
+// TestCapture_RefusesRotatedSecret is the fail-closed backstop for a ROTATED
+// secret: the source field is ${secret:}-templated, but the user changed the
+// dest value to a NEW token the vault doesn't know. Re-reference can't match it,
+// so capture must REFUSE rather than persist the new cleartext.
+func TestCapture_RefusesRotatedSecret(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "ghp_old_value_xyz")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\ntype = \"stdio\"\ncommand = \"npx\"\n[server.env]\nAUTH = \"${secret:TOK}\"\n")
+
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID: "srv",
+		Server: source.MCPServerSpec{
+			Type: "stdio", Command: "npx",
+			Env: map[string]string{"AUTH": "ghp_ROTATED_new_value"},
+		},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err == nil {
+		t.Fatal("capture must REFUSE a rotated (vault-unknown) secret value, got nil")
+	}
+	if raw, _ := os.ReadFile(filepath.Join(home, "mcp", "srv.toml")); strings.Contains(string(raw), "ghp_ROTATED_new_value") {
+		t.Fatalf("LEAK: rotated cleartext persisted despite refusal:\n%s", raw)
+	}
+}
+
+// TestCapture_AllowsLegitWriteBacks proves the backstop does NOT false-refuse:
+// an unchanged secret (re-referenced cleanly) and a non-secret-part edit of a
+// templated field (secret re-referenced, edit captured) both write successfully.
+func TestCapture_AllowsLegitWriteBacks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TOK", "ghp_live_value_abc")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\ntype = \"stdio\"\ncommand = \"serve --port=8080 --tok=${secret:TOK}\"\n")
+
+	// User edited the non-secret port; the secret resolved value is unchanged.
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "srv",
+		Server: source.MCPServerSpec{Type: "stdio", Command: "serve --port=9090 --tok=ghp_live_value_abc"},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("legit non-secret-part edit must write back, got refusal: %v", err)
+	}
+	got, _, _ := source.ReadMCP(home, "srv")
+	if got.Server.Command != "serve --port=9090 --tok=${secret:TOK}" {
+		t.Fatalf("expected port edit captured + secret re-referenced, got: %q", got.Server.Command)
+	}
+}
+
 // TestCapture_RejectsTraversalID is the regression for an arbitrary-file-write
 // primitive via import/capture: an ingested component id/event (taken from a
 // foreign / synced / project-supplied native config) was joined straight into a

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -296,9 +296,17 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	if err != nil {
 		return err
 	}
+	home := paths.AgentsyncHome(paths.OSEnv{})
 	v, ok := agents[name]
 	if !ok {
-		return fmt.Errorf("agent %q not registered", name)
+		// Not registered. A removed (or never-registered) agent can still own
+		// orphaned destination files + state keys; `--purge` is the reachable
+		// cleanup path for it, working purely from state. Without --purge there
+		// is nothing to disable.
+		if purge {
+			return purgeAgentDests(cmd, name, home)
+		}
+		return fmt.Errorf("agent %q not registered (pass --purge to clean up an already-removed agent's leftover files)", name)
 	}
 	v["enabled"] = false
 	agents[name] = v
@@ -314,7 +322,6 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	// The whole disable command (including this purge) already runs under the
 	// global lock via lockedRun, so call purge directly — re-acquiring here
 	// would deadlock on the re-entrant flock.
-	home := paths.AgentsyncHome(paths.OSEnv{})
 	return purgeAgentDests(cmd, name, home)
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -306,11 +306,14 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	v, ok := agents[name]
 	if !ok {
-		// Not registered. A removed (or never-registered) agent can still own
-		// orphaned destination files + state keys; `--purge` is the reachable
-		// cleanup path for it, working purely from state. Without --purge there
-		// is nothing to disable.
+		// Not registered. A removed agent can still own orphaned destination
+		// files + state keys; `--purge` is the reachable cleanup path for it,
+		// working purely from state. Still reject a name that was never a valid
+		// agent, so `disable bogus --purge` doesn't report a misleading success.
 		if purge {
+			if err := validateAgent(name); err != nil {
+				return err
+			}
 			return purgeAgentDests(cmd, name, home)
 		}
 		return fmt.Errorf("agent %q not registered (pass --purge to clean up an already-removed agent's leftover files)", name)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -184,6 +184,13 @@ func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
 	} else {
 		tail := append([]string(nil), out[insertAt:]...)
 		out = append(out[:insertAt], newLines...)
+		// Keep a blank line between the regenerated [agents] block and whatever
+		// section follows, so repeated agent edits don't collapse the file's
+		// section spacing. The loop above drops blank lines inside the agents
+		// section, so a single separator is re-added each run (no accumulation).
+		if len(tail) > 0 && strings.TrimSpace(tail[0]) != "" {
+			out = append(out, "")
+		}
 		out = append(out, tail...)
 	}
 	return iox.AtomicWrite(p, []byte(strings.Join(out, "\n")), 0o644)

--- a/internal/cli/agent_orphan_test.go
+++ b/internal/cli/agent_orphan_test.go
@@ -1,0 +1,50 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAgent_OrphanVisibilityAndReachablePurge covers the round-5 finding: after
+// `agent remove`, the agent's rendered native config + state keys are orphaned.
+// `status` must surface them (not silently accumulate), and `disable --purge`
+// must be reachable for the now-deregistered agent to clean them up.
+func TestAgent_OrphanVisibilityAndReachablePurge(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Deregister the agent — leaves ~/.claude.json content + state keys behind.
+	if _, err := runCLI(t, env, "agent", "remove", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// status must surface the orphan (even though no agent is now enabled).
+	out, _ := runCLI(t, env, "status")
+	if !strings.Contains(out, "claude") || !strings.Contains(out, "orphaned") {
+		t.Fatalf("status must surface the orphaned removed agent; got:\n%s", out)
+	}
+
+	// disable --purge must be reachable for the removed agent and clean it up.
+	if out, err := runCLI(t, env, "agent", "disable", "claude", "--purge"); err != nil {
+		t.Fatalf("disable --purge of a removed agent must work: %v\n%s", err, out)
+	}
+
+	// No orphan should remain afterward.
+	out2, _ := runCLI(t, env, "status")
+	if strings.Contains(out2, "orphaned") {
+		t.Fatalf("after purge, no orphan should remain; got:\n%s", out2)
+	}
+}

--- a/internal/cli/agent_orphan_test.go
+++ b/internal/cli/agent_orphan_test.go
@@ -48,3 +48,17 @@ func TestAgent_OrphanVisibilityAndReachablePurge(t *testing.T) {
 		t.Fatalf("after purge, no orphan should remain; got:\n%s", out2)
 	}
 }
+
+// TestAgent_DisablePurgeRejectsUnknownName proves `disable <bogus> --purge`
+// validates the name (consistent with add/enable) instead of reporting a
+// misleading "purged ... 0 files" success.
+func TestAgent_DisablePurgeRejectsUnknownName(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "disable", "not-an-agent", "--purge"); err == nil {
+		t.Fatal("disable --purge of an unknown agent must error, not report success")
+	}
+}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -166,7 +166,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	if err != nil {
 		return err
 	}
-	collisions, written, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
+	collisions, written, unchanged, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
 	if len(collisions) > 0 {
 		ew := cmd.ErrOrStderr()
 		fmt.Fprintf(ew, "agentsync: backed up %d pre-existing target(s) before overwriting:\n", len(collisions))
@@ -213,7 +213,14 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	_ = render.PruneBackups(home, render.DefaultBackupKeep)
 
 	w := cmd.OutOrStdout()
-	fmt.Fprintln(w, "applied:", plan.Total(), "ops")
+	// Report a clean no-op distinctly from real work: when every destination
+	// path already held our exact bytes (write skipped, no mtime churn), say so
+	// instead of the misleading "applied: N ops".
+	if len(written) > 0 && len(unchanged) == len(written) {
+		fmt.Fprintf(w, "up to date: %d ops, no changes\n", plan.Total())
+	} else {
+		fmt.Fprintln(w, "applied:", plan.Total(), "ops")
+	}
 	report := render.BuildReport(c, plan, agents)
 	if len(report.Rows) > 0 {
 		fmt.Fprintln(w)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -95,6 +95,17 @@ func checkHomeDir(w io.Writer, home string) int {
 		fmt.Fprintf(w, "  home dir   exists but is not a directory: %s\n", home)
 		return 1
 	}
+	// A home dir without agentsync.toml is half-initialized (e.g. an authoring
+	// command run before `init`); naming it explicitly, like `verify` does,
+	// avoids calling the schema "ok" on a config-less home.
+	if _, err := os.Stat(filepath.Join(home, "agentsync.toml")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(w, "  home dir   missing agentsync.toml (half-initialized) — run `agentsync init`\n")
+			return 1
+		}
+		fmt.Fprintf(w, "  home dir   agentsync.toml unreadable: %v\n", err)
+		return 1
+	}
 	fmt.Fprintf(w, "  home dir   ok\n")
 	return 0
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -547,10 +547,13 @@ func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Ca
 	total := 0
 	for _, comp := range importComponentOrder {
 		ids, err := importComponent(cmd, home, c, comp, "", dryRun)
+		// Seed whatever WAS written even on error: a component can fail partway
+		// after writing earlier items, and those must be owned or the next apply
+		// foreign-collides on a file just imported from.
+		imp.add(comp, ids)
 		if err != nil {
 			return imp, err
 		}
-		imp.add(comp, ids)
 		if len(ids) > 0 {
 			counts[comp] = len(ids)
 			total += len(ids)
@@ -596,8 +599,10 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 	}
 	if !dryRun {
 		single := source.Canonical{MCPServers: matched}
-		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return nil, err
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			// Seed the servers capture DID write before failing, so a partial
+			// import doesn't leave them foreign-collided on the next apply.
+			return idsFromWritten(res.Written), err
 		}
 	}
 	ids := make([]string, len(matched))
@@ -606,6 +611,17 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 		ids[i] = m.ID
 	}
 	return ids, nil
+}
+
+// idsFromWritten extracts component ids/events from capture.Capture's
+// Result.Written paths ("mcp/<id>.toml", "lsp/<id>.toml", "hooks/<event>.toml"),
+// so a partial capture seeds exactly what was written.
+func idsFromWritten(written []string) []string {
+	out := make([]string, 0, len(written))
+	for _, w := range written {
+		out = append(out, strings.TrimSuffix(filepath.Base(w), ".toml"))
+	}
+	return out
 }
 
 func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
@@ -630,7 +646,9 @@ func importSkill(cmd *cobra.Command, home string, c source.Canonical, name strin
 	for _, sk := range matched {
 		if !dryRun {
 			if err := source.WriteSkill(home, sk); err != nil {
-				return nil, fmt.Errorf("write skill %s: %w", sk.Name, err)
+				// Return the names already written so the caller seeds them;
+				// otherwise the next apply foreign-collides on a file just imported.
+				return names, fmt.Errorf("write skill %s: %w", sk.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s skills/%s/SKILL.md\n", importVerb(dryRun), sk.Name)
@@ -661,7 +679,7 @@ func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name st
 	for _, sa := range matched {
 		if !dryRun {
 			if err := source.WriteSubagent(home, sa); err != nil {
-				return nil, fmt.Errorf("write subagent %s: %w", sa.Name, err)
+				return names, fmt.Errorf("write subagent %s: %w", sa.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s agents/%s.md\n", importVerb(dryRun), sa.Name)
@@ -692,7 +710,7 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 	for _, cm := range matched {
 		if !dryRun {
 			if err := source.WriteCommand(home, cm); err != nil {
-				return nil, fmt.Errorf("write command %s: %w", cm.Name, err)
+				return names, fmt.Errorf("write command %s: %w", cm.Name, err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%s commands/%s.md\n", importVerb(dryRun), cm.Name)
@@ -726,8 +744,8 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 	}
 	if !dryRun {
 		single := source.Canonical{Hooks: matched}
-		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return nil, err
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return idsFromWritten(res.Written), err
 		}
 	}
 	// One file per event; report each, preserving first-seen order.
@@ -765,8 +783,8 @@ func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string,
 	}
 	if !dryRun {
 		single := source.Canonical{LSPServers: matched}
-		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return nil, err
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+			return idsFromWritten(res.Written), err
 		}
 	}
 	ids := make([]string, 0, len(matched))

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -203,6 +203,50 @@ func TestImport_PartialFailureStillSeedsWritten(t *testing.T) {
 	}
 }
 
+// TestImport_IntraComponentPartialFailureSeedsWritten is the regression for an
+// intra-component partial failure: importing a whole component (e.g.
+// claude:command) writes item k, then item k+1 fails. The already-written item
+// must still be seeded into state, or the next apply treats it as
+// ForeignCollision and overwrites the file just imported from. Previously the
+// importer returned nil ids on a mid-loop failure, dropping the written item.
+func TestImport_IntraComponentPartialFailureSeedsWritten(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	// Two native commands; ReadDir ingests them alphabetically, so a-cmd is
+	// written before z-cmd.
+	cmdDir := filepath.Join(tmp, ".claude", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"a-cmd", "z-cmd"} {
+		if err := os.WriteFile(filepath.Join(cmdDir, n+".md"),
+			[]byte("---\nname: "+n+"\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Block z-cmd's source write: pre-create commands/z-cmd.md as a non-empty
+	// directory so the atomic rename onto it fails mid-import.
+	blocked := filepath.Join(tmp, ".agentsync", "commands", "z-cmd.md")
+	if err := os.MkdirAll(filepath.Join(blocked, "occupied"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "import", "claude:command"); err == nil {
+		t.Fatal("expected partial import to surface the z-cmd write error")
+	}
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	stData, _ := os.ReadFile(statePath)
+	if !strings.Contains(string(stData), "a-cmd") {
+		t.Fatalf("intra-component partial import left the written a-cmd unseeded (foreign-collision hazard); state:\n%s", stData)
+	}
+}
+
 // TestImport_UnknownAgent verifies that an unknown agent returns an error.
 func TestImport_UnknownAgent(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -90,7 +90,11 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 					fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace name %q is reserved\n", mp.Name)
 				}
 			}
-			mpName = sanitizeSlug(mp.Name)
+			// Only adopt the declared name if it sanitises to something usable;
+			// a name like "..." sanitises to "" and would author marketplaces/.toml.
+			if s := sanitizeSlug(mp.Name); s != "" {
+				mpName = s
+			}
 		}
 	}
 
@@ -306,10 +310,14 @@ func deriveMarketplaceSlug(rawURL string) string {
 		s = strings.ReplaceAll(s, "--", "-")
 	}
 	s = strings.Trim(s, "-")
+	// Sanitise FIRST, then fall back: a punctuation-only source (e.g. "...")
+	// survives the trim above but sanitises to "", which would otherwise write
+	// marketplaces/.toml and a marketplaces/_ cache dir.
+	s = sanitizeSlug(s)
 	if s == "" {
 		s = "marketplace"
 	}
-	return sanitizeSlug(s)
+	return s
 }
 
 // sanitizeSlug makes a string safe for use as a filename.

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -170,6 +170,9 @@ func validateMCPID(id string) error {
 	if id == "" {
 		return fmt.Errorf("mcp id is empty")
 	}
+	if strings.TrimSpace(id) == "" || id == "." {
+		return fmt.Errorf("mcp id %q is empty or a bare '.'", id)
+	}
 	if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
 		return fmt.Errorf("mcp id %q contains a path component", id)
 	}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/marketplace"
@@ -511,18 +510,21 @@ func searchAllMarketplaces(home, pluginID string) ([]byte, marketplace.PluginEnt
 // verifying anyway (missing plugin.json → nil).
 func computeManifestSHA(home, id string, entry marketplace.PluginEntry, mpData []byte, cacheDir string) string {
 	pluginJSONPath := filepath.Join(cacheDir, ".claude-plugin", "plugin.json")
-	if data, err := os.ReadFile(pluginJSONPath); err == nil {
-		h := sha256.Sum256(data)
-		return hex.EncodeToString(h[:])
+	if _, err := os.Stat(pluginJSONPath); err == nil {
+		// Hash the whole cache tree (every projected component body, not just
+		// plugin.json) so the pin certifies what projection actually ships.
+		h, herr := marketplace.PluginTreeHash(afero.NewOsFs(), cacheDir)
+		if herr != nil {
+			return ""
+		}
+		return h
 	}
-	// No plugin.json (entry-only plugin): SHA over the marketplace entry bytes
-	// (re-marshal for stability).
-	entryBytes, err := json.Marshal(entry)
+	// No plugin.json (entry-only plugin): pin the marketplace entry instead.
+	h, err := marketplace.PluginEntryHash(entry)
 	if err != nil {
 		return ""
 	}
-	h := sha256.Sum256(entryBytes)
-	return hex.EncodeToString(h[:])
+	return h
 }
 
 // readPluginTOML reads and parses a plugins/<id>.toml file.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -140,6 +140,11 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	// non-zero rather than report success (a scripted `reconcile --auto-writeback
 	// && deploy` must not proceed, and the next apply would clobber the edit).
 	writeBackFailed := 0
+	// writtenSources records, per canonical source file written this run, the
+	// bytes that landed — so a SECOND write-back to the same file (a server/skill
+	// that fanned out to multiple agents, each drifted differently) is detected
+	// instead of silently last-writer-wins clobbering the first.
+	writtenSources := map[string][]byte{}
 
 	br := bufio.NewReader(in)
 
@@ -284,11 +289,8 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 		switch action {
 		case 'w':
 			// write-back: persist destination value into the canonical source.
-			if err := writeBackItem(cmd, home, it); err != nil {
-				fmt.Fprintf(w, "  write-back error: %v\n", err)
+			if attemptWriteBack(cmd, w, home, it, writtenSources) {
 				writeBackFailed++
-			} else {
-				fmt.Fprintf(w, "  write-back: %s\n", itemLabel(it))
 			}
 		case 'o':
 			// override: queue a re-apply of this item's op.
@@ -547,6 +549,70 @@ func readChar(r *bufio.Reader) (byte, error) {
 // writeBackItem persists the current destination value for item it back into
 // the canonical source (~/.agentsync/). Only MCP-server items are fully
 // supported in v1; other item types fall back to a raw file copy.
+// attemptWriteBack writes one item back and guards against silent
+// last-writer-wins when a single reconcile run writes the SAME canonical source
+// file from more than one agent. A server/skill that fans out to claude AND
+// opencode produces two drift items pointing at one source file
+// (mcp/<id>.toml, …); if the user edited the two destinations DIFFERENTLY, the
+// second capture would clobber the first with no warning and leave the first
+// agent stuck in `conflict`. So: if a prior write this run produced this source
+// file and this write changes it, revert to the first write and report a
+// conflict (counted as a failure → non-zero exit) for the user to resolve.
+// Returns true on failure/conflict.
+func attemptWriteBack(cmd *cobra.Command, w io.Writer, home string, it reconcileItem, writtenSources map[string][]byte) bool {
+	srcFile := itemSourceFile(home, it)
+	var prior []byte
+	priorWritten := false
+	if srcFile != "" {
+		prior, priorWritten = writtenSources[srcFile]
+	}
+	if err := writeBackItem(cmd, home, it); err != nil {
+		fmt.Fprintf(w, "  write-back error: %v\n", err)
+		return true
+	}
+	if srcFile != "" {
+		if after, rerr := os.ReadFile(srcFile); rerr == nil {
+			if priorWritten && string(prior) != string(after) {
+				_ = iox.AtomicWrite(srcFile, prior, 0o644) // revert to the first write
+				rel, _ := filepath.Rel(home, srcFile)
+				fmt.Fprintf(w, "  conflict: %s — another agent drifted the same source (%s) to a different "+
+					"value this run; kept the first write and skipped this one. Make the agents agree, or "+
+					"reconcile one at a time, then re-run.\n", itemLabel(it), rel)
+				return true
+			}
+			writtenSources[srcFile] = after
+		}
+	}
+	fmt.Fprintf(w, "  write-back: %s\n", itemLabel(it))
+	return false
+}
+
+// itemSourceFile returns the absolute canonical source file a write-back item
+// targets, so two agents writing the same component can be detected. Both the
+// claude (/mcpServers/<id>) and opencode (/mcp/<id>) pointers map to the SAME
+// mcp/<id>.toml. Returns "" for items with no single source-of-record.
+func itemSourceFile(home string, it reconcileItem) string {
+	if it.ptr == "" {
+		if it.op.SourceID == "" || strings.HasSuffix(it.op.SourceID, "(multiple)") {
+			return ""
+		}
+		return filepath.Join(home, it.op.SourceID)
+	}
+	parts := strings.SplitN(strings.TrimPrefix(it.ptr, "/"), "/", 3)
+	if len(parts) < 2 || parts[1] == "" {
+		return ""
+	}
+	switch parts[0] {
+	case "mcpServers", "mcp":
+		return filepath.Join(home, "mcp", parts[1]+".toml")
+	case "lspServers", "lsp":
+		return filepath.Join(home, "lsp", parts[1]+".toml")
+	case "hooks":
+		return filepath.Join(home, "hooks", parts[1]+".toml")
+	}
+	return ""
+}
+
 func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 	if it.ptr != "" {
 		return writeBackKeyItem(cmd, home, it)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/opencode"
 	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/iox"
@@ -554,9 +555,11 @@ func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 	dest := readJSONFile(it.op.Path)
 	// Expected ptr shape: /mcpServers/<serverID>/... (claude) or
-	// /mcp/<serverID>/... (opencode). Both render MCP entries with identical
-	// lowercase field names, so the reconstruction below is shape-identical;
-	// only the top-level container key differs per adapter.
+	// /mcp/<serverID>/... (opencode). The container key also tells us the dest
+	// shape: Claude's `mcpServers` value matches the canonical model 1:1, but
+	// OpenCode's `mcp` value is its NATIVE shape (command as a string array,
+	// `environment` not `env`, type local|remote), so it must be translated
+	// through the adapter's inverse-of-Render rather than unmarshaled directly.
 	parts := strings.SplitN(strings.TrimPrefix(it.ptr, "/"), "/", 3)
 	if len(parts) >= 2 && (parts[0] == "mcpServers" || parts[0] == "mcp") {
 		topKey := parts[0]
@@ -574,14 +577,23 @@ func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 			// so the user can pick [d]elete-source via a follow-up flow.
 			return fmt.Errorf("destination dropped %s/%s — no write-back possible; remove the source manually or use [o]verride to push canonical back", topKey, serverID)
 		}
-		// Round-trip through JSON to get a typed spec.
-		specBytes, err := json.Marshal(specRaw)
-		if err != nil {
-			return fmt.Errorf("marshal mcp spec %s: %w", serverID, err)
-		}
 		var spec source.MCPServerSpec
-		if err := json.Unmarshal(specBytes, &spec); err != nil {
-			return fmt.Errorf("unmarshal mcp spec %s: %w", serverID, err)
+		if topKey == "mcp" {
+			// OpenCode native shape → canonical, via the single adapter translator.
+			rawMap, _ := specRaw.(map[string]any)
+			if rawMap == nil {
+				return fmt.Errorf("opencode mcp spec %s is not an object", serverID)
+			}
+			spec = opencode.IngestMCPSpec(rawMap)
+		} else {
+			// Claude's mcpServers value matches the canonical model 1:1.
+			specBytes, err := json.Marshal(specRaw)
+			if err != nil {
+				return fmt.Errorf("marshal mcp spec %s: %w", serverID, err)
+			}
+			if err := json.Unmarshal(specBytes, &spec); err != nil {
+				return fmt.Errorf("unmarshal mcp spec %s: %w", serverID, err)
+			}
 		}
 		// The spec was reconstructed from the destination, where apply wrote any
 		// ${secret:…} as resolved cleartext and which never carries source-only

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -135,6 +135,11 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	// autoSkipped counts items an --auto-* mode left unresolved, so the run
 	// ends with a summary instead of silently doing nothing.
 	autoSkipped := 0
+	// writeBackFailed counts [w]rite-back attempts that errored. A failed
+	// write-back did NOT persist the user's dest edit, so the run must exit
+	// non-zero rather than report success (a scripted `reconcile --auto-writeback
+	// && deploy` must not proceed, and the next apply would clobber the edit).
+	writeBackFailed := 0
 
 	br := bufio.NewReader(in)
 
@@ -281,6 +286,7 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			// write-back: persist destination value into the canonical source.
 			if err := writeBackItem(cmd, home, it); err != nil {
 				fmt.Fprintf(w, "  write-back error: %v\n", err)
+				writeBackFailed++
 			} else {
 				fmt.Fprintf(w, "  write-back: %s\n", itemLabel(it))
 			}
@@ -346,6 +352,11 @@ done:
 
 	if autoSkipped > 0 {
 		fmt.Fprintf(w, "%d item(s) left unresolved; run `agentsync reconcile` interactively to handle them\n", autoSkipped)
+	}
+	// A write-back that errored did NOT persist the edit; surface it as a
+	// non-zero exit so callers (and scripts) don't treat the sync as complete.
+	if writeBackFailed > 0 {
+		return fmt.Errorf("reconcile: %d item(s) failed to write back", writeBackFailed)
 	}
 	return nil
 }

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -366,16 +366,50 @@ func TestReconcile_WriteBackUnsupportedReturnsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dst := filepath.Join(tmp, ".claude.json")
+	dst := filepath.Join(tmp, ".claude", "settings.json")
 	body, _ := os.ReadFile(dst)
 	// Drift the hook in the destination so reconcile classifies it as Drift.
 	_ = os.WriteFile(dst, []byte(strings.Replace(string(body), `echo pre`, `echo edited`, 1)), 0o644)
 
 	// Press w (write-back this item, single).
-	out, _ := runCLIWithStdin(t, env, "w\n", "reconcile")
+	out, err := runCLIWithStdin(t, env, "w\n", "reconcile")
 	// Should NOT silently print success for the hook write-back.
 	if strings.Contains(out, "write-back: ") && !strings.Contains(out, "write-back error") {
 		t.Fatalf("hook write-back must surface an error, not silent success; got:\n%s", out)
+	}
+	// And it must exit non-zero — a failed write-back did not persist the edit.
+	if err == nil {
+		t.Fatalf("interactive write-back of an unsupported item must exit non-zero; got nil err, out:\n%s", out)
+	}
+}
+
+// TestReconcile_AutoWritebackFailureExitsNonZero is the regression for a silent
+// failure on the SCRIPTABLE path: `reconcile --auto-writeback` printed a
+// "write-back error" line but still exited 0, so `reconcile --auto-writeback &&
+// deploy` proceeded as if the dest edit had been captured (the next apply would
+// then clobber it). A failed write-back must exit non-zero.
+func TestReconcile_AutoWritebackFailureExitsNonZero(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	hookDir := filepath.Join(tmp, ".agentsync", "hooks")
+	_ = os.MkdirAll(hookDir, 0o755)
+	_ = os.WriteFile(filepath.Join(hookDir, "PreToolUse.toml"),
+		[]byte("[[hook]]\nmatcher = \"*\"\ntype = \"command\"\ncommand = \"echo pre\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, ".claude", "settings.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.Replace(string(body), `echo pre`, `echo edited`, 1)), 0o644)
+
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err == nil {
+		t.Fatal("reconcile --auto-writeback with a failed write-back must exit non-zero")
 	}
 }
 

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -413,6 +413,79 @@ func TestReconcile_AutoWritebackFailureExitsNonZero(t *testing.T) {
 	}
 }
 
+// TestReconcile_SharedMCPDivergentWriteBackConflicts is the regression for a
+// silent last-writer-wins data loss: an MCP server fanned out to two agents
+// (agents=["*"]) edited DIFFERENTLY in each native config produced two
+// write-back items targeting one source file; the second silently clobbered the
+// first and left the first agent stuck in conflict. The run must now detect the
+// divergence, keep the first write, refuse the second, and exit non-zero.
+func TestReconcile_SharedMCPDivergentWriteBackConflicts(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	for _, a := range [][]string{{"init"}, {"agent", "add", "claude"}, {"agent", "add", "opencode"}} {
+		if _, err := runCLI(t, env, a...); err != nil {
+			t.Fatalf("%v: %v", a, err)
+		}
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "shared.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"orig\"\nagents=[\"*\"]\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Divergent edits in each agent's native config.
+	claudeDest := filepath.Join(tmp, ".claude.json")
+	ocDest := filepath.Join(tmp, ".config", "opencode", "opencode.json")
+	cb, _ := os.ReadFile(claudeDest)
+	_ = os.WriteFile(claudeDest, []byte(strings.Replace(string(cb), "orig", "CLAUDE_EDIT", 1)), 0o644)
+	ob, _ := os.ReadFile(ocDest)
+	_ = os.WriteFile(ocDest, []byte(strings.Replace(string(ob), "orig", "OC_EDIT", 1)), 0o644)
+
+	out, err := runCLI(t, env, "reconcile", "--auto-writeback")
+	if err == nil {
+		t.Fatalf("divergent shared-MCP write-back must NOT silently succeed; out:\n%s", out)
+	}
+	if !strings.Contains(out, "conflict") {
+		t.Fatalf("expected a conflict report; got:\n%s", out)
+	}
+	// Source kept exactly ONE consistent value (the first writer), not silently
+	// the second; and not a half-merged mess.
+	src, _ := os.ReadFile(mcp)
+	hasClaude := strings.Contains(string(src), "CLAUDE_EDIT")
+	hasOC := strings.Contains(string(src), "OC_EDIT")
+	if hasClaude == hasOC { // both or neither
+		t.Fatalf("source must hold exactly one writer's value after a conflict; got:\n%s", src)
+	}
+}
+
+// TestReconcile_SharedMCPIdenticalWriteBackOK proves the conflict guard does NOT
+// false-fire when both agents drifted the shared server to the SAME value.
+func TestReconcile_SharedMCPIdenticalWriteBackOK(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	for _, a := range [][]string{{"init"}, {"agent", "add", "claude"}, {"agent", "add", "opencode"}} {
+		if _, err := runCLI(t, env, a...); err != nil {
+			t.Fatalf("%v: %v", a, err)
+		}
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "shared.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"orig\"\nagents=[\"*\"]\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	for _, dest := range []string{filepath.Join(tmp, ".claude.json"), filepath.Join(tmp, ".config", "opencode", "opencode.json")} {
+		b, _ := os.ReadFile(dest)
+		_ = os.WriteFile(dest, []byte(strings.Replace(string(b), "orig", "SAME_EDIT", 1)), 0o644)
+	}
+	if _, err := runCLI(t, env, "reconcile", "--auto-writeback"); err != nil {
+		t.Fatalf("identical shared-MCP edits must not conflict: %v", err)
+	}
+	if src, _ := os.ReadFile(mcp); !strings.Contains(string(src), "SAME_EDIT") {
+		t.Fatalf("expected SAME_EDIT captured; got:\n%s", src)
+	}
+}
+
 func TestReconcile_InteractiveQuit(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -182,23 +182,21 @@ func setNestedKey(m map[string]any, dottedKey, value string) {
 	setNestedKey(subMap, parts[1], value)
 }
 
-// getNestedKey retrieves a dotted key from a nested map.
-func getNestedKey(m map[string]any, dottedKey string) (string, bool) {
+// getNestedKey retrieves a dotted key from a nested map, returning the raw
+// value so the caller can enforce the string-only contract (apply rejects
+// non-string leaves; `get` must not print a value apply would refuse).
+func getNestedKey(m map[string]any, dottedKey string) (any, bool) {
 	parts := strings.SplitN(dottedKey, ".", 2)
 	v, ok := m[parts[0]]
 	if !ok {
-		return "", false
+		return nil, false
 	}
 	if len(parts) == 1 {
-		s, ok := v.(string)
-		if !ok {
-			return fmt.Sprint(v), true
-		}
-		return s, true
+		return v, true
 	}
 	sub, ok := v.(map[string]any)
 	if !ok {
-		return "", false
+		return nil, false
 	}
 	return getNestedKey(sub, parts[1])
 }
@@ -266,12 +264,16 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Open $EDITOR (default: vi).
+	// Open $EDITOR (default: vi). $EDITOR commonly carries flags
+	// ("code --wait", "vim -u NONE", "emacsclient -c"); split on whitespace so
+	// they aren't treated as part of the executable path (which fails outright).
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = "vi"
 	}
-	editorCmd := exec.Command(editor, tmpPath) //nolint:gosec
+	editorParts := strings.Fields(editor)
+	editorArgs := append(editorParts[1:], tmpPath)
+	editorCmd := exec.Command(editorParts[0], editorArgs...) //nolint:gosec
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr
@@ -279,16 +281,17 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("editor: %w", err)
 	}
 
-	// Read back edited bytes, validate they parse as TOML (so a typo doesn't
-	// silently encrypt a broken store), and re-encrypt with the
-	// identity-can-decrypt verification.
+	// Read back edited bytes and validate with the SAME contract apply uses
+	// (valid TOML + flatten: string-only leaves, no dup/colliding keys), so a
+	// typo — or a `"a.b"` quoted key colliding with a `[a] b` table, or a
+	// non-string value — is rejected here instead of being happily encrypted and
+	// then failing every apply.
 	edited, err := os.ReadFile(tmpPath)
 	if err != nil {
 		return fmt.Errorf("read edited tmp: %w", err)
 	}
-	var check map[string]any
-	if err := toml.Unmarshal(edited, &check); err != nil {
-		return fmt.Errorf("edited secrets are not valid TOML (not saved): %w", err)
+	if err := secrets.ValidateVaultTOML(edited); err != nil {
+		return fmt.Errorf("edited secrets are invalid (not saved): %w", err)
 	}
 	if err := writeSecretsVerified(edited, cfg, home); err != nil {
 		return fmt.Errorf("re-encrypt: %w", err)
@@ -315,7 +318,11 @@ func secretsGet(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("secret %q not found", args[0])
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), v)
+	s, isStr := v.(string)
+	if !isStr {
+		return fmt.Errorf("secret %q is not a string value (%T); secret values must be quoted strings (apply rejects non-string secrets)", args[0], v)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), s)
 	return nil
 }
 
@@ -369,8 +376,11 @@ func resolveSecretKeyValue(cmd *cobra.Command, arg string, useStdin bool) (strin
 		if err != nil {
 			return "", "", fmt.Errorf("read secret from stdin: %w", err)
 		}
-		v := strings.TrimRight(string(raw), "\n")
-		v = strings.TrimRight(v, "\r")
+		// Strip a SINGLE trailing newline (the shell/echo/heredoc artifact),
+		// not all of them, so a secret that legitimately ends in newline(s)
+		// (e.g. a PEM block) isn't silently truncated.
+		v := strings.TrimSuffix(string(raw), "\n")
+		v = strings.TrimSuffix(v, "\r")
 		return key, v, nil
 	}
 

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -272,7 +272,9 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		editor = "vi"
 	}
 	editorParts := strings.Fields(editor)
-	editorArgs := append(editorParts[1:], tmpPath)
+	editorArgs := make([]string, 0, len(editorParts))
+	editorArgs = append(editorArgs, editorParts[1:]...)
+	editorArgs = append(editorArgs, tmpPath)
 	editorCmd := exec.Command(editorParts[0], editorArgs...) //nolint:gosec
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -182,6 +182,18 @@ func setNestedKey(m map[string]any, dottedKey, value string) {
 	setNestedKey(subMap, parts[1], value)
 }
 
+// editorArgv builds the editor argv from $EDITOR and the file to edit. $EDITOR
+// may be empty, whitespace-only, or carry flags ("code --wait"); it is
+// word-split, with a "vi" fallback when it yields no words — so the launch
+// never panics indexing an empty split (the bug a bare strings.Fields had).
+func editorArgv(editorEnv, file string) []string {
+	parts := strings.Fields(editorEnv)
+	if len(parts) == 0 {
+		parts = []string{"vi"}
+	}
+	return append(parts, file)
+}
+
 // getNestedKey retrieves a dotted key from a nested map, returning the raw
 // value so the caller can enforce the string-only contract (apply rejects
 // non-string leaves; `get` must not print a value apply would refuse).
@@ -267,15 +279,8 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	// Open $EDITOR (default: vi). $EDITOR commonly carries flags
 	// ("code --wait", "vim -u NONE", "emacsclient -c"); split on whitespace so
 	// they aren't treated as part of the executable path (which fails outright).
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vi"
-	}
-	editorParts := strings.Fields(editor)
-	editorArgs := make([]string, 0, len(editorParts))
-	editorArgs = append(editorArgs, editorParts[1:]...)
-	editorArgs = append(editorArgs, tmpPath)
-	editorCmd := exec.Command(editorParts[0], editorArgs...) //nolint:gosec
+	argv := editorArgv(os.Getenv("EDITOR"), tmpPath)
+	editorCmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -92,6 +92,65 @@ func TestSecretsGetSet(t *testing.T) {
 	}
 }
 
+// TestSecretsGet_RejectsNonStringLeaf proves `get` enforces apply's string-only
+// contract: a non-string leaf (number/bool/table) errors rather than printing a
+// Go-formatted value apply would later refuse.
+func TestSecretsGet_RejectsNonStringLeaf(t *testing.T) {
+	env, agePath, _, id := setupSecretsEnv(t)
+	plain := []byte("[svc]\nport = 8080\nname = \"ok\"\n")
+	if err := secrets_pkg.Encrypt(plain, id.Recipient().String(), agePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "secrets", "get", "svc.port"); err == nil {
+		t.Fatal("get of a non-string leaf must error (matches apply's flatten contract)")
+	}
+	// A string leaf in the same vault still works.
+	if out, err := runCLI(t, env, "secrets", "get", "svc.name"); err != nil || !strings.Contains(out, "ok") {
+		t.Fatalf("get of a string leaf must succeed: err=%v out=%q", err, out)
+	}
+}
+
+// TestSecretsEdit_EditorWithArgs proves $EDITOR carrying flags ("code --wait")
+// is word-split, not treated as a single executable path.
+func TestSecretsEdit_EditorWithArgs(t *testing.T) {
+	env, agePath, _, id := setupSecretsEnv(t)
+	if err := secrets_pkg.Encrypt([]byte("[a]\nb = \"orig\"\n"), id.Recipient().String(), agePath); err != nil {
+		t.Fatal(err)
+	}
+	// An "editor" script that writes fixed content to its LAST argument.
+	dir := t.TempDir()
+	ed := filepath.Join(dir, "ed.sh")
+	if err := os.WriteFile(ed, []byte("#!/bin/sh\nfor a in \"$@\"; do f=\"$a\"; done\nprintf '[edited]\\nval = \"yes\"\\n' > \"$f\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EDITOR", ed+" --wait")
+	if out, err := runCLI(t, env, "secrets", "edit"); err != nil {
+		t.Fatalf("secrets edit with $EDITOR carrying a flag must work: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "secrets", "get", "edited.val"); err != nil || !strings.Contains(out, "yes") {
+		t.Fatalf("edit did not save via the flagged editor: err=%v out=%q", err, out)
+	}
+}
+
+// TestSecretsEdit_RejectsCollidingKeys proves `edit` validates against apply's
+// flatten contract: a quoted "a.b" key colliding with a [a] b table is refused
+// (not silently encrypted into a vault apply would reject).
+func TestSecretsEdit_RejectsCollidingKeys(t *testing.T) {
+	env, agePath, _, id := setupSecretsEnv(t)
+	if err := secrets_pkg.Encrypt([]byte("[a]\nb = \"orig\"\n"), id.Recipient().String(), agePath); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	ed := filepath.Join(dir, "ed.sh")
+	if err := os.WriteFile(ed, []byte("#!/bin/sh\nfor a in \"$@\"; do f=\"$a\"; done\nprintf '\"x.y\" = \"one\"\\n[x]\\ny = \"two\"\\n' > \"$f\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EDITOR", ed)
+	if _, err := runCLI(t, env, "secrets", "edit"); err == nil {
+		t.Fatal("edit must reject a flatten-colliding vault rather than save it")
+	}
+}
+
 // TestSecretsSet_RejectsRecipientIdentityMismatch is the regression for
 // `secrets set` re-encrypting the whole store to a recipient the configured
 // identity_file cannot decrypt — silently locking the user out of their own

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -54,6 +55,14 @@ func newStatusCmd() *cobra.Command {
 			}
 			if len(agents) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				// Still surface orphaned state from a removed/disabled agent, so
+				// removing the LAST agent doesn't hide its leftover native config.
+				for _, a := range orphanedStateAgents(s, agents) {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: agent %q is not enabled but still owns tracked files/keys in state; its "+
+							"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
+						a, a)
+				}
 				return nil
 			}
 			// apply WRITES (and RecordOpsState HASHES) the secret-RESOLVED
@@ -128,12 +137,53 @@ func newStatusCmd() *cobra.Command {
 					fmt.Fprintf(w, "  %-20s %s\n", cls, orphan)
 				}
 			}
+			// Surface agents that still own tracked state (and thus orphaned
+			// native config) but are no longer enabled — a removed, or
+			// disabled-not-purged, agent. status/apply otherwise iterate only the
+			// enabled set, so these would accumulate silently with no diagnostic.
+			for _, a := range orphanedStateAgents(s, agents) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: agent %q is not enabled but still owns tracked files/keys in state; its "+
+						"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
+					a, a)
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	return cmd
+}
+
+// orphanedStateAgents returns, sorted, the agent names that appear as a state
+// key prefix ("agent:scope:…") but are not in the enabled set — i.e. agents
+// whose rendered native config and state entries linger after a `remove` or a
+// `disable` without `--purge`.
+func orphanedStateAgents(s *state.Targets, enabled []string) []string {
+	en := make(map[string]bool, len(enabled))
+	for _, n := range enabled {
+		en[n] = true
+	}
+	found := map[string]bool{}
+	collect := func(key string) {
+		if i := strings.IndexByte(key, ':'); i > 0 {
+			if a := key[:i]; !en[a] {
+				found[a] = true
+			}
+		}
+	}
+	for k := range s.Files {
+		collect(k)
+	}
+	for k := range s.Keys {
+		collect(k)
+	}
+	out := make([]string, 0, len(found))
+	for a := range found {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // stateFileKey builds the state Files map key matching render.RecordOpsState.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -215,7 +215,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		if err != nil {
 			return fmt.Errorf("plan after update: %w", err)
 		}
-		collisions, written, applyErr := render.Apply(plan, reg, st, home, userHome, sc, projectRoot)
+		collisions, written, _, applyErr := render.Apply(plan, reg, st, home, userHome, sc, projectRoot)
 		if applyErr != nil {
 			// Mirror `apply`: if render.Apply fails mid-pipeline, the files
 			// that already landed must be recorded so the next apply doesn't

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -138,7 +138,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	}
 
 	// Compute pending bumps.
-	bumps := marketplace.ComputePendingBumps(st, c.Marketplaces, c.Plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(st, c.Marketplaces, c.Plugins, fetched, c.Config.Updates.DefaultMode)
 
 	// --auto-safe: drop bumps whose candidate version would introduce a new
 	// translation loss (an adapter Skip) for any enabled agent. Each bump is

--- a/internal/cli/validate_names_test.go
+++ b/internal/cli/validate_names_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import "testing"
+
+// TestValidateMCPID_RejectsDegenerate mirrors source.ValidateComponentID: a
+// lone "." or an all-whitespace id passes the separator/traversal check but
+// would author mcp/..toml or "mcp/ .toml" — confusing artifacts no later
+// command can address cleanly. The CLI gate should reject them early with a
+// clear message rather than defer to the write boundary.
+func TestValidateMCPID_RejectsDegenerate(t *testing.T) {
+	bad := []string{"", ".", " ", "   ", "\t", "a/b", "a\\b", "a..b"}
+	for _, s := range bad {
+		if err := validateMCPID(s); err == nil {
+			t.Errorf("validateMCPID(%q) = nil; want error", s)
+		}
+	}
+	good := []string{"github", "my-server", "a.b.c", "srv1"}
+	for _, s := range good {
+		if err := validateMCPID(s); err != nil {
+			t.Errorf("validateMCPID(%q) = %v; want nil", s, err)
+		}
+	}
+}
+
+// TestDeriveMarketplaceSlug_NeverEmpty proves the empty-fallback runs AFTER
+// sanitisation: a punctuation-only source like "..." sanitises to "" and must
+// still yield the usable "marketplace" slug, not "" (which would author
+// marketplaces/.toml and a marketplaces/_ cache dir).
+func TestDeriveMarketplaceSlug_NeverEmpty(t *testing.T) {
+	for _, in := range []string{"...", ".", "//", "   ", "https://"} {
+		if got := deriveMarketplaceSlug(in); got == "" {
+			t.Errorf("deriveMarketplaceSlug(%q) = %q; want non-empty", in, got)
+		}
+	}
+	// A normal source still derives a sensible, non-empty slug.
+	if got := deriveMarketplaceSlug("https://github.com/obra/superpowers.git"); got == "" {
+		t.Errorf("deriveMarketplaceSlug of a real URL returned empty")
+	}
+}

--- a/internal/cli/validate_names_test.go
+++ b/internal/cli/validate_names_test.go
@@ -2,6 +2,36 @@ package cli
 
 import "testing"
 
+// TestEditorArgv covers the regression where a whitespace-only $EDITOR made
+// strings.Fields return an empty slice and the indexing panicked. It must fall
+// back to vi, and split flags out of the executable path.
+func TestEditorArgv(t *testing.T) {
+	cases := []struct {
+		env  string
+		want []string
+	}{
+		{"", []string{"vi", "/f"}},
+		{"   ", []string{"vi", "/f"}},
+		{"\t", []string{"vi", "/f"}},
+		{"nano", []string{"nano", "/f"}},
+		{"code --wait", []string{"code", "--wait", "/f"}},
+		{"  vim -u NONE ", []string{"vim", "-u", "NONE", "/f"}},
+	}
+	for _, tc := range cases {
+		got := editorArgv(tc.env, "/f")
+		if len(got) != len(tc.want) {
+			t.Errorf("editorArgv(%q) = %v, want %v", tc.env, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("editorArgv(%q) = %v, want %v", tc.env, got, tc.want)
+				break
+			}
+		}
+	}
+}
+
 // TestValidateMCPID_RejectsDegenerate mirrors source.ValidateComponentID: a
 // lone "." or an all-whitespace id passes the separator/traversal check but
 // would author mcp/..toml or "mcp/ .toml" — confusing artifacts no later

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -26,6 +27,17 @@ func newVerifyCmd() *cobra.Command {
 					return fmt.Errorf("agentsync home %s does not exist; run `agentsync init` first", home)
 				}
 				return fmt.Errorf("verify: stat %s: %w", home, err)
+			}
+			// A home dir can exist without agentsync.toml — an authoring command
+			// (e.g. `mcp add`) run before `init` scaffolds component dirs + .state
+			// but not the config. source.Load tolerates the missing file (empty
+			// Config), so without this guard verify reported a false "ok" on a
+			// half-initialized home. Require the config marker.
+			if _, err := os.Stat(filepath.Join(home, "agentsync.toml")); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("agentsync home %s is missing agentsync.toml (half-initialized); run `agentsync init`", home)
+				}
+				return fmt.Errorf("verify: stat agentsync.toml: %w", err)
 			}
 			c, err := source.Load(afero.NewOsFs(), home)
 			if err != nil {

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -10,6 +10,28 @@ import (
 // TestVerify_UninitializedHomeErrors is the regression for verify printing a
 // false "ok" (exit 0) when run before `init` — source.Load tolerates a
 // missing home, so the user got a green light on a non-existent config.
+func TestVerify_HalfInitMissingToml(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	// Scaffold component dirs/files but NO agentsync.toml (the half-init an
+	// authoring command leaves when run before `init`). verify must flag it
+	// rather than report a false "ok: schema valid".
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "x.toml")
+	if err := os.MkdirAll(filepath.Dir(mcp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"y\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "verify")
+	if err == nil {
+		t.Fatal("verify on a home missing agentsync.toml must error")
+	}
+	if !strings.Contains(err.Error(), "agentsync.toml") || !strings.Contains(err.Error(), "init") {
+		t.Fatalf("error should name agentsync.toml + point at init; got: %v", err)
+	}
+}
+
 func TestVerify_UninitializedHomeErrors(t *testing.T) {
 	tmp := t.TempDir()
 	// Note: no `init` — the agentsync home does not exist.

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -262,8 +262,9 @@ func resolveInstalledEntry(home, id, mpName string) PluginEntry {
 // the pin is an entry-only plugin (no cached bodies to hash).
 //
 // A pre-tree-hash pin (a bare sha256 hex with no tree: prefix) covered only
-// plugin.json and cannot certify the bodies, so it is REFUSED with a re-pin
-// instruction rather than silently honoured.
+// plugin.json; it is verified under that PRIOR scheme (sha256 of plugin.json)
+// so existing installs are not broken — a re-install or `plugin upgrade`
+// rewrites it as a tree hash that then covers the bodies.
 func verifyPluginManifestSHA(fs afero.Fs, pluginCacheDir, expected, id string) error {
 	if expected == "" {
 		return nil

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -105,7 +107,57 @@ func loadProjected(fs afero.Fs, home, pluginCacheRoot string, disabled []string,
 		c.Hooks = append(c.Hooks, proj.Hooks...)
 		c.LSPServers = append(c.LSPServers, proj.LSPServers...)
 	}
+	if err := checkProjectedConflicts(&c, lenient); err != nil {
+		return c, err
+	}
 	return c, nil
+}
+
+// checkProjectedConflicts surfaces a silent cross-source hijack. The projected
+// canonical unions the user's own servers with EVERY enabled plugin's, but the
+// adapters render MCP/LSP into an id-keyed map (last write wins). So two plugins
+// — or a plugin and the user's own config — declaring the same server id with
+// DIFFERENT content would let the later one silently override the earlier, e.g.
+// an untrusted plugin repointing a trusted server's command/url/headers at a
+// malicious target. Within a single plugin this is already caught by
+// resolveConflicts; this is the union guard across plugins + user. Identical
+// duplicates are harmless (render dedups them) and pass. Mutating loads
+// (apply/reconcile/import/update) fail closed; lenient read-only loads
+// (status/diff/explain) warn so they still show state rather than refuse.
+func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
+	if id, ok := firstDivergentByKey(c.MCPServers, func(s source.MCPServer) string { return s.ID }); ok {
+		if !lenient {
+			return fmt.Errorf("mcp server %q is provided by more than one source (a plugin and/or your "+
+				"own config) with different content; rename or disable one so a plugin cannot silently "+
+				"override another server's command/url", id)
+		}
+		slog.Warn("mcp server provided by multiple sources with different content; render keeps the last", "id", id)
+	}
+	if id, ok := firstDivergentByKey(c.LSPServers, func(s source.LSPServer) string { return s.ID }); ok {
+		if !lenient {
+			return fmt.Errorf("lsp server %q is provided by more than one source with different content; "+
+				"rename or disable one so a plugin cannot silently override another server", id)
+		}
+		slog.Warn("lsp server provided by multiple sources with different content; render keeps the last", "id", id)
+	}
+	return nil
+}
+
+// firstDivergentByKey returns the first key shared by two items with DIFFERENT
+// content. Identical duplicates (same key, deep-equal) are ignored.
+func firstDivergentByKey[T any](items []T, key func(T) string) (string, bool) {
+	seen := make(map[string]T, len(items))
+	for _, it := range items {
+		k := key(it)
+		if prev, ok := seen[k]; ok {
+			if !reflect.DeepEqual(prev, it) {
+				return k, true
+			}
+			continue
+		}
+		seen[k] = it
+	}
+	return "", false
 }
 
 // resolveInstalledEntry finds the marketplace entry for an installed plugin

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -125,7 +125,7 @@ func loadProjected(fs afero.Fs, home, pluginCacheRoot string, disabled []string,
 // (apply/reconcile/import/update) fail closed; lenient read-only loads
 // (status/diff/explain) warn so they still show state rather than refuse.
 func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
-	if id, ok := firstDivergentByKey(c.MCPServers, func(s source.MCPServer) string { return s.ID }); ok {
+	if id, ok := firstDivergentByKey(c.MCPServers, func(s source.MCPServer) string { return s.ID }, sameMCPRender); ok {
 		if !lenient {
 			return fmt.Errorf("mcp server %q is provided by more than one source (a plugin and/or your "+
 				"own config) with different content; rename or disable one so a plugin cannot silently "+
@@ -133,7 +133,7 @@ func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
 		}
 		slog.Warn("mcp server provided by multiple sources with different content; render keeps the last", "id", id)
 	}
-	if id, ok := firstDivergentByKey(c.LSPServers, func(s source.LSPServer) string { return s.ID }); ok {
+	if id, ok := firstDivergentByKey(c.LSPServers, func(s source.LSPServer) string { return s.ID }, sameLSPRender); ok {
 		if !lenient {
 			return fmt.Errorf("lsp server %q is provided by more than one source with different content; "+
 				"rename or disable one so a plugin cannot silently override another server", id)
@@ -143,14 +143,14 @@ func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
 	return nil
 }
 
-// firstDivergentByKey returns the first key shared by two items with DIFFERENT
-// content. Identical duplicates (same key, deep-equal) are ignored.
-func firstDivergentByKey[T any](items []T, key func(T) string) (string, bool) {
+// firstDivergentByKey returns the first key shared by two items the sameRender
+// predicate considers DIFFERENT. Duplicates that render identically are ignored.
+func firstDivergentByKey[T any](items []T, key func(T) string, sameRender func(a, b T) bool) (string, bool) {
 	seen := make(map[string]T, len(items))
 	for _, it := range items {
 		k := key(it)
 		if prev, ok := seen[k]; ok {
-			if !reflect.DeepEqual(prev, it) {
+			if !sameRender(prev, it) {
 				return k, true
 			}
 			continue
@@ -158,6 +158,47 @@ func firstDivergentByKey[T any](items []T, key func(T) string) (string, bool) {
 		seen[k] = it
 	}
 	return "", false
+}
+
+// sameMCPRender / sameLSPRender compare only the fields that reach the agent
+// destination — the ones a hijack would repoint (type/command/args/url/env/
+// headers). The source-only `agents`/`enabled` targeting metadata is excluded:
+// render strips it and capture preserves it, so two sources differing ONLY on it
+// are not a divergent override. nil and empty collections compare equal.
+func sameMCPRender(a, b source.MCPServer) bool {
+	return reflect.DeepEqual(mcpRenderFields(a.Server), mcpRenderFields(b.Server))
+}
+
+func mcpRenderFields(s source.MCPServerSpec) source.MCPServerSpec {
+	out := source.MCPServerSpec{Type: s.Type, Command: s.Command, URL: s.URL}
+	if len(s.Args) > 0 {
+		out.Args = s.Args
+	}
+	if len(s.Env) > 0 {
+		out.Env = s.Env
+	}
+	if len(s.Headers) > 0 {
+		out.Headers = s.Headers
+	}
+	return out
+}
+
+func sameLSPRender(a, b source.LSPServer) bool {
+	return reflect.DeepEqual(lspRenderFields(a.Spec), lspRenderFields(b.Spec))
+}
+
+func lspRenderFields(s source.LSPServerSpec) source.LSPServerSpec {
+	out := source.LSPServerSpec{Command: s.Command, URL: s.URL}
+	if len(s.Args) > 0 {
+		out.Args = s.Args
+	}
+	if len(s.Env) > 0 {
+		out.Env = s.Env
+	}
+	if len(s.Headers) > 0 {
+		out.Headers = s.Headers
+	}
+	return out
 }
 
 // resolveInstalledEntry finds the marketplace entry for an installed plugin

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -1,8 +1,6 @@
 package marketplace
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -211,12 +209,18 @@ func resolveInstalledEntry(home, id, mpName string) PluginEntry {
 	return PluginEntry{Name: id}
 }
 
-// verifyPluginManifestSHA checks the on-disk plugin.json against the SHA
-// recorded in plugins/<id>.toml at install. A mismatch means the plugin cache
-// was tampered with (or hand-edited) since install. Returns nil when: expected
-// is empty (legacy/hand-managed), AGENTSYNC_ALLOW_PLUGIN_DRIFT=1, or the cached
-// plugin.json is missing. (Moved here from the source loader so projection and
-// verification live in one package.)
+// verifyPluginManifestSHA checks the on-disk plugin cache against the SHA
+// recorded in plugins/<id>.toml at install/update. A mismatch means the cache
+// was tampered with (or upstream rolled) since the pin was recorded. The pin is
+// a PluginTreeHash over EVERY projected component body (not just plugin.json),
+// so a tampered SKILL.md / command markdown with an unchanged plugin.json is
+// caught. Returns nil when: expected is empty (hand-managed),
+// AGENTSYNC_ALLOW_PLUGIN_DRIFT=1, the cache dir is gone (nothing to verify), or
+// the pin is an entry-only plugin (no cached bodies to hash).
+//
+// A pre-tree-hash pin (a bare sha256 hex with no tree: prefix) covered only
+// plugin.json and cannot certify the bodies, so it is REFUSED with a re-pin
+// instruction rather than silently honoured.
 func verifyPluginManifestSHA(fs afero.Fs, pluginCacheDir, expected, id string) error {
 	if expected == "" {
 		return nil
@@ -224,18 +228,29 @@ func verifyPluginManifestSHA(fs afero.Fs, pluginCacheDir, expected, id string) e
 	if os.Getenv("AGENTSYNC_ALLOW_PLUGIN_DRIFT") == "1" {
 		return nil
 	}
-	data, err := afero.ReadFile(fs, filepath.Join(pluginCacheDir, ".claude-plugin", "plugin.json"))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
+	// Entry-only plugins ship no cached bodies; the marketplace entry that
+	// defines them isn't available here, so there is nothing to recompute.
+	if strings.HasPrefix(expected, entryHashPrefix) {
+		return nil
+	}
+	if strings.HasPrefix(expected, treeHashPrefix) {
+		if _, err := fs.Stat(pluginCacheDir); errors.Is(err, os.ErrNotExist) {
+			return nil // cache gone; projection will surface the absence
 		}
-		return fmt.Errorf("verify plugin %s manifest SHA: %w", id, err)
+		got, err := PluginTreeHash(fs, pluginCacheDir)
+		if err != nil {
+			return fmt.Errorf("verify plugin %s manifest SHA: %w", id, err)
+		}
+		if got != expected {
+			return fmt.Errorf("plugin %s manifest SHA mismatch (cache tampered or upstream rolled): "+
+				"want %s got %s; run `agentsync plugin upgrade %s` to accept the new manifest, "+
+				"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass this check", id, expected, got, id)
+		}
+		return nil
 	}
-	sum := sha256.Sum256(data)
-	if got := hex.EncodeToString(sum[:]); got != expected {
-		return fmt.Errorf("plugin %s manifest SHA mismatch (cache tampered or upstream rolled): "+
-			"want %s got %s; run `agentsync plugin upgrade %s` to accept the new manifest, "+
-			"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass this check", id, expected, got, id)
-	}
-	return nil
+	// Legacy bare-hex pin: covered only plugin.json, so it cannot certify the
+	// component bodies. Refuse with an actionable re-pin instruction.
+	return fmt.Errorf("plugin %s is pinned with a pre-tree-hash manifest SHA that does not cover "+
+		"component bodies; run `agentsync plugin upgrade %s` (or `agentsync update`) to re-pin it, "+
+		"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass once", id, id)
 }

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -1,6 +1,8 @@
 package marketplace
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -248,9 +250,24 @@ func verifyPluginManifestSHA(fs afero.Fs, pluginCacheDir, expected, id string) e
 		}
 		return nil
 	}
-	// Legacy bare-hex pin: covered only plugin.json, so it cannot certify the
-	// component bodies. Refuse with an actionable re-pin instruction.
-	return fmt.Errorf("plugin %s is pinned with a pre-tree-hash manifest SHA that does not cover "+
-		"component bodies; run `agentsync plugin upgrade %s` (or `agentsync update`) to re-pin it, "+
-		"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass once", id, id)
+	// Legacy bare-hex pin (pre-tree-hash): verify under the PRIOR scheme
+	// (sha256 over plugin.json only) so existing installs keep working — they
+	// were never body-pinned, and refusing them would brick a plugin whose only
+	// offered remediation (`agentsync update`) does not re-pin a non-bumping
+	// plugin. Re-installing or `agentsync plugin upgrade <id>` rewrites the pin
+	// as a tree hash, which DOES cover the bodies going forward.
+	data, err := afero.ReadFile(fs, filepath.Join(pluginCacheDir, ".claude-plugin", "plugin.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("verify plugin %s manifest SHA: %w", id, err)
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != expected {
+		return fmt.Errorf("plugin %s manifest SHA mismatch (cache tampered or upstream rolled): "+
+			"want %s got %s; run `agentsync plugin upgrade %s` to accept the new manifest, "+
+			"or set AGENTSYNC_ALLOW_PLUGIN_DRIFT=1 to bypass this check", id, expected, got, id)
+	}
+	return nil
 }

--- a/internal/marketplace/loadprojected_test.go
+++ b/internal/marketplace/loadprojected_test.go
@@ -1,6 +1,8 @@
 package marketplace_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,16 +294,30 @@ func TestLoadProjected_CrossPluginIdenticalMCPOK(t *testing.T) {
 	}
 }
 
-// TestLoadProjected_LegacyBareHexPinRefused proves a pre-tree-hash pin (a bare
-// sha256 hex, which covered only plugin.json) is refused with a re-pin
-// instruction rather than silently honoured — it cannot certify the bodies.
-func TestLoadProjected_LegacyBareHexPinRefused(t *testing.T) {
+// TestLoadProjected_LegacyPinVerifiesUnderPriorScheme proves a pre-tree-hash
+// pin (a bare sha256 hex over plugin.json) still VERIFIES under the prior scheme
+// rather than being refused — refusing it bricked existing installs whose only
+// remediation (`agentsync update`) does not re-pin a non-bumping plugin. An
+// untampered plugin.json passes; a changed plugin.json is a real mismatch.
+func TestLoadProjected_LegacyPinVerifiesUnderPriorScheme(t *testing.T) {
+	pluginJSON := `{"name":"old","mcpServers":{"a":{"command":"x"}}}`
+	sum := sha256.Sum256([]byte(pluginJSON))
+	legacy := hex.EncodeToString(sum[:])
+
 	home, cache := writeProjFixture(t,
+		"[plugin]\nid = \"old@m\"\nversion = \"1\"\nmanifest_sha = \""+legacy+"\"\n",
+		"old", pluginJSON)
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache); err != nil {
+		t.Fatalf("legacy pin with untampered plugin.json must verify, got: %v", err)
+	}
+
+	// A legacy pin that no longer matches plugin.json is a real tamper.
+	home2, cache2 := writeProjFixture(t,
 		"[plugin]\nid = \"old@m\"\nversion = \"1\"\nmanifest_sha = \"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\"\n",
-		"old", `{"name":"old","mcpServers":{"a":{"command":"x"}}}`)
-	_, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache)
-	if err == nil || !strings.Contains(err.Error(), "pre-tree-hash") {
-		t.Fatalf("expected legacy-pin refusal, got: %v", err)
+		"old", pluginJSON)
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home2, cache2); err == nil ||
+		!strings.Contains(err.Error(), "manifest SHA mismatch") {
+		t.Fatalf("legacy pin mismatch must error, got: %v", err)
 	}
 }
 

--- a/internal/marketplace/loadprojected_test.go
+++ b/internal/marketplace/loadprojected_test.go
@@ -292,13 +292,62 @@ func TestLoadProjected_CrossPluginIdenticalMCPOK(t *testing.T) {
 	}
 }
 
-func TestLoadProjected_ManifestSHAMismatchRefuses(t *testing.T) {
+// TestLoadProjected_LegacyBareHexPinRefused proves a pre-tree-hash pin (a bare
+// sha256 hex, which covered only plugin.json) is refused with a re-pin
+// instruction rather than silently honoured — it cannot certify the bodies.
+func TestLoadProjected_LegacyBareHexPinRefused(t *testing.T) {
 	home, cache := writeProjFixture(t,
-		"[plugin]\nid = \"tamper@m\"\nversion = \"1\"\nmanifest_sha = \"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\"\n",
-		"tamper", `{"name":"tamper","mcpServers":{"backdoor":{"command":"evil"}}}`)
+		"[plugin]\nid = \"old@m\"\nversion = \"1\"\nmanifest_sha = \"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\"\n",
+		"old", `{"name":"old","mcpServers":{"a":{"command":"x"}}}`)
 	_, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache)
-	if err == nil || !strings.Contains(err.Error(), "manifest SHA mismatch") {
-		t.Fatalf("expected SHA-mismatch error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "pre-tree-hash") {
+		t.Fatalf("expected legacy-pin refusal, got: %v", err)
+	}
+}
+
+// TestLoadProjected_TamperedBodyDetected is the core regression: the manifest
+// pin now hashes the whole plugin tree, so a tampered component body (here a
+// convention-discovered SKILL.md) with an UNCHANGED plugin.json is detected.
+// Under the old plugin.json-only pin this passed silently.
+func TestLoadProjected_TamperedBodyDetected(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(home, ".state", "cache", "plugins")
+	pdir := filepath.Join(cache, "p")
+	if err := os.MkdirAll(filepath.Join(pdir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pdir, "skills", "s"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, ".claude-plugin", "plugin.json"), []byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skill := filepath.Join(pdir, "skills", "s", "SKILL.md")
+	if err := os.WriteFile(skill, []byte("---\nname: s\n---\noriginal body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pin, err := marketplace.PluginTreeHash(afero.NewOsFs(), pdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "plugins", "p.toml"),
+		[]byte("[plugin]\nid = \"p@m\"\nversion = \"1\"\nmanifest_sha = \""+pin+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Unmodified tree verifies clean.
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache); err != nil {
+		t.Fatalf("unmodified plugin should verify: %v", err)
+	}
+	// Tamper the body; leave plugin.json byte-identical.
+	if err := os.WriteFile(skill, []byte("---\nname: s\n---\nMALICIOUS body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache); err == nil ||
+		!strings.Contains(err.Error(), "manifest SHA mismatch") {
+		t.Fatalf("tampered SKILL.md body must be detected; got: %v", err)
 	}
 }
 

--- a/internal/marketplace/loadprojected_test.go
+++ b/internal/marketplace/loadprojected_test.go
@@ -233,6 +233,65 @@ func TestLoadProjected_RejectsTraversalComponentName(t *testing.T) {
 	}
 }
 
+// twoPluginFixture lays down two plugins (a, b) on one home, each with its own
+// cached plugin.json, so cross-plugin projection collisions can be exercised.
+func twoPluginFixture(t *testing.T, jsonA, jsonB string) (home, cache string) {
+	t.Helper()
+	home = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for id, pj := range map[string]string{"a": jsonA, "b": jsonB} {
+		if err := os.WriteFile(filepath.Join(home, "plugins", id+".toml"),
+			[]byte("[plugin]\nid = \""+id+"@m\"\nversion = \"1\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		d := filepath.Join(home, ".state", "cache", "plugins", id, ".claude-plugin")
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "plugin.json"), []byte(pj), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home, filepath.Join(home, ".state", "cache", "plugins")
+}
+
+// TestLoadProjected_CrossPluginMCPCollisionConflicts is the regression for a
+// silent cross-plugin hijack: two plugins declaring the same MCP server id with
+// DIFFERENT content collapse into the id-keyed render map last-wins, so an
+// untrusted plugin could silently repoint a trusted server's command/url with
+// no error. A mutating projection load must refuse rather than pick one.
+func TestLoadProjected_CrossPluginMCPCollisionConflicts(t *testing.T) {
+	home, cache := twoPluginFixture(t,
+		`{"name":"a","mcpServers":{"shared":{"command":"/usr/bin/trusted"}}}`,
+		`{"name":"b","mcpServers":{"shared":{"command":"/tmp/evil"}}}`)
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache); err == nil {
+		t.Fatal("expected a cross-plugin MCP id conflict error, got nil (silent clobber)")
+	}
+}
+
+// TestLoadProjected_CrossPluginIdenticalMCPOK proves two plugins declaring the
+// SAME server with IDENTICAL content do not error — render would dedup them.
+func TestLoadProjected_CrossPluginIdenticalMCPOK(t *testing.T) {
+	home, cache := twoPluginFixture(t,
+		`{"name":"a","mcpServers":{"shared":{"command":"same"}}}`,
+		`{"name":"b","mcpServers":{"shared":{"command":"same"}}}`)
+	c, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache)
+	if err != nil {
+		t.Fatalf("identical cross-plugin servers must not conflict: %v", err)
+	}
+	n := 0
+	for _, m := range c.MCPServers {
+		if m.ID == "shared" {
+			n++
+		}
+	}
+	if n == 0 {
+		t.Fatal("shared server lost")
+	}
+}
+
 func TestLoadProjected_ManifestSHAMismatchRefuses(t *testing.T) {
 	home, cache := writeProjFixture(t,
 		"[plugin]\nid = \"tamper@m\"\nversion = \"1\"\nmanifest_sha = \"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\"\n",

--- a/internal/marketplace/loadprojected_test.go
+++ b/internal/marketplace/loadprojected_test.go
@@ -273,6 +273,28 @@ func TestLoadProjected_CrossPluginMCPCollisionConflicts(t *testing.T) {
 	}
 }
 
+// TestLoadProjected_SameRenderDiffMetadataOK proves the cross-source conflict
+// guard compares only RENDER-relevant fields: a user server and a plugin server
+// with identical command/args/env/url/headers that differ only on the
+// source-only `agents`/`enabled` targeting metadata (which capture preserves and
+// render strips) must NOT be flagged as a divergent hijack.
+func TestLoadProjected_SameRenderDiffMetadataOK(t *testing.T) {
+	home, cache := writeProjFixture(t,
+		"[plugin]\nid = \"p@m\"\nversion = \"1\"\n", "p",
+		`{"name":"p","mcpServers":{"shared":{"command":"npx"}}}`)
+	if err := os.MkdirAll(filepath.Join(home, "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User's own server: same command, plus source-only agents + enabled.
+	if err := os.WriteFile(filepath.Join(home, "mcp", "shared.toml"),
+		[]byte("[server]\ncommand = \"npx\"\nagents = [\"*\"]\nenabled = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := marketplace.LoadProjected(afero.NewOsFs(), home, cache); err != nil {
+		t.Fatalf("same render content with differing source-only metadata must not conflict: %v", err)
+	}
+}
+
 // TestLoadProjected_CrossPluginIdenticalMCPOK proves two plugins declaring the
 // SAME server with IDENTICAL content do not error — render would dedup them.
 func TestLoadProjected_CrossPluginIdenticalMCPOK(t *testing.T) {

--- a/internal/marketplace/treehash.go
+++ b/internal/marketplace/treehash.go
@@ -1,0 +1,92 @@
+package marketplace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// treeHashPrefix tags a manifest SHA computed over the whole plugin cache tree
+// (every projected component body, not just plugin.json). The version segment
+// lets the formula evolve without silently mis-verifying old pins.
+const treeHashPrefix = "tree:v1:"
+
+// entryHashPrefix tags the pin of an entry-only plugin (one with no cached
+// plugin.json / component files — its definition lives solely in the
+// marketplace entry). Such a plugin ships no bodies, so there is nothing in the
+// cache dir to tree-hash; verify skips it (the entry isn't available at verify
+// time), matching the pre-tree-hash "no plugin.json → nothing to verify".
+const entryHashPrefix = treeHashPrefix + "entry:"
+
+// PluginTreeHash computes a deterministic content hash over every file in a
+// plugin's cache dir, EXCLUDING .git/ (which projection never reads and which
+// would otherwise make a git-sourced plugin's pin non-deterministic across
+// clones). It covers the component bodies projection actually ships —
+// convention-discovered skills, command/subagent markdown — not just
+// plugin.json, so a body tamper with an unchanged plugin.json is detected.
+//
+// The hash is sha256 over the sorted "<slash-relpath>\x00<sha256(content)>"
+// lines, so it captures file additions/removals as well as edits, and is
+// independent of walk order and OS path separators. A symlink is REFUSED (not
+// skipped): skipping one would let a swapped link target hide from the hash.
+func PluginTreeHash(fs afero.Fs, cacheDir string) (string, error) {
+	var lines []string
+	err := afero.Walk(fs, cacheDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, os.ErrNotExist) {
+				return nil
+			}
+			return walkErr
+		}
+		rel, rerr := filepath.Rel(cacheDir, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == ".git" || strings.HasPrefix(rel, ".git/") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("plugin cache contains a symlink %q; refusing to hash", rel)
+		}
+		data, rerr := afero.ReadFile(fs, path)
+		if rerr != nil {
+			return fmt.Errorf("hash %s: %w", rel, rerr)
+		}
+		sum := sha256.Sum256(data)
+		lines = append(lines, rel+"\x00"+hex.EncodeToString(sum[:]))
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return treeHashPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+// PluginEntryHash pins an entry-only plugin — one with no cached plugin.json or
+// component bodies — over its marketplace entry definition. The entry-prefix
+// tag tells verify to skip recomputation (the entry isn't available there).
+func PluginEntryHash(entry PluginEntry) (string, error) {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return entryHashPrefix + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/marketplace/update.go
+++ b/internal/marketplace/update.go
@@ -50,6 +50,13 @@ func DetectSHADrift(plugins []source.Plugin, freshSHAs map[string]string) []SHAW
 		if recorded == "" || recorded == freshSHA {
 			continue
 		}
+		// A pre-tree-hash (legacy bare-hex) pin and a freshly computed tree:v1:
+		// hash are different SCHEMES; their difference is a format change, not a
+		// re-upload. The legacy pin is verified under the prior scheme at apply,
+		// so skip the cross-scheme comparison to avoid a false re-upload warning.
+		if strings.HasPrefix(recorded, treeHashPrefix) != strings.HasPrefix(freshSHA, treeHashPrefix) {
+			continue
+		}
 		out = append(out, SHAWarning{
 			ID:          pl.ID,
 			Version:     pl.Plugin.Version,

--- a/internal/marketplace/update.go
+++ b/internal/marketplace/update.go
@@ -81,14 +81,20 @@ func ComputePendingBumps(
 	_ []source.Marketplace,
 	plugins []source.Plugin,
 	fetched map[string]map[string]PluginEntry,
+	defaultMode string,
 ) []Bump {
 	var out []Bump
 
 	for _, pl := range plugins {
 		spec := pl.Plugin
 
-		// Resolve effective update mode.
+		// Resolve effective update mode: a plugin's own `update` wins; otherwise
+		// the canonical `[updates] default_mode` (so a user who sets it to
+		// "pinned" is not silently auto-bumped); otherwise "track".
 		mode := spec.Update
+		if mode == "" {
+			mode = defaultMode
+		}
 		if mode == "" {
 			mode = "track"
 		}

--- a/internal/marketplace/update_test.go
+++ b/internal/marketplace/update_test.go
@@ -25,7 +25,7 @@ func TestComputePendingBumps_TrackMode_Bumps(t *testing.T) {
 		},
 	}
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 1 {
 		t.Fatalf("expected 1 bump, got %d", len(bumps))
 	}
@@ -52,7 +52,7 @@ func TestComputePendingBumps_TrackMode_NoDowngrade(t *testing.T) {
 	fetched := map[string]map[string]marketplace.PluginEntry{
 		"test-mp": {"demo": {Name: "demo", Version: "1.5.0"}},
 	}
-	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched); len(bumps) != 0 {
+	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, ""); len(bumps) != 0 {
 		t.Fatalf("expected no bump for a rollback/downgrade, got %d: %+v", len(bumps), bumps)
 	}
 }
@@ -67,7 +67,7 @@ func TestComputePendingBumps_NonSemverTracksLatest(t *testing.T) {
 	fetched := map[string]map[string]marketplace.PluginEntry{
 		"test-mp": {"demo": {Name: "demo", Version: "edge"}},
 	}
-	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched); len(bumps) != 1 {
+	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, ""); len(bumps) != 1 {
 		t.Fatalf("expected track-latest fallback to bump on non-semver change, got %d", len(bumps))
 	}
 }
@@ -90,7 +90,7 @@ func TestComputePendingBumps_PinnedMode_NoBump(t *testing.T) {
 		},
 	}
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 0 {
 		t.Errorf("pinned plugin should not bump, got %d bumps", len(bumps))
 	}
@@ -113,7 +113,7 @@ func TestComputePendingBumps_ManualMode_NoBump(t *testing.T) {
 		},
 	}
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 0 {
 		t.Errorf("manual plugin should not bump, got %d bumps", len(bumps))
 	}
@@ -137,9 +137,28 @@ func TestComputePendingBumps_DefaultMode_Bumps(t *testing.T) {
 		},
 	}
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 1 {
 		t.Fatalf("default update mode should bump, got %d", len(bumps))
+	}
+}
+
+// TestComputePendingBumps_DefaultModePinned_NoBump proves [updates] default_mode
+// is honored: a plugin with no explicit `update` inherits the canonical default,
+// so default_mode="pinned" suppresses the auto-bump it would otherwise receive.
+func TestComputePendingBumps_DefaultModePinned_NoBump(t *testing.T) {
+	plugins := []source.Plugin{
+		{ID: "d", Plugin: source.PluginSpec{ID: "d@test-mp", Version: "1.0.0", Update: ""}},
+	}
+	fetched := map[string]map[string]marketplace.PluginEntry{
+		"test-mp": {"d": {Name: "d", Version: "2.0.0"}},
+	}
+	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "pinned"); len(bumps) != 0 {
+		t.Fatalf("default_mode=pinned must suppress the bump, got %d: %+v", len(bumps), bumps)
+	}
+	// Sanity: an explicit default of "track" still bumps.
+	if bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "track"); len(bumps) != 1 {
+		t.Fatalf("default_mode=track must allow the bump, got %d", len(bumps))
 	}
 }
 
@@ -160,7 +179,7 @@ func TestComputePendingBumps_AlreadyLatest_NoBump(t *testing.T) {
 		},
 	}
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 0 {
 		t.Errorf("already-latest plugin should not bump, got %d bumps", len(bumps))
 	}
@@ -180,7 +199,7 @@ func TestComputePendingBumps_NoMarketplace_NoBump(t *testing.T) {
 	}
 	fetched := map[string]map[string]marketplace.PluginEntry{} // empty
 
-	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched)
+	bumps := marketplace.ComputePendingBumps(nil, nil, plugins, fetched, "")
 	if len(bumps) != 0 {
 		t.Errorf("plugin with no matching marketplace should not bump, got %d", len(bumps))
 	}

--- a/internal/marketplace/update_test.go
+++ b/internal/marketplace/update_test.go
@@ -237,6 +237,21 @@ func TestDetectSHADrift_Drift(t *testing.T) {
 	}
 }
 
+// TestDetectSHADrift_LegacyVsTreeSchemeSkipped guards against a false
+// "re-uploaded?" warning: a legacy bare-hex pin and a freshly computed
+// tree:v1: hash are different SCHEMES, so their difference is a format change,
+// not a re-upload. The legacy pin is verified under the prior scheme at apply;
+// drift detection must skip the cross-scheme comparison.
+func TestDetectSHADrift_LegacyVsTreeSchemeSkipped(t *testing.T) {
+	plugins := []source.Plugin{
+		{ID: "demo", Plugin: source.PluginSpec{ID: "demo@mp", Version: "1.0.0", ManifestSHA: "deadbeefdeadbeef"}},
+	}
+	warnings := marketplace.DetectSHADrift(plugins, map[string]string{"demo": "tree:v1:abc123"})
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning for a legacy-vs-tree scheme difference, got %d: %+v", len(warnings), warnings)
+	}
+}
+
 func TestDetectSHADrift_NoRecordedSHA(t *testing.T) {
 	// If plugin has no recorded SHA, no warning (it may not have been installed with pinning).
 	plugins := []source.Plugin{

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -335,14 +335,15 @@ func Apply(
 	userHome string,
 	scope adapter.Scope,
 	project string,
-) ([]CollisionReport, map[string]bool, error) {
+) ([]CollisionReport, map[string]bool, map[string]bool, error) {
 	written := map[string]bool{}
+	unchanged := map[string]bool{}
 	if st == nil {
 		// Defensive: a nil state would make every write look like a
 		// foreign collision and produce duplicate backups. Callers that
 		// don't yet have a state object should construct an empty one
 		// (state.New) rather than passing nil.
-		return nil, written, fmt.Errorf("render.Apply: nil state")
+		return nil, written, unchanged, fmt.Errorf("render.Apply: nil state")
 	}
 
 	var allReports []CollisionReport
@@ -354,7 +355,7 @@ func Apply(
 		}
 		a := reg.Lookup(name)
 		if a == nil {
-			return allReports, written, fmt.Errorf("adapter %q not registered at apply", name)
+			return allReports, written, unchanged, fmt.Errorf("adapter %q not registered at apply", name)
 		}
 		var deduped []adapter.FileOp
 		for _, op := range res.Ops {
@@ -373,7 +374,7 @@ func Apply(
 					// dropping one agent's bytes would be data loss — so fail
 					// loud rather than pick a winner.
 					if !bytes.Equal(prev, op.Content) {
-						return allReports, written, fmt.Errorf(
+						return allReports, written, unchanged, fmt.Errorf(
 							"agent %q renders different content than an earlier agent for the same path %s; "+
 								"refusing to silently drop one (shared paths must render identical bytes)",
 							name, op.Path,
@@ -391,9 +392,12 @@ func Apply(
 		for path := range w.Wrote() {
 			written[path] = true
 		}
+		for path := range w.Unchanged() {
+			unchanged[path] = true
+		}
 		if err != nil {
-			return allReports, written, fmt.Errorf("apply %s: %w", name, err)
+			return allReports, written, unchanged, fmt.Errorf("apply %s: %w", name, err)
 		}
 	}
-	return allReports, written, nil
+	return allReports, written, unchanged, nil
 }

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -84,7 +84,7 @@ func TestPipeline_DedupesIdenticalWritesAcrossAdapters(t *testing.T) {
 		},
 	}
 
-	if _, _, err := render.Apply(plan, reg, state.New(), t.TempDir(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
+	if _, _, _, err := render.Apply(plan, reg, state.New(), t.TempDir(), t.TempDir(), adapter.ScopeUser, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/render/sibling_section_test.go
+++ b/internal/render/sibling_section_test.go
@@ -21,7 +21,7 @@ func applyOnce(t *testing.T, reg *adapter.Registry, c source.Canonical, st *stat
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
-	if _, _, err := render.Apply(plan, reg, st, home, userHome, adapter.ScopeUser, ""); err != nil {
+	if _, _, _, err := render.Apply(plan, reg, st, home, userHome, adapter.ScopeUser, ""); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	for name, res := range plan.PerAgent {

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -275,8 +275,8 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 		if _, owned := w.state.Keys[stateKey]; owned {
 			continue
 		}
-		ev := getPointer(existingMap, ptr)
-		if ev == nil {
+		ev, present := getPointerOK(existingMap, ptr)
+		if !present {
 			continue
 		}
 		ov := getPointer(ours, ptr)

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -85,7 +86,8 @@ type Writer struct {
 
 	backupRoot string          // <home>/.state/backups/<ts>; created lazily
 	backedUp   map[string]bool // path → already-backed-up this run
-	wrote      map[string]bool // path → destination actually written this run
+	wrote      map[string]bool // path → destination owned/written this run
+	unchanged  map[string]bool // path → already held our exact bytes (write skipped)
 	reports    []CollisionReport
 	// dryRun, when true, skips both the destination write AND the backup
 	// write. The reports slice is still populated so callers can preview
@@ -132,6 +134,7 @@ func NewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, pr
 		backupRoot: filepath.Join(home, ".state", "backups", ts),
 		backedUp:   map[string]bool{},
 		wrote:      map[string]bool{},
+		unchanged:  map[string]bool{},
 	}
 }
 
@@ -154,9 +157,27 @@ func (w *Writer) Reports() []CollisionReport { return w.reports }
 // attempted must not be recorded as owned (that would suppress its backup).
 func (w *Writer) Wrote() map[string]bool { return w.wrote }
 
+// Unchanged returns the set of destination paths that already held exactly the
+// bytes apply would write, so the atomic write (and its mtime churn) was
+// skipped. apply uses it to report "up to date" instead of "applied: N ops".
+func (w *Writer) Unchanged() map[string]bool { return w.unchanged }
+
 // Write satisfies adapter.DestWriter. finalBytes is the post-merge content
 // for merge ops, or op.Content for replace ops.
 func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
+	// Convergence short-circuit: if the destination already holds exactly the
+	// bytes we'd write, skip the write so a no-op apply doesn't churn the file's
+	// mtime (which misleads mtime-watching tooling and makes a clean re-apply
+	// look like real work). The post-condition (dest == finalBytes) already
+	// holds, so still mark it owned for state recording; nothing is overwritten,
+	// so there is nothing to back up. Skipped under dry-run (no read needed).
+	if !w.dryRun {
+		if cur, err := os.ReadFile(op.Path); err == nil && bytes.Equal(cur, finalBytes) {
+			w.wrote[op.Path] = true
+			w.unchanged[op.Path] = true
+			return nil
+		}
+	}
 	if err := w.maybeBackup(op, finalBytes); err != nil {
 		return err
 	}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -71,6 +71,43 @@ func (f *fakeJSONApply) Apply(ops []adapter.FileOp, w adapter.DestWriter) error 
 	return nil
 }
 
+// TestWriter_SkipsUnchangedWrite proves the convergence short-circuit: writing
+// the exact bytes a file already holds is a no-op — recorded as Unchanged (so
+// apply can report "up to date"), still owned (Wrote), and not backed up.
+func TestWriter_SkipsUnchangedWrite(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+	dest := filepath.Join(tmp, "note.md")
+	content := []byte("stable content\n")
+	if err := os.WriteFile(dest, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st := state.New()
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
+	op := adapter.FileOp{Action: "write", Path: dest, Content: content, Mode: 0o644, SourceID: "note.md"}
+	if err := w.Write(op, content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !w.Unchanged()[dest] {
+		t.Fatalf("identical write should be recorded Unchanged; got %v", w.Unchanged())
+	}
+	if !w.Wrote()[dest] {
+		t.Fatalf("an unchanged file must still be marked owned (Wrote) for state recording")
+	}
+	if len(w.Reports()) != 0 {
+		t.Fatalf("no backup should occur on a no-op write; got %v", w.Reports())
+	}
+	// A genuinely different write is NOT unchanged.
+	w2 := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
+	if err := w2.Write(op, []byte("different\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if w2.Unchanged()[dest] {
+		t.Fatal("a changed write must not be recorded Unchanged")
+	}
+}
+
 // TestWriter_FileLevelBackup is the regression for the HIGH-severity
 // finding: a pre-existing native file with no state entry is copied to
 // <home>/.state/backups/<ts>/ before the writer's iox.AtomicWrite
@@ -360,7 +397,7 @@ func TestRenderApply_MultipleMergeOpsSamePathAllApplied(t *testing.T) {
 			}},
 		},
 	}
-	if _, _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
+	if _, _, _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
@@ -403,7 +440,7 @@ func TestRenderApply_SharedWriteDivergence(t *testing.T) {
 		_ = reg.Register(&fakeJSONApply{name: "claude"})
 		_ = reg.Register(&fakeJSONApply{name: "opencode"})
 
-		_, _, err := render.Apply(newPlan(dest, "shared-body", "DIVERGENT-body"), reg, state.New(), home, tmp, adapter.ScopeUser, "")
+		_, _, _, err := render.Apply(newPlan(dest, "shared-body", "DIVERGENT-body"), reg, state.New(), home, tmp, adapter.ScopeUser, "")
 		if err == nil {
 			t.Fatal("expected divergent shared-write to fail loud, got nil error")
 		}
@@ -422,7 +459,7 @@ func TestRenderApply_SharedWriteDivergence(t *testing.T) {
 		_ = reg.Register(&fakeJSONApply{name: "claude"})
 		_ = reg.Register(&fakeJSONApply{name: "opencode"})
 
-		if _, _, err := render.Apply(newPlan(dest, "shared-body", "shared-body"), reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
+		if _, _, _, err := render.Apply(newPlan(dest, "shared-body", "shared-body"), reg, state.New(), home, tmp, adapter.ScopeUser, ""); err != nil {
 			t.Fatalf("identical shared-write should dedup cleanly, got: %v", err)
 		}
 		data, err := os.ReadFile(dest)
@@ -480,7 +517,7 @@ func TestRenderApply_FullPathBacksUpAcrossAgents(t *testing.T) {
 		},
 	}
 	st := state.New()
-	reports, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, "")
+	reports, _, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, "")
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -224,6 +224,44 @@ func TestWriter_KeyLevelBackup_ForeignNonObjectAtOwnedKey(t *testing.T) {
 	}
 }
 
+// TestWriter_KeyLevelBackup_ForeignNullAtOwnedPointer is the regression for a
+// gap in the foreign-collision backup: a hand-authored dest holding an explicit
+// `null` at a second-level pointer agentsync is about to write (e.g.
+// `mcpServers.github = null`) collapsed to the same nil as an ABSENT pointer in
+// getPointer, so the per-child loop skipped the backup and overlayOwned then
+// overwrote the user's explicit null with no backup. A present value — even
+// null — is foreign content and must be backed up before the overwrite.
+func TestWriter_KeyLevelBackup_ForeignNullAtOwnedPointer(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+	dest := filepath.Join(tmp, ".claude.json")
+	_ = os.WriteFile(dest, []byte(`{"mcpServers":{"github":null},"preserveMe":"keep"}`), 0o644)
+
+	st := state.New()
+	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
+	ours := []byte(`{"mcpServers":{"github":{"command":"npx"}}}`)
+	op := adapter.FileOp{
+		Action:        "write",
+		Path:          dest,
+		Content:       ours,
+		MergeStrategy: "merge-json-keys",
+		Mode:          0o644,
+		SourceID:      "mcp/github.toml",
+	}
+	final := []byte(`{"mcpServers":{"github":{"command":"npx"}},"preserveMe":"keep"}` + "\n")
+	if err := w.Write(op, final); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	reports := w.Reports()
+	if len(reports) == 0 {
+		t.Fatal("expected a foreign-collision backup for an explicit null at an owned pointer, got none")
+	}
+	if reports[0].Pointer != "/mcpServers/github" {
+		t.Fatalf("want collision at /mcpServers/github; got %+v", reports[0])
+	}
+}
+
 // TestWriter_NoCollisionWhenAlreadyOwned asserts that when state already
 // records the file (file-level FileEntry), no backup is written even if
 // the bytes differ — that's just an in-place update by an owning agent.

--- a/internal/secrets/age.go
+++ b/internal/secrets/age.go
@@ -90,6 +90,19 @@ func (b *AgeBackend) Resolve(dottedKey string) (string, error) {
 // rather than coerced via fmt.Sprint: a TOML `token = 0123` would otherwise
 // resolve to "123" (or "83" for octal) and an array to Go's "[a b]" syntax,
 // substituting a silently-wrong credential into the user's agent config.
+// ValidateVaultTOML parses decrypted vault bytes as TOML and applies the exact
+// contract apply uses at resolve time (flatten: string-only leaves, no
+// dup/colliding keys). `secrets edit` calls it so a vault that apply would later
+// refuse is rejected at save time rather than silently encrypted.
+func ValidateVaultTOML(data []byte) error {
+	var m map[string]any
+	if err := toml.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("not valid TOML: %w", err)
+	}
+	_, err := flatten("", m)
+	return err
+}
+
 func flatten(prefix string, m map[string]any) (map[string]string, error) {
 	out := map[string]string{}
 	for k, v := range m {

--- a/internal/secrets/leakscan.go
+++ b/internal/secrets/leakscan.go
@@ -45,21 +45,17 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 		return nil
 	}
 	secretVals := sourceSecretValues(against, sec) // resolved value -> placeholder
-
-	// Source ${secret:K} placeholders referenced by each group.
-	srcPlaceholders := map[secretGroup][]string{}
+	srcByLoc := make(map[secretFieldLoc]string)
 	walkSecretFields(against, func(loc secretFieldLoc, s string) string {
-		if phs := secretPlaceholders(s); len(phs) > 0 {
-			srcPlaceholders[groupOf(loc)] = append(srcPlaceholders[groupOf(loc)], phs...)
-		}
+		srcByLoc[loc] = s
 		return s
 	})
-
-	// All ingested field values, per group.
-	ingestedByGroup := map[secretGroup][]string{}
+	// Per-group concatenation of the ingested fields, so a secret legitimately
+	// SHIFTED within a group (its placeholder restored at a new position) is not
+	// mistaken for one rotated away.
+	groupText := map[secretGroup]string{}
 	walkSecretFields(ingested, func(loc secretFieldLoc, s string) string {
-		g := groupOf(loc)
-		ingestedByGroup[g] = append(ingestedByGroup[g], s)
+		groupText[groupOf(loc)] += "\x00" + s
 		return s
 	})
 
@@ -72,26 +68,35 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 		}
 	}
 
-	// VALUE prong: a live vault secret value sits verbatim in an ingested field.
-	for g, vals := range ingestedByGroup {
-		for _, s := range vals {
-			for v := range secretVals {
-				if strings.Contains(s, v) {
-					flag(g)
-				}
-			}
-		}
-	}
-	// SLOT prong: a ${secret:K} the source group referenced no longer appears
-	// anywhere in the ingested group (rotated / edited away).
-	for g, phs := range srcPlaceholders {
-		joined := strings.Join(ingestedByGroup[g], "\x00")
-		for _, ph := range phs {
-			if !strings.Contains(joined, ph) {
+	walkSecretFields(ingested, func(loc secretFieldLoc, s string) string {
+		g := groupOf(loc)
+		// VALUE prong: a live vault secret value sits verbatim in this field —
+		// a known secret moved/embedded where re-reference couldn't mask it.
+		for v := range secretVals {
+			if strings.Contains(s, v) {
 				flag(g)
+				return s
 			}
 		}
-	}
+		// SLOT prong: this field's OWN source counterpart was a ${secret:K} slot,
+		// but the field now holds a non-empty value that is NOT the placeholder
+		// AND the placeholder is gone from the whole group — an in-place
+		// rotation/edit to cleartext that re-reference couldn't match. Keying on
+		// THIS field's counterpart (not the whole source) means a single-item
+		// write-back isn't refused over an unrelated server's secret, and a field
+		// removed entirely (absent / empty here) isn't mistaken for a rotation;
+		// the group check spares a legitimately shifted-and-restored secret.
+		if s == "" {
+			return s
+		}
+		for _, ph := range secretPlaceholders(srcByLoc[loc]) {
+			if !strings.Contains(s, ph) && !strings.Contains(groupText[g], ph) {
+				flag(g)
+				return s
+			}
+		}
+		return s
+	})
 	return leaks
 }
 

--- a/internal/secrets/leakscan.go
+++ b/internal/secrets/leakscan.go
@@ -2,10 +2,14 @@ package secrets
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// secretMarker matches a ${secret:K} reference only (not ${env:…}).
+var secretMarker = regexp.MustCompile(`\$\{secret:[A-Za-z0-9._-]+\}`)
 
 // secretGroup identifies one server/hook-event in the canonical (scope+kind+id),
 // independent of intra-group position (arg index, env/header key). Re-reference
@@ -70,34 +74,77 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 
 	walkSecretFields(ingested, func(loc secretFieldLoc, s string) string {
 		g := groupOf(loc)
-		// VALUE prong: a live vault secret value sits verbatim in this field —
-		// a known secret moved/embedded where re-reference couldn't mask it.
+		src := srcByLoc[loc]
+		// VALUE prong (field-local): a live vault secret value present in THIS
+		// field that is NOT already part of the field's own source counterpart —
+		// i.e. a known secret moved/embedded here. A literal the user already had
+		// in source (even one that coincidentally equals another secret's value)
+		// is pre-existing, not a new leak, so it must not be refused.
 		for v := range secretVals {
-			if strings.Contains(s, v) {
+			if strings.Contains(s, v) && !strings.Contains(src, v) {
 				flag(g)
 				return s
 			}
 		}
-		// SLOT prong: this field's OWN source counterpart was a ${secret:K} slot,
-		// but the field now holds a non-empty value that is NOT the placeholder
-		// AND the placeholder is gone from the whole group — an in-place
-		// rotation/edit to cleartext that re-reference couldn't match. Keying on
-		// THIS field's counterpart (not the whole source) means a single-item
-		// write-back isn't refused over an unrelated server's secret, and a field
-		// removed entirely (absent / empty here) isn't mistaken for a rotation;
-		// the group check spares a legitimately shifted-and-restored secret.
-		if s == "" {
+		// SLOT prong: the field's source counterpart was a ${secret:K} slot, the
+		// ingested value still has that slot's literal SHAPE with non-placeholder
+		// content (a rotation/edit to cleartext re-reference couldn't match — NOT
+		// a trim that removes the slot, which leaves no cleartext), AND the
+		// placeholder is gone from the whole group (so a secret legitimately
+		// SHIFTED elsewhere in the group, or an unrelated server's secret on a
+		// single-item write-back, isn't flagged).
+		if s == "" || !strings.Contains(src, "${secret:") {
 			return s
 		}
-		for _, ph := range secretPlaceholders(srcByLoc[loc]) {
-			if !strings.Contains(s, ph) && !strings.Contains(groupText[g], ph) {
-				flag(g)
-				return s
+		if fieldRetainsRotatedSecret(src, s) {
+			for _, ph := range secretPlaceholders(src) {
+				if !strings.Contains(groupText[g], ph) {
+					flag(g)
+					return s
+				}
 			}
 		}
 		return s
 	})
 	return leaks
+}
+
+// fieldRetainsRotatedSecret reports whether `ingested` matches the literal
+// SHAPE of the source template `src` (each ${secret:K} standing for any run)
+// with at least one slot holding non-placeholder cleartext. That distinguishes
+// a ROTATION/edit ("a=${secret:K}" -> "a=newtoken", shape kept, slot has
+// cleartext) from a TRIM that removes the secret and its surrounding context
+// ("a=${secret:K} b=x" -> "b=x", shape broken -> no match -> not a leak).
+func fieldRetainsRotatedSecret(src, ingested string) bool {
+	segs := secretMarker.Split(src, -1)
+	if len(segs) < 2 {
+		return false // no ${secret:} marker in the counterpart
+	}
+	var pat strings.Builder
+	pat.WriteString("^")
+	for i, seg := range segs {
+		if i > 0 {
+			pat.WriteString("(.*)")
+		}
+		pat.WriteString(regexp.QuoteMeta(seg))
+	}
+	pat.WriteString("$")
+	rx, err := regexp.Compile(pat.String())
+	if err != nil {
+		return true // can't build the matcher; fail safe (refuse)
+	}
+	caps := rx.FindStringSubmatch(ingested)
+	if caps == nil {
+		return false // shape broken (trim/restructure) — no cleartext slot
+	}
+	for _, cap := range caps[1:] {
+		// A slot is cleartext if, after removing any ${secret:…}/${env:…}
+		// placeholders that re-reference restored, non-whitespace remains.
+		if strings.TrimSpace(re.ReplaceAllString(cap, "")) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // secretPlaceholders extracts the ${secret:K} markers in s (ignores ${env:…}).

--- a/internal/secrets/leakscan.go
+++ b/internal/secrets/leakscan.go
@@ -1,0 +1,118 @@
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// secretGroup identifies one server/hook-event in the canonical (scope+kind+id),
+// independent of intra-group position (arg index, env/header key). Re-reference
+// can relocate a secret WITHIN a group (a shifted arg, a renamed env key), so
+// the leak scan reasons per group, not per field — otherwise a legitimately
+// shifted-but-restored secret would look like a missing slot.
+type secretGroup struct{ scope, kind, id string }
+
+func groupOf(loc secretFieldLoc) secretGroup {
+	return secretGroup{scope: loc.scope, kind: loc.kind, id: loc.id}
+}
+
+// ResidualSecretCleartext is the fail-closed backstop for the dest->source write
+// path. After ReReferenceCanonical has done its best to restore ${secret:…}
+// placeholders, this scans the about-to-be-written canonical for a resolved
+// secret that would still persist as CLEARTEXT into the source (a committed
+// dotfiles repo) — the dangerous class re-reference alone cannot fully close,
+// because by value it cannot tell "moved/rotated secret" from "deliberate
+// non-secret literal edit." capture.Capture refuses to write when this returns
+// anything (it errs toward refusing rather than guessing).
+//
+// `ingested` is the re-referenced canonical about to be written; `against` is
+// the current templated source. Two leak shapes, evaluated per secretGroup:
+//
+//   - VALUE: a live vault secret value appears verbatim in any field of the
+//     group — a secret moved into a field whose source counterpart is a literal,
+//     so re-reference left it unmasked.
+//   - SLOT: a ${secret:K} the source group referenced is ABSENT from the entire
+//     ingested group — a rotated/edited secret value re-reference couldn't match
+//     (its cleartext, or a now-unreferenced credential, would persist). A
+//     legitimately *shifted* secret keeps its placeholder somewhere in the
+//     group, so it does NOT trip this.
+//
+// Returns human-readable group descriptions (empty = safe to write).
+func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resolver) []string {
+	if ingested == nil || against == nil {
+		return nil
+	}
+	secretVals := sourceSecretValues(against, sec) // resolved value -> placeholder
+
+	// Source ${secret:K} placeholders referenced by each group.
+	srcPlaceholders := map[secretGroup][]string{}
+	walkSecretFields(against, func(loc secretFieldLoc, s string) string {
+		if phs := secretPlaceholders(s); len(phs) > 0 {
+			srcPlaceholders[groupOf(loc)] = append(srcPlaceholders[groupOf(loc)], phs...)
+		}
+		return s
+	})
+
+	// All ingested field values, per group.
+	ingestedByGroup := map[secretGroup][]string{}
+	walkSecretFields(ingested, func(loc secretFieldLoc, s string) string {
+		g := groupOf(loc)
+		ingestedByGroup[g] = append(ingestedByGroup[g], s)
+		return s
+	})
+
+	seen := map[secretGroup]bool{}
+	var leaks []string
+	flag := func(g secretGroup) {
+		if !seen[g] {
+			seen[g] = true
+			leaks = append(leaks, describeGroup(g))
+		}
+	}
+
+	// VALUE prong: a live vault secret value sits verbatim in an ingested field.
+	for g, vals := range ingestedByGroup {
+		for _, s := range vals {
+			for v := range secretVals {
+				if strings.Contains(s, v) {
+					flag(g)
+				}
+			}
+		}
+	}
+	// SLOT prong: a ${secret:K} the source group referenced no longer appears
+	// anywhere in the ingested group (rotated / edited away).
+	for g, phs := range srcPlaceholders {
+		joined := strings.Join(ingestedByGroup[g], "\x00")
+		for _, ph := range phs {
+			if !strings.Contains(joined, ph) {
+				flag(g)
+			}
+		}
+	}
+	return leaks
+}
+
+// secretPlaceholders extracts the ${secret:K} markers in s (ignores ${env:…}).
+func secretPlaceholders(s string) []string {
+	if !strings.Contains(s, "${secret:") {
+		return nil
+	}
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(s, -1) {
+		if len(m) >= 3 && m[1] == "secret" {
+			out = append(out, m[0])
+		}
+	}
+	return out
+}
+
+func describeGroup(g secretGroup) string {
+	scope := ""
+	if g.scope != "" {
+		scope = g.scope + " "
+	}
+	return fmt.Sprintf("%s%s %q", scope, g.kind, g.id)
+}

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -73,18 +73,22 @@ func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, e
 		//    (the bug a blind value-wide replace would cause):
 		//      - counterpart TEMPLATED but changed → the secret is genuinely this
 		//        field's; re-reference its resolved cleartext (substring ok).
-		//      - NO counterpart (shifted/renamed) → re-reference only when the
-		//        WHOLE value is a known secret, never a substring, so an unrelated
-		//        new field that merely contains a secret value is left alone.
+		//      - NO counterpart (shifted/renamed) → re-reference any embedded
+		//        known-secret cleartext (substring). A relocated field (renamed
+		//        env/header key, renamed server id, shifted arg index) carries the
+		//        secret to a location with no source counterpart, and the secret is
+		//        frequently EMBEDDED in a larger value (e.g. "Bearer <token>"), so a
+		//        whole-value-only match would persist the credential cleartext into
+		//        the canonical source. Leaking a live credential into a committed
+		//        dotfiles repo is far worse than over-masking a genuinely-unrelated
+		//        new field that merely contains a secret value, so mask substrings.
 		//      - counterpart is a LITERAL → leave it exactly as written.
 		//    Only ${secret:…} is inverted (never ${env:…}, matching restoreField).
 		switch {
 		case hasCounterpart && strings.Contains(srcVal, "${secret:"):
 			return MaskResolved(ingested, secretVals)
 		case !hasCounterpart:
-			if ph, ok := secretVals[ingested]; ok {
-				return ph
-			}
+			return MaskResolved(ingested, secretVals)
 		}
 		return ingested
 	})

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -16,25 +16,27 @@ import (
 // a live credential would be persisted into ~/.agentsync (often a committed
 // dotfiles repo).
 //
-// Matching is FIELD-POSITIONAL FIRST: a field is restored to its templated form
-// when (a) the corresponding source field actually referenced a secret and (b)
-// the ingested value still resolves to the same thing (the field is unchanged).
-// A field the source did NOT template (e.g. command = "npx") is never rewritten
-// by this pass, even if its literal happens to equal some secret's value.
+// Each secret-bearing field is decided FIELD-LOCALLY, from its own source
+// counterpart, so re-referencing can never over-mask a value the user typed as a
+// literal in an unrelated field:
 //
-// A VALUE-BASED FALLBACK then catches structural edits the positional pass can't
-// see (a shifted MCP arg index, a renamed env key / server id): it replaces any
-// source-referenced ${secret:…} resolved cleartext that remains with its
-// placeholder, so the resolved credential is never persisted into the canonical
-// source. To keep the positional pass's "don't rewrite a coincidental literal"
-// guarantee, a value that ALSO appears as a non-templated source literal is
-// treated as ambiguous and left untouched (see sourceSecretValues /
-// sourceLiterals). ${env:…} is never inverted by either pass.
+//   - FIELD-POSITIONAL restore (primary): an unchanged templated field whose
+//     source counterpart resolves to the same value is restored to its
+//     ${secret:…} placeholder. A field the source did NOT template (e.g.
+//     command = "npx") is never rewritten here, even if its literal happens to
+//     equal some secret's value.
+//   - VALUE-BASED fallback (for structural edits the positional pass can't see —
+//     a shifted MCP arg index, a renamed env/header key or server id, a secret
+//     embedded in an edited command): if the field's source counterpart was
+//     templated, re-reference its resolved cleartext (substring); if the field
+//     has NO counterpart (shifted/renamed), re-reference only when the WHOLE
+//     value is a known secret. A field whose counterpart is a literal is left
+//     untouched. ${env:…} is never inverted.
 //
 // Both c and against are walked through the one walkSecretFields enumeration, so
 // a new secret-bearing field is re-referenced automatically. Hooks have no
 // stable id, so they are matched by event + resolution (see rereferenceHook),
-// and the value-based fallback covers a hook command edited out of position too.
+// with a value-based fallback for a hook command edited out of position.
 func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, env Resolver) {
 	if c == nil || against == nil {
 		return
@@ -44,40 +46,61 @@ func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, e
 		srcByLoc[loc] = s
 		return s
 	})
+	// secretVals maps each source-referenced secret's resolved cleartext to its
+	// ${secret:…} placeholder, for the field-local value-based fallback below.
+	secretVals := sourceSecretValues(against, sec)
+
 	walkSecretFields(c, func(loc secretFieldLoc, ingested string) string {
 		if loc.kind == "hook" {
-			return rereferenceHook(against, loc.id, ingested, sec, env)
+			// Positional-by-event restore first; then a value-based fallback for
+			// a hook command edited out of its positional match.
+			if restored := rereferenceHook(against, loc.id, ingested, sec, env); restored != ingested {
+				return restored
+			}
+			return rereferenceHookByValue(against, loc.id, ingested, secretVals)
 		}
-		return restoreField(srcByLoc[loc], ingested, sec, env)
+		srcVal, hasCounterpart := srcByLoc[loc]
+		// 1. Field-positional restore: an unchanged templated field whose source
+		//    counterpart resolves to the same value is restored to its placeholder.
+		if restored := restoreField(srcVal, ingested, sec, env); restored != ingested {
+			return restored
+		}
+		// 2. Field-LOCAL value-based fallback for structural changes the
+		//    positional pass can't see (a shifted arg index, a renamed env/header
+		//    key or server id, a secret embedded in an edited command). Deciding
+		//    per field from that field's source counterpart means it can NEVER
+		//    over-mask a value the user typed as a literal in an unrelated field
+		//    (the bug a blind value-wide replace would cause):
+		//      - counterpart TEMPLATED but changed → the secret is genuinely this
+		//        field's; re-reference its resolved cleartext (substring ok).
+		//      - NO counterpart (shifted/renamed) → re-reference only when the
+		//        WHOLE value is a known secret, never a substring, so an unrelated
+		//        new field that merely contains a secret value is left alone.
+		//      - counterpart is a LITERAL → leave it exactly as written.
+		//    Only ${secret:…} is inverted (never ${env:…}, matching restoreField).
+		switch {
+		case hasCounterpart && strings.Contains(srcVal, "${secret:"):
+			return MaskResolved(ingested, secretVals)
+		case !hasCounterpart:
+			if ph, ok := secretVals[ingested]; ok {
+				return ph
+			}
+		}
+		return ingested
 	})
+}
 
-	// Value-based fallback for STRUCTURAL changes the positional pass can't see.
-	// The positional restore above only fires when the dest field kept the same
-	// location (same arg index, env/header key, server id). A native edit that
-	// shifts structure — prepending an MCP arg, renaming an env key or a server
-	// id — moves the resolved cleartext to a location with no source counterpart,
-	// so srcByLoc misses it and the cleartext would be persisted into the
-	// canonical source (a committed dotfiles repo) with no warning. Re-reference
-	// by value as a safety net: replace any source-referenced secret's resolved
-	// cleartext with its ${secret:…} placeholder.
-	//
-	// To preserve the deliberate "don't rewrite a coincidental literal" property
-	// (see restoreField + TestReReferenceCanonical_FieldPositional), EXCLUDE any
-	// value that also appears verbatim as a non-templated source literal: such a
-	// value is ambiguous (it could be the user's own literal, not the leaked
-	// secret), so leave it exactly as the positional pass would. Only ${secret:…}
-	// is inverted (never ${env:…}, matching restoreField); short values are
-	// skipped so a low-entropy "secret" can't corrupt unrelated text.
-	refs := sourceSecretValues(against, sec)
-	for lit := range sourceLiterals(against) {
-		delete(refs, lit)
+// rereferenceHookByValue is the value-based fallback for a hook command that was
+// edited out of its positional match (rereferenceHook already ran). Hooks have
+// no stable id, so scope the masking to events that have at least one templated
+// source hook — a hook the user never templated is left untouched.
+func rereferenceHookByValue(against *source.Canonical, event, ingested string, secretVals map[string]string) string {
+	for _, h := range against.Hooks {
+		if h.Event == event && strings.Contains(h.Command, "${secret:") {
+			return MaskResolved(ingested, secretVals)
+		}
 	}
-	if len(refs) == 0 {
-		return
-	}
-	walkSecretFields(c, func(_ secretFieldLoc, ingested string) string {
-		return MaskResolved(ingested, refs)
-	})
+	return ingested
 }
 
 // minReReferenceLen is the shortest resolved secret value the value-based
@@ -105,24 +128,6 @@ func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]stri
 				continue
 			}
 			out[v] = m[0]
-		}
-		return s
-	})
-	return out
-}
-
-// sourceLiterals returns the set of secret-bearing field values in against that
-// contain NO ${secret:…}/${env:…} reference — i.e. values the user typed
-// verbatim. A resolved secret value that also appears in this set is ambiguous
-// (literal vs leaked credential), so the value-based fallback leaves it alone.
-func sourceLiterals(against *source.Canonical) map[string]struct{} {
-	out := map[string]struct{}{}
-	if against == nil {
-		return out
-	}
-	walkSecretFields(against, func(_ secretFieldLoc, s string) string {
-		if s != "" && !re.MatchString(s) {
-			out[s] = struct{}{}
 		}
 		return s
 	})

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -16,16 +16,25 @@ import (
 // a live credential would be persisted into ~/.agentsync (often a committed
 // dotfiles repo).
 //
-// Matching is FIELD-POSITIONAL, not value-based: a field is restored to its
-// templated form only when (a) the corresponding source field actually
-// referenced a secret and (b) the ingested value still resolves to the same
-// thing (the field is unchanged). A field the source did NOT template (e.g.
-// command = "npx") is never rewritten, even if its literal happens to equal
-// some secret's value — value-based masking would corrupt it.
+// Matching is FIELD-POSITIONAL FIRST: a field is restored to its templated form
+// when (a) the corresponding source field actually referenced a secret and (b)
+// the ingested value still resolves to the same thing (the field is unchanged).
+// A field the source did NOT template (e.g. command = "npx") is never rewritten
+// by this pass, even if its literal happens to equal some secret's value.
+//
+// A VALUE-BASED FALLBACK then catches structural edits the positional pass can't
+// see (a shifted MCP arg index, a renamed env key / server id): it replaces any
+// source-referenced ${secret:…} resolved cleartext that remains with its
+// placeholder, so the resolved credential is never persisted into the canonical
+// source. To keep the positional pass's "don't rewrite a coincidental literal"
+// guarantee, a value that ALSO appears as a non-templated source literal is
+// treated as ambiguous and left untouched (see sourceSecretValues /
+// sourceLiterals). ${env:…} is never inverted by either pass.
 //
 // Both c and against are walked through the one walkSecretFields enumeration, so
 // a new secret-bearing field is re-referenced automatically. Hooks have no
-// stable id, so they are matched by event + resolution (see rereferenceHook).
+// stable id, so they are matched by event + resolution (see rereferenceHook),
+// and the value-based fallback covers a hook command edited out of position too.
 func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, env Resolver) {
 	if c == nil || against == nil {
 		return
@@ -41,6 +50,83 @@ func ReReferenceCanonical(c *source.Canonical, against *source.Canonical, sec, e
 		}
 		return restoreField(srcByLoc[loc], ingested, sec, env)
 	})
+
+	// Value-based fallback for STRUCTURAL changes the positional pass can't see.
+	// The positional restore above only fires when the dest field kept the same
+	// location (same arg index, env/header key, server id). A native edit that
+	// shifts structure — prepending an MCP arg, renaming an env key or a server
+	// id — moves the resolved cleartext to a location with no source counterpart,
+	// so srcByLoc misses it and the cleartext would be persisted into the
+	// canonical source (a committed dotfiles repo) with no warning. Re-reference
+	// by value as a safety net: replace any source-referenced secret's resolved
+	// cleartext with its ${secret:…} placeholder.
+	//
+	// To preserve the deliberate "don't rewrite a coincidental literal" property
+	// (see restoreField + TestReReferenceCanonical_FieldPositional), EXCLUDE any
+	// value that also appears verbatim as a non-templated source literal: such a
+	// value is ambiguous (it could be the user's own literal, not the leaked
+	// secret), so leave it exactly as the positional pass would. Only ${secret:…}
+	// is inverted (never ${env:…}, matching restoreField); short values are
+	// skipped so a low-entropy "secret" can't corrupt unrelated text.
+	refs := sourceSecretValues(against, sec)
+	for lit := range sourceLiterals(against) {
+		delete(refs, lit)
+	}
+	if len(refs) == 0 {
+		return
+	}
+	walkSecretFields(c, func(_ secretFieldLoc, ingested string) string {
+		return MaskResolved(ingested, refs)
+	})
+}
+
+// minReReferenceLen is the shortest resolved secret value the value-based
+// fallback will invert. A 1–3 char "secret" is not a credential worth the risk
+// of substring-rewriting unrelated text (a flag, a path segment); the
+// field-positional pass still restores it when the dest field is unchanged.
+const minReReferenceLen = 4
+
+// sourceSecretValues resolves every ${secret:…} reference in against and returns
+// a map from the resolved cleartext to its placeholder. ${env:…} is excluded:
+// an env value is not a credential-at-rest concern and is never inverted (see
+// restoreField). Values shorter than minReReferenceLen are skipped.
+func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]string {
+	out := map[string]string{}
+	if against == nil || sec == nil {
+		return out
+	}
+	walkSecretFields(against, func(_ secretFieldLoc, s string) string {
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			if len(m) < 3 || m[1] != "secret" {
+				continue
+			}
+			v, err := sec.Resolve(m[2])
+			if err != nil || len(v) < minReReferenceLen {
+				continue
+			}
+			out[v] = m[0]
+		}
+		return s
+	})
+	return out
+}
+
+// sourceLiterals returns the set of secret-bearing field values in against that
+// contain NO ${secret:…}/${env:…} reference — i.e. values the user typed
+// verbatim. A resolved secret value that also appears in this set is ambiguous
+// (literal vs leaked credential), so the value-based fallback leaves it alone.
+func sourceLiterals(against *source.Canonical) map[string]struct{} {
+	out := map[string]struct{}{}
+	if against == nil {
+		return out
+	}
+	walkSecretFields(against, func(_ secretFieldLoc, s string) string {
+		if s != "" && !re.MatchString(s) {
+			out[s] = struct{}{}
+		}
+		return s
+	})
+	return out
 }
 
 // restoreField returns the source field's templated value when it referenced a

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -191,6 +191,68 @@ func TestReReferenceCanonical_ValueFallbackOnStructuralShift(t *testing.T) {
 	})
 }
 
+// TestReReferenceCanonical_NoOverMaskSubstringLiteral is the regression for an
+// over-mask the value-based fallback introduced: a field the user authored as a
+// LITERAL that merely CONTAINS a secret's value as a substring must not be
+// rewritten into a ${secret:…} reference. Here server "b"'s command is a literal
+// that contains server "a"'s resolved secret value; capturing an unchanged "b"
+// must leave it byte-for-byte, while "a"'s genuine templated field is restored.
+func TestReReferenceCanonical_NoOverMaskSubstringLiteral(t *testing.T) {
+	sec := fakeResolver{"TOK": "tok12345abc"}
+	env := fakeResolver{}
+	against := &source.Canonical{MCPServers: []source.MCPServer{
+		{ID: "a", Server: source.MCPServerSpec{Env: map[string]string{"K": "${secret:TOK}"}}},
+		{ID: "b", Server: source.MCPServerSpec{Command: "run --note=tok12345abc-extra"}},
+	}}
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{
+		{ID: "a", Server: source.MCPServerSpec{Env: map[string]string{"K": "tok12345abc"}}},
+		{ID: "b", Server: source.MCPServerSpec{Command: "run --note=tok12345abc-extra"}},
+	}}
+	ReReferenceCanonical(ingested, against, sec, env)
+	if got := ingested.MCPServers[0].Server.Env["K"]; got != "${secret:TOK}" {
+		t.Errorf("server a templated secret not restored: %q", got)
+	}
+	if got := ingested.MCPServers[1].Server.Command; got != "run --note=tok12345abc-extra" {
+		t.Fatalf("over-mask: server b's literal command rewritten to %q", got)
+	}
+}
+
+// TestReReferenceCanonical_NoOverMaskCrossScopeLiteral proves a user-scope
+// secret that is structurally shifted is still re-referenced even when the same
+// value appears as a PROJECT-scope literal (the per-field decision is keyed by
+// scope, so the project literal does not disable the user-scope safety net).
+func TestReReferenceCanonical_NoOverMaskCrossScopeLiteral(t *testing.T) {
+	sec := fakeResolver{"TOK": "tok12345abc"}
+	env := fakeResolver{}
+	against := &source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "u", Server: source.MCPServerSpec{Args: []string{"--tok", "${secret:TOK}"}}},
+		},
+		Project: &source.Canonical{
+			MCPServers: []source.MCPServer{
+				{ID: "p", Server: source.MCPServerSpec{Command: "tok12345abc"}}, // literal
+			},
+		},
+	}
+	ingested := &source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "u", Server: source.MCPServerSpec{Args: []string{"--verbose", "--tok", "tok12345abc"}}},
+		},
+		Project: &source.Canonical{
+			MCPServers: []source.MCPServer{
+				{ID: "p", Server: source.MCPServerSpec{Command: "tok12345abc"}},
+			},
+		},
+	}
+	ReReferenceCanonical(ingested, against, sec, env)
+	if got := ingested.MCPServers[0].Server.Args[2]; got != "${secret:TOK}" {
+		t.Errorf("user-scope shifted secret not re-referenced (cross-scope literal disabled the net): %q", got)
+	}
+	if got := ingested.Project.MCPServers[0].Server.Command; got != "tok12345abc" {
+		t.Errorf("project-scope literal over-masked: %q", got)
+	}
+}
+
 // TestReReferenceCanonical_ProjectOverlay proves the field-positional restore
 // recurses into the project overlay: a project-scope secret field is matched to
 // its project-scope source counterpart (the secretFieldLoc carries a scope

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -168,6 +168,24 @@ func TestReReferenceCanonical_ValueFallbackOnStructuralShift(t *testing.T) {
 		}
 	})
 
+	t.Run("renamed header embeds the secret in a larger value", func(t *testing.T) {
+		// A renamed header key has no source counterpart, and the secret is
+		// embedded in "Bearer <token>" — a whole-value-only match would miss it
+		// and persist the cleartext. The substring fallback must re-reference it.
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Headers: map[string]string{"Authorization": "Bearer ${secret:T}"}},
+		}}}
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Headers: map[string]string{"Auth": "Bearer " + live}},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		if got := ingested.MCPServers[0].Server.Headers["Auth"]; got != "Bearer ${secret:T}" {
+			t.Fatalf("embedded secret in a relocated header not re-referenced (leak): %q", got)
+		}
+	})
+
 	t.Run("idempotent: re-referenced value resolves back unchanged", func(t *testing.T) {
 		against := &source.Canonical{MCPServers: []source.MCPServer{{
 			ID:     "srv",

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -90,6 +90,107 @@ func TestReReferenceCanonical_FieldPositional(t *testing.T) {
 	}
 }
 
+// TestReReferenceCanonical_ValueFallbackOnStructuralShift is the regression for
+// a silent cleartext-secret leak: the positional restore matches a templated
+// source field to its ingested counterpart by location, so a native edit that
+// SHIFTS structure (prepend an MCP arg, rename an env key / server id) moves the
+// resolved cleartext to a location with no source counterpart — the positional
+// lookup misses and the resolved secret would be persisted into ~/.agentsync.
+// The value-based fallback must restore the placeholder in each of these cases.
+func TestReReferenceCanonical_ValueFallbackOnStructuralShift(t *testing.T) {
+	const live = "ghp_LIVE_SECRET_TOKEN"
+	sec := fakeResolver{"T": live}
+	env := fakeResolver{}
+
+	t.Run("arg index shift", func(t *testing.T) {
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Type: "stdio", Command: "x", Args: []string{"--token", "${secret:T}"}},
+		}}}
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Type: "stdio", Command: "x", Args: []string{"--verbose", "--token", live}},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		for _, a := range ingested.MCPServers[0].Server.Args {
+			if a == live {
+				t.Fatalf("LEAK: resolved secret persisted in args: %v", ingested.MCPServers[0].Server.Args)
+			}
+		}
+		if ingested.MCPServers[0].Server.Args[2] != "${secret:T}" {
+			t.Errorf("shifted secret arg not re-referenced: %q", ingested.MCPServers[0].Server.Args[2])
+		}
+	})
+
+	t.Run("env key rename", func(t *testing.T) {
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Env: map[string]string{"OLD": "${secret:T}"}},
+		}}}
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Env: map[string]string{"NEW": live}},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		if got := ingested.MCPServers[0].Server.Env["NEW"]; got != "${secret:T}" {
+			t.Errorf("renamed env secret not re-referenced: %q", got)
+		}
+	})
+
+	t.Run("server id rename", func(t *testing.T) {
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "old-id",
+			Server: source.MCPServerSpec{Env: map[string]string{"K": "${secret:T}"}},
+		}}}
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "new-id",
+			Server: source.MCPServerSpec{Env: map[string]string{"K": live}},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		if got := ingested.MCPServers[0].Server.Env["K"]; got != "${secret:T}" {
+			t.Errorf("renamed-server env secret not re-referenced: %q", got)
+		}
+	})
+
+	t.Run("secret embedded in command, structurally changed", func(t *testing.T) {
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Command: "auth --tok=${secret:T}"},
+		}}}
+		// User appended a flag to the command in the native UI.
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Command: "auth --tok=" + live + " --verbose"},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		if got := ingested.MCPServers[0].Server.Command; got != "auth --tok=${secret:T} --verbose" {
+			t.Errorf("embedded secret not re-referenced after edit: %q", got)
+		}
+	})
+
+	t.Run("idempotent: re-referenced value resolves back unchanged", func(t *testing.T) {
+		against := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Args: []string{"${secret:T}"}},
+		}}}
+		ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+			ID:     "srv",
+			Server: source.MCPServerSpec{Args: []string{"pre", live}},
+		}}}
+		ReReferenceCanonical(ingested, against, sec, env)
+		// Re-render: the templated arg must resolve back to the same cleartext,
+		// so the next apply sees no spurious drift.
+		got := ingested.MCPServers[0].Server.Args[1]
+		if got != "${secret:T}" {
+			t.Fatalf("not re-referenced: %q", got)
+		}
+		resolved, _, _ := SubstituteRefs(got, sec, env)
+		if resolved != live {
+			t.Errorf("re-referenced value does not round-trip: %q -> %q", got, resolved)
+		}
+	})
+}
+
 // TestReReferenceCanonical_ProjectOverlay proves the field-positional restore
 // recurses into the project overlay: a project-scope secret field is matched to
 // its project-scope source counterpart (the secretFieldLoc carries a scope

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -417,20 +417,34 @@ func loadMemory(fs afero.Fs, home string) (Memory, error) {
 
 	m.Fragments = map[string]string{}
 	fragDir := filepath.Join(home, "memory", "fragments")
-	entries, err := afero.ReadDir(fs, fragDir)
-	if err == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
+	// Walk recursively and key each fragment by its slash-separated path UNDER
+	// memory/fragments/, because the @import directive accepts
+	// "./fragments/<name>" where <name> may contain "/" (a nested fragment).
+	// A flat, basename-only read silently never loaded those, leaving the
+	// directive literal in the rendered memory.
+	werr := afero.Walk(fs, fragDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil // no fragments/ dir is fine
 			}
-			data, err := afero.ReadFile(fs, filepath.Join(fragDir, e.Name()))
-			if err != nil {
-				return m, fmt.Errorf("read fragment %s: %w", e.Name(), err)
-			}
-			m.Fragments[e.Name()] = string(data)
+			return err
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return m, fmt.Errorf("read memory/fragments: %w", err)
+		if info.IsDir() {
+			return nil
+		}
+		data, rerr := afero.ReadFile(fs, path)
+		if rerr != nil {
+			return fmt.Errorf("read fragment %s: %w", path, rerr)
+		}
+		rel, rerr := filepath.Rel(fragDir, path)
+		if rerr != nil {
+			return rerr
+		}
+		m.Fragments[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if werr != nil {
+		return m, fmt.Errorf("read memory/fragments: %w", werr)
 	}
 	return m, nil
 }

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -369,17 +369,42 @@ func ParseFrontmatter(data []byte) (map[string]any, string, error) {
 		return map[string]any{}, string(data), nil
 	}
 	rest := data[len("---\n"):]
-	end := bytes.Index(rest, []byte("\n---\n"))
-	if end < 0 {
+	yml, body, ok := splitFrontmatterBody(rest)
+	if !ok {
 		return nil, "", fmt.Errorf("unterminated frontmatter")
 	}
-	yml := rest[:end]
-	body := rest[end+len("\n---\n"):]
+	// An empty frontmatter block ("---\n---\n…") is a valid empty mapping.
+	if len(bytes.TrimSpace(yml)) == 0 {
+		return map[string]any{}, string(body), nil
+	}
 	fm, err := jsonkeys.DecodeYAML(yml)
 	if err != nil {
 		return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
 	}
 	return fm, string(body), nil
+}
+
+// splitFrontmatterBody splits the bytes AFTER the opening "---\n" into the YAML
+// frontmatter and the body. It accepts the closing "---" fence whether it sits
+// mid-file ("\n---\n"), at end-of-file with no trailing newline ("\n---"), or —
+// for an empty frontmatter mapping — as the very first line ("---\n…" or just
+// "---"). ok is false only when there is no closing fence at all. (Editors that
+// strip a trailing newline, and frontmatter-only files, are common; requiring a
+// trailing "\n" after the fence used to abort the whole source.Load.)
+func splitFrontmatterBody(rest []byte) (yml, body []byte, ok bool) {
+	switch {
+	case bytes.HasPrefix(rest, []byte("---\n")):
+		return nil, rest[len("---\n"):], true
+	case bytes.Equal(rest, []byte("---")):
+		return nil, nil, true
+	}
+	if i := bytes.Index(rest, []byte("\n---\n")); i >= 0 {
+		return rest[:i], rest[i+len("\n---\n"):], true
+	}
+	if bytes.HasSuffix(rest, []byte("\n---")) {
+		return rest[:len(rest)-len("\n---")], nil, true
+	}
+	return nil, nil, false
 }
 
 func loadMemory(fs afero.Fs, home string) (Memory, error) {

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -27,6 +27,57 @@ defauls_mode = "track"
 	}
 }
 
+// TestParseFrontmatter_ClosingFenceAtEOF guards the parser against two common
+// real-world shapes that previously returned "unterminated frontmatter":
+// a closing "---" at end-of-file with no trailing newline (editors strip it),
+// and an empty frontmatter block. Each must parse, not error.
+func TestParseFrontmatter_ClosingFenceAtEOF(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantName any
+		wantBody string
+	}{
+		{"fence at EOF no trailing newline", "---\nname: demo\n---", "demo", ""},
+		{"fence at EOF with body no trailing newline", "---\nname: demo\n---\nbody", "demo", "body"},
+		{"normal with trailing newline", "---\nname: demo\n---\nbody\n", "demo", "body\n"},
+		{"empty frontmatter with body", "---\n---\nbody\n", nil, "body\n"},
+		{"empty frontmatter at EOF", "---\n---", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fm, body, err := source.ParseFrontmatter([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("ParseFrontmatter(%q) = error %v; want success", tc.in, err)
+			}
+			if fm["name"] != tc.wantName {
+				t.Errorf("name = %v, want %v", fm["name"], tc.wantName)
+			}
+			if body != tc.wantBody {
+				t.Errorf("body = %q, want %q", body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestLoad_SkillWithFenceAtEOF proves the parser bug's blast radius: source.Load
+// is the entry point for every command, so a single benign SKILL.md whose
+// closing fence sits at EOF must not abort the whole load.
+func TestLoad_SkillWithFenceAtEOF(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(""), 0o644)
+	// No trailing newline after the closing fence.
+	_ = afero.WriteFile(fs, "/home/.agentsync/skills/demo/SKILL.md",
+		[]byte("---\nname: demo\ndescription: x\n---"), 0o644)
+	c, err := source.Load(fs, "/home/.agentsync")
+	if err != nil {
+		t.Fatalf("Load aborted on a benign skill file: %v", err)
+	}
+	if len(c.Skills) != 1 || c.Skills[0].Name != "demo" {
+		t.Fatalf("skill not loaded: %+v", c.Skills)
+	}
+}
+
 // contains is a small substring helper so the new test reads cleanly
 // without bringing in strings.Contains for one call.
 func contains(haystack, needle string) bool {

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -78,6 +78,30 @@ func TestLoad_SkillWithFenceAtEOF(t *testing.T) {
 	}
 }
 
+// TestLoad_NestedMemoryFragments proves fragments in subdirectories are loaded
+// and keyed by their path under memory/fragments/, matching the @import regex
+// which accepts "./fragments/<name>" where <name> may contain "/". Previously
+// the loader read fragments non-recursively (basename only), so a nested
+// fragment was never loaded and its @import silently stayed literal.
+func TestLoad_NestedMemoryFragments(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(""), 0o644)
+	_ = afero.WriteFile(fs, "/home/.agentsync/memory/AGENTS.md", []byte("Top\n@import ./fragments/sub/frag.md\n"), 0o644)
+	_ = afero.WriteFile(fs, "/home/.agentsync/memory/fragments/sub/frag.md", []byte("nested body"), 0o644)
+	_ = afero.WriteFile(fs, "/home/.agentsync/memory/fragments/top.md", []byte("top body"), 0o644)
+
+	c, err := source.Load(fs, "/home/.agentsync")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, ok := c.Memory.Fragments["sub/frag.md"]; !ok || got != "nested body" {
+		t.Fatalf("nested fragment not loaded under its sub-path: %#v", c.Memory.Fragments)
+	}
+	if got, ok := c.Memory.Fragments["top.md"]; !ok || got != "top body" {
+		t.Fatalf("flat fragment regressed: %#v", c.Memory.Fragments)
+	}
+}
+
 // contains is a small substring helper so the new test reads cleanly
 // without bringing in strings.Contains for one call.
 func contains(haystack, needle string) bool {

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -151,5 +151,5 @@ type LSPServerSpec struct {
 // Memory mirrors memory/AGENTS.md and memory/fragments/.
 type Memory struct {
 	Body      string            // resolved AGENTS.md after @import expansion
-	Fragments map[string]string // path -> body, keyed by repo-relative path under memory/
+	Fragments map[string]string // body, keyed by slash path under memory/fragments/ (loaded recursively)
 }

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -68,10 +68,15 @@ type Skill struct {
 }
 
 // Plugin mirrors plugins/<id>.toml.
+//
+// NOTE: a per-agent `[plugin.overrides.<agent>]` table is NOT wired in v1 — the
+// projector does not consult it. It was previously a struct field that never
+// parsed and was read nowhere, so it has been removed rather than left as a
+// silent no-op. (Per-agent fan-out is still controllable via a component's
+// `agents` allowlist.)
 type Plugin struct {
-	ID        string                       `toml:"-"`
-	Plugin    PluginSpec                   `toml:"plugin"`
-	Overrides map[string]PluginOverrideSet `toml:"plugin.overrides"` // per-agent
+	ID     string     `toml:"-"`
+	Plugin PluginSpec `toml:"plugin"`
 }
 
 type PluginSpec struct {
@@ -87,10 +92,6 @@ type PluginSpec struct {
 	// into the canonical model and apply would ship them.
 	Disabled bool `toml:"disabled,omitempty"`
 }
-
-// PluginOverrideSet captures per-agent component overrides for one plugin.
-// e.g. [plugin.overrides.cursor] commands = "skip"
-type PluginOverrideSet map[string]string // component -> action ("skip" today; future: "force", etc.)
 
 // Marketplace mirrors marketplaces/<name>.toml.
 type Marketplace struct {

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -41,6 +41,13 @@ func ValidateComponentID(kind, id string) error {
 	if id == "" {
 		return fmt.Errorf("%s id is empty", kind)
 	}
+	// An all-whitespace id, or a lone ".", passes the separator/traversal checks
+	// below yet writes a nonsense file into the canonical source (" .toml",
+	// "..toml") that no command can address cleanly. Reject it as a degenerate
+	// name rather than persist the confusing artifact.
+	if strings.TrimSpace(id) == "" || id == "." {
+		return fmt.Errorf("%s id %q is empty or a bare '.'", kind, id)
+	}
 	// Reject path separators, traversal, and absolute paths (write-anywhere
 	// guard), plus ':' — the id becomes a filename, and a colon is illegal on
 	// Windows, so allowing it would make the canonical source non-portable.

--- a/internal/source/writer_test.go
+++ b/internal/source/writer_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
+// TestValidateComponentID_RejectsDegenerate guards the write boundary against
+// ids that are syntactically free of separators/traversal yet still produce a
+// nonsense file in the canonical source: a lone "." (→ "..toml") or an
+// all-whitespace id (→ " .toml"). Every Write*/Read* routes through
+// ValidateComponentID, so rejecting these here covers MCP/LSP/hook/plugin/
+// skill/subagent/command in one place.
+func TestValidateComponentID_RejectsDegenerate(t *testing.T) {
+	for _, id := range []string{".", " ", "   ", "\t", "\n"} {
+		if err := source.ValidateComponentID("mcp", id); err == nil {
+			t.Errorf("ValidateComponentID(%q) = nil; want error", id)
+		}
+	}
+	// Sanity: a normal id still passes.
+	if err := source.ValidateComponentID("mcp", "github"); err != nil {
+		t.Errorf("ValidateComponentID(%q) = %v; want nil", "github", err)
+	}
+}
+
 func TestWriteMCP_RoundTrip(t *testing.T) {
 	home := t.TempDir()
 


### PR DESCRIPTION
Multi-round adversarial **review → verify → fix** hardening loop. Fresh parallel root-cause agents each round + a dedicated regression-hunter; every finding reproduced before any fix; fixes test-first, full gate green before push.

Running log, **newest first**.

---

## Narrow review round — secret re-reference / capture backstop ✅
Two deep agents on *only* this boundary: one hunting a missed leak, one hunting false-refusals.
- **Leak direction: SOLID.** The leak-hunter could not get a real `${secret:}` value persisted as cleartext via any shape (embedded/shifted/rotated/cross-scope/hooks). Only the documented value-ambiguity residual remains (never a real resolved secret).
- 🔴 **`fix(capture)`: backstop is now field-local + shape-aware** — the round found two real *false-refusals* (blocking legit, leak-free write-backs): an unchanged literal coincidentally containing another server's secret value, and trimming a secret out of an embedded field. The VALUE prong now fires only for a value not already in the field's own source counterpart; the SLOT prong matches the source template's literal shape to tell a *rotation* (slot holds cleartext → refuse) from a *trim* (slot removed → allow). No leak re-opened — embedded rotation to a vault-unknown value is still refused (locked by a new test).

## Follow review round ✅
Scoped the backstop per-field (was refusing single-item `import`/reconcile over an *unrelated* server's secret — a showstopper two reviewers independently flagged); `agent disable --purge` validates the name; `doctor` flags a half-init home.

## Polish pass ✅
`apply` no-op skips the write (no mtime churn → `up to date`); `verify` rejects a half-init home; `agent add`/`disable` keep section spacing; shared-component write-back conflict (round-5 real-bug).

## Round 5 ✅ — **`fix(capture)`: fail-closed backstop** 🔴 (the decisive secret fix, after 4 prior re-reference revisions); orphan visibility + reachable `--purge`; blank-`$EDITOR` panic.

## Rounds 1–4 (summary)
R1 (5): structural-edit secret leak; OpenCode MCP native schema; null-pointer backup; degenerate ids/slugs; `time.Now` doc. R2 (7, 3 security): field-local re-reference; frontmatter fence-at-EOF; tree-hash plugin pinning; cross-plugin collision refusal; nested fragments; removed dead `[plugin.overrides]`; refuted JSONC `settings.json`. R3 (5, 3 regressions of R1–2): legacy-pin verify; conflict-guard render-only compare; reconcile non-zero exit; `default_mode`; launch audit CLEAN. R4 (4): embedded-relocated-secret leak; partial-`import` seeding; secrets CLI.

The secret boundary was the recurring hot spot (a genuine value-ambiguity); it's now robust in **both** directions — fail-closed against leaks, and precise enough not to block legit edits.

### Verification gate (green before every push)
`just build` · `just lint` (0 issues, golangci-lint v2.12.2) · `just fmt` · `just tidy` · `just test-fast` — plus targeted in-container runs of every touched package.

🤖 Generated in a Claude Code hardening session. CI/PR checks intentionally skipped this run (GHA minutes).