### PR TITLE
feat(import): capture installed plugins + marketplaces, fan out to all agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   real plugin import needs network access. Plugins from an unregistered or
   auto-available marketplace (e.g. the built-in `claude-plugins-official`, which
   Claude does not list in `extraKnownMarketplaces`) are reported and skipped.
+- **Plugin nudge in `status` / `doctor`** — both now surface plugins installed
+  natively in an agent (Claude in v1) that aren't declared in your source,
+  pointing at `import <agent>:plugin`. Informational only: agentsync still treats
+  natively-installed plugins as foreign-managed, so this never blocks an apply or
+  auto-imports anything.
 - **Safety primitives** — two-phase atomic writes, an apply lock, first-apply
   foreign-collision backups, symlinked-destination refusal, and a schema-versioned
   state file with portable (`${HOME}`-relative) keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   still captures one item. Empty scopes report a notice and exit cleanly.
   `import --dry-run` previews which source files an import would write without
   touching `~/.agentsync/`.
+- **Plugin import** — `import` now captures the agent's installed plugins and
+  their marketplaces (Claude only in v1) via the new `plugin` component, so a
+  full `import claude` reproduces a plugin-heavy setup in one pass. It reads
+  Claude's native `enabledPlugins` / `extraKnownMarketplaces` and re-fetches each
+  marketplace + plugin into the agentsync cache (pinning a manifest SHA),
+  producing the same artifacts as `marketplace add` + `plugin install` — so a
+  real plugin import needs network access. Plugins from an unregistered or
+  auto-available marketplace (e.g. the built-in `claude-plugins-official`, which
+  Claude does not list in `extraKnownMarketplaces`) are reported and skipped.
 - **Safety primitives** — two-phase atomic writes, an apply lock, first-apply
   foreign-collision backups, symlinked-destination refusal, and a schema-versioned
   state file with portable (`${HOME}`-relative) keys.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,24 @@ Two design points worth internalizing:
 `Capability` is a bitmask, so the OpenCode adapter simply omits `CapHook` and
 `CapLSP` and the pipeline reports those components as skipped.
 
+One **optional** extension sits beside the core interface:
+
+```go
+type PluginIngester interface {
+    IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
+}
+```
+
+An adapter implements it only if the agent tracks installed plugins +
+marketplaces in its native config (Claude reads `enabledPlugins` /
+`extraKnownMarketplaces` from `settings.json`). `import` type-asserts for it: an
+adapter that doesn't implement it imports no plugins. It's kept off the core
+`Adapter` because the canonical schema doesn't otherwise depend on a native
+plugin concept, and only Claude has one in v1. The CLI maps each result onto an
+agentsync marketplace source and re-fetches it through the same code path as
+`marketplace add` + `plugin install`, so a captured plugin lands as a normal
+`plugins/<id>.toml` + `marketplaces/<name>.toml` pair with a pinned manifest SHA.
+
 ---
 
 ## 4. The apply pipeline (Source ▶ Destination)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,23 @@ agentsync marketplace source and re-fetches it through the same code path as
 `marketplace add` + `plugin install`, so a captured plugin lands as a normal
 `plugins/<id>.toml` + `marketplaces/<name>.toml` pair with a pinned manifest SHA.
 
+The planned **Codex** and **Cursor** adapters are the intended next implementors;
+both have native plugin systems, so the same import + apply fan-out (a plugin's
+components projected to every enabled agent via its capability matrix) applies
+unchanged once each implements `IngestPlugins`:
+
+- **Codex** records enable-state in `~/.codex/config.toml` under
+  `[plugins."<name>@<source>"]` tables, plus its own marketplace concept — the
+  same `name@source` shape Claude uses. `IngestPlugins` is "parse those TOML
+  tables + marketplace sources into `NativeMarketplace`/`NativePlugin`."
+- **Cursor** ships an even closer content schema — `.cursor-plugin/plugin.json` +
+  `.cursor-plugin/marketplace.json`, near-identical to Claude's `.claude-plugin/*`
+  (rules, skills, agents, commands, hooks, MCP) — so the projection layer largely
+  transfers. The open question is where Cursor records local enable-state (not yet
+  documented; possibly app-local like its user rules).
+
+See the capability matrix for source links.
+
 ---
 
 ## 4. The apply pipeline (Source ▶ Destination)

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -20,10 +20,10 @@ nothing is dropped silently.
 
 | Agent | Status in v1.0 / beta | Notes |
 |---|---|---|
-| **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. Also the only agent whose installed **plugins + marketplaces** are captured by `import` (re-fetched from `enabledPlugins` / `extraKnownMarketplaces`). |
-| **OpenCode** | ✅ Adapter (some components projected/skipped) | MCP, memory, skills, subagents, commands. Hooks and LSP are skipped with a warning. |
-| **Codex CLI** | 🔜 Planned | Registered as a no-op. `agent add codex` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. |
-| **Cursor** | 🔜 Planned | Registered as a no-op. Planned coverage is broad — MCP, memory, skills, subagents, slash commands, and hooks all project (see the matrix); only LSP is unsupported. User-level rules/memory live in Cursor's app-local storage, so those stay project-scope. |
+| **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. Also the only agent **in v1** whose installed **plugins + marketplaces** are captured by `import` (re-fetched from `enabledPlugins` / `extraKnownMarketplaces`); the planned Codex and Cursor adapters both have native plugin systems and should do the same (see their rows). |
+| **OpenCode** | ✅ Adapter (some components projected/skipped) | MCP, memory, skills, subagents, commands. Hooks and LSP are skipped with a warning. No native plugin/marketplace concept, so nothing for plugin `import` to capture; it still *receives* plugin-projected components (skills, MCP, …) on `apply`. |
+| **Codex CLI** | 🔜 Planned | Registered as a no-op. `agent add codex` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. Codex **has a native plugin system**[^codex-plugins] — skills, apps, and MCP servers, with enable-state in `~/.codex/config.toml` as `[plugins."<name>@<source>"] enabled = …` and a marketplace concept — structurally close to Claude's. The Codex adapter should therefore implement the same `import <agent>:plugin` capture + cross-agent fan-out as Claude (its `[plugins.*]` enable-state maps onto agentsync's `PluginIngester`). |
+| **Cursor** | 🔜 Planned | Registered as a no-op. Planned coverage is broad — MCP, memory, skills, subagents, slash commands, and hooks all project (see the matrix); only LSP is unsupported. User-level rules/memory live in Cursor's app-local storage, so those stay project-scope. Cursor **has a native plugin system**[^cursor-plugins] (rules, skills, agents, commands, hooks, MCP servers) whose `.cursor-plugin/marketplace.json` + `.cursor-plugin/plugin.json` schema is almost identical to Claude's `.claude-plugin/*` — so projection largely carries over and the adapter should support `import <agent>:plugin` too. The open question is purely *where Cursor records local enable-state* (undocumented, possibly app-local like its rules); the plugin/marketplace content schema is already a near-match. |
 
 ---
 
