### PR TITLE
chore: pin lint/fmt tooling via `go run` for supply-chain safety

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,14 +62,15 @@ test-fast:
 test-live:
     AGENTSYNC_LIVE_PLUGIN_TEST=1 go test -tags=live -count=1 -v ./internal/marketplace/...
 
-# Run golangci-lint over every package.
+# Run golangci-lint over every package. Pinned via `go run` (matches CI's
+# golangci-lint-action version) so no separate install/PATH step is needed.
 lint:
-    golangci-lint run ./...
+    go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
 
 # Format Go sources with gofmt + gofumpt.
 fmt:
     gofmt -w -s .
-    go run mvdan.cc/gofumpt@latest -w .
+    go run mvdan.cc/gofumpt@v0.10.0 -w .
 
 # Run `go mod tidy`.
 tidy:


### PR DESCRIPTION
## What

Two changes to the `justfile` tooling recipes, both about pinning the versions of dev tools we execute:

| Recipe | Before | After |
|--------|--------|-------|
| `lint` | `golangci-lint run ./...` (assumes binary on PATH) | `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...` |
| `fmt`  | `go run mvdan.cc/gofumpt@latest -w .` | `go run mvdan.cc/gofumpt@v0.10.0 -w .` |

## Why

- **`lint` was not self-bootstrapping.** The old recipe required `golangci-lint` to already be installed on your PATH; a fresh checkout just fails with `command not found`. Running it via `go run …@v2.12.2` — the exact version CI's `golangci-lint-action` pins (`.github/workflows/ci.yml`) — means no separate install step and no chance of local/CI version drift. `go run pkg@version` resolves the tool *outside* the main module, so `go.mod`/`go.sum` are untouched (verified below).
- **`@latest` is a supply-chain risk.** A floating `@latest` silently fetches and executes whatever the newest release happens to be, and makes formatting non-reproducible across machines and over time. Pinning gofumpt to its current latest release (v0.10.0) keeps the upgrade an explicit, reviewable bump.

## Verification

- `just lint` → compiles golangci-lint v2.12.2 via `go run`, reports `0 issues`.
- `go run mvdan.cc/gofumpt@v0.10.0 -l .` → empty (repo already gofumpt-clean).
- `go.mod` / `go.sum` checksums byte-identical before and after both `go run` invocations — confirming the module graph is not polluted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)