### PR TITLE
docs(user-guide): add age key generation to Secrets setup

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -322,6 +322,28 @@ Never put a credential in a config file. Reference it:
 GITHUB_TOKEN = "${secret:github.token}"
 ```
 
+First, create an age keypair. The vault is encrypted to the **recipient**
+(public key — safe to commit); decryption needs the **identity** (private key —
+per-machine). agentsync embeds age, but generating the key uses the `age-keygen`
+CLI (`brew install age`, `apt install age`, …):
+
+```bash
+mkdir -p ~/.config/agentsync
+age-keygen -o ~/.config/agentsync/age.key   # prints "Public key: age1…" to stderr
+chmod 600 ~/.config/agentsync/age.key        # agentsync refuses a group/other-readable identity
+```
+
+Then point `agentsync.toml` at it — `recipient` is the `age1…` public key
+`age-keygen` printed (agentsync encrypts to a single X25519 recipient, so use the
+age-keygen key, not an SSH key):
+
+```toml
+[secrets]
+backend       = "age"
+recipient     = "age1…"
+identity_file = "${env:HOME}/.config/agentsync/age.key"
+```
+
 Store the value in the age-encrypted vault — three ways:
 
 ```bash


### PR DESCRIPTION
## Summary

The Secrets section of the user guide jumped straight from `${secret:…}`
references to `agentsync secrets set …`, and elsewhere only warned users to
back up their age key — it never showed how to **create** the keypair in the
first place. New users hit a wall: `secrets set`/`edit` require `recipient` and
`identity_file` to be configured, but nothing told them how to produce those.

This adds a short setup block to `docs/user-guide.md`:

- `age-keygen` step to create the keypair (noting agentsync embeds age, but key
  generation uses the `age-keygen` CLI), with the `chmod 600` that agentsync's
  identity-permission check requires.
- The `[secrets]` config wiring (`backend` / `recipient` / `identity_file`).
- A callout that agentsync encrypts to a **single X25519 recipient**, so users
  should use the age-keygen key rather than an SSH key (the encrypt path is
  X25519-only).

Docs-only change.

## Test plan

- [x] Rendered the Secrets section and confirmed the new bash + toml blocks read
      correctly in context (ordering: generate key → wire config → store values).
- [ ] No code paths touched; no build/test impact.

https://claude.ai/code/session_0165P4SkHmi3sdYBe5QQJazS

---
_Generated by [Claude Code](https://claude.ai/code/session_0165P4SkHmi3sdYBe5QQJazS)_