@@ -178,3 +178,23 @@ See the [user guide](user-guide.md) to put this into practice.
     registered as no-ops today, so these columns describe the *intended*
     projection per the design spec. `agent add codex` / `agent add cursor` are
     rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`.
+
+[^codex-plugins]: Codex plugin system:
+    [developers.openai.com/codex/plugins](https://developers.openai.com/codex/plugins).
+    Enable-state lives in `~/.codex/config.toml` under
+    `[plugins."<name>@<source>"]` tables (an `enabled` bool) — the same
+    `name@source` shape as Claude's `enabledPlugins`, so a future Codex
+    `PluginIngester` parses those tables (plus its marketplace sources) into the
+    same `NativeMarketplace` / `NativePlugin` descriptors `import` already
+    consumes.
+
+[^cursor-plugins]: Cursor plugin system:
+    [cursor.com/docs/reference/plugins](https://cursor.com/docs/reference/plugins).
+    Plugins bundle rules, skills (`SKILL.md`), agents, commands, hooks, and MCP
+    servers; the manifest is `.cursor-plugin/plugin.json` and multi-plugin repos
+    use `.cursor-plugin/marketplace.json` — nearly identical to Claude's
+    `.claude-plugin/*`, so agentsync's projection layer largely transfers. Not
+    yet documented: where Cursor records which plugins are installed/enabled
+    locally (the `enabledPlugins`-equivalent a `PluginIngester` would read);
+    given Cursor keeps user rules in app-local storage, this may not be a plain
+    config file and needs investigation when the adapter is built.

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -20,7 +20,7 @@ nothing is dropped silently.
 
 | Agent | Status in v1.0 / beta | Notes |
 |---|---|---|
-| **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. |
+| **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. Also the only agent whose installed **plugins + marketplaces** are captured by `import` (re-fetched from `enabledPlugins` / `extraKnownMarketplaces`). |
 | **OpenCode** | ✅ Adapter (some components projected/skipped) | MCP, memory, skills, subagents, commands. Hooks and LSP are skipped with a warning. |
 | **Codex CLI** | 🔜 Planned | Registered as a no-op. `agent add codex` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. |
 | **Cursor** | 🔜 Planned | Registered as a no-op. Planned coverage is broad — MCP, memory, skills, subagents, slash commands, and hooks all project (see the matrix); only LSP is unsupported. User-level rules/memory live in Cursor's app-local storage, so those stay project-scope. |

--- a/docs/components.md
+++ b/docs/components.md
@@ -106,9 +106,9 @@ keys.
 - **Key:** `New(Options) *Adapter`; the `Adapter` methods; `ParseFrontmatter`/
   `EncodeFrontmatter`; `MergeKeys`.
 - **Depends on:** adapter, secrets, source, paths, iox, jsonkeys.
-- **Files:** `claude.go`, `render.go`, `ingest.go`, `apply.go`, `paths.go`,
-  `frontmatter.go`, `skill.go`, `command.go`, `subagent.go`, `hook.go`, `lsp.go`,
-  `memory.go`, `settings.go`.
+- **Files:** `claude.go`, `render.go`, `ingest.go`, `ingest_plugins.go`,
+  `apply.go`, `paths.go`, `frontmatter.go`, `skill.go`, `command.go`,
+  `subagent.go`, `hook.go`, `lsp.go`, `memory.go`, `settings.go`.
 
 ### `internal/adapter/opencode`
 The OpenCode adapter — MCP, memory, skills, subagents, commands via JSONC

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -137,11 +137,13 @@ per agent, what landed:
 - **◐ projected** — lossy but defensible translation, explicitly reported.
 - **✗ skipped** — no honest translation exists; logged so it's never silent.
 
-### Update (the only networked verb)
-`agentsync update` is the *only* command that touches the network: it polls
-marketplaces, refreshes the cache, and recomputes version pins. `apply` then
-runs entirely from cache. This split keeps `apply` fast, reproducible, and
-offline-safe.
+### Update (the networked verb)
+`agentsync update` is the command that touches the network in the daily loop: it
+polls marketplaces, refreshes the cache, and recomputes version pins. `apply`
+then runs entirely from cache. This split keeps `apply` fast, reproducible, and
+offline-safe. (The one other networked path is setup-time: `import`'s `plugin`
+component re-fetches the plugins + marketplaces it captures from an agent's
+native config.)
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -155,6 +155,7 @@ agentsync import claude --dry-run       # preview what a full import would write
 agentsync import claude                 # the agent's full native config
 agentsync import claude:mcp             # every MCP server
 agentsync import claude:mcp:github      # a single MCP server
+agentsync import claude:plugin          # every installed plugin + marketplace
 agentsync import opencode:mcp:linear
 
 # Now it's in ~/.agentsync/ — apply to fan it out to your other agents.
@@ -163,9 +164,19 @@ agentsync apply
 
 Dropping the name imports every entry of a component; dropping the component
 too imports everything the agent has (MCP, skills, subagents, commands, hooks,
-LSP, and memory) in one pass. A bulk import that finds nothing for a component
-reports it and exits cleanly rather than erroring. Add `--dry-run` to list the
-source files an import would write without touching `~/.agentsync/`.
+LSP, memory, **and plugins**) in one pass. A bulk import that finds nothing for a
+component reports it and exits cleanly rather than erroring. Add `--dry-run` to
+list the source files an import would write without touching `~/.agentsync/`.
+
+**Plugins are a special case.** The `plugin` component (Claude only in v1) reads
+the agent's installed plugins and their marketplaces from its native config and
+re-fetches each one into the agentsync cache, pinning a manifest SHA — the same
+artifacts `marketplace add` + `plugin install` produce. Because it re-fetches, a
+real plugin import (not `--dry-run`) needs network access. A plugin installed
+from a marketplace that isn't registered in the agent's native config — most
+notably Claude's built-in `claude-plugins-official`, which doesn't appear in
+`extraKnownMarketplaces` — can't be resolved, so it's reported and skipped; add
+the marketplace with `agentsync marketplace add <source>` and re-import.
 
 On a populated machine, the **first** apply will see pre-existing native files it
 didn't write and treat them as `foreign-collision`: it backs each one up to
@@ -287,7 +298,7 @@ and every enabled agent gets the components it understands:
 agentsync marketplace add github:anthropics/claude-plugins-official
 agentsync plugin install atlassian@anthropic
 
-agentsync update           # fetch from the network (the only networked verb)
+agentsync update           # fetch from the network (refresh + re-pin plugins)
 agentsync apply            # render from cache → all agents
 ```
 
@@ -470,7 +481,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `status` | Summarize drift/pending across agents. | `--scope --project` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
-| `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. | `--dry-run` |
+| `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. | `--dry-run` |
 | `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
 
 Global: `-v/--verbose` for verbose logging on any command.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -469,7 +469,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | Command | Purpose | Key flags / args |
 |---|---|---|
 | `init [<git-url>]` | Create `~/.agentsync/`; optionally clone a bootstrap repo. | |
-| `doctor` | Diagnose setup: PATH, home/state writability, config schema, secrets backend. | |
+| `doctor` | Diagnose setup: PATH, home/state writability, config schema, secrets backend; flags natively-installed plugins missing from source. | |
 | `verify` | Validate config and surface every unresolved `${secret:}`/`${env:}` ref. | |
 | `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
@@ -478,7 +478,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift/pending across agents. | `--scope --project` |
+| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. | `--scope --project` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. | `--dry-run` |

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -87,6 +87,46 @@ type Adapter interface {
 	Apply(ops []FileOp, w DestWriter) error
 }
 
+// NativeSource describes where a natively-registered marketplace is fetched
+// from, in the agent's own vocabulary. `import` maps it onto an agentsync
+// marketplace source. Fields mirror Claude's extraKnownMarketplaces `source`
+// object; only the fields relevant to a given Type are populated.
+type NativeSource struct {
+	Type    string // "github" | "git" | "url" | "npm" | "file" | "directory" | …
+	Repo    string // "owner/repo" for github
+	URL     string // for git/url
+	Path    string // for file/directory
+	Ref     string // branch/tag/commit
+	Package string // for npm
+}
+
+// NativeMarketplace is a marketplace registered in an agent's native config,
+// as discovered by `import`. ID is the agent's own marketplace identifier (the
+// "@<marketplace>" half of a plugin reference), which need not match the name
+// declared inside the fetched marketplace.json.
+type NativeMarketplace struct {
+	ID     string
+	Source NativeSource
+}
+
+// NativePlugin is a plugin recorded in an agent's native config, as discovered
+// by `import`. Enabled is false for an explicitly-disabled entry.
+type NativePlugin struct {
+	Name          string // the "<plugin>" half of a plugin reference
+	MarketplaceID string // the marketplace it was installed from
+	Enabled       bool
+}
+
+// PluginIngester is an OPTIONAL extension to Adapter: an agent that tracks
+// installed plugins + marketplaces in its native config implements it so
+// `import` can capture them into the canonical source. import type-asserts for
+// it; an adapter that does not implement it simply imports no plugins. It is
+// kept off the core Adapter interface because only Claude has a native plugin
+// concept in v1 and the canonical schema does not otherwise depend on it.
+type PluginIngester interface {
+	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
+}
+
 // DestWriter is the single funnel for any write that targets a native agent
 // destination file (~/.claude.json, ~/.claude/agents/*.md, ~/.config/opencode/*,
 // etc). It enforces the foreign-collision backup invariant: a pre-existing

--- a/internal/adapter/claude/ingest_plugins.go
+++ b/internal/adapter/claude/ingest_plugins.go
@@ -1,0 +1,125 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// IngestPlugins discovers the marketplaces and enabled plugins recorded in
+// Claude's native settings.json — the documented `extraKnownMarketplaces` and
+// `enabledPlugins` keys. It is the read side of plugin `import`: the CLI maps
+// each result onto an agentsync marketplace source and replays
+// `marketplace add` + `plugin install` to capture them.
+//
+// The built-in `claude-plugins-official` marketplace is auto-available in
+// Claude and is NOT listed in extraKnownMarketplaces, so a plugin installed
+// from it appears in enabledPlugins with no resolvable source here; the CLI
+// warns and skips such plugins.
+//
+// Parsing is lenient: a missing settings.json yields no plugins, and a
+// malformed one is treated as "no plugins discovered" rather than failing the
+// whole import (matching the hooks/LSP blocks in Ingest). Only a genuine read
+// error (e.g. a permission problem) is surfaced.
+func (a *Adapter) IngestPlugins(scope adapter.Scope, project string) ([]adapter.NativeMarketplace, []adapter.NativePlugin, error) {
+	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+	data, err := os.ReadFile(p.Settings)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("read %s: %w", p.Settings, err)
+	}
+	var top map[string]any
+	if json.Unmarshal(data, &top) != nil {
+		return nil, nil, nil
+	}
+	return parseExtraKnownMarketplaces(top["extraKnownMarketplaces"]),
+		parseEnabledPlugins(top["enabledPlugins"]), nil
+}
+
+// parseExtraKnownMarketplaces decodes the settings.json `extraKnownMarketplaces`
+// map into NativeMarketplace records, sorted by id for deterministic output.
+func parseExtraKnownMarketplaces(v any) []adapter.NativeMarketplace {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make([]adapter.NativeMarketplace, 0, len(m))
+	for id, raw := range m {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		src, ok := entry["source"].(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, adapter.NativeMarketplace{
+			ID: id,
+			Source: adapter.NativeSource{
+				Type:    asStr(src["source"]),
+				Repo:    asStr(src["repo"]),
+				URL:     asStr(src["url"]),
+				Path:    asStr(src["path"]),
+				Ref:     asStr(src["ref"]),
+				Package: asStr(src["package"]),
+			},
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// parseEnabledPlugins decodes the settings.json `enabledPlugins` map into
+// NativePlugin records, sorted by (name, marketplace) for deterministic output.
+func parseEnabledPlugins(v any) []adapter.NativePlugin {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make([]adapter.NativePlugin, 0, len(m))
+	for key, raw := range m {
+		name, mpID := splitPluginKey(key)
+		out = append(out, adapter.NativePlugin{
+			Name:          name,
+			MarketplaceID: mpID,
+			Enabled:       enabledTruthy(raw),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].MarketplaceID < out[j].MarketplaceID
+	})
+	return out
+}
+
+// splitPluginKey splits an enabledPlugins key "plugin@marketplace" into its
+// parts. A key with no "@" yields an empty marketplace id (the CLI then warns
+// it cannot resolve a source).
+func splitPluginKey(key string) (name, mpID string) {
+	if i := strings.LastIndex(key, "@"); i >= 0 {
+		return key[:i], key[i+1:]
+	}
+	return key, ""
+}
+
+// enabledTruthy reports whether an enabledPlugins value means "enabled". The
+// schema allows a bool, an array of strings, or null: true or a non-empty array
+// counts as enabled; false, null, and an empty array count as disabled.
+func enabledTruthy(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case []any:
+		return len(t) > 0
+	default:
+		return false
+	}
+}

--- a/internal/adapter/claude/ingest_plugins_test.go
+++ b/internal/adapter/claude/ingest_plugins_test.go
@@ -1,0 +1,106 @@
+package claude_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
+)
+
+// writeSettings writes a user-scope settings.json under tmp/.claude/.
+func writeSettings(t *testing.T, tmp, body string) {
+	t.Helper()
+	dir := filepath.Join(tmp, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestIngestPlugins_ParsesMarketplacesAndEnabled verifies the documented
+// settings.json keys (extraKnownMarketplaces + enabledPlugins) decode into
+// native descriptors, that disabled/false entries are marked not-enabled, and
+// that results are deterministically ordered.
+func TestIngestPlugins_ParsesMarketplacesAndEnabled(t *testing.T) {
+	tmp := t.TempDir()
+	writeSettings(t, tmp, `{
+		"extraKnownMarketplaces": {
+			"obra-superpowers": {"source": {"source": "github", "repo": "obra/superpowers", "ref": "main"}},
+			"local-mp": {"source": {"source": "directory", "path": "/home/u/mp"}}
+		},
+		"enabledPlugins": {
+			"superpowers@obra-superpowers": true,
+			"helper@local-mp": ["partial"],
+			"off@obra-superpowers": false,
+			"null-plugin@local-mp": null
+		}
+	}`)
+
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	mps, plugins, err := a.IngestPlugins(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("IngestPlugins: %v", err)
+	}
+
+	if len(mps) != 2 {
+		t.Fatalf("want 2 marketplaces, got %+v", mps)
+	}
+	// Sorted by ID: local-mp, obra-superpowers.
+	if mps[0].ID != "local-mp" || mps[0].Source.Type != "directory" || mps[0].Source.Path != "/home/u/mp" {
+		t.Errorf("local-mp parsed wrong: %+v", mps[0])
+	}
+	if mps[1].ID != "obra-superpowers" || mps[1].Source.Type != "github" ||
+		mps[1].Source.Repo != "obra/superpowers" || mps[1].Source.Ref != "main" {
+		t.Errorf("obra-superpowers parsed wrong: %+v", mps[1])
+	}
+
+	// Sorted by (name, marketplace): helper, null-plugin, off, superpowers.
+	want := []adapter.NativePlugin{
+		{Name: "helper", MarketplaceID: "local-mp", Enabled: true},       // non-empty array → enabled
+		{Name: "null-plugin", MarketplaceID: "local-mp", Enabled: false}, // null → disabled
+		{Name: "off", MarketplaceID: "obra-superpowers", Enabled: false}, // false → disabled
+		{Name: "superpowers", MarketplaceID: "obra-superpowers", Enabled: true},
+	}
+	if len(plugins) != len(want) {
+		t.Fatalf("want %d plugins, got %+v", len(want), plugins)
+	}
+	for i, w := range want {
+		if plugins[i] != w {
+			t.Errorf("plugin[%d] = %+v, want %+v", i, plugins[i], w)
+		}
+	}
+}
+
+// TestIngestPlugins_MissingSettings returns empty (not an error) when there is
+// no settings.json, so a full `import` of a plugin-free agent stays clean.
+func TestIngestPlugins_MissingSettings(t *testing.T) {
+	tmp := t.TempDir()
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	mps, plugins, err := a.IngestPlugins(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("IngestPlugins: %v", err)
+	}
+	if mps != nil || plugins != nil {
+		t.Fatalf("want nil/nil for missing settings; got %+v / %+v", mps, plugins)
+	}
+}
+
+// TestIngestPlugins_MalformedIsLenient treats an unparseable settings.json as
+// "no plugins discovered" rather than failing the whole import (matching the
+// hooks/LSP blocks in Ingest).
+func TestIngestPlugins_MalformedIsLenient(t *testing.T) {
+	tmp := t.TempDir()
+	writeSettings(t, tmp, `{ this is : not json `)
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	mps, plugins, err := a.IngestPlugins(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("malformed settings should be lenient, got error: %v", err)
+	}
+	if mps != nil || plugins != nil {
+		t.Fatalf("want nil/nil for malformed settings; got %+v / %+v", mps, plugins)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -66,6 +67,14 @@ func newDoctorCmd() *cobra.Command {
 					continue
 				}
 				fmt.Fprintf(w, "  %-10s %s\n", agent.name, p)
+			}
+
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Plugins")
+			if schemaOK {
+				checkPlugins(w, home)
+			} else {
+				fmt.Fprintln(w, "  skipped (schema invalid above)")
 			}
 
 			fmt.Fprintln(w, "")
@@ -151,6 +160,34 @@ func checkSchema(w io.Writer, home string) (source.Config, bool) {
 	fmt.Fprintf(w, "  schema     ok (%d mcp, %d plugin(s), %d marketplace(s))\n",
 		len(c.MCPServers), len(c.Plugins), len(c.Marketplaces))
 	return c.Config, true
+}
+
+// checkPlugins surfaces plugins installed natively in an agent (Claude in v1)
+// that are NOT declared in the canonical source — informational only, never a
+// failure: agentsync treats them as foreign-managed, and `import <agent>:plugin`
+// brings them under management. Probes every registered adapter (not just the
+// enabled set) so a fresh user with Claude plugins but no agentsync config still
+// sees the nudge.
+func checkPlugins(w io.Writer, home string) {
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		fmt.Fprintln(w, "  skipped (source not loadable)")
+		return
+	}
+	reg := registryFactory()
+	undeclared := undeclaredNativePlugins(c, reg, reg.Names())
+	if len(undeclared) == 0 {
+		fmt.Fprintln(w, "  ok (no undeclared native plugins)")
+		return
+	}
+	for _, name := range reg.Names() {
+		missing := undeclared[name]
+		if len(missing) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %-10s %d not in source: %s — run `agentsync import %s:plugin`\n",
+			name, len(missing), strings.Join(missing, ", "), name)
+	}
 }
 
 // checkSecrets validates the [secrets] block: backend present, identity

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -114,17 +114,26 @@ into ~/.agentsync/ as the canonical source of truth.
 
 Selector grammar: <agent>[:<component>[:<name>]]
   agent     - registered agent name (claude, opencode, codex, cursor)
-  component - mcp | skill | agent | command | hook | lsp | memory
-  name      - item name (server id, skill name, subagent name, hook event)
+  component - mcp | skill | agent | command | hook | lsp | memory | plugin
+  name      - item name (server id, skill/subagent/command name, hook event,
+              or plugin name)
 
 Dropping the name imports every entry of that component; dropping the
 component too imports the agent's full native config in one pass. Use
 --dry-run to preview which source files would be written, without writing.
 
+The plugin component captures the agent's installed plugins + their
+marketplaces (Claude only in v1): it re-fetches each marketplace and plugin
+into the agentsync cache and pins them, so a real import needs network access.
+A plugin whose marketplace is not registered in the agent's native config
+(e.g. the built-in 'claude-plugins-official') is reported and skipped; add it
+with 'agentsync marketplace add <source>' and re-import.
+
 Examples:
   agentsync import claude                 # all importable components
   agentsync import claude:mcp             # every MCP server
   agentsync import claude:mcp:github      # a single MCP server
+  agentsync import claude:plugin          # every installed plugin + marketplace
   agentsync import claude --dry-run       # preview without writing
   agentsync import opencode:agent:reviewer`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -187,9 +196,9 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	var importErr error
 	switch component {
 	case "":
-		imp, importErr = importAllComponents(cmd, home, agentName, c, dryRun)
+		imp, importErr = importAllComponents(cmd, home, a, agentName, c, dryRun)
 	default:
-		ids, err := importComponent(cmd, home, c, component, name, dryRun)
+		ids, err := importComponent(cmd, home, a, agentName, c, component, name, dryRun)
 		importErr = err
 		imp.add(component, ids)
 		// A bulk component import (no name) that matched nothing is not an
@@ -462,8 +471,10 @@ func parseSelector(sel string) (agentName, component, name string, err error) {
 // importComponentOrder lists the importable components in the order a
 // full-agent import walks them (and the order they appear in the summary).
 // "subagent" is an accepted alias for "agent" in selectors but is not listed
-// here to avoid importing subagents twice.
-var importComponentOrder = []string{"mcp", "lsp", "skill", "agent", "command", "hook", "memory"}
+// here to avoid importing subagents twice. "plugin" walks last because it
+// re-fetches from the network (see importPlugins), so the offline components
+// are captured first even if a plugin fetch later fails.
+var importComponentOrder = []string{"mcp", "lsp", "skill", "agent", "command", "hook", "memory", "plugin"}
 
 // importVerb is the past/conditional verb used in per-item and summary lines so
 // a --dry-run preview reads "would import …" instead of "imported …".
@@ -515,7 +526,7 @@ func (s *importedSet) add(component string, ids []string) {
 // writes nothing and only reports what it would write. It returns the identities
 // (server id, skill/subagent/command name, hook event) that were (or would be)
 // imported; len is the item count.
-func importComponent(cmd *cobra.Command, home string, c source.Canonical, component, name string, dryRun bool) ([]string, error) {
+func importComponent(cmd *cobra.Command, home string, a adapter.Adapter, agentName string, c source.Canonical, component, name string, dryRun bool) ([]string, error) {
 	switch component {
 	case "mcp":
 		return importMCP(cmd, home, c, name, dryRun)
@@ -531,8 +542,10 @@ func importComponent(cmd *cobra.Command, home string, c source.Canonical, compon
 		return importLSP(cmd, home, c, name, dryRun)
 	case "memory":
 		return importMemory(cmd, home, c, dryRun)
+	case "plugin":
+		return importPlugins(cmd, home, agentName, a, name, dryRun)
 	default:
-		return nil, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory", component)
+		return nil, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory, plugin", component)
 	}
 }
 
@@ -541,12 +554,12 @@ func importComponent(cmd *cobra.Command, home string, c source.Canonical, compon
 // with nothing to import reports that and exits cleanly. dryRun is threaded
 // through so the preview writes nothing. The returned set names everything
 // captured, so the caller can scope state seeding to it.
-func importAllComponents(cmd *cobra.Command, home, agentName string, c source.Canonical, dryRun bool) (importedSet, error) {
+func importAllComponents(cmd *cobra.Command, home string, a adapter.Adapter, agentName string, c source.Canonical, dryRun bool) (importedSet, error) {
 	var imp importedSet
 	counts := map[string]int{}
 	total := 0
 	for _, comp := range importComponentOrder {
-		ids, err := importComponent(cmd, home, c, comp, "", dryRun)
+		ids, err := importComponent(cmd, home, a, agentName, c, comp, "", dryRun)
 		// Seed whatever WAS written even on error: a component can fail partway
 		// after writing earlier items, and those must be owned or the next apply
 		// foreign-collides on a file just imported from.
@@ -810,4 +823,157 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 	// A non-empty marker so importedSet.add flags memory was captured (it has no
 	// id; the seeder includes c.Memory when this is set).
 	return []string{"memory"}, nil
+}
+
+// importPlugins captures the agent's installed plugins + their marketplaces into
+// the canonical source. It is the read-back of `marketplace add` + `plugin
+// install`: for each enabled plugin whose marketplace is resolvable from the
+// agent's native config, it re-fetches the marketplace and the plugin into the
+// agentsync cache and writes marketplaces/<name>.toml + plugins/<id>.toml,
+// producing byte-identical artifacts to the manual commands.
+//
+// Only agents implementing adapter.PluginIngester have a native plugin concept
+// (Claude in v1); others import no plugins (not an error, so a full
+// `import <agent>` stays clean for them). A real import needs network access to
+// re-fetch; --dry-run discovers and previews without fetching or writing.
+//
+// Plugins from an unregistered/auto marketplace — e.g. claude-plugins-official,
+// which Claude does not list in extraKnownMarketplaces — are reported and
+// skipped, as is a marketplace whose source type agentsync cannot fetch. name,
+// when non-empty, selects a single plugin (matched by its name or
+// "name@marketplace"); a no-match is an error. A fetch/install failure for one
+// marketplace or plugin warns and skips rather than aborts, so one bad item
+// does not strand the rest. Plugins are NOT dest-seeded into state (unlike the
+// file components): they are a source-side declaration whose projected
+// components materialise as new dest files on the next apply.
+func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter, name string, dryRun bool) ([]string, error) {
+	pi, ok := a.(adapter.PluginIngester)
+	if !ok {
+		return nil, nil
+	}
+	mps, plugins, err := pi.IngestPlugins(adapter.ScopeUser, "")
+	if err != nil {
+		return nil, fmt.Errorf("discover %s plugins: %w", agentName, err)
+	}
+
+	mpByID := make(map[string]adapter.NativeMarketplace, len(mps))
+	for _, m := range mps {
+		mpByID[m.ID] = m
+	}
+
+	var want []adapter.NativePlugin
+	for _, pl := range plugins {
+		if !pl.Enabled {
+			continue
+		}
+		if name != "" && pl.Name != name && pl.Name+"@"+pl.MarketplaceID != name {
+			continue
+		}
+		want = append(want, pl)
+	}
+	if len(want) == 0 {
+		if name != "" {
+			return nil, fmt.Errorf("plugin %q not found among %s's enabled plugins", name, agentName)
+		}
+		return nil, nil
+	}
+
+	out := cmd.OutOrStdout()
+	ew := cmd.ErrOrStderr()
+	verb := importVerb(dryRun)
+
+	// Resolve (and, on a real run, fetch) each needed marketplace exactly once.
+	// The cached value is the agentsync marketplace name a plugin installs from;
+	// "" marks an unresolvable marketplace already warned about.
+	resolved := map[string]string{}
+	resolveMp := func(mpID string) (string, bool) {
+		if n, done := resolved[mpID]; done {
+			return n, n != ""
+		}
+		nm, known := mpByID[mpID]
+		if !known {
+			fmt.Fprintf(ew, "warning: skipping plugins from marketplace %q: not registered in %s's native config "+
+				"(e.g. the built-in 'claude-plugins-official'); run `agentsync marketplace add <source>` then re-import\n",
+				mpID, agentName)
+			resolved[mpID] = ""
+			return "", false
+		}
+		src, rawURL, mappable := claudeSourceToAgentsync(nm.Source)
+		if !mappable {
+			fmt.Fprintf(ew, "warning: skipping marketplace %q: unsupported source type %q\n", mpID, nm.Source.Type)
+			resolved[mpID] = ""
+			return "", false
+		}
+		if dryRun {
+			// No fetch, so the declared agentsync name is unknown; preview by the
+			// native id. The real run resolves and prints the actual filename.
+			fmt.Fprintf(out, "%s marketplaces/%s.toml\n", verb, mpID)
+			resolved[mpID] = mpID
+			return mpID, true
+		}
+		mpName, _, ferr := addMarketplaceSource(home, src, rawURL, ew)
+		if ferr != nil {
+			fmt.Fprintf(ew, "warning: skipping marketplace %q: %v\n", mpID, ferr)
+			resolved[mpID] = ""
+			return "", false
+		}
+		fmt.Fprintf(out, "%s marketplaces/%s.toml\n", verb, mpName)
+		resolved[mpID] = mpName
+		return mpName, true
+	}
+
+	var ids []string
+	for _, pl := range want {
+		if pl.MarketplaceID == "" {
+			fmt.Fprintf(ew, "warning: skipping plugin %q: native config records no marketplace for it\n", pl.Name)
+			continue
+		}
+		// The plugin name becomes plugins/<name>.toml; validate it up front (and
+		// in dry-run) so a hostile native id can't escape the source dir and the
+		// preview matches a real import.
+		if verr := source.ValidateComponentID("plugin", pl.Name); verr != nil {
+			fmt.Fprintf(ew, "warning: skipping plugin %q: %v\n", pl.Name, verr)
+			continue
+		}
+		mpName, mpOK := resolveMp(pl.MarketplaceID)
+		if !mpOK {
+			continue
+		}
+		if dryRun {
+			fmt.Fprintf(out, "%s plugins/%s.toml\n", verb, pl.Name)
+			ids = append(ids, pl.Name)
+			continue
+		}
+		if _, ierr := installPluginInto(home, pl.Name, mpName); ierr != nil {
+			fmt.Fprintf(ew, "warning: skipping plugin %q from %q: %v\n", pl.Name, mpName, ierr)
+			continue
+		}
+		fmt.Fprintf(out, "%s plugins/%s.toml\n", verb, pl.Name)
+		ids = append(ids, pl.Name)
+	}
+	return ids, nil
+}
+
+// claudeSourceToAgentsync maps a native marketplace source (Claude's
+// extraKnownMarketplaces `source` object) onto an agentsync marketplace Source
+// plus the raw source string stored in marketplaces/<name>.toml. ok is false
+// for source kinds agentsync cannot fetch (npm/hostPattern/unknown) or a
+// well-formed kind missing its required field — the caller warns and skips.
+func claudeSourceToAgentsync(s adapter.NativeSource) (src marketplace.Source, rawURL string, ok bool) {
+	switch s.Type {
+	case "github":
+		raw := "github:" + s.Repo
+		if s.Ref != "" {
+			raw += "@" + s.Ref
+		}
+		return marketplace.Source{Kind: "github", Repo: s.Repo, Ref: s.Ref}, raw, s.Repo != ""
+	case "git":
+		return marketplace.Source{Kind: "url", URL: s.URL, Ref: s.Ref}, s.URL, s.URL != ""
+	case "url":
+		return marketplace.Source{Kind: "url", URL: s.URL}, s.URL, s.URL != ""
+	case "file", "directory":
+		return marketplace.Source{Relative: s.Path}, s.Path, s.Path != ""
+	default:
+		return marketplace.Source{}, "", false
+	}
 }

--- a/internal/cli/import_plugin_fanout_test.go
+++ b/internal/cli/import_plugin_fanout_test.go
@@ -1,0 +1,85 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeSkillMarketplace builds a local marketplace whose single plugin ships both
+// a skill (convention-discovered from skills/<name>/SKILL.md) and an MCP server,
+// returning the marketplace root. It exists to prove a Claude marketplace
+// projects its components out to OTHER agents on apply.
+func makeSkillMarketplace(t *testing.T, dir string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "skill-marketplace")
+
+	write := func(rel, body string) {
+		p := filepath.Join(mpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(".claude-plugin/marketplace.json", `{
+		"name": "toolkit-mp",
+		"owner": {"name": "tester"},
+		"plugins": [{"name": "toolkit", "source": "./plugins/toolkit"}]
+	}`)
+	write("plugins/toolkit/.claude-plugin/plugin.json", `{
+		"name": "toolkit",
+		"version": "1.0.0",
+		"mcpServers": {"tk-mcp": {"command": "tk-server"}}
+	}`)
+	// Convention-discovered skill (plugin.json lists none).
+	write("plugins/toolkit/skills/greeter/SKILL.md",
+		"---\nname: greeter\ndescription: say hi\n---\nGreet the user.\n")
+	return mpDir
+}
+
+// TestImport_PluginComponentsFanOutToOpenCode is the end-to-end guarantee behind
+// "a marketplace is just a bag of entities fanned out via supported mechanisms":
+// importing a Claude marketplace plugin, then `apply` with OpenCode also enabled,
+// projects the plugin's skill and MCP server out to OpenCode — the skill to the
+// shared .claude/skills path OpenCode reads, the MCP into opencode.json.
+func TestImport_PluginComponentsFanOutToOpenCode(t *testing.T) {
+	tmp, env := importTestEnv(t) // inits + enables claude
+	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+		t.Fatalf("agent add opencode: %v", err)
+	}
+	mpDir := makeSkillMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("toolkit-mp", mpDir, "toolkit"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// The skill landed at the shared .claude/skills path OpenCode reads natively.
+	skill := filepath.Join(tmp, ".claude", "skills", "greeter", "SKILL.md")
+	data, err := os.ReadFile(skill)
+	if err != nil {
+		t.Fatalf("plugin skill did not project to the shared skills path: %v", err)
+	}
+	if !strings.Contains(string(data), "Greet the user") {
+		t.Fatalf("projected skill missing body; got:\n%s", data)
+	}
+
+	// The plugin's MCP server fanned out into OpenCode's own config — a genuinely
+	// OpenCode-specific render target, proving cross-agent fan-out (not just a
+	// shared path).
+	ocConfig := filepath.Join(tmp, ".config", "opencode", "opencode.json")
+	oc, err := os.ReadFile(ocConfig)
+	if err != nil {
+		t.Fatalf("opencode.json not written: %v", err)
+	}
+	if !strings.Contains(string(oc), "tk-mcp") {
+		t.Fatalf("plugin MCP server did not fan out to opencode.json; got:\n%s", oc)
+	}
+}

--- a/internal/cli/import_plugin_test.go
+++ b/internal/cli/import_plugin_test.go
@@ -1,0 +1,177 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeClaudeSettings writes a user-scope ~/.claude/settings.json under tmp.
+func writeClaudeSettings(t *testing.T, tmp string, v any) {
+	t.Helper()
+	dir := filepath.Join(tmp, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// directoryMarketplaceSettings builds a settings.json value registering mpDir as
+// a "directory" marketplace under mpID and enabling each plugin@mpID.
+func directoryMarketplaceSettings(mpID, mpDir string, plugins ...string) map[string]any {
+	enabled := map[string]any{}
+	for _, p := range plugins {
+		enabled[p+"@"+mpID] = true
+	}
+	return map[string]any{
+		"extraKnownMarketplaces": map[string]any{
+			mpID: map[string]any{"source": map[string]any{"source": "directory", "path": mpDir}},
+		},
+		"enabledPlugins": enabled,
+	}
+}
+
+// TestImport_PluginsFromClaude is the core happy path: a Claude config with a
+// registered (directory) marketplace and an enabled plugin is captured into the
+// canonical source — both the marketplace and plugin TOMLs plus the agentsync
+// caches — by re-fetching, mirroring `marketplace add` + `plugin install`.
+func TestImport_PluginsFromClaude(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+
+	home := filepath.Join(tmp, ".agentsync")
+	// Canonical records.
+	if _, err := os.Stat(filepath.Join(home, "marketplaces", "test-mp.toml")); err != nil {
+		t.Fatalf("marketplaces/test-mp.toml not written: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(home, "plugins", "demo.toml")); err != nil {
+		t.Fatalf("plugins/demo.toml not written: %v\n%s", err, out)
+	}
+	// Caches seeded so projection works on the next apply.
+	if _, err := os.Stat(filepath.Join(home, ".state", "cache", "marketplaces", "test-mp", ".claude-plugin", "marketplace.json")); err != nil {
+		t.Fatalf("marketplace cache not seeded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".state", "cache", "plugins", "demo", ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatalf("plugin cache not seeded: %v", err)
+	}
+	// The plugin TOML pins a marketplace-scoped id so projection can resolve
+	// entry-level overrides.
+	data, _ := os.ReadFile(filepath.Join(home, "plugins", "demo.toml"))
+	if !strings.Contains(string(data), "demo@test-mp") {
+		t.Fatalf("plugins/demo.toml missing marketplace-scoped id; got:\n%s", data)
+	}
+}
+
+// TestImport_PluginsWarnsUnregisteredMarketplace verifies the warn-and-skip
+// path: a plugin enabled from the auto-available 'claude-plugins-official'
+// marketplace (which Claude does not list in extraKnownMarketplaces) cannot be
+// resolved, so it is reported and skipped without failing the import.
+func TestImport_PluginsWarnsUnregisteredMarketplace(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	writeClaudeSettings(t, tmp, map[string]any{
+		"enabledPlugins": map[string]any{"github@claude-plugins-official": true},
+	})
+
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
+		t.Fatalf("import should warn+skip, not error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "claude-plugins-official") {
+		t.Fatalf("expected a warning naming the unregistered marketplace; got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "plugins", "github.toml")); !os.IsNotExist(err) {
+		t.Fatalf("an unresolvable plugin must not be written; stat err=%v", err)
+	}
+}
+
+// TestImport_PluginsDryRun previews without fetching or writing any marketplace
+// / plugin TOML or cache.
+func TestImport_PluginsDryRun(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "import", "claude:plugin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "would import") {
+		t.Fatalf("dry-run should preview; got:\n%s", out)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	for _, rel := range []string{
+		filepath.Join("marketplaces", "test-mp.toml"),
+		filepath.Join("plugins", "demo.toml"),
+		filepath.Join(".state", "cache", "plugins", "demo"),
+	} {
+		if _, err := os.Stat(filepath.Join(home, rel)); !os.IsNotExist(err) {
+			t.Fatalf("dry-run must not create %s; stat err=%v", rel, err)
+		}
+	}
+}
+
+// TestImport_PluginNamedSelector imports a single named plugin, and errors on a
+// name that no enabled plugin matches.
+func TestImport_PluginNamedSelector(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin:demo"); err != nil {
+		t.Fatalf("import claude:plugin:demo: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "plugins", "demo.toml")); err != nil {
+		t.Fatalf("named plugin import did not write plugins/demo.toml: %v", err)
+	}
+
+	if _, err := runCLI(t, env, "import", "claude:plugin:nope"); err == nil {
+		t.Fatal("expected error importing a plugin that is not enabled")
+	}
+}
+
+// TestImport_FullAgentIncludesPlugins verifies plugins are part of a full
+// `import claude`: the summary counts them and both file components and plugins
+// land in the canonical source.
+func TestImport_FullAgentIncludesPlugins(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+
+	// A native MCP server (offline component) plus a registered plugin.
+	if err := os.WriteFile(filepath.Join(tmp, ".claude.json"),
+		[]byte(`{"mcpServers": {"github": {"type": "stdio", "command": "npx"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "import", "claude")
+	if err != nil {
+		t.Fatalf("import claude: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "plugin") {
+		t.Fatalf("full-agent summary should mention plugins; got:\n%s", out)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	for _, rel := range []string{
+		filepath.Join("mcp", "github.toml"),
+		filepath.Join("plugins", "demo.toml"),
+		filepath.Join("marketplaces", "test-mp.toml"),
+	} {
+		if _, err := os.Stat(filepath.Join(home, rel)); err != nil {
+			t.Fatalf("full-agent import did not write %s: %v", rel, err)
+		}
+	}
+}

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -803,8 +803,8 @@ func TestImport_UnknownComponent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := runCLI(t, env, "import", "claude:plugin:foo")
+	_, err := runCLI(t, env, "import", "claude:widget:foo")
 	if err == nil {
-		t.Fatal("expected error for unknown component 'plugin'; got nil")
+		t.Fatal("expected error for unknown component 'widget'; got nil")
 	}
 }

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,6 +68,25 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL, cmd.ErrOrStderr())
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "added marketplace %s (sha=%s)\n",
+		mpName, truncate(headSHA, 12))
+	return nil
+}
+
+// addMarketplaceSource fetches src into the marketplace cache, writes
+// marketplaces/<name>.toml, and records the fetch in state. It returns the
+// resolved marketplace name (the declared name from marketplace.json, falling
+// back to a URL-derived slug) and the fetched head SHA. rawURL is the original
+// source string stored in the TOML; warnOut receives the reserved-name notice.
+//
+// It does not print a success line or acquire the global lock — callers do.
+// Both `marketplace add` and `import` use it so the two produce byte-identical
+// canonical artifacts.
+func addMarketplaceSource(home string, src marketplace.Source, rawURL string, warnOut io.Writer) (mpName, headSHA string, err error) {
 	// Derive a slug for the marketplace.
 	slug := deriveMarketplaceSlug(rawURL)
 	cacheDir := marketplaceCacheDir(home, slug)
@@ -75,11 +95,11 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	fetcher := marketplace.Dispatch(src)
 	result, err := fetcher.Fetch(src, cacheDir)
 	if err != nil {
-		return fmt.Errorf("fetch marketplace %s: %w", rawURL, err)
+		return "", "", fmt.Errorf("fetch marketplace %s: %w", rawURL, err)
 	}
 
 	// Read marketplace.json to extract the declared name.
-	mpName := slug
+	mpName = slug
 	mpJSONPath := filepath.Join(cacheDir, ".claude-plugin", "marketplace.json")
 	if data, err := os.ReadFile(mpJSONPath); err == nil {
 		var mp marketplace.Marketplace
@@ -87,7 +107,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 			// Check reserved names.
 			for _, reserved := range marketplace.ReservedMarketplaceNames {
 				if mp.Name == reserved {
-					fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace name %q is reserved\n", mp.Name)
+					fmt.Fprintf(warnOut, "warning: marketplace name %q is reserved\n", mp.Name)
 				}
 			}
 			// Only adopt the declared name if it sanitises to something usable;
@@ -119,11 +139,11 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	}
 	data, err := toml.Marshal(mp)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 	mpPath := filepath.Join(home, "marketplaces", mpName+".toml")
 	if err := iox.AtomicWrite(mpPath, data, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", mpPath, err)
+		return "", "", fmt.Errorf("write %s: %w", mpPath, err)
 	}
 
 	// Update state.json so the update command can track fetch timestamps and SHAs.
@@ -139,9 +159,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	}
 	_ = state.Save(statePath, st) // best-effort; don't fail add on state write errors
 
-	fmt.Fprintf(cmd.OutOrStdout(), "added marketplace %s (sha=%s)\n",
-		mpName, truncate(result.HeadSHA, 12))
-	return nil
+	return mpName, result.HeadSHA, nil
 }
 
 // ---- remove -----------------------------------------------------------------

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -69,10 +69,25 @@ func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
+	spec, err := installPluginInto(home, id, mpName)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "installed plugin %s (version=%s sha=%s)\n",
+		id, spec.Version, truncate(spec.ManifestSHA, 12))
+	return nil
+}
+
+// installPluginInto fetches plugin id from the named marketplace into the
+// plugin cache and writes plugins/<id>.toml, returning the written spec. mpName
+// may be empty (the marketplace is then searched for across all caches). It
+// does not print or acquire the global lock — callers do. Both `plugin install`
+// and `import` use it so the two produce byte-identical canonical artifacts.
+func installPluginInto(home, id, mpName string) (pluginTOMLSpec, error) {
 	// Resolve marketplace.json from the marketplace cache.
 	mpData, mpEntry, err := resolveMarketplaceEntry(home, mpName, id)
 	if err != nil {
-		return err
+		return pluginTOMLSpec{}, err
 	}
 
 	// Compute cache path.
@@ -90,7 +105,7 @@ func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	fetcher := marketplace.Dispatch(src)
 	result, err := fetcher.Fetch(src, cacheDir)
 	if err != nil {
-		return fmt.Errorf("fetch plugin %s: %w", id, err)
+		return pluginTOMLSpec{}, fmt.Errorf("fetch plugin %s: %w", id, err)
 	}
 
 	// Compute manifest SHA.
@@ -113,15 +128,12 @@ func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	}
 	data, err := toml.Marshal(pluginTOML{Plugin: spec})
 	if err != nil {
-		return fmt.Errorf("marshal plugin toml: %w", err)
+		return pluginTOMLSpec{}, fmt.Errorf("marshal plugin toml: %w", err)
 	}
 	if err := iox.AtomicWrite(pluginPath, data, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", pluginPath, err)
+		return pluginTOMLSpec{}, fmt.Errorf("write %s: %w", pluginPath, err)
 	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "installed plugin %s (version=%s sha=%s)\n",
-		id, spec.Version, truncate(spec.ManifestSHA, 12))
-	return nil
+	return spec, nil
 }
 
 // ---- upgrade ----------------------------------------------------------------

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"sort"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// undeclaredNativePlugins reports, per agent, the plugins enabled in that
+// agent's native config that are NOT declared in the canonical source — a
+// read-only nudge surfaced by `status` and `doctor`.
+//
+// agentsync treats natively-installed plugins as foreign-managed (the design's
+// "jointly-owned cache" note), so this never blocks or auto-imports; it just
+// points the user at `import <agent>:plugin`. Only agents whose adapter
+// implements adapter.PluginIngester are probed (others yield nothing), and a
+// discovery error is skipped silently since the nudge is best-effort.
+//
+// Matching is by plugin NAME — the plugins/<name>.toml stem — not by
+// "name@marketplace", because the marketplace id an agent records natively can
+// differ from the declared marketplace name agentsync keys its file on. Name
+// matching errs toward NOT nagging (a same-named plugin from another
+// marketplace counts as declared), which suits a nudge.
+func undeclaredNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]string {
+	declared := make(map[string]bool, len(c.Plugins))
+	for _, pl := range c.Plugins {
+		declared[pl.ID] = true
+	}
+	out := map[string][]string{}
+	for _, name := range agents {
+		pi, ok := reg.Lookup(name).(adapter.PluginIngester)
+		if !ok {
+			continue
+		}
+		_, plugins, err := pi.IngestPlugins(adapter.ScopeUser, "")
+		if err != nil {
+			continue
+		}
+		var missing []string
+		seen := map[string]bool{}
+		for _, pl := range plugins {
+			if !pl.Enabled || declared[pl.Name] || seen[pl.Name] {
+				continue
+			}
+			seen[pl.Name] = true
+			missing = append(missing, pl.Name)
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			out[name] = missing
+		}
+	}
+	return out
+}

--- a/internal/cli/plugin_drift_test.go
+++ b/internal/cli/plugin_drift_test.go
@@ -1,0 +1,83 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStatus_NudgesUndeclaredPlugins verifies status emits a note for a plugin
+// enabled in Claude's native config that isn't declared in the canonical
+// source, pointing the user at `import claude:plugin`.
+func TestStatus_NudgesUndeclaredPlugins(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "import claude:plugin") || !strings.Contains(out, "demo") {
+		t.Fatalf("status should nudge about the undeclared plugin 'demo'; got:\n%s", out)
+	}
+}
+
+// TestStatus_NoNudgeWhenPluginDeclared verifies that once a plugin is declared
+// in the source, status stops nudging about it.
+func TestStatus_NoNudgeWhenPluginDeclared(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	// Declare demo in the canonical source (as `plugin install` would).
+	pluginsDir := filepath.Join(tmp, ".agentsync", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsDir, "demo.toml"),
+		[]byte("[plugin]\nid = \"demo@test-mp\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "import claude:plugin") {
+		t.Fatalf("status must not nudge about a declared plugin; got:\n%s", out)
+	}
+}
+
+// TestDoctor_ReportsUndeclaredPlugins verifies doctor's Plugins section lists a
+// natively-installed plugin missing from source without failing the run.
+func TestDoctor_ReportsUndeclaredPlugins(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor should not fail on an informational plugin nudge: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Plugins") {
+		t.Fatalf("doctor missing Plugins section; got:\n%s", out)
+	}
+	if !strings.Contains(out, "demo") || !strings.Contains(out, "import claude:plugin") {
+		t.Fatalf("doctor should report undeclared plugin 'demo'; got:\n%s", out)
+	}
+}
+
+// TestDoctor_PluginsOKWhenNoneInstalled verifies the Plugins section reports a
+// clean state when no native plugins are installed.
+func TestDoctor_PluginsOKWhenNoneInstalled(t *testing.T) {
+	_, env := importTestEnv(t)
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "no undeclared native plugins") {
+		t.Fatalf("doctor should report a clean plugin state; got:\n%s", out)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -147,6 +147,20 @@ func newStatusCmd() *cobra.Command {
 						"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
 					a, a)
 			}
+			// Nudge: plugins installed natively in an enabled agent but not yet
+			// declared in source. agentsync treats them as foreign-managed (never
+			// drift), so this is informational — it points at `import`.
+			undeclared := undeclaredNativePlugins(c, reg, agents)
+			for _, name := range reg.Names() {
+				missing := undeclared[name]
+				if len(missing) == 0 {
+					continue
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"note: %d plugin(s) installed in %s are not in your source (%s); "+
+						"run `agentsync import %s:plugin` to manage them.\n",
+					len(missing), name, strings.Join(missing, ", "), name)
+			}
 			return nil
 		},
 	}

--- a/website/src/content/docs/getting-started/existing-configs.mdx
+++ b/website/src/content/docs/getting-started/existing-configs.mdx
@@ -41,21 +41,34 @@ the right to widen the scope.
 
 | Selector | Imports |
 | --- | --- |
-| `claude` | the agent's **full** native config (MCP, skills, subagents, commands, hooks, LSP, memory) |
+| `claude` | the agent's **full** native config (MCP, skills, subagents, commands, hooks, LSP, memory, plugins) |
 | `claude:mcp` | **every** MCP server |
 | `claude:mcp:github` | a **single** MCP server |
+| `claude:plugin` | every installed **plugin** + its marketplace (Claude only) |
 | `opencode:mcp:linear` | a single server from a different agent |
 
 ```bash
 agentsync import claude
 agentsync import claude:mcp
 agentsync import claude:mcp:github
+agentsync import claude:plugin
 agentsync import opencode:mcp:linear
 ```
 
 A bulk import that finds nothing for a component reports it and exits cleanly
 rather than erroring. Add `--dry-run` to list the source files an import *would*
 write without touching `~/.agentsync/`.
+
+<Aside type="note" title="Importing plugins reaches the network">
+	The `plugin` component (Claude only in v1) reads your installed plugins and
+	their marketplaces from Claude's native config and **re-fetches** each one into
+	the agentsync cache — the same artifacts `marketplace add` + `plugin install`
+	produce — so a real plugin import needs network access (`--dry-run` does not).
+	A plugin installed from a marketplace that isn't registered in Claude's native
+	config — most notably the built-in `claude-plugins-official`, which doesn't
+	appear in `extraKnownMarketplaces` — is reported and skipped; add it with
+	`agentsync marketplace add <source>` and re-import.
+</Aside>
 
 <Aside type="caution" title="The first apply on a populated machine">
 	On a machine that already has native config, the **first** `apply` sees files it

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -27,7 +27,7 @@ every enabled agent gets the components it understands.
    agentsync plugin install atlassian@anthropic
    ```
 
-3. **Fetch from the network** — `update` is the only networked verb:
+3. **Fetch from the network** — `update` is the networked verb of the daily loop (`import`'s `plugin` component is the other, setup-time, networked path):
 
    ```bash
    agentsync update

--- a/website/src/content/docs/guides/updating.mdx
+++ b/website/src/content/docs/guides/updating.mdx
@@ -1,15 +1,17 @@
 ---
 title: Updating from the network
-description: update is the only networked verb — it refreshes the marketplace cache and version pins without touching agent config. apply then renders offline.
+description: update is the networked verb of the daily loop — it refreshes the marketplace cache and version pins without touching agent config. apply then renders offline.
 sidebar:
   order: 7
 ---
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
-`update` is the **only** command that touches the network. It polls marketplaces,
-refreshes the local cache, and recomputes version pins — without touching any
-agent config. `apply` then renders from that cache, so it's always fast, offline,
+`update` is the command that touches the network in the daily loop. It polls
+marketplaces, refreshes the local cache, and recomputes version pins — without
+touching any agent config. (The one other networked path is setup-time:
+`import`'s `plugin` component re-fetches the plugins it captures from an agent's
+native config.) `apply` then renders from that cache, so it's always fast, offline,
 and reproducible.
 
 ```bash

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -44,7 +44,9 @@ existing bootstrap config instead of starting empty.
 ### `doctor`
 A health check: verifies your `PATH`, that home and state directories are
 writable, that the config schema parses, and that the secrets backend is reachable.
-Run it first when something feels off.
+It also lists plugins installed natively in an agent (Claude) that aren't in your
+source yet — run `import <agent>:plugin` to capture them. Run it first when
+something feels off.
 
 ### `verify`
 Validates the canonical config and surfaces **every** unresolved `${secret:…}` /

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -133,11 +133,16 @@ The interactive merge UX for drift and conflicts. Full guide:
 
 ### `import <agent>[:<component>[:<name>]]`
 Captures native config back into your canonical source. Drop parts of the selector
-to widen scope. Full guide: [Already have configs?](/getting-started/existing-configs/).
+to widen scope. The `plugin` component (Claude only in v1) captures installed
+plugins + their marketplaces by re-fetching them into the agentsync cache, so a
+real plugin import **uses the network**; a plugin from an unregistered or
+auto-available marketplace (e.g. `claude-plugins-official`) is reported and
+skipped. Full guide: [Already have configs?](/getting-started/existing-configs/).
 
 ### `update`
-**The only networked verb.** Refreshes the marketplace cache and recomputes
-version pins, then optionally applies. Full guide:
+**The main networked verb.** Refreshes the marketplace cache and recomputes
+version pins, then optionally applies. (`import`'s `plugin` component also reaches
+the network, to re-fetch the plugins it captures.) Full guide:
 [Updating from the network](/guides/updating/).
 
 ```bash


### PR DESCRIPTION
## Summary

Closes the gap where `agentsync import` silently skipped an agent's installed plugins — a real pain when adopting agentsync on a Claude setup that's heavily configured via marketplaces.

- **Plugin import** — `import` gains a `plugin` component (Claude in v1). It reads Claude's native `enabledPlugins` / `extraKnownMarketplaces` and re-fetches each marketplace + plugin into the agentsync cache (pinning a manifest SHA), producing the **same artifacts as `marketplace add` + `plugin install`**. A full `import claude` now reproduces a plugin-heavy setup in one pass. `--dry-run` previews without fetching/writing.
- **Fans out to every agent** — once imported, a plugin is just a bag of components, and `apply` projects them to all enabled agents via each adapter's capability matrix (e.g. a Claude marketplace plugin's skill lands for OpenCode at the shared `.claude/skills/`, its MCP server into `opencode.json`). Locked in by an end-to-end regression test.
- **`status` / `doctor` nudge** — both now surface plugins installed natively but not yet declared in source, pointing at `import <agent>:plugin`. Informational only — natively-installed plugins stay foreign-managed, so this never blocks an apply or auto-imports.
- **Forward-looking docs for Codex + Cursor** — both planned agents have native plugin systems; captured the native formats so their adapters can support the same import + fan-out (Codex `~/.codex/config.toml` `[plugins."name@source"]`; Cursor `.cursor-plugin/{plugin,marketplace}.json`, near-identical to Claude's).

## Design decisions

- **Full re-fetch** (vs records-only / cache-copy): imported plugins work immediately on the next apply, and it reuses the existing, security-hardened fetch path rather than reverse-engineering Claude's internal cache layout.
- **Warn-and-skip** for plugins from an unregistered/auto-available marketplace (e.g. the built-in `claude-plugins-official`, absent from `extraKnownMarketplaces`).
- **Optional `adapter.PluginIngester` interface** — kept off the core `Adapter` contract since only Claude has a native plugin concept in v1; `import` type-asserts for it, so other adapters import no plugins without any special-casing.
- **Nudge matches by plugin name** (the `plugins/<id>.toml` stem) to avoid false nags when the native marketplace id differs from the declared name.

## Docs kept in sync (same commits)

import reference + guides, capability matrix (incl. Codex/Cursor rows + sourced footnotes), architecture (adapter contract), components map, CHANGELOG, and the "only networked verb" claims now note import's setup-time network use.

## Test plan

- [x] `IngestPlugins` unit tests — parses `extraKnownMarketplaces`/`enabledPlugins`, enabled/disabled/array/null values, deterministic ordering, missing + malformed settings are lenient.
- [x] CLI e2e — plugin import happy path (TOMLs + caches seeded), warn-and-skip for unregistered marketplace, `--dry-run` writes nothing, named selector + not-found error, full-agent import includes plugins.
- [x] Cross-agent fan-out regression — Claude marketplace plugin's skill + MCP project to OpenCode on apply.
- [x] `status`/`doctor` nudge present when undeclared, silent once declared, doctor doesn't fail on it.
- [x] Full suite green (`go test ./...`), `golangci-lint` clean, `go vet` clean.

https://claude.ai/code/session_014vWcXsMLpXG5DQFfVScXKN