### PR TITLE
docs: note GitHub Actions quota-exhaustion CI failure pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
   "The job was not started because recent account payments have failed or your
   spending limit needs to be increased") is GitHub Actions quota / spending-limit
   exhaustion, not a code or workflow problem. Call it out and move on — don't dig
-  through logs or spend tokens trying to debug it.
+  through logs or spend tokens trying to debug it. 🥲
 
 ## Code conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,11 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
   `just test-bdd`, `just test-live` (network, opt-in, not in the release gate).
 - Go version is `go.mod`'s `go` directive (currently **1.26.2**); CI reads it via
   `go-version-file`. Bump in one place.
+- **CI checks all failing within seconds with zero steps run** (run annotation:
+  "The job was not started because recent account payments have failed or your
+  spending limit needs to be increased") is GitHub Actions quota / spending-limit
+  exhaustion, not a code or workflow problem. Call it out and move on — don't dig
+  through logs or spend tokens trying to debug it.
 
 ## Code conventions
 


### PR DESCRIPTION
## What

Adds one bullet to the **Build / test / lint** section of `CLAUDE.md`: when a PR's GitHub Actions checks all fail within seconds with **zero steps run** and a run annotation like _"The job was not started because recent account payments have failed or your spending limit needs to be increased,"* that's Actions quota / spending-limit exhaustion — not a code or workflow bug. Call it out and move on instead of burning tokens debugging.

## Why

We hit exactly this while working on #33: all six CI jobs went red in 2–3s with `steps=0`, which reads as a catastrophic failure but was purely the monthly Actions quota. The note keeps future sessions from chasing a phantom code bug.

## Note

The same guidance was added to the global `~/.claude/CLAUDE.md` (pushed directly to the dotfiles repo, per request) so it applies across all repos; this bullet keeps it discoverable in-repo too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)