### PR TITLE
fix(import): resolve a plugin's marketplace from agentsync's own store first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   git-subdir, npm), `strict`-mode conflict policy, `${CLAUDE_PLUGIN_ROOT}`
   substitution, per-component projection, translation report, manifest-SHA
   pinning, and update modes. `marketplace add` treats every marketplace
-  identically — no name is reserved.
+  identically — no name is reserved. `marketplace remove` errors on an
+  unregistered or invalid name and points at `marketplace list`.
 - **Project-local overlays** — `.agentsync.toml` walk-up discovery, overlay
   merge, project-scope state tracking.
 - **age-encrypted secrets** — `${secret:…}`/`${env:…}` resolution at apply time,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 - **Marketplaces & plugins** — all five plugin sources (relative, github, url,
   git-subdir, npm), `strict`-mode conflict policy, `${CLAUDE_PLUGIN_ROOT}`
   substitution, per-component projection, translation report, manifest-SHA
-  pinning, and update modes.
+  pinning, and update modes. `marketplace add` treats every marketplace
+  identically — no name is reserved.
 - **Project-local overlays** — `.agentsync.toml` walk-up discovery, overlay
   merge, project-scope state tracking.
 - **age-encrypted secrets** — `${secret:…}`/`${env:…}` resolution at apply time,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   still captures one item. Empty scopes report a notice and exit cleanly.
   `import --dry-run` previews which source files an import would write without
   touching `~/.agentsync/`.
+  Plugin import resolves a marketplace from agentsync's own registered
+  marketplaces first, then the agent's native config, so `marketplace add` then
+  re-import captures plugins from any marketplace (including Claude built-ins
+  such as `claude-plugins-official`).
 - **Plugin import** — `import` now captures the agent's installed plugins and
   their marketplaces (Claude only in v1) via the new `plugin` component, so a
   full `import claude` reproduces a plugin-heavy setup in one pass. It reads

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -169,14 +169,15 @@ component reports it and exits cleanly rather than erroring. Add `--dry-run` to
 list the source files an import would write without touching `~/.agentsync/`.
 
 **Plugins are a special case.** The `plugin` component (Claude only in v1) reads
-the agent's installed plugins and their marketplaces from its native config and
-re-fetches each one into the agentsync cache, pinning a manifest SHA — the same
-artifacts `marketplace add` + `plugin install` produce. Because it re-fetches, a
-real plugin import (not `--dry-run`) needs network access. A plugin installed
-from a marketplace that isn't registered in the agent's native config — most
-notably Claude's built-in `claude-plugins-official`, which doesn't appear in
-`extraKnownMarketplaces` — can't be resolved, so it's reported and skipped; add
-the marketplace with `agentsync marketplace add <source>` and re-import.
+the agent's installed plugins and their marketplaces and re-fetches each one into
+the agentsync cache, pinning a manifest SHA — the same artifacts `marketplace
+add` + `plugin install` produce. Because it re-fetches, a real plugin import (not
+`--dry-run`) needs network access. A plugin's marketplace is resolved from
+agentsync's own registered marketplaces first, then the agent's native config. A
+plugin whose marketplace is registered in neither — for example a plugin from
+Claude's built-in `claude-plugins-official` (which doesn't appear in
+`extraKnownMarketplaces`) before you have registered it — is reported and
+skipped; register it with `agentsync marketplace add <source>` and re-import.
 
 On a populated machine, the **first** apply will see pre-existing native files it
 didn't write and treat them as `foreign-collision`: it backs each one up to

--- a/internal/adapter/claude/ingest_plugins.go
+++ b/internal/adapter/claude/ingest_plugins.go
@@ -17,9 +17,10 @@ import (
 // `marketplace add` + `plugin install` to capture them.
 //
 // The built-in `claude-plugins-official` marketplace is auto-available in
-// Claude and is NOT listed in extraKnownMarketplaces, so a plugin installed
-// from it appears in enabledPlugins with no resolvable source here; the CLI
-// warns and skips such plugins.
+// Claude and is NOT listed in extraKnownMarketplaces, so it has no resolvable
+// source here. The CLI resolves such a marketplace from agentsync's own
+// registered marketplaces instead (run `agentsync marketplace add <source>`);
+// only a marketplace registered in neither place is warned about and skipped.
 //
 // Parsing is lenient: a missing settings.json yields no plugins, and a
 // malformed one is treated as "no plugins discovered" rather than failing the

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -125,9 +125,11 @@ component too imports the agent's full native config in one pass. Use
 The plugin component captures the agent's installed plugins + their
 marketplaces (Claude only in v1): it re-fetches each marketplace and plugin
 into the agentsync cache and pins them, so a real import needs network access.
-A plugin whose marketplace is not registered in the agent's native config
-(e.g. the built-in 'claude-plugins-official') is reported and skipped; add it
-with 'agentsync marketplace add <source>' and re-import.
+A plugin's marketplace is resolved from agentsync's own registered marketplaces
+first, then the agent's native config; a plugin whose marketplace is registered
+in neither (e.g. a built-in like 'claude-plugins-official' you have not yet
+added) is reported and skipped. Register it with 'agentsync marketplace add
+<source>' and re-import.
 
 Examples:
   agentsync import claude                 # all importable components
@@ -837,10 +839,12 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 // `import <agent>` stays clean for them). A real import needs network access to
 // re-fetch; --dry-run discovers and previews without fetching or writing.
 //
-// Plugins from an unregistered/auto marketplace — e.g. claude-plugins-official,
-// which Claude does not list in extraKnownMarketplaces — are reported and
-// skipped, as is a marketplace whose source type agentsync cannot fetch. name,
-// when non-empty, selects a single plugin (matched by its name or
+// A plugin's marketplace is resolved from agentsync's own registered
+// marketplaces first (so `marketplace add` then re-import captures plugins from
+// any marketplace, including Claude built-ins like claude-plugins-official),
+// then from the agent's native config. A plugin whose marketplace is registered
+// in neither — or one whose source type agentsync cannot fetch — is reported and
+// skipped. name, when non-empty, selects a single plugin (matched by its name or
 // "name@marketplace"); a no-match is an error. A fetch/install failure for one
 // marketplace or plugin warns and skips rather than aborts, so one bad item
 // does not strand the rest. Plugins are NOT dest-seeded into state (unlike the
@@ -885,15 +889,26 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 	// Resolve (and, on a real run, fetch) each needed marketplace exactly once.
 	// The cached value is the agentsync marketplace name a plugin installs from;
 	// "" marks an unresolvable marketplace already warned about.
+	registered := registeredMarketplaceNames(home)
 	resolved := map[string]string{}
 	resolveMp := func(mpID string) (string, bool) {
 		if n, done := resolved[mpID]; done {
 			return n, n != ""
 		}
+		// Store-first: a marketplace already registered with `agentsync
+		// marketplace add` is authoritative and already cached, so its plugins
+		// install straight from it — no re-fetch, no marketplace-TOML rewrite, and
+		// (in dry-run) no marketplace preview line, since it is already in source.
+		if registered[mpID] {
+			resolved[mpID] = mpID
+			return mpID, true
+		}
+		// Fallback: discover the marketplace from the agent's native config,
+		// fetch it, and register it.
 		nm, known := mpByID[mpID]
 		if !known {
-			fmt.Fprintf(ew, "warning: skipping plugins from marketplace %q: not registered in %s's native config "+
-				"(e.g. the built-in 'claude-plugins-official'); run `agentsync marketplace add <source>` then re-import\n",
+			fmt.Fprintf(ew, "warning: skipping plugins from marketplace %q: registered in neither %s's "+
+				"native config nor agentsync; run `agentsync marketplace add <source>` then re-import\n",
 				mpID, agentName)
 			resolved[mpID] = ""
 			return "", false

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -899,6 +899,9 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 		// marketplace add` is authoritative and already cached, so its plugins
 		// install straight from it — no re-fetch, no marketplace-TOML rewrite, and
 		// (in dry-run) no marketplace preview line, since it is already in source.
+		// mpID doubles as the install/cache-dir key here; native marketplace ids
+		// are clean slugs, so a name that would need sanitizing simply misses the
+		// cache and degrades to a warn+skip in installPluginInto (no leak/crash).
 		if registered[mpID] {
 			resolved[mpID] = mpID
 			return mpID, true

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -911,7 +911,7 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 			resolved[mpID] = mpID
 			return mpID, true
 		}
-		mpName, _, ferr := addMarketplaceSource(home, src, rawURL, ew)
+		mpName, _, ferr := addMarketplaceSource(home, src, rawURL)
 		if ferr != nil {
 			fmt.Fprintf(ew, "warning: skipping marketplace %q: %v\n", mpID, ferr)
 			resolved[mpID] = ""

--- a/internal/cli/import_plugin_test.go
+++ b/internal/cli/import_plugin_test.go
@@ -197,6 +197,34 @@ func TestImport_PluginNamedSelector(t *testing.T) {
 	}
 }
 
+// TestImport_PluginsStoreBeatsNativeConfig pins the store-first precedence: when
+// a marketplace is registered BOTH in agentsync's store and in the agent's
+// native config, import resolves it from the store and does not re-fetch — in
+// dry-run that means no "marketplaces/<mp>.toml" preview line (the native path
+// would print one), while the plugin still imports.
+func TestImport_PluginsStoreBeatsNativeConfig(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir()) // declared name "test-mp", plugin "demo"
+
+	// Register the marketplace in agentsync's store.
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	// AND register the same marketplace in Claude's native config.
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, "demo"))
+
+	out, err := runCLI(t, env, "import", "claude:plugin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "plugins/demo.toml") {
+		t.Fatalf("dry-run should preview the plugin; got:\n%s", out)
+	}
+	if strings.Contains(out, "marketplaces/test-mp.toml") {
+		t.Fatalf("store-registered marketplace must win (no marketplace preview line); got:\n%s", out)
+	}
+}
+
 // TestImport_FullAgentIncludesPlugins verifies plugins are part of a full
 // `import claude`: the summary counts them and both file components and plugins
 // land in the canonical source.

--- a/internal/cli/import_plugin_test.go
+++ b/internal/cli/import_plugin_test.go
@@ -77,9 +77,10 @@ func TestImport_PluginsFromClaude(t *testing.T) {
 }
 
 // TestImport_PluginsWarnsUnregisteredMarketplace verifies the warn-and-skip
-// path: a plugin enabled from the auto-available 'claude-plugins-official'
-// marketplace (which Claude does not list in extraKnownMarketplaces) cannot be
-// resolved, so it is reported and skipped without failing the import.
+// path: a plugin whose marketplace is registered in neither Claude's native
+// config nor agentsync's own store (here 'claude-plugins-official', which Claude
+// does not list in extraKnownMarketplaces and the user has not `marketplace
+// add`ed) is reported and skipped without failing the import.
 func TestImport_PluginsWarnsUnregisteredMarketplace(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	writeClaudeSettings(t, tmp, map[string]any{
@@ -93,8 +94,61 @@ func TestImport_PluginsWarnsUnregisteredMarketplace(t *testing.T) {
 	if !strings.Contains(out, "claude-plugins-official") {
 		t.Fatalf("expected a warning naming the unregistered marketplace; got:\n%s", out)
 	}
+	if !strings.Contains(out, "nor agentsync") {
+		t.Fatalf("warning should reflect store-first resolution wording; got:\n%s", out)
+	}
 	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "plugins", "github.toml")); !os.IsNotExist(err) {
 		t.Fatalf("an unresolvable plugin must not be written; stat err=%v", err)
+	}
+}
+
+// TestImport_PluginsFromAgentsyncStore is the fix's core behavior: a plugin
+// enabled from a marketplace that is registered in agentsync's own store (via
+// `marketplace add`) but NOT in Claude's extraKnownMarketplaces is resolved from
+// the store and imported — no warning, no skip. This is exactly what the skip
+// warning's "marketplace add then re-import" remediation promises.
+func TestImport_PluginsFromAgentsyncStore(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir()) // declared name "test-mp", plugin "demo"
+
+	// Register the marketplace in agentsync's store (this is the `marketplace add`
+	// the user runs). It is NOT added to Claude's native config below.
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+
+	// Claude has the plugin enabled from test-mp but does not list test-mp in
+	// extraKnownMarketplaces — mirroring a built-in/auto marketplace.
+	writeClaudeSettings(t, tmp, map[string]any{
+		"enabledPlugins": map[string]any{"demo@test-mp": true},
+	})
+
+	// Dry-run previews the plugin only; the marketplace is already registered, so
+	// there is no marketplace line to "import".
+	dry, err := runCLI(t, env, "import", "claude:plugin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, dry)
+	}
+	if !strings.Contains(dry, "plugins/demo.toml") {
+		t.Fatalf("dry-run should preview the plugin; got:\n%s", dry)
+	}
+	if strings.Contains(dry, "marketplaces/test-mp.toml") {
+		t.Fatalf("already-registered marketplace must not be previewed for import; got:\n%s", dry)
+	}
+	if strings.Contains(dry, "skipping") {
+		t.Fatalf("registered marketplace must not be skipped; got:\n%s", dry)
+	}
+
+	// Real import writes the plugin TOML.
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "skipping") {
+		t.Fatalf("registered marketplace must not be skipped; got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "plugins", "demo.toml")); err != nil {
+		t.Fatalf("plugins/demo.toml not written from store-resolved marketplace: %v\n%s", err, out)
 	}
 }
 

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -250,6 +250,35 @@ func marketplaceListRun(cmd *cobra.Command, _ []string) error {
 
 // ---- helpers ----------------------------------------------------------------
 
+// registeredMarketplaceNames returns the set of marketplace names registered in
+// ~/.agentsync/marketplaces/. Both each TOML's declared `name` field and its
+// filename stem map to true, so a native marketplace id matches whichever the
+// store recorded. It mirrors how `marketplace list` enumerates the store and
+// lets import resolve a plugin's marketplace from agentsync's own store before
+// the agent's native config. A missing or unreadable store yields an empty set.
+func registeredMarketplaceNames(home string) map[string]bool {
+	entries, err := os.ReadDir(filepath.Join(home, "marketplaces"))
+	if err != nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		out[strings.TrimSuffix(e.Name(), ".toml")] = true
+		data, err := os.ReadFile(filepath.Join(home, "marketplaces", e.Name()))
+		if err != nil {
+			continue
+		}
+		var mp marketplaceTOML
+		if toml.Unmarshal(data, &mp) == nil && mp.Marketplace.Name != "" {
+			out[mp.Marketplace.Name] = true
+		}
+	}
+	return out
+}
+
 // parseMarketplaceSource converts a user-provided URL/path string into a Source.
 // Handles:
 //   - github:owner/repo[@ref]     → github source

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -68,7 +67,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL, cmd.ErrOrStderr())
+	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL)
 	if err != nil {
 		return err
 	}
@@ -81,12 +80,12 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 // marketplaces/<name>.toml, and records the fetch in state. It returns the
 // resolved marketplace name (the declared name from marketplace.json, falling
 // back to a URL-derived slug) and the fetched head SHA. rawURL is the original
-// source string stored in the TOML; warnOut receives the reserved-name notice.
+// source string stored in the TOML.
 //
 // It does not print a success line or acquire the global lock — callers do.
 // Both `marketplace add` and `import` use it so the two produce byte-identical
 // canonical artifacts.
-func addMarketplaceSource(home string, src marketplace.Source, rawURL string, warnOut io.Writer) (mpName, headSHA string, err error) {
+func addMarketplaceSource(home string, src marketplace.Source, rawURL string) (mpName, headSHA string, err error) {
 	// Derive a slug for the marketplace.
 	slug := deriveMarketplaceSlug(rawURL)
 	cacheDir := marketplaceCacheDir(home, slug)
@@ -104,12 +103,6 @@ func addMarketplaceSource(home string, src marketplace.Source, rawURL string, wa
 	if data, err := os.ReadFile(mpJSONPath); err == nil {
 		var mp marketplace.Marketplace
 		if json.Unmarshal(data, &mp) == nil && mp.Name != "" {
-			// Check reserved names.
-			for _, reserved := range marketplace.ReservedMarketplaceNames {
-				if mp.Name == reserved {
-					fmt.Fprintf(warnOut, "warning: marketplace name %q is reserved\n", mp.Name)
-				}
-			}
 			// Only adopt the declared name if it sanitises to something usable;
 			// a name like "..." sanitises to "" and would author marketplaces/.toml.
 			if s := sanitizeSlug(mp.Name); s != "" {

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -169,14 +169,26 @@ func newMarketplaceRemoveCmd() *cobra.Command {
 	}
 }
 
+// marketplaceListHint points users at the command that lists registered
+// marketplace names; used in `marketplace remove` error messages.
+const marketplaceListHint = "run: agentsync marketplace list to see registered names"
+
 func marketplaceRemoveRun(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	if err := validateCacheKey("marketplace", name); err != nil {
-		return err
+		return fmt.Errorf("%w; %s", err, marketplaceListHint)
 	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
 	tomlPath := filepath.Join(home, "marketplaces", name+".toml")
+	// Removing an unregistered name is a user mistake, not a silent no-op: report
+	// it and point at `marketplace list` rather than printing "removed".
+	if _, err := os.Stat(tomlPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("marketplace %q is not registered; %s", name, marketplaceListHint)
+		}
+		return fmt.Errorf("stat %s: %w", tomlPath, err)
+	}
 	if err := os.Remove(tomlPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove %s: %w", tomlPath, err)
 	}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -664,3 +664,49 @@ func TestPlugin_GitMarketplace(t *testing.T) {
 		t.Errorf("install output: %s", out)
 	}
 }
+
+// TestMarketplace_AddNameNoReservedWarning verifies `marketplace add` no longer
+// warns that a name is "reserved": a marketplace whose declared name was
+// formerly reserved (claude-plugins-official) is added cleanly. Treating every
+// marketplace identically is the whole point — there is no special-cased list.
+func TestMarketplace_AddNameNoReservedWarning(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A local marketplace whose declared name was previously "reserved".
+	mpDir := filepath.Join(t.TempDir(), "official-mp")
+	cp := filepath.Join(mpDir, ".claude-plugin")
+	if err := os.MkdirAll(cp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mpJSON := `{
+		"name": "claude-plugins-official",
+		"owner": {"name": "tester"},
+		"plugins": [{"name": "demo", "source": "./plugins/demo"}]
+	}`
+	if err := os.WriteFile(filepath.Join(cp, "marketplace.json"), []byte(mpJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := filepath.Join(mpDir, "plugins", "demo", ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"demo","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "marketplace", "add", mpDir)
+	if err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "added marketplace") {
+		t.Fatalf("expected success line; got:\n%s", out)
+	}
+	if strings.Contains(out, "reserved") {
+		t.Fatalf("a formerly-reserved name must no longer warn; got:\n%s", out)
+	}
+}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -315,6 +315,49 @@ func TestMarketplace_RemoveUpdatesState(t *testing.T) {
 	}
 }
 
+// TestMarketplace_RemoveUnknownNameErrors verifies that removing a valid but
+// unregistered marketplace name fails (rather than silently reporting success)
+// and points the user at `marketplace list`.
+func TestMarketplace_RemoveUnknownNameErrors(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "marketplace", "remove", "never-registered")
+	if err == nil {
+		t.Fatalf("removing an unregistered marketplace should error; got success:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "not registered") {
+		t.Errorf("error should say the marketplace is not registered; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "marketplace list") {
+		t.Errorf("error should hint at `marketplace list`; got: %v", err)
+	}
+}
+
+// TestMarketplace_RemoveInvalidNameHint verifies the invalid-name error (e.g. a
+// source URL passed where a name was expected) also points at `marketplace list`.
+func TestMarketplace_RemoveInvalidNameHint(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runCLI(t, env, "marketplace", "remove", "github:anthropics/claude-plugins-official")
+	if err == nil {
+		t.Fatal("removing an invalid marketplace id should error")
+	}
+	if !strings.Contains(err.Error(), "path separators") {
+		t.Errorf("expected the path-separator validation error; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "marketplace list") {
+		t.Errorf("invalid-name error should also hint at `marketplace list`; got: %v", err)
+	}
+}
+
 // ---- plugin install/list/enable/disable/remove tests -----------------------
 
 func TestPlugin_InstallFromLocalMarketplace(t *testing.T) {

--- a/internal/marketplace/manifest.go
+++ b/internal/marketplace/manifest.go
@@ -123,15 +123,3 @@ type PluginManifest struct {
 	Hooks       any            `json:"hooks,omitempty"`
 	LSPServers  map[string]any `json:"lspServers,omitempty"`
 }
-
-// ReservedMarketplaceNames are names that trigger a warning on `marketplace add`.
-var ReservedMarketplaceNames = []string{
-	"claude-code-marketplace",
-	"claude-code-plugins",
-	"claude-plugins-official",
-	"anthropic-marketplace",
-	"anthropic-plugins",
-	"agent-skills",
-	"knowledge-work-plugins",
-	"life-sciences",
-}

--- a/internal/marketplace/manifest_test.go
+++ b/internal/marketplace/manifest_test.go
@@ -157,14 +157,3 @@ func TestPluginManifest_Parse(t *testing.T) {
 		t.Errorf("lspServers count = %d", len(pm.LSPServers))
 	}
 }
-
-func TestReservedMarketplaceNames(t *testing.T) {
-	if len(marketplace.ReservedMarketplaceNames) == 0 {
-		t.Fatal("ReservedMarketplaceNames is empty")
-	}
-	for _, name := range marketplace.ReservedMarketplaceNames {
-		if name == "" {
-			t.Fatal("empty reserved name")
-		}
-	}
-}

--- a/website/src/content/docs/getting-started/existing-configs.mdx
+++ b/website/src/content/docs/getting-started/existing-configs.mdx
@@ -61,13 +61,14 @@ write without touching `~/.agentsync/`.
 
 <Aside type="note" title="Importing plugins reaches the network">
 	The `plugin` component (Claude only in v1) reads your installed plugins and
-	their marketplaces from Claude's native config and **re-fetches** each one into
-	the agentsync cache — the same artifacts `marketplace add` + `plugin install`
-	produce — so a real plugin import needs network access (`--dry-run` does not).
-	A plugin installed from a marketplace that isn't registered in Claude's native
-	config — most notably the built-in `claude-plugins-official`, which doesn't
-	appear in `extraKnownMarketplaces` — is reported and skipped; add it with
-	`agentsync marketplace add <source>` and re-import.
+	their marketplaces and **re-fetches** each one into the agentsync cache — the
+	same artifacts `marketplace add` + `plugin install` produce — so a real plugin
+	import needs network access (`--dry-run` does not). A plugin's marketplace is
+	resolved from agentsync's own registered marketplaces first, then Claude's
+	native config. A plugin whose marketplace is registered in neither — for
+	example one from the built-in `claude-plugins-official` (which doesn't appear
+	in `extraKnownMarketplaces`) before you register it — is reported and skipped;
+	add it with `agentsync marketplace add <source>` and re-import.
 </Aside>
 
 <Aside type="caution" title="The first apply on a populated machine">

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -137,8 +137,10 @@ The interactive merge UX for drift and conflicts. Full guide:
 Captures native config back into your canonical source. Drop parts of the selector
 to widen scope. The `plugin` component (Claude only in v1) captures installed
 plugins + their marketplaces by re-fetching them into the agentsync cache, so a
-real plugin import **uses the network**; a plugin from an unregistered or
-auto-available marketplace (e.g. `claude-plugins-official`) is reported and
+real plugin import **uses the network**. A plugin's marketplace is resolved from
+agentsync's own registered marketplaces first, then the agent's native config; a
+plugin whose marketplace is registered in neither (e.g. a built-in like
+`claude-plugins-official` you have not yet `marketplace add`ed) is reported and
 skipped. Full guide: [Already have configs?](/getting-started/existing-configs/).
 
 ### `update`


### PR DESCRIPTION
## Summary

`agentsync import <agent>:plugin` now resolves each plugin's marketplace from agentsync's **own** registered marketplaces (`~/.agentsync/marketplaces/*.toml`) first, then falls back to the agent's native config (Claude's `extraKnownMarketplaces`).

Previously import consulted **only** native config, so a marketplace you'd registered with `agentsync marketplace add` was never seen by import — its plugins were warned about and skipped, and the warning's own "run `agentsync marketplace add <source>` then re-import" remediation could never actually succeed. This was most visible for Claude built-ins like `claude-plugins-official`, which Claude never lists in `extraKnownMarketplaces`.

This PR also tidies up the `marketplace` command's UX:
- Removes the misleading **"marketplace name is reserved"** warning from `marketplace add` — no name is reserved; every marketplace is treated identically (no hardcoded default-marketplace list to chase).
- `marketplace remove` now **errors** on an unregistered name (instead of silently printing `removed`) and **both** the unknown-name and invalid-name (e.g. a source URL passed where a name was expected) errors point the user at `agentsync marketplace list`.

## Behavior

The originally-broken workflow now works as the warning promised:

```
agentsync marketplace add github:anthropics/claude-plugins-official   # no "reserved" warning
agentsync import claude --dry-run                                     # official plugins resolve instead of being skipped
```

Resolution order in `importPlugins`:
1. **Store-first** — a marketplace already registered via `marketplace add` is authoritative and already cached; install its plugins directly (no re-fetch, no marketplace-TOML rewrite; in dry-run, no marketplace preview line since it's already in source).
2. **Native fallback** — discover from the agent's native config, fetch, register (unchanged path; the `document-skills@anthropic-agent-skills` flow still works).
3. **Neither** — warn and skip, reworded to "registered in neither `<agent>`'s native config nor agentsync".

`installPluginInto` already operated entirely off agentsync's local store/cache, so the only change needed was the resolver.

## Changes

- `internal/cli/import.go` — store-first `resolveMp`; reworded skip warning; updated command help + doc comments.
- `internal/cli/marketplace.go` — new `registeredMarketplaceNames` helper; removed the reserved-name check and the now-unused `warnOut` param from `addMarketplaceSource`; `marketplace remove` errors on unknown/invalid name with a `marketplace list` hint.
- `internal/marketplace/manifest.go` — removed `ReservedMarketplaceNames` (+ its test).
- `internal/adapter/claude/ingest_plugins.go` — doc comment now reflects store-first resolution.
- **Tests**: store-first import (incl. dry-run), store-beats-native precedence, no-"reserved"-warning on `add`, `remove` unknown-name error + list hint, `remove` invalid-name hint; updated the warn-when-registered-nowhere test; removed the obsolete reserved-names test.
- **Docs (same commit per repo policy)**: `docs/user-guide.md`, `website/.../reference/cli.mdx`, `website/.../getting-started/existing-configs.mdx`, `CHANGELOG.md`.

## Test plan

- [x] `just build` and `just lint` — clean (0 issues)
- [x] `just test-release` (hermetic container, incl. unit + e2e + bdd) — all gates green
- [x] New/updated tests: store-first import, store-vs-native precedence, warn-when-unregistered, reserved-name removal, `marketplace remove` unknown/invalid-name errors + hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)