### PR TITLE
feat(skills): full artifact fidelity for skills & memory + faithful-model guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   Removing a skill (or one bundled file) from the source reclaims it from the
   destination on the next `apply` — a hand-edited orphan is backed up first, and
   now-empty skill directories are pruned up to the skills root.
+- **Memory fragment write-back guard** — when canonical memory is composed of
+  `memory/fragments/`, the native memory file is the fully expanded text, which
+  can't be de-resolved back into fragments. `import` now skips memory (with a
+  warning) and `reconcile`/`source.WriteMemory` refuse to write it back when
+  fragments exist, rather than silently flattening `AGENTS.md` and orphaning the
+  fragment files. Drift still surfaces in `status`/`diff`.
 - **Claude Code adapter** — full support for all seven components (MCP, memory,
   skill, subagent, command, hook, LSP) with per-key merge into `~/.claude.json`
   and `settings.json` that preserves foreign keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 - **Canonical source model** in `~/.agentsync/` — hand-editable TOML + markdown
   for agents, MCP servers, marketplaces, plugins, memory, and skills.
+- **Full Agent Skills directory support** — a skill is treated as a *directory*
+  per the [Agent Skills](https://agentskills.io) spec, not just its `SKILL.md`.
+  Bundled `scripts/`, `references/`, `assets/`, and nested files are carried
+  verbatim (binary included, executable bit preserved) end-to-end: across the
+  canonical loader/writer, every adapter's render + ingest (Claude, OpenCode,
+  Codex), plugin/marketplace projection, and `apply`/`import`/`reconcile`.
 - **Claude Code adapter** — full support for all seven components (MCP, memory,
   skill, subagent, command, hook, LSP) with per-key merge into `~/.claude.json`
   and `settings.json` that preserves foreign keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   Removing a skill (or one bundled file) from the source reclaims it from the
   destination on the next `apply` — a hand-edited orphan is backed up first, and
   now-empty skill directories are pruned up to the skills root.
+- **Unmodeled native MCP/LSP fields preserved (`Extra`)** — native server fields
+  agentsync doesn't model (e.g. `timeout`, `disabled`, `cwd`) are captured into a
+  passthrough `[server.extra]` table on import/reconcile and rendered back
+  verbatim, instead of being silently dropped (and then erased from the
+  destination on the next apply). `Extra` is verbatim only — values are never
+  secret-resolved (`${secret:…}` there is written literally) and never visited by
+  the secret walker; the capture leak backstop scans it and refuses any write that
+  would persist a live secret value through it.
 - **Memory fragment write-back guard** — when canonical memory is composed of
   `memory/fragments/`, the native memory file is the fully expanded text, which
   can't be de-resolved back into fragments. `import` now skips memory (with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   verbatim (binary included, executable bit preserved) end-to-end: across the
   canonical loader/writer, every adapter's render + ingest (Claude, OpenCode,
   Codex), plugin/marketplace projection, and `apply`/`import`/`reconcile`.
+  Removing a skill (or one bundled file) from the source reclaims it from the
+  destination on the next `apply` — a hand-edited orphan is backed up first, and
+  now-empty skill directories are pruned up to the skills root.
 - **Claude Code adapter** — full support for all seven components (MCP, memory,
   skill, subagent, command, hook, LSP) with per-key merge into `~/.claude.json`
   and `settings.json` that preserves foreign keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,15 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   secret-resolved (`${secret:…}` there is written literally) and never visited by
   the secret walker; the capture leak backstop scans it and refuses any write that
   would persist a live secret value through it.
-- **Memory fragment write-back guard** — when canonical memory is composed of
-  `memory/fragments/`, the native memory file is the fully expanded text, which
-  can't be de-resolved back into fragments. `import` now skips memory (with a
-  warning) and `reconcile`/`source.WriteMemory` refuse to write it back when
-  fragments exist, rather than silently flattening `AGENTS.md` and orphaning the
-  fragment files. Drift still surfaces in `status`/`diff`.
+- **Bidirectional memory fragments** — `apply` wraps each inlined fragment in
+  HTML-comment boundary markers (`<!-- agentsync:fragment <name> -->` …) in the
+  native memory file, so `import`/`reconcile` can **reverse** the expansion: a
+  native edit inside a fragment block is captured back into that fragment file
+  with the `@import` structure preserved, instead of flattening `AGENTS.md` and
+  orphaning the fragments. When markers are absent (a fragment containing the
+  marker token disables them) or hand-mangled into an unbalanced/ambiguous state,
+  the write-back is refused rather than guessed; reverse paths are
+  traversal-checked. Drift still surfaces in `status`/`diff`.
 - **Claude Code adapter** — full support for all seven components (MCP, memory,
   skill, subagent, command, hook, LSP) with per-key merge into `~/.claude.json`
   and `settings.json` that preserves foreign keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,37 @@ authored prose that is the source of truth for *itself*; when you change the CLI
 surface or agent coverage, update the website pages listed in the table above in
 the same commit, just like the `docs/` files. See `website/README.md`.
 
+## Models must stay faithful to their on-disk artifacts — non-negotiable
+
+A whole class of silent bug: a canonical struct models a *subset* of the artifact
+it claims to represent, and every downstream piece (loader, adapters, writer,
+projection) faithfully mirrors that subset — so nothing fails a test, no
+invariant breaks, no lint fires, yet data is dropped. `source.Skill` once held
+only `SKILL.md` (frontmatter + body) and silently discarded the rest of the skill
+*directory* (`scripts/`, `references/`, `assets/`, nested files). It survived
+because the round-trip tests' oracle was the parsed model, not the filesystem —
+and a round-trip over an impoverished model is trivially "lossless." **The
+on-disk artifact — what the upstream spec actually defines — is the source of
+truth, never the struct that parses it.** Three rules follow:
+
+- **Fidelity tests anchor to the artifact, not the model.** For any component
+  backed by a file tree or a structured file, the round-trip test MUST start from
+  a *spec-complete* on-disk fixture (a skill with bundled files; an MCP server
+  with an unmodeled native key; memory with `fragments/`) and assert the *on-disk
+  result* survives — byte-for-byte where applicable. Asserting "the parsed model
+  round-trips" proves nothing about what the model can't see.
+- **Capture it or acknowledge it — never drop it silently.** If the model can't
+  represent part of an artifact, the loss MUST surface: through the translation
+  report, an `adapter.Skip`, a `◐` in the capability matrix, or (at minimum) an
+  explicit code comment + doc note. Reflective guards (cf. `TestNewSecretFieldGuard`)
+  are the gold standard. A silent drop is a bug, full stop. A *deliberate* subset
+  is fine only if it is written down where a reviewer will see it.
+- **Doc claims are not self-certifying.** Generation keeps the contract pages in
+  sync with `docs/*.md`, but nothing proves a prose *capability* claim is true in
+  code (the skills matrix asserted `scripts/`/`references/`/`assets/` support the
+  code never had). When you assert a capability, point to — or add — the test
+  that backs it.
+
 ## Mental map of the code
 
 - **`internal/source`** — the canonical model (`source.Canonical`). The TOML

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,17 @@ there** — every operation then picks it up automatically. `TestNewSecretFieldG
 (reflect-based) fails if a string-shaped field is added to those structs without
 being classified.
 
+> **Deliberate exception — `MCPServerSpec.Extra` / `LSPServerSpec.Extra`.** These
+> `map[string]any` passthrough maps hold unmodeled native fields verbatim and are
+> intentionally NOT in `walkSecretFields`: their values are never secret-resolved
+> (a `${secret:…}` there is written literally, not substituted) and never
+> re-referenced. The guard does not flag them (a `map[string]any` is not
+> "string-shaped"). The safety they'd otherwise lose is restored by the capture
+> leak backstop, which scans `Extra` (`secrets.ResidualSecretCleartext` →
+> `scanExtraResidual`) and refuses any write that would persist a live secret
+> value through it. If you ever make `Extra` secret-resolving, it MUST join
+> `walkSecretFields` (and the paired re-reference) like every other field.
+
 **2. One dest→source path.** All write-backs go through `capture.Capture`
 (`internal/capture`). It re-references secrets (`secrets.ReReferenceCanonical`),
 preserves source-only fields the rendered dest never carries (MCP/LSP

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ consumes them — the schema is the contract between the two.
 source.Canonical
 ├── Config          (agentsync.toml: agents, update defaults, secrets backend)
 ├── MCPServers      (mcp/*.toml)
-├── Skills          (skills/*/SKILL.md)
+├── Skills          (skills/<name>/ — SKILL.md + bundled scripts/references/assets)
 ├── Subagents, Commands, Hooks, LSPServers
 ├── Plugins, Marketplaces   (plugins/*.toml, marketplaces/*.toml)
 ├── Memory          (memory/AGENTS.md + fragments/)
@@ -285,7 +285,8 @@ this hard to do by accident with three tiers of defense:
 - **Value-invariant (load-bearing).** Secret substitution clones the model
   before resolving (no aliasing back to the caller's templated copy), and the
   field walker only visits secret-bearing fields — so text components (memory,
-  skills, commands) physically cannot carry a substituted secret.
+  skills incl. their bundled files, commands) physically cannot carry a
+  substituted secret.
 - **Lint fence (defense-in-depth).** A `forbidigo` rule forbids unwrapping a
   `Resolved` outside the two adapter `Render` egress sites.
 - **Capture fail-closed backstop (defense-in-depth).** The *dest→source*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,6 +316,12 @@ always re-references. The single field list lives in `walkSecretFields`
 (`internal/secrets/walk.go`); a reflection-based test fails if a new
 string-shaped secret-bearing field is added without classification.
 
+The MCP/LSP `Extra` passthrough maps (unmodeled native fields, carried verbatim)
+are a **deliberate exception**: they are not in `walkSecretFields`, so a
+`${secret:…}` in `Extra` is written literally rather than resolved. The leak
+backstop scans `Extra` separately (`scanExtraResidual`) and refuses a write that
+would persist a live secret value through it.
+
 > If you ever find yourself unwrapping a `secrets.Resolved` outside an adapter's
 > `Render`, stop — you almost certainly want `capture.Capture`. The full set of
 > invariants is in [`CLAUDE.md`](../CLAUDE.md) and [`SECURITY.md`](../SECURITY.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,18 @@ key:
 `drift.SafeForAutoApply(class)` is what `reconcile --auto-safe` consults — it
 auto-resolves only the cases that can't lose work (`converged`, `pending`).
 
+**Orphan reclamation on `apply`.** `apply` itself reclaims two kinds of orphan so
+a removed component doesn't linger in the destination: emptied key-merge sections
+(an MCP/hook/LSP section whose source went empty — cleaned via a synthesized
+empty-merge op) and **skill files** (a whole skill, or one bundled
+`scripts/`/`references/`/`assets/` file, removed from `~/.agentsync/skills/`). A
+skill is a directory under the Agent Skills spec, so removal must reclaim the
+whole tree; the writer deletes each orphaned file, **backs up an `orphan-drifted`
+dest first** (a hand-edit is never destroyed un-preserved), and prunes the
+now-empty directories up to — never including — the agent's skills root. Other
+replace-strategy orphans (subagents, commands) are still surfaced for the
+interactive `reconcile` loop rather than auto-deleted.
+
 **Granularity.** Structured files (JSON/JSONC/TOML) are tracked per **JSON
 pointer**, so agentsync can own `$.mcpServers.github` inside `~/.claude.json`
 without touching keys it didn't write. Those untouched keys are **foreign keys**

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -148,8 +148,10 @@ A few ✓ cells still change shape on the way out — same content, no loss:
   **plus any bundled `scripts/`/`references/`/`assets/` and nested files**, all
   carried verbatim (binary included, executable bit preserved) on apply, import,
   and reconcile — agentsync is not lossy for anything but the directory itself.
-  Codex installs them under `~/.agents/skills/` (enabled by default — no feature
-  flag), Cursor under `.cursor/skills/`, and both also read the shared
+  Removing a skill (or one bundled file) from the source reclaims it from each
+  destination on the next `apply` (drifted files backed up first; empty dirs
+  pruned). Codex installs them under `~/.agents/skills/` (enabled by default — no
+  feature flag), Cursor under `.cursor/skills/`, and both also read the shared
   `.claude/skills/`.
 
 ## Escape hatches

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -35,7 +35,7 @@ Component support across agents.
 |---|:--:|:--:|:--:|:--:|
 | **MCP server** | ✓ `~/.claude.json` | ✓ `opencode.json` | ✓ `config.toml` | ✓ `.cursor/mcp.json` |
 | **Memory** | ✓ `CLAUDE.md` | ✓ `AGENTS.md` | ✓ `~/.codex/AGENTS.md` | ◐ `AGENTS.md` |
-| **Skill** | ✓ `~/.claude/skills/X/SKILL.md` | ✓ shared `.claude/skills/` | ✓ `~/.agents/skills/` | ✓ `.cursor/skills/` |
+| **Skill** | ✓ `~/.claude/skills/X/` (dir) | ✓ shared `.claude/skills/` | ✓ `~/.agents/skills/` | ✓ `.cursor/skills/` |
 | **Subagent** | ✓ `~/.claude/agents/X.md` | ◐ frontmatter munged | ◐ markdown → TOML | ◐ `.cursor/agents/` |
 | **Slash command** | ✓ `~/.claude/commands/X.md` | ◐ `argument-hint` dropped | ◐ `~/.codex/prompts/` | ◐ `.cursor/commands/` |
 | **Hook** | ✓ JSON in settings | ✗ skip (JS/TS plugins) | ◐ `config.toml` `[hooks.*]` | ◐ `.cursor/hooks.json` |
@@ -143,10 +143,14 @@ A few ✓ cells still change shape on the way out — same content, no loss:
 - **Cursor MCP** — `.cursor/mcp.json` uses the same `mcpServers` shape as Claude,
   down to `${env:…}` references.
 - **Codex memory** — the same markdown lands at `~/.codex/AGENTS.md`.
-- **Skills (Codex & Cursor)** — the same `SKILL.md` (name + description +
-  `scripts/`/`references/`/`assets/`). Codex installs them under `~/.agents/skills/`
-  (enabled by default — no feature flag), Cursor under `.cursor/skills/`, and both
-  also read the shared `.claude/skills/`.
+- **Skills (Codex & Cursor)** — the same skill *directory* per the
+  [Agent Skills](https://agentskills.io) spec: `SKILL.md` (name + description)
+  **plus any bundled `scripts/`/`references/`/`assets/` and nested files**, all
+  carried verbatim (binary included, executable bit preserved) on apply, import,
+  and reconcile — agentsync is not lossy for anything but the directory itself.
+  Codex installs them under `~/.agents/skills/` (enabled by default — no feature
+  flag), Cursor under `.cursor/skills/`, and both also read the shared
+  `.claude/skills/`.
 
 ## Escape hatches
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -69,6 +69,12 @@ plugin: atlassian@anthropic
 Every projected (◐) cell above is a deliberate, reported translation. Here's what
 doesn't carry over.
 
+Note that **MCP/LSP capture is not field-lossy**: native server fields agentsync
+doesn't model (e.g. `timeout`, `disabled`, `cwd`) are preserved verbatim through a
+passthrough `[server.extra]` table on import/reconcile and re-rendered on apply,
+rather than dropped. (`Extra` is verbatim only — `${secret:…}` there is written
+literally, never resolved.)
+
 **OpenCode**
 
 - **Subagent** — Claude's `tools` allowlist is remapped onto OpenCode's

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -47,7 +47,11 @@ The genius of the model is that **drift is just a hash comparison**:
 ### Canonical source (`~/.agentsync/`)
 The single directory you own and (optionally) commit to git. It holds small,
 hand-editable TOML files (one MCP server per file, one plugin per file) plus
-markdown for memory and skills. Override its location with `AGENTSYNC_HOME`.
+markdown for memory and skills. A **skill** follows the [Agent Skills](https://agentskills.io)
+spec — it is a *directory* `skills/<name>/` whose only required member is
+`SKILL.md`, and any bundled `scripts/`, `references/`, `assets/`, or nested files
+are carried verbatim (binary included), not just the `SKILL.md`. Override the
+canonical location with `AGENTSYNC_HOME`.
 There is **no hidden internal representation** — the Go structs that parse these
 TOML files *are* the canonical model.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -234,6 +234,10 @@ first-class. Layout:
 ~/.agentsync/
 ├── agentsync.toml            # agents, update defaults, secrets backend
 ├── mcp/<server>.toml         # one MCP server per file
+├── lsp/<server>.toml         # one LSP server per file
+├── agents/<name>.md          # one subagent per file
+├── commands/<name>.md        # one slash command per file
+├── hooks/<event>.toml        # one hook per file
 ├── marketplaces/<name>.toml  # one marketplace per file
 ├── plugins/<id>.toml         # one plugin enablement per file
 ├── memory/AGENTS.md          # canonical memory (+ fragments/*.md)
@@ -291,6 +295,14 @@ reusable fragments:
 @import ./fragments/style.md
 @import ./fragments/security-rules.md
 ```
+
+When you compose memory from fragments, edit the fragments directly — agentsync
+**will not write memory back the other way**. The agent's native file is the
+*expanded* memory (every `@import` already inlined), and that expansion can't be
+un-done into the original fragments, so `import` skips memory (with a warning) and
+`reconcile` refuses to write a memory edit back when fragments exist — rather than
+silently flatten `AGENTS.md` and orphan the fragment files. A drifted native
+memory still shows in `status`/`diff`; fold the change into `memory/` by hand.
 
 ### Marketplaces & plugins — the fan-out payoff
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -296,13 +296,23 @@ reusable fragments:
 @import ./fragments/security-rules.md
 ```
 
-When you compose memory from fragments, edit the fragments directly — agentsync
-**will not write memory back the other way**. The agent's native file is the
-*expanded* memory (every `@import` already inlined), and that expansion can't be
-un-done into the original fragments, so `import` skips memory (with a warning) and
-`reconcile` refuses to write a memory edit back when fragments exist — rather than
-silently flatten `AGENTS.md` and orphan the fragment files. A drifted native
-memory still shows in `status`/`diff`; fold the change into `memory/` by hand.
+Fragments **round-trip both ways**. On `apply`, agentsync wraps each inlined
+fragment in HTML-comment boundary markers in the native file:
+
+```markdown
+<!-- agentsync:fragment style.md -->
+Be concise.
+<!-- /agentsync:fragment style.md -->
+```
+
+so `import`/`reconcile` can reverse the expansion — a native memory edit *inside*
+a fragment block is captured back into that **fragment file**, and the `@import`
+structure is preserved (the edit is never flattened into `AGENTS.md`). The
+markers read as metadata, not instructions. If the markers are missing (a
+fragment whose own text contains the marker token disables them) or were
+hand-mangled into an unbalanced/ambiguous state, agentsync refuses the write-back
+rather than guess; the drift still shows in `status`/`diff` and you fold it into
+`memory/` by hand.
 
 ### Marketplaces & plugins — the fan-out payoff
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -237,7 +237,9 @@ first-class. Layout:
 ├── marketplaces/<name>.toml  # one marketplace per file
 ├── plugins/<id>.toml         # one plugin enablement per file
 ├── memory/AGENTS.md          # canonical memory (+ fragments/*.md)
-├── skills/<name>/SKILL.md    # standalone skills
+├── skills/<name>/            # a skill is a DIRECTORY: SKILL.md + bundled
+│   ├── SKILL.md              #   scripts/, references/, assets/, nested files —
+│   └── scripts/ …            #   all carried verbatim, executable bit preserved
 └── secrets/secrets.age       # age-encrypted secrets
 ```
 

--- a/internal/adapter/claude/extra.go
+++ b/internal/adapter/claude/extra.go
@@ -1,0 +1,39 @@
+package claude
+
+// ExtraNativeKeys returns the entries of a decoded native config object whose
+// keys are NOT in modeled — the fields agentsync does not represent in its
+// canonical model. Adapters capture these verbatim into source.*Spec.Extra so
+// the dest→source round-trip (import/reconcile) is not lossy for native fields
+// agentsync doesn't understand (e.g. an MCP server's timeout/disabled/cwd).
+// Returns nil when there are none, so an empty Extra omits the canonical
+// [server.extra] table entirely.
+func ExtraNativeKeys(raw map[string]any, modeled ...string) map[string]any {
+	skip := make(map[string]bool, len(modeled))
+	for _, k := range modeled {
+		skip[k] = true
+	}
+	var extra map[string]any
+	for k, v := range raw {
+		if skip[k] {
+			continue
+		}
+		if extra == nil {
+			extra = map[string]any{}
+		}
+		extra[k] = v
+	}
+	return extra
+}
+
+// MergeExtra projects passthrough native fields back into a rendered destination
+// object. A modeled key the renderer already set always wins — Extra never
+// clobbers a field agentsync owns — so a value that was promoted into the model
+// can't be shadowed by a stale Extra copy.
+func MergeExtra(spec, extra map[string]any) {
+	for k, v := range extra {
+		if _, exists := spec[k]; exists {
+			continue
+		}
+		spec[k] = v
+	}
+}

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -173,7 +173,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from CLAUDE.md (verbatim; fragments not de-resolved)
+	// Memory from CLAUDE.md (verbatim, including fragment markers). The reverse-
+	// collapse into AGENTS.md + fragment files happens in the write-back layer
+	// (source.CollapseMemoryMarkers, used by import/reconcile), not here.
 	if data, err := os.ReadFile(p.Memory); err == nil {
 		c.Memory.Body = string(data)
 	}

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/afero"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -48,13 +50,14 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Skills from ~/.claude/skills/<name>/SKILL.md
+	// Skills from ~/.claude/skills/<name>/ (SKILL.md + bundled files)
 	if entries, err := os.ReadDir(p.SkillsDir); err == nil {
 		for _, e := range entries {
 			if !e.IsDir() {
 				continue
 			}
-			data, err := os.ReadFile(filepath.Join(p.SkillsDir, e.Name(), "SKILL.md"))
+			skillDir := filepath.Join(p.SkillsDir, e.Name())
+			data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 			if err != nil {
 				continue
 			}
@@ -62,7 +65,11 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
+			if err != nil {
+				continue
+			}
+			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
 		}
 	}
 

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -44,6 +44,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 					Env:     asStrMap(spec["env"]),
 					URL:     asStr(spec["url"]),
 					Headers: asStrMap(spec["headers"]),
+					Extra:   ExtraNativeKeys(spec, "type", "command", "args", "env", "url", "headers"),
 				}}
 				c.MCPServers = append(c.MCPServers, m)
 			}
@@ -164,6 +165,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 							Env:     asStrMap(spec["env"]),
 							URL:     asStr(spec["url"]),
 							Headers: asStrMap(spec["headers"]),
+							Extra:   ExtraNativeKeys(spec, "command", "args", "env", "url", "headers"),
 						},
 					})
 				}

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -47,6 +47,55 @@ func TestIngest_RoundTripsMCPAndSkills(t *testing.T) {
 	}
 }
 
+// TestIngest_RoundTripsMCPExtra proves unmodeled native MCP fields survive the
+// apply→ingest round-trip via the passthrough Extra map, and that a modeled
+// field is NOT duplicated into Extra.
+func TestIngest_RoundTripsMCPExtra(t *testing.T) {
+	tmp := t.TempDir()
+	in := source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "github",
+			Server: source.MCPServerSpec{
+				Type:    "stdio",
+				Command: "npx",
+				Extra: map[string]any{
+					"timeout":  float64(30), // JSON numbers round-trip as float64
+					"disabled": true,
+					"cwd":      "/work",
+				},
+			},
+		}},
+	}
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("mcp = %d", len(out.MCPServers))
+	}
+	srv := out.MCPServers[0].Server
+	if srv.Command != "npx" {
+		t.Fatalf("modeled command lost: %q", srv.Command)
+	}
+	ex := srv.Extra
+	if ex["timeout"] != float64(30) || ex["disabled"] != true || ex["cwd"] != "/work" {
+		t.Fatalf("unmodeled fields not preserved via Extra: %+v", ex)
+	}
+	for _, k := range []string{"type", "command"} {
+		if _, dup := ex[k]; dup {
+			t.Fatalf("modeled key %q duplicated into Extra: %+v", k, ex)
+		}
+	}
+}
+
 func TestIngest_RoundTripsSubagentsAndCommands(t *testing.T) {
 	tmp := t.TempDir()
 	in := source.Canonical{

--- a/internal/adapter/claude/lsp.go
+++ b/internal/adapter/claude/lsp.go
@@ -39,6 +39,7 @@ func (a *Adapter) renderLSP(c source.Canonical, p Paths) ([]adapter.FileOp, erro
 		if len(lsp.Spec.Headers) > 0 {
 			spec["headers"] = lsp.Spec.Headers
 		}
+		MergeExtra(spec, lsp.Spec.Extra)
 		lspMap[lsp.ID] = spec
 		ownedKeys = append(ownedKeys, "/lspServers/"+lsp.ID)
 	}

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -102,6 +102,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([
 		if len(m.Server.Headers) > 0 {
 			spec["headers"] = m.Server.Headers
 		}
+		MergeExtra(spec, m.Server.Extra)
 		targeted[m.ID] = spec
 	}
 	if len(targeted) == 0 {

--- a/internal/adapter/claude/skill.go
+++ b/internal/adapter/claude/skill.go
@@ -9,20 +9,45 @@ import (
 )
 
 func (a *Adapter) renderSkills(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+	return SkillFileOps(c.Skills, p.SkillsDir)
+}
+
+// SkillFileOps projects each skill into FileOps under skillsDir: the SKILL.md
+// (frontmatter + body) plus one verbatim op per bundled file (scripts/,
+// references/, assets/, …), preserving each bundled file's mode. It is shared
+// by every adapter that writes skills to a skills directory (Claude, OpenCode,
+// Codex) so the "a skill is a directory, not just SKILL.md" projection stays
+// identical across them — when two adapters target the same skills dir, the
+// render pipeline dedupes the byte-identical ops per path.
+func SkillFileOps(skills []source.Skill, skillsDir string) ([]adapter.FileOp, error) {
 	var ops []adapter.FileOp
-	for _, s := range c.Skills {
+	for _, s := range skills {
 		body, err := EncodeFrontmatter(s.Frontmatter, s.Body)
 		if err != nil {
 			return nil, fmt.Errorf("encode skill %s: %w", s.Name, err)
 		}
 		ops = append(ops, adapter.FileOp{
 			Action:        "write",
-			Path:          filepath.Join(p.SkillsDir, s.Name, "SKILL.md"),
+			Path:          filepath.Join(skillsDir, s.Name, "SKILL.md"),
 			Content:       body,
 			Mode:          0o644,
 			SourceID:      filepath.Join("skills", s.Name, "SKILL.md"),
 			MergeStrategy: "replace",
 		})
+		for _, f := range s.Files {
+			mode := f.Mode
+			if mode == 0 {
+				mode = 0o644
+			}
+			ops = append(ops, adapter.FileOp{
+				Action:        "write",
+				Path:          filepath.Join(skillsDir, s.Name, filepath.FromSlash(f.Path)),
+				Content:       f.Content,
+				Mode:          mode,
+				SourceID:      filepath.Join("skills", s.Name, filepath.FromSlash(f.Path)),
+				MergeStrategy: "replace",
+			})
+		}
 	}
 	return ops, nil
 }

--- a/internal/adapter/claude/skill_test.go
+++ b/internal/adapter/claude/skill_test.go
@@ -1,0 +1,103 @@
+package claude_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestSkillFileOps_EmitsBundledOps proves the renderer projects a skill as a
+// whole directory: one op for SKILL.md plus one verbatim op per bundled file,
+// each with the matching dest Path, canonical SourceID, and preserved mode.
+func TestSkillFileOps_EmitsBundledOps(t *testing.T) {
+	skills := []source.Skill{{
+		Name:        "deploy",
+		Frontmatter: map[string]any{"name": "deploy", "description": "ship it"},
+		Body:        "Body.\n",
+		Files: []source.SkillFile{
+			{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\n"), Mode: 0o755},
+			{Path: "references/REF.md", Content: []byte("# ref\n"), Mode: 0o644},
+		},
+	}}
+	ops, err := claude.SkillFileOps(skills, "/root/skills")
+	if err != nil {
+		t.Fatalf("SkillFileOps: %v", err)
+	}
+	byPath := map[string]adapter.FileOp{}
+	for _, op := range ops {
+		byPath[op.Path] = op
+	}
+	if len(ops) != 3 {
+		t.Fatalf("ops = %d, want 3 (%+v)", len(ops), ops)
+	}
+
+	script := byPath[filepath.Join("/root/skills", "deploy", "scripts", "run.sh")]
+	if script.SourceID != filepath.Join("skills", "deploy", "scripts", "run.sh") {
+		t.Fatalf("script SourceID = %q", script.SourceID)
+	}
+	if script.Mode != 0o755 {
+		t.Fatalf("script mode = %o, want 0755", script.Mode)
+	}
+	if string(script.Content) != "#!/bin/sh\n" {
+		t.Fatalf("script content = %q", script.Content)
+	}
+	if _, ok := byPath[filepath.Join("/root/skills", "deploy", "SKILL.md")]; !ok {
+		t.Fatal("SKILL.md op missing")
+	}
+}
+
+// TestIngest_RoundTripsSkillBundledFiles renders a skill with bundled files,
+// applies it, ingests it back, and asserts the directory survives intact —
+// content byte-for-byte and the script's executable bit preserved.
+func TestIngest_RoundTripsSkillBundledFiles(t *testing.T) {
+	tmp := t.TempDir()
+	binary := []byte{0x00, 0x01, 0xff, 0x7f}
+	in := source.Canonical{
+		Skills: []source.Skill{{
+			Name:        "deploy",
+			Frontmatter: map[string]any{"name": "deploy", "description": "ship it"},
+			Body:        "Body.\n",
+			Files: []source.SkillFile{
+				{Path: "assets/logo.png", Content: binary, Mode: 0o644},
+				{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\necho hi\n"), Mode: 0o755},
+			},
+		}},
+	}
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	ops, _, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.Skills) != 1 {
+		t.Fatalf("skills = %d", len(out.Skills))
+	}
+	files := out.Skills[0].Files
+	if len(files) != 2 {
+		t.Fatalf("bundled files lost on round-trip: %+v", files)
+	}
+	for _, f := range files {
+		switch f.Path {
+		case "scripts/run.sh":
+			if f.Mode&0o100 == 0 {
+				t.Fatalf("run.sh lost +x: %o", f.Mode)
+			}
+		case "assets/logo.png":
+			if string(f.Content) != string(binary) {
+				t.Fatalf("binary asset corrupted")
+			}
+		default:
+			t.Fatalf("unexpected bundled file %s", f.Path)
+		}
+	}
+}

--- a/internal/adapter/codex/ingest.go
+++ b/internal/adapter/codex/ingest.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/afero"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
@@ -41,13 +42,14 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Skills from ~/.agents/skills/<name>/SKILL.md
+	// Skills from ~/.agents/skills/<name>/ (SKILL.md + bundled files)
 	if entries, err := os.ReadDir(p.SkillsDir); err == nil {
 		for _, e := range entries {
 			if !e.IsDir() {
 				continue
 			}
-			data, err := os.ReadFile(filepath.Join(p.SkillsDir, e.Name(), "SKILL.md"))
+			skillDir := filepath.Join(p.SkillsDir, e.Name())
+			data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 			if err != nil {
 				continue
 			}
@@ -55,7 +57,11 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
+			if err != nil {
+				continue
+			}
+			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
 		}
 	}
 

--- a/internal/adapter/codex/mcp.go
+++ b/internal/adapter/codex/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -57,6 +58,7 @@ func codexMCPSpec(s source.MCPServerSpec) map[string]any {
 		if len(s.Headers) > 0 {
 			spec["http_headers"] = s.Headers
 		}
+		claude.MergeExtra(spec, s.Extra)
 		return spec
 	}
 	if s.Command != "" {
@@ -68,6 +70,7 @@ func codexMCPSpec(s source.MCPServerSpec) map[string]any {
 	if len(s.Env) > 0 {
 		spec["env"] = s.Env
 	}
+	claude.MergeExtra(spec, s.Extra)
 	return spec
 }
 
@@ -103,6 +106,7 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 		Env:     asStrMap(raw["env"]),
 		URL:     url,
 		Headers: asStrMap(raw["http_headers"]),
+		Extra:   claude.ExtraNativeKeys(raw, "command", "args", "env", "url", "http_headers"),
 	}
 }
 

--- a/internal/adapter/codex/skill.go
+++ b/internal/adapter/codex/skill.go
@@ -1,33 +1,16 @@
 package codex
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// renderSkills writes each canonical skill to ~/.agents/skills/<name>/SKILL.md.
-// Codex reads personal skills from the shared cross-agent ~/.agents/skills
-// directory (not under ~/.codex), with the same frontmatter (name + description)
-// + body format Claude and OpenCode use, so this is a full-fidelity projection.
+// renderSkills writes each skill (SKILL.md plus its bundled scripts/references/
+// assets) to ~/.agents/skills/<name>/. Codex reads personal skills from the
+// shared cross-agent ~/.agents/skills directory (not under ~/.codex), with the
+// same SKILL.md format Claude and OpenCode use, so this is a full-fidelity
+// projection of the whole skill directory.
 func (a *Adapter) renderSkills(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
-	var ops []adapter.FileOp
-	for _, s := range c.Skills {
-		body, err := claude.EncodeFrontmatter(s.Frontmatter, s.Body)
-		if err != nil {
-			return nil, fmt.Errorf("encode skill %s: %w", s.Name, err)
-		}
-		ops = append(ops, adapter.FileOp{
-			Action:        "write",
-			Path:          filepath.Join(p.SkillsDir, s.Name, "SKILL.md"),
-			Content:       body,
-			Mode:          0o644,
-			SourceID:      filepath.Join("skills", s.Name, "SKILL.md"),
-			MergeStrategy: "replace",
-		})
-	}
-	return ops, nil
+	return claude.SkillFileOps(c.Skills, p.SkillsDir)
 }

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/afero"
+	"github.com/tailscale/hujson"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/source"
-	"github.com/tailscale/hujson"
 )
 
 // Ingest reads OpenCode's native config files and returns a partial
@@ -44,13 +46,14 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Skills from ~/.claude/skills/<name>/SKILL.md (shared with Claude)
+	// Skills from ~/.claude/skills/<name>/ (SKILL.md + bundled files; shared with Claude)
 	if entries, err := os.ReadDir(p.ClaudeSkillsDir); err == nil {
 		for _, e := range entries {
 			if !e.IsDir() {
 				continue
 			}
-			data, err := os.ReadFile(filepath.Join(p.ClaudeSkillsDir, e.Name(), "SKILL.md"))
+			skillDir := filepath.Join(p.ClaudeSkillsDir, e.Name())
+			data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
 			if err != nil {
 				continue
 			}
@@ -58,7 +61,11 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
+			if err != nil {
+				continue
+			}
+			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
 		}
 	}
 

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -136,6 +136,7 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 		Env:     asStrMap(raw["environment"]),
 		URL:     asStr(raw["url"]),
 		Headers: asStrMap(raw["headers"]),
+		Extra:   claude.ExtraNativeKeys(raw, "type", "command", "environment", "url", "headers", "enabled"),
 	}
 }
 

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -105,6 +106,7 @@ func opencodeMCPSpec(s source.MCPServerSpec) map[string]any {
 		if len(s.Headers) > 0 {
 			spec["headers"] = s.Headers
 		}
+		claude.MergeExtra(spec, s.Extra)
 		return spec
 	}
 	spec["type"] = "local"
@@ -114,6 +116,7 @@ func opencodeMCPSpec(s source.MCPServerSpec) map[string]any {
 	if len(s.Env) > 0 {
 		spec["environment"] = s.Env
 	}
+	claude.MergeExtra(spec, s.Extra)
 	return spec
 }
 

--- a/internal/adapter/opencode/skill.go
+++ b/internal/adapter/opencode/skill.go
@@ -1,32 +1,15 @@
 package opencode
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// renderSkills writes each skill to the shared .claude/skills/<name>/SKILL.md
-// path that OpenCode reads natively (same as Claude). When both adapters are
-// active, render.Apply dedupes per-path so the file is written once.
+// renderSkills writes each skill (SKILL.md plus its bundled scripts/references/
+// assets) to the shared .claude/skills/<name>/ tree that OpenCode reads
+// natively (same as Claude). When both adapters are active, render.Apply dedupes
+// per-path so each file is written once.
 func (a *Adapter) renderSkills(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
-	var ops []adapter.FileOp
-	for _, s := range c.Skills {
-		body, err := claude.EncodeFrontmatter(s.Frontmatter, s.Body)
-		if err != nil {
-			return nil, fmt.Errorf("encode skill %s: %w", s.Name, err)
-		}
-		ops = append(ops, adapter.FileOp{
-			Action:        "write",
-			Path:          filepath.Join(p.ClaudeSkillsDir, s.Name, "SKILL.md"),
-			Content:       body,
-			Mode:          0o644,
-			SourceID:      filepath.Join("skills", s.Name, "SKILL.md"),
-			MergeStrategy: "replace",
-		})
-	}
-	return ops, nil
+	return claude.SkillFileOps(c.Skills, p.ClaudeSkillsDir)
 }

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -332,3 +332,115 @@ func TestApply_NoFlag_WritesDestinations_M1(t *testing.T) {
 		t.Fatalf("apply in M1 should succeed; got err: %v\n%s", err, out)
 	}
 }
+
+// TestApply_SkillOrphanCleanup verifies apply converges the destination when a
+// skill — or a single bundled file within one — is removed from the canonical
+// source: the leftover dest files (and the empty dirs they leave) are reclaimed,
+// while a destination the user hand-edited is backed up before removal.
+func TestApply_SkillOrphanCleanup(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	srcSkill := filepath.Join(tmp, ".agentsync", "skills", "deploy")
+	writeSkill := func() {
+		_ = os.MkdirAll(filepath.Join(srcSkill, "scripts"), 0o755)
+		_ = os.MkdirAll(filepath.Join(srcSkill, "references"), 0o755)
+		if err := os.WriteFile(filepath.Join(srcSkill, "SKILL.md"), []byte("---\nname: deploy\ndescription: d\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(srcSkill, "scripts", "run.sh"), []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(srcSkill, "references", "REF.md"), []byte("# ref\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	destSkill := filepath.Join(tmp, ".claude", "skills", "deploy")
+	exists := func(p string) bool { _, err := os.Stat(p); return err == nil }
+
+	// 1. Apply the full skill directory.
+	writeSkill()
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 1: %v\n%s", err, out)
+	}
+	for _, rel := range []string{"SKILL.md", "scripts/run.sh", "references/REF.md"} {
+		if !exists(filepath.Join(destSkill, filepath.FromSlash(rel))) {
+			t.Fatalf("apply 1 did not write %s", rel)
+		}
+	}
+
+	// 2. Remove a single bundled file from source; apply must reclaim it and
+	//    prune the now-empty references/ dir, leaving the rest intact.
+	if err := os.RemoveAll(filepath.Join(srcSkill, "references")); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 2: %v\n%s", err, out)
+	}
+	if exists(filepath.Join(destSkill, "references", "REF.md")) {
+		t.Fatal("orphaned bundled file references/REF.md was not deleted")
+	}
+	if exists(filepath.Join(destSkill, "references")) {
+		t.Fatal("empty references/ dir was not pruned")
+	}
+	if !exists(filepath.Join(destSkill, "SKILL.md")) || !exists(filepath.Join(destSkill, "scripts", "run.sh")) {
+		t.Fatal("apply 2 wrongly removed surviving skill files")
+	}
+
+	// 3. Remove the whole skill from source; apply must reclaim the entire
+	//    destination directory.
+	if err := os.RemoveAll(srcSkill); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 3: %v\n%s", err, out)
+	}
+	if exists(destSkill) {
+		t.Fatalf("orphaned skill directory %s was not removed", destSkill)
+	}
+	// The skills root itself must survive (it may hold other skills).
+	if !exists(filepath.Join(tmp, ".claude", "skills")) {
+		t.Fatal("skills root was wrongly pruned")
+	}
+
+	// 4. Drift: re-apply, hand-edit the dest SKILL.md, then remove the source
+	//    skill. Apply must back the edit up before deleting it.
+	writeSkill()
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 4: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(destSkill, "SKILL.md"), []byte("HAND EDITED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(srcSkill); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 5: %v\n%s", err, out)
+	}
+	if exists(destSkill) {
+		t.Fatal("drifted orphan skill was not removed")
+	}
+	if !backupContains(t, filepath.Join(tmp, ".agentsync", ".state", "backups"), "HAND EDITED\n") {
+		t.Fatal("hand-edited skill file was deleted without a backup")
+	}
+}
+
+// backupContains reports whether any file under root has the given content.
+func backupContains(t *testing.T, root, want string) bool {
+	t.Helper()
+	found := false
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr == nil && string(data) == want {
+			found = true
+		}
+		return nil
+	})
+	return found
+}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -853,6 +853,15 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 	if strings.TrimSpace(c.Memory.Body) == "" {
 		return nil, nil
 	}
+	// The ingested memory is the fully EXPANDED destination file. If the
+	// canonical memory is fragment-composed, writing that back would inline
+	// every @import and orphan the fragment files — so skip with a warning
+	// rather than silently flatten the user's structure. (Ingest cannot
+	// de-resolve which inlined text came from which fragment.)
+	if source.MemoryHasFragments(home) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — canonical memory uses fragments/ (memory/AGENTS.md @imports them) and the imported memory is fully expanded; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.\n")
+		return nil, nil
+	}
 	if !dryRun {
 		if err := source.WriteMemory(home, c.Memory); err != nil {
 			return nil, fmt.Errorf("write memory: %w", err)

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -853,18 +853,32 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 	if strings.TrimSpace(c.Memory.Body) == "" {
 		return nil, nil
 	}
-	// The ingested memory is the fully EXPANDED destination file. If the
-	// canonical memory is fragment-composed, writing that back would inline
-	// every @import and orphan the fragment files — so skip with a warning
-	// rather than silently flatten the user's structure. (Ingest cannot
-	// de-resolve which inlined text came from which fragment.)
-	if source.MemoryHasFragments(home) {
-		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — canonical memory uses fragments/ (memory/AGENTS.md @imports them) and the imported memory is fully expanded; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.\n")
+	// The ingested memory is the rendered destination file. If apply wrote
+	// fragment markers, reverse them back into AGENTS.md + the fragment files so
+	// the round-trip is not lossy; otherwise fall back to the guard.
+	mem, hadMarkers, err := source.CollapseMemoryMarkers(c.Memory.Body)
+	switch {
+	case err != nil:
+		// Markers present but malformed/ambiguous — skip rather than guess.
+		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — fragment markers could not be reversed (%v). Reconcile memory/ by hand, then apply.\n", err)
 		return nil, nil
-	}
-	if !dryRun {
-		if err := source.WriteMemory(home, c.Memory); err != nil {
-			return nil, fmt.Errorf("write memory: %w", err)
+	case hadMarkers:
+		if !dryRun {
+			if werr := source.WriteMemory(home, mem); werr != nil {
+				return nil, fmt.Errorf("write memory: %w", werr)
+			}
+		}
+	case source.MemoryHasFragments(home):
+		// No markers (collision/legacy) but the source is fragment-composed:
+		// writing the expanded body would inline the @imports and orphan the
+		// fragment files — skip with a warning rather than flatten silently.
+		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — canonical memory uses fragments/ and the imported memory has no reversible markers; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.\n")
+		return nil, nil
+	default:
+		if !dryRun {
+			if werr := source.WriteMemory(home, c.Memory); werr != nil {
+				return nil, fmt.Errorf("write memory: %w", werr)
+			}
 		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s memory/AGENTS.md\n", importVerb(dryRun))

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -620,6 +620,50 @@ func TestImport_MemoryFromClaude(t *testing.T) {
 	}
 }
 
+// TestImport_MemorySkippedWhenSourceUsesFragments guards the silent flatten-and-
+// orphan hazard: if the canonical memory is fragment-composed, importing the
+// (fully expanded) destination CLAUDE.md must NOT overwrite memory/AGENTS.md —
+// that would inline the @imports and orphan the fragment files. Import skips it
+// with a warning and leaves the source untouched.
+func TestImport_MemorySkippedWhenSourceUsesFragments(t *testing.T) {
+	tmp, env := importTestEnv(t)
+
+	// Canonical memory composed of a fragment.
+	memDir := filepath.Join(tmp, ".agentsync", "memory")
+	fragDir := filepath.Join(memDir, "fragments")
+	if err := os.MkdirAll(fragDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcAgents := "# Memory\n@import ./fragments/style.md\n"
+	if err := os.WriteFile(filepath.Join(memDir, "AGENTS.md"), []byte(srcAgents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fragDir, "style.md"), []byte("Be concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A native (expanded) CLAUDE.md to import.
+	if err := os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".claude", "CLAUDE.md"), []byte("# Memory\nBe concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:memory")
+	if err != nil {
+		t.Fatalf("import should not error, just skip memory: %v\n%s", err, out)
+	}
+	// Source AGENTS.md must be untouched (still references the fragment).
+	got, _ := os.ReadFile(filepath.Join(memDir, "AGENTS.md"))
+	if string(got) != srcAgents {
+		t.Fatalf("fragment-composed memory was flattened by import: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(fragDir, "style.md")); err != nil {
+		t.Fatalf("fragment file was orphaned/removed: %v", err)
+	}
+}
+
 // TestImport_AllMCPFromClaude verifies the bulk component form: import
 // claude:mcp (no name) captures every native MCP server in one pass.
 func TestImport_AllMCPFromClaude(t *testing.T) {

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -599,6 +599,65 @@ func TestImport_LSPFromClaude(t *testing.T) {
 	}
 }
 
+// TestImport_MemoryReversesFragmentEdit is the bidirectional payoff: apply
+// writes fragment markers into the native memory file; a hand-edit inside a
+// fragment block is reversed by `import` back into the fragment FILE (not
+// flattened into AGENTS.md), and the @import structure survives.
+func TestImport_MemoryReversesFragmentEdit(t *testing.T) {
+	tmp, env := importTestEnv(t)
+
+	memDir := filepath.Join(tmp, ".agentsync", "memory")
+	fragDir := filepath.Join(memDir, "fragments")
+	if err := os.MkdirAll(fragDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcAgents := "# Memory\n@import ./fragments/style.md\n"
+	if err := os.WriteFile(filepath.Join(memDir, "AGENTS.md"), []byte(srcAgents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fragDir, "style.md"), []byte("Be concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// apply renders the marked memory to the native file.
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".claude", "CLAUDE.md")
+	rendered, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rendered), "<!-- agentsync:fragment style.md -->") {
+		t.Fatalf("apply did not emit fragment markers:\n%s", rendered)
+	}
+
+	// Hand-edit the content INSIDE the fragment block, then import it back.
+	edited := strings.Replace(string(rendered), "Be concise.", "Be very concise.", 1)
+	if edited == string(rendered) {
+		t.Fatal("test setup: fragment content not found in rendered memory")
+	}
+	if err := os.WriteFile(dest, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:memory"); err != nil {
+		t.Fatalf("import: %v\n%s", err, out)
+	}
+
+	// The edit landed in the FRAGMENT file; AGENTS.md still @imports it.
+	frag, _ := os.ReadFile(filepath.Join(fragDir, "style.md"))
+	if string(frag) != "Be very concise.\n" {
+		t.Fatalf("fragment not updated by reverse-collapse: %q", frag)
+	}
+	agents, _ := os.ReadFile(filepath.Join(memDir, "AGENTS.md"))
+	if !strings.Contains(string(agents), "@import ./fragments/style.md") {
+		t.Fatalf("AGENTS.md lost its @import (flattened): %q", agents)
+	}
+	if strings.Contains(string(agents), "Be very concise") {
+		t.Fatalf("edit was flattened into AGENTS.md instead of the fragment: %q", agents)
+	}
+}
+
 // TestImport_MemoryFromClaude round-trips CLAUDE.md into memory/AGENTS.md.
 func TestImport_MemoryFromClaude(t *testing.T) {
 	tmp, env := importTestEnv(t)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/adapter/codex"
 	"github.com/spxrogers/agentsync/internal/adapter/opencode"
 	"github.com/spxrogers/agentsync/internal/capture"
@@ -681,6 +682,12 @@ func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 			}
 			if err := json.Unmarshal(specBytes, &spec); err != nil {
 				return fmt.Errorf("unmarshal mcp spec %s: %w", serverID, err)
+			}
+			// json.Unmarshal into the struct drops unmodeled native keys; capture
+			// them into Extra so write-back is not field-lossy (matching ingest and
+			// the opencode/codex branches above).
+			if rawMap, ok := specRaw.(map[string]any); ok {
+				spec.Extra = claude.ExtraNativeKeys(rawMap, "type", "command", "args", "env", "url", "headers")
 			}
 		}
 		// The spec was reconstructed from the destination, where apply wrote any

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -722,6 +722,13 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	if strings.HasSuffix(srcID, "(multiple)") {
 		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)
 	}
+	// Same hazard for fragment-composed memory: the rendered op's SourceID is
+	// the single "memory/AGENTS.md" (never the "(multiple)" marker), but the
+	// dest is the fully expanded memory. Writing it back would inline every
+	// @import and orphan the fragment files, so refuse.
+	if filepath.ToSlash(srcID) == "memory/AGENTS.md" && source.MemoryHasFragments(home) {
+		return fmt.Errorf("write-back for %s is unsafe: canonical memory is composed of fragments/, and the dest is the fully expanded memory. Persisting it would inline every @import and orphan the fragments. Edit the fragments under %s/memory/ directly, then apply", it.op.Path, home)
+	}
 	dest := filepath.Join(home, srcID)
 	// Defense-in-depth: srcID derives from a component Name, and AtomicWrite
 	// does no containment check. A "../" segment in the name would let this

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -729,12 +729,22 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	if strings.HasSuffix(srcID, "(multiple)") {
 		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)
 	}
-	// Same hazard for fragment-composed memory: the rendered op's SourceID is
-	// the single "memory/AGENTS.md" (never the "(multiple)" marker), but the
-	// dest is the fully expanded memory. Writing it back would inline every
-	// @import and orphan the fragment files, so refuse.
-	if filepath.ToSlash(srcID) == "memory/AGENTS.md" && source.MemoryHasFragments(home) {
-		return fmt.Errorf("write-back for %s is unsafe: canonical memory is composed of fragments/, and the dest is the fully expanded memory. Persisting it would inline every @import and orphan the fragments. Edit the fragments under %s/memory/ directly, then apply", it.op.Path, home)
+	// Memory is fragment-aware. If apply wrote fragment markers, reverse them
+	// into AGENTS.md + the fragment files instead of writing the expanded dest
+	// verbatim (which would put markers in the source and never restore the
+	// fragments). With no markers but a fragment-composed source, writing back
+	// would inline every @import and orphan the fragments — refuse.
+	if filepath.ToSlash(srcID) == "memory/AGENTS.md" {
+		mem, hadMarkers, cerr := source.CollapseMemoryMarkers(string(data))
+		switch {
+		case cerr != nil:
+			return fmt.Errorf("write-back for %s is unsafe: memory fragment markers could not be reversed (%w); reconcile memory/ by hand, then apply", it.op.Path, cerr)
+		case hadMarkers:
+			return source.WriteMemory(home, mem)
+		case source.MemoryHasFragments(home):
+			return fmt.Errorf("write-back for %s is unsafe: canonical memory is composed of fragments/ and the dest has no reversible markers. Persisting it would inline every @import and orphan the fragments. Edit the fragments under %s/memory/ directly, then apply", it.op.Path, home)
+		}
+		// No fragments: fall through to the plain verbatim write below.
 	}
 	dest := filepath.Join(home, srcID)
 	// Defense-in-depth: srcID derives from a component Name, and AtomicWrite

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -733,7 +733,15 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	if !withinDir(home, dest) {
 		return fmt.Errorf("write-back for %s escapes the source tree %s (SourceID %q has a traversal segment); refusing", it.op.Path, home, srcID)
 	}
-	return iox.AtomicWrite(dest, data, 0o644)
+	// Preserve the rendering op's mode so an executable bundled skill script
+	// (scripts/*.sh, scripts/*.py) keeps its +x bit through write-back. Text
+	// components (subagents/commands/memory) render with Mode 0o644, so this is
+	// a no-op for them; only bundled skill files carry a non-default mode.
+	mode := os.FileMode(it.op.Mode)
+	if mode == 0 {
+		mode = 0o644
+	}
+	return iox.AtomicWrite(dest, data, mode)
 }
 
 // withinDir reports whether path is dir itself or sits lexically inside it,

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/source"
@@ -85,7 +86,7 @@ func projectWithFuncs(entry PluginEntry, cacheDir string, readFile func(string) 
 			return pr, err
 		}
 	}
-	if err := applyEntryOverrides(entry, &pr, cacheDir, readFile); err != nil {
+	if err := applyEntryOverrides(entry, &pr, cacheDir, readFile, listDir); err != nil {
 		return pr, err
 	}
 	strict := entry.Strict == nil || *entry.Strict
@@ -281,7 +282,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		if err != nil {
 			return err
 		}
-		skill, err := loadSkillEntry(p, readFile)
+		skill, err := loadSkillEntry(p, readFile, listDir)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -343,7 +344,7 @@ func discoverSkillDirs(skillsDir string, listDir func(string) ([]os.DirEntry, er
 
 // applyEntryOverrides merges component fields from a PluginEntry into an
 // already-seeded ProjectionResult (strict mode overlay).
-func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error)) error {
+func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) error {
 	for name, raw := range entry.MCPServers {
 		spec := parseMCPSpec(raw, cacheDir)
 		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
@@ -357,7 +358,7 @@ func applyEntryOverrides(entry PluginEntry, pr *ProjectionResult, cacheDir strin
 		if err != nil {
 			return err
 		}
-		skill, err := loadSkillEntry(p, readFile)
+		skill, err := loadSkillEntry(p, readFile, listDir)
 		if err != nil {
 			return fmt.Errorf("load skill %q: %w", sk, err)
 		}
@@ -406,7 +407,14 @@ type markdownEntry struct {
 // SKILL.md or a SKILL.md file directly. Returns nil (no error) if the file is
 // simply missing — the caller should skip that entry with a warning.
 // Returns an error only for real I/O problems or malformed frontmatter.
-func loadSkillEntry(path string, readFile func(string) ([]byte, error)) (*source.Skill, error) {
+//
+// A skill is a DIRECTORY, not just SKILL.md: when listDir is non-nil, every
+// other file under the skill directory (scripts/, references/, assets/, nested
+// files) is captured verbatim into Skill.Files so a plugin-bundled skill is not
+// lossy on apply. listDir is nil only on the ProjectWithReader/in-memory path
+// (tests), where bundled-file capture is disabled just like convention-based
+// discovery.
+func loadSkillEntry(path string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) (*source.Skill, error) {
 	// Try directory convention first: <path>/SKILL.md
 	skillPath := filepath.Join(path, "SKILL.md")
 	data, err := readFile(skillPath)
@@ -444,7 +452,74 @@ func loadSkillEntry(path string, readFile func(string) ([]byte, error)) (*source
 		return nil, err
 	}
 
-	return &source.Skill{Name: name, Frontmatter: fm, Body: body}, nil
+	var files []source.SkillFile
+	if listDir != nil {
+		files, err = collectSkillFiles(filepath.Dir(skillPath), readFile, listDir)
+		if err != nil {
+			return nil, fmt.Errorf("collect bundled files for skill %q: %w", name, err)
+		}
+	}
+
+	return &source.Skill{Name: name, Frontmatter: fm, Body: body, Files: files}, nil
+}
+
+// collectSkillFiles recursively gathers every regular file under skillDir other
+// than SKILL.md into source.SkillFile entries (slash-separated relative path,
+// preserved mode), sorted by path. It is the projection-layer analog of
+// source.ReadSkillFiles, implemented over the injected readFile/listDir funcs so
+// the in-memory test path can opt out by passing a nil listDir. Symlinks are
+// skipped — a fetched plugin repo is untrusted, and following a symlink (e.g.
+// skills/x/evil -> /etc) must never pull foreign content into the projection.
+func collectSkillFiles(skillDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) ([]source.SkillFile, error) {
+	var files []source.SkillFile
+	var walk func(dir string) error
+	walk = func(dir string) error {
+		entries, err := listDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, e := range entries {
+			if e.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			full := filepath.Join(dir, e.Name())
+			if e.IsDir() {
+				if err := walk(full); err != nil {
+					return err
+				}
+				continue
+			}
+			if !e.Type().IsRegular() {
+				continue
+			}
+			rel, err := filepath.Rel(skillDir, full)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(rel)
+			if rel == "SKILL.md" {
+				continue
+			}
+			data, err := readFile(full)
+			if err != nil {
+				return err
+			}
+			mode := uint32(0o644)
+			if info, infoErr := e.Info(); infoErr == nil {
+				mode = uint32(info.Mode().Perm())
+			}
+			files = append(files, source.SkillFile{Path: rel, Content: data, Mode: mode})
+		}
+		return nil
+	}
+	if err := walk(skillDir); err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
 }
 
 // loadMarkdownEntry reads a markdown file at path. Returns nil (no error) if

--- a/internal/marketplace/projection_internal_test.go
+++ b/internal/marketplace/projection_internal_test.go
@@ -77,7 +77,7 @@ func TestLoadComponentEntry_RejectsTraversalName(t *testing.T) {
 	if _, err := loadMarkdownEntry("cmd.md", readFile); err == nil {
 		t.Fatal("expected loadMarkdownEntry to reject a traversal name")
 	}
-	if _, err := loadSkillEntry("skills/x", readFile); err == nil {
+	if _, err := loadSkillEntry("skills/x", readFile, nil); err == nil {
 		t.Fatal("expected loadSkillEntry to reject a traversal name")
 	}
 }

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -136,6 +136,61 @@ func TestProject_StrictPluginJSON_MultipleComponents(t *testing.T) {
 	}
 }
 
+// TestProject_SkillBundledFiles proves a plugin-bundled skill is projected as a
+// DIRECTORY: scripts/, references/, and nested files come along (with the
+// script's executable bit preserved), not just SKILL.md. This is the plugin/
+// apply-path guard against the "only SKILL.md survives" lossiness bug.
+func TestProject_SkillBundledFiles(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"x","skills":["pdf"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillDir := filepath.Join(cache, "pdf")
+	if err := os.MkdirAll(filepath.Join(skillDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: pdf\ndescription: pdfs\n---\nBody.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "scripts", "extract.py"), []byte("print('hi')\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "references", "REF.md"), []byte("# ref\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "x"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Skills) != 1 {
+		t.Fatalf("skills = %d, want 1", len(pr.Skills))
+	}
+	files := pr.Skills[0].Files
+	if len(files) != 2 {
+		t.Fatalf("bundled files = %d, want 2: %+v", len(files), files)
+	}
+	byPath := map[string]uint32{}
+	for _, f := range files {
+		byPath[f.Path] = f.Mode
+	}
+	if _, ok := byPath["references/REF.md"]; !ok {
+		t.Fatalf("references/REF.md not projected: %+v", files)
+	}
+	if mode, ok := byPath["scripts/extract.py"]; !ok {
+		t.Fatalf("scripts/extract.py not projected: %+v", files)
+	} else if mode&0o100 == 0 {
+		t.Fatalf("scripts/extract.py lost +x: %o", mode)
+	}
+}
+
 func TestProject_NonStrict_EntryComponents(t *testing.T) {
 	cache := t.TempDir()
 	f := false

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -379,6 +379,7 @@ func Apply(
 
 	var allReports []CollisionReport
 	seen := map[string][]byte{}
+	deletedSkillOrphans := map[string]struct{}{}
 	for _, name := range reg.Names() {
 		res, ok := p.PerAgent[name]
 		if !ok {
@@ -416,6 +417,17 @@ func Apply(
 				seen[op.Path] = op.Content
 			}
 			deduped = append(deduped, op)
+		}
+		// Reclaim skill files (a whole skill, or a single bundled file) that
+		// this agent owns in state but the source no longer renders. Deduped by
+		// path across agents that share a skills dir (claude + opencode →
+		// .claude/skills/), since the first agent's writer already removed it.
+		for _, del := range skillOrphanDeletes(st, userHome, name, scope, project, res.Ops) {
+			if _, done := deletedSkillOrphans[del.Path]; done {
+				continue
+			}
+			deletedSkillOrphans[del.Path] = struct{}{}
+			deduped = append(deduped, del)
 		}
 		w := NewWriter(st, home, userHome, scope, project, name)
 		err := a.Apply(deduped, w)

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -138,6 +138,56 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 	return out
 }
 
+// skillOrphanDeletes returns delete FileOps for skill files this agent owns in
+// state — entries whose SourceID is under "skills/" — that the current plan no
+// longer renders. It is how `apply` converges a destination when a whole skill,
+// or a single bundled file within one, is removed from the canonical source:
+// the leftover dest file is removed instead of lingering forever.
+//
+// Scoped deliberately to skills (the Agent Skills spec treats a skill as a whole
+// directory, so removal must reclaim the whole tree). Other replace-strategy
+// components (subagents/commands) keep their established reconcile-driven
+// cleanup. Each op carries the state SourceID + Mode so the writer can back up a
+// drifted dest before deleting and bound empty-directory pruning to the skills
+// root. Sorted deepest-path-first so a directory empties out before it is pruned.
+func skillOrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) []adapter.FileOp {
+	if s == nil {
+		return nil
+	}
+	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	rendered := map[string]struct{}{}
+	for _, op := range ops {
+		if op.Action != "" && op.Action != "write" {
+			continue
+		}
+		if IsKeyMerge(op.MergeStrategy) {
+			continue
+		}
+		rendered[paths.HomeRelative(userHome, op.Path)] = struct{}{}
+	}
+	var out []adapter.FileOp
+	for key, entry := range s.Files {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		if !strings.HasPrefix(entry.SourceID, "skills/") {
+			continue
+		}
+		path := strings.TrimPrefix(key, prefix)
+		if _, ok := rendered[path]; ok {
+			continue
+		}
+		out = append(out, adapter.FileOp{
+			Action:   "delete",
+			Path:     paths.FromHomeRelative(userHome, path),
+			SourceID: entry.SourceID,
+			Mode:     entry.Mode,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path > out[j].Path })
+	return out
+}
+
 // RecordOpsState updates s with hashes for files and keys produced by ops.
 // Caller is expected to call this AFTER a successful Apply.
 //

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -193,11 +195,76 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 }
 
 // Delete satisfies adapter.DestWriter. Idempotent on missing files.
+//
+// Skill-orphan deletes (op.SourceID under "skills/", synthesized by Apply when a
+// skill or bundled file is removed from source) get two extra guarantees: a dest
+// that drifted from what agentsync last wrote is backed up before removal (the
+// never-destroy-unsynced-content invariant the write path enforces), and empty
+// skill directories left behind are pruned up to — but never including — the
+// agent's skills root. Other delete callers (agent disable --purge, reconcile
+// orphan removal) pass an empty SourceID and keep the plain idempotent remove.
 func (w *Writer) Delete(op adapter.FileOp) error {
+	if w.dryRun {
+		return nil
+	}
+	skillOrphan := strings.HasPrefix(op.SourceID, "skills/")
+	if skillOrphan {
+		if err := w.backupOrphanIfDrifted(op); err != nil {
+			return err
+		}
+	}
 	if err := os.Remove(op.Path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete %s: %w", op.Path, err)
 	}
+	if skillOrphan {
+		pruneEmptySkillDirs(op.Path, op.SourceID)
+	}
 	return nil
+}
+
+// backupOrphanIfDrifted copies a soon-to-be-deleted skill file to the backup
+// root iff its on-disk content is not exactly what agentsync last wrote (i.e.
+// the user hand-edited it). A file matching our last-applied hash is our own
+// output and is removed without a backup; anything else is preserved first so an
+// orphan delete can never silently destroy an unsynced edit.
+func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) error {
+	existing, err := os.ReadFile(op.Path)
+	if err != nil {
+		return nil // already gone (or unreadable): nothing to preserve
+	}
+	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
+		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
+	if entry, owned := w.state.Files[stateKey]; owned {
+		sum := sha256.Sum256(existing)
+		if hex.EncodeToString(sum[:]) == entry.SHA256 {
+			return nil // unchanged since our last apply — safe to delete
+		}
+	}
+	dest, err := w.backup(op.Path, existing)
+	if err != nil {
+		return err
+	}
+	w.reports = append(w.reports, CollisionReport{Agent: w.agent, Path: op.Path, BackupTo: dest})
+	return nil
+}
+
+// pruneEmptySkillDirs removes now-empty directories left after deleting a skill
+// file, walking up from the file toward the skills root and stopping at the
+// first non-empty directory (os.Remove fails on a non-empty dir) or at the root
+// itself. The root is derived from sourceID ("skills/<name>/<rest>"): the dest
+// has exactly that many path components below it, so stripping them yields the
+// agent's skills directory, which is never removed.
+func pruneEmptySkillDirs(absPath, sourceID string) {
+	below := len(strings.Split(filepath.ToSlash(sourceID), "/")) - 1
+	root := absPath
+	for i := 0; i < below; i++ {
+		root = filepath.Dir(root)
+	}
+	for dir := filepath.Dir(absPath); len(dir) > len(root) && dir != root; dir = filepath.Dir(dir) {
+		if err := os.Remove(dir); err != nil {
+			return // non-empty (holds untracked files) or error: stop
+		}
+	}
 }
 
 // maybeBackup performs the foreign-collision check and conditionally

--- a/internal/render/writer_internal_test.go
+++ b/internal/render/writer_internal_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -8,6 +9,55 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// TestPruneEmptySkillDirs_StopsAtSkillsRoot locks the boundary math: emptied
+// directories below the skills root are removed, the skills root and any
+// non-empty ancestor survive, and the SourceID's depth alone decides where to
+// stop (so the function never walks above the skill it owns).
+func TestPruneEmptySkillDirs_StopsAtSkillsRoot(t *testing.T) {
+	root := t.TempDir()
+	skills := filepath.Join(root, ".claude", "skills")
+	deep := filepath.Join(skills, "deploy", "scripts")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSh := filepath.Join(deep, "run.sh")
+	if err := os.WriteFile(runSh, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the delete, then prune.
+	if err := os.Remove(runSh); err != nil {
+		t.Fatal(err)
+	}
+	pruneEmptySkillDirs(runSh, "skills/deploy/scripts/run.sh")
+
+	if _, err := os.Stat(filepath.Join(skills, "deploy")); !os.IsNotExist(err) {
+		t.Fatalf("empty skill dir was not pruned: %v", err)
+	}
+	if _, err := os.Stat(skills); err != nil {
+		t.Fatalf("skills root must survive pruning: %v", err)
+	}
+}
+
+// TestPruneEmptySkillDirs_KeepsNonEmptyDirs ensures a directory that still holds
+// other (e.g. untracked) files is never removed.
+func TestPruneEmptySkillDirs_KeepsNonEmptyDirs(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, ".agents", "skills", "deploy")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removed := filepath.Join(skillDir, "SKILL.md")
+	kept := filepath.Join(skillDir, "user-notes.txt")
+	if err := os.WriteFile(kept, []byte("mine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pruneEmptySkillDirs(removed, "skills/deploy/SKILL.md")
+
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("non-empty skill dir holding an untracked file was wrongly pruned: %v", err)
+	}
+}
 
 // TestOwnedKeysFor_DisambiguatesColonPaths is the regression for the colon-
 // ambiguity bug PruneStaleState/orphanCleanupOps were hardened against but

--- a/internal/secrets/leakscan.go
+++ b/internal/secrets/leakscan.go
@@ -106,7 +106,82 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 		}
 		return s
 	})
+
+	// Passthrough Extra is verbatim and NOT secret-walked (see
+	// source.MCPServerSpec.Extra), so the walk above can't see it. Scan it
+	// separately for the VALUE shape: a live vault secret value appearing in an
+	// Extra field that its source counterpart did not already hold — a resolved
+	// secret a native tool duplicated into an unmodeled field — must not be
+	// persisted as cleartext.
+	scanExtraResidual(ingested, against, "", secretVals, flag)
 	return leaks
+}
+
+// scanExtraResidual flags any secretGroup whose ingested passthrough Extra holds
+// a live vault secret value the source counterpart's Extra did not — the only
+// way a resolved secret can reach the verbatim, non-walked Extra. Recurses the
+// Project overlay so a project-scoped server is covered too.
+func scanExtraResidual(ingested, against *source.Canonical, scope string, secretVals map[string]string, flag func(secretGroup)) {
+	if ingested == nil {
+		return
+	}
+	srcMCP, srcLSP := map[string]string{}, map[string]string{}
+	if against != nil {
+		for _, m := range against.MCPServers {
+			srcMCP[m.ID] = joinExtraStrings(m.Server.Extra)
+		}
+		for _, l := range against.LSPServers {
+			srcLSP[l.ID] = joinExtraStrings(l.Spec.Extra)
+		}
+	}
+	scan := func(kind, id, srcExtra string, extra map[string]any) {
+		var ss []string
+		extraStrings(extra, &ss)
+		for _, s := range ss {
+			for v := range secretVals {
+				if v != "" && strings.Contains(s, v) && !strings.Contains(srcExtra, v) {
+					flag(secretGroup{scope: scope, kind: kind, id: id})
+					return
+				}
+			}
+		}
+	}
+	for _, m := range ingested.MCPServers {
+		scan("mcp", m.ID, srcMCP[m.ID], m.Server.Extra)
+	}
+	for _, l := range ingested.LSPServers {
+		scan("lsp", l.ID, srcLSP[l.ID], l.Spec.Extra)
+	}
+	if ingested.Project != nil {
+		var ap *source.Canonical
+		if against != nil {
+			ap = against.Project
+		}
+		scanExtraResidual(ingested.Project, ap, "project", secretVals, flag)
+	}
+}
+
+// extraStrings recursively collects every string leaf in a passthrough Extra
+// value (string, slice element, or nested-map value).
+func extraStrings(v any, out *[]string) {
+	switch t := v.(type) {
+	case string:
+		*out = append(*out, t)
+	case []any:
+		for _, e := range t {
+			extraStrings(e, out)
+		}
+	case map[string]any:
+		for _, e := range t {
+			extraStrings(e, out)
+		}
+	}
+}
+
+func joinExtraStrings(extra map[string]any) string {
+	var ss []string
+	extraStrings(extra, &ss)
+	return strings.Join(ss, "\x00")
 }
 
 // fieldRetainsRotatedSecret reports whether `ingested` matches the literal

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -315,3 +315,44 @@ func TestReReferenceCanonical_ProjectOverlay(t *testing.T) {
 		t.Errorf("user-scope non-secret field corrupted by project-scope match: got %q", got)
 	}
 }
+
+// TestResidualSecretCleartext_ExtraValue covers the passthrough-Extra leak
+// backstop: a live vault secret value that appears in an unmodeled Extra field
+// (never secret-walked or re-referenced) must be refused, while a literal the
+// source Extra already held is not a new leak. Env is shown already restored to
+// its placeholder by re-reference, so the ONLY residual cleartext is in Extra.
+func TestResidualSecretCleartext_ExtraValue(t *testing.T) {
+	sec := fakeResolver{"TOKEN": "tok_LIVE"}
+	env := fakeResolver{}
+
+	ingested := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "github",
+			Server: source.MCPServerSpec{
+				Type:  "stdio",
+				Env:   map[string]string{"TOKEN": "${secret:TOKEN}"}, // re-referenced
+				Extra: map[string]any{"authMirror": "tok_LIVE"},      // resolved value lingers here
+			},
+		}},
+	}
+	against := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "github",
+			Server: source.MCPServerSpec{
+				Type: "stdio",
+				Env:  map[string]string{"TOKEN": "${secret:TOKEN}"},
+				// Extra empty in source — the value is newly appearing.
+			},
+		}},
+	}
+	if leaks := ResidualSecretCleartext(ingested, against, sec, env); len(leaks) == 0 {
+		t.Fatal("expected refusal: a live secret value in Extra must be flagged")
+	}
+
+	// Now the literal was ALREADY in source Extra (a deliberate, pre-existing
+	// literal that happens to equal the value) → not a new leak.
+	against.MCPServers[0].Server.Extra = map[string]any{"authMirror": "tok_LIVE"}
+	if leaks := ResidualSecretCleartext(ingested, against, sec, env); len(leaks) != 0 {
+		t.Fatalf("pre-existing source Extra literal must not be flagged, got %v", leaks)
+	}
+}

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -82,6 +82,7 @@ func cloneMCPServers(in []source.MCPServer) []source.MCPServer {
 		m.Server.Args = append([]string(nil), m.Server.Args...)
 		m.Server.Env = cloneStrMap(m.Server.Env)
 		m.Server.Headers = cloneStrMap(m.Server.Headers)
+		m.Server.Extra = cloneAnyMap(m.Server.Extra)
 		out[i] = m
 	}
 	return out
@@ -96,6 +97,7 @@ func cloneLSPServers(in []source.LSPServer) []source.LSPServer {
 		l.Spec.Args = append([]string(nil), l.Spec.Args...)
 		l.Spec.Env = cloneStrMap(l.Spec.Env)
 		l.Spec.Headers = cloneStrMap(l.Spec.Headers)
+		l.Spec.Extra = cloneAnyMap(l.Spec.Extra)
 		out[i] = l
 	}
 	return out
@@ -106,6 +108,21 @@ func cloneStrMap(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// cloneAnyMap detaches the top level of a passthrough Extra map so the resolved
+// copy does not alias the caller's templated source. Resolve never mutates Extra
+// (it is not secret-walked), so a shallow copy is sufficient to keep the two
+// models independent.
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
 	for k, v := range in {
 		out[k] = v
 	}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -192,7 +193,8 @@ func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
 		if !e.IsDir() {
 			continue
 		}
-		raw, err := afero.ReadFile(fs, filepath.Join(dir, e.Name(), "SKILL.md"))
+		skillDir := filepath.Join(dir, e.Name())
+		raw, err := afero.ReadFile(fs, filepath.Join(skillDir, "SKILL.md"))
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
@@ -203,9 +205,51 @@ func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
-		out = append(out, Skill{Name: e.Name(), Frontmatter: fm, Body: body})
+		files, err := ReadSkillFiles(fs, skillDir)
+		if err != nil {
+			return nil, fmt.Errorf("read bundled files for skill %s: %w", e.Name(), err)
+		}
+		out = append(out, Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
 	}
 	return out, nil
+}
+
+// ReadSkillFiles walks skillDir and returns every regular file other than
+// SKILL.md as a SkillFile, with a slash-separated path relative to skillDir and
+// the file's permission bits preserved. It is the single bundled-file capture
+// implementation shared by the canonical loader and every adapter's Ingest, so
+// the "a skill is a directory, not just SKILL.md" rule cannot drift between
+// them. Non-regular files (symlinks, devices) are skipped — only real bundled
+// resources are captured. Results are sorted by path for deterministic ordering.
+func ReadSkillFiles(fs afero.Fs, skillDir string) ([]SkillFile, error) {
+	var files []SkillFile
+	walkErr := afero.Walk(fs, skillDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(skillDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "SKILL.md" {
+			return nil
+		}
+		data, err := afero.ReadFile(fs, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, SkillFile{Path: rel, Content: data, Mode: uint32(info.Mode().Perm())})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
 }
 
 // loadSubagents walks agents/<name>.md, parsing YAML frontmatter if present.

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -8,6 +9,23 @@ import (
 )
 
 var memoryImportRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
+
+// Fragment boundary markers. ExpandMemoryImports wraps each inlined fragment in
+// these so the expansion is REVERSIBLE: capture (import/reconcile) parses them
+// back into memory/AGENTS.md (`@import` directives) plus the fragment files,
+// giving fragmented memory a bidirectional round-trip instead of the apply-only
+// guard. They are HTML comments (the only "ignorable" Markdown syntax) carrying
+// the fragment's relative path, so an agent reading the rendered memory treats
+// them as metadata, not instructions, and no absolute path leaks into the prompt.
+const fragmentMarkerToken = "agentsync:fragment"
+
+var (
+	fragStartRe = regexp.MustCompile(`^<!-- agentsync:fragment (\S+) -->$`)
+	fragEndRe   = regexp.MustCompile(`^<!-- /agentsync:fragment (\S+) -->$`)
+)
+
+func fragmentStartMarker(name string) string { return "<!-- agentsync:fragment " + name + " -->" }
+func fragmentEndMarker(name string) string   { return "<!-- /agentsync:fragment " + name + " -->" }
 
 // MemoryHasFragments reports whether the canonical memory at home is composed of
 // fragment files (memory/fragments/*). Write-back of memory (import / reconcile)
@@ -42,11 +60,30 @@ const maxMemoryImportDepth = 16
 // AGENTS.md. Cycles are broken (a fragment already being expanded is left as a
 // literal directive), recursion is depth-bounded, and unknown fragments are
 // left as literal directives so the user notices.
+//
+// Each inlined fragment is wrapped in boundary markers (see fragmentMarkerToken)
+// so CollapseMemoryMarkers can reverse the expansion. The one exception is a
+// MARKER COLLISION: if the body or any fragment already contains the marker
+// token, markers are omitted entirely (plain expansion) so they can't corrupt
+// the reverse parse — the write-back guard then keeps that memory apply-only.
 func ExpandMemoryImports(body string, fragments map[string]string) string {
-	return expandMemoryImports(body, fragments, map[string]bool{}, 0)
+	markers := !markerCollision(body, fragments)
+	return expandMemoryImports(body, fragments, map[string]bool{}, 0, markers)
 }
 
-func expandMemoryImports(body string, fragments map[string]string, visiting map[string]bool, depth int) string {
+func markerCollision(body string, fragments map[string]string) bool {
+	if strings.Contains(body, fragmentMarkerToken) {
+		return true
+	}
+	for _, v := range fragments {
+		if strings.Contains(v, fragmentMarkerToken) {
+			return true
+		}
+	}
+	return false
+}
+
+func expandMemoryImports(body string, fragments map[string]string, visiting map[string]bool, depth int, markers bool) string {
 	if depth >= maxMemoryImportDepth {
 		return body
 	}
@@ -61,8 +98,95 @@ func expandMemoryImports(body string, fragments map[string]string, visiting map[
 			return line
 		}
 		visiting[name] = true
-		expanded := expandMemoryImports(frag, fragments, visiting, depth+1)
+		expanded := strings.TrimRight(expandMemoryImports(frag, fragments, visiting, depth+1, markers), "\n")
 		delete(visiting, name)
-		return strings.TrimRight(expanded, "\n")
+		if !markers {
+			return expanded
+		}
+		return fragmentStartMarker(name) + "\n" + expanded + "\n" + fragmentEndMarker(name)
 	})
+}
+
+// CollapseMemoryMarkers reverses ExpandMemoryImports' marker emission: it parses
+// a rendered memory file back into memory/AGENTS.md (with `@import` directives
+// restored where each fragment block was) plus the fragment files. It is how
+// import/reconcile capture a native memory edit back into the fragment structure
+// instead of flattening it.
+//
+// Returns (mem, true, nil) when balanced markers were found and collapsed;
+// (zero, false, nil) when the input carries no markers (caller takes the plain
+// path); (zero, true, err) when markers are present but malformed, unbalanced,
+// reference a traversing path, or the same fragment appears twice with differing
+// content — the caller must then refuse rather than guess.
+func CollapseMemoryMarkers(dest string) (Memory, bool, error) {
+	if !strings.Contains(dest, fragmentMarkerToken) {
+		return Memory{}, false, nil
+	}
+	type frame struct {
+		name  string
+		lines []string
+	}
+	var bodyLines []string
+	var stack []*frame
+	frags := map[string]string{}
+	emit := func(s string) {
+		if len(stack) == 0 {
+			bodyLines = append(bodyLines, s)
+			return
+		}
+		top := stack[len(stack)-1]
+		top.lines = append(top.lines, s)
+	}
+	for _, ln := range strings.Split(dest, "\n") {
+		if m := fragStartRe.FindStringSubmatch(ln); m != nil {
+			name := m[1]
+			if err := validateFragmentName(name); err != nil {
+				return Memory{}, true, err
+			}
+			emit("@import ./fragments/" + name) // restore the directive in the parent
+			stack = append(stack, &frame{name: name})
+			continue
+		}
+		if m := fragEndRe.FindStringSubmatch(ln); m != nil {
+			name := m[1]
+			if len(stack) == 0 || stack[len(stack)-1].name != name {
+				return Memory{}, true, fmt.Errorf("unbalanced memory fragment marker for %q", name)
+			}
+			top := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			content := strings.TrimRight(strings.Join(top.lines, "\n"), "\n") + "\n"
+			if prev, dup := frags[name]; dup && prev != content {
+				return Memory{}, true, fmt.Errorf("memory fragment %q appears multiple times with differing content; resolve it by hand", name)
+			}
+			frags[name] = content
+			continue
+		}
+		emit(ln)
+	}
+	if len(stack) != 0 {
+		return Memory{}, true, fmt.Errorf("unterminated memory fragment marker for %q", stack[len(stack)-1].name)
+	}
+	// Normalize the reconstructed AGENTS.md to a single trailing newline (the
+	// markdown convention loadMemory/WriteMemory round-trip on): expansion's
+	// `\s*$` consumes the newline after a trailing `@import`, so it can't be
+	// recovered positionally.
+	body := strings.Join(bodyLines, "\n")
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return Memory{Body: body, Fragments: frags}, true, nil
+}
+
+// validateFragmentName rejects a fragment path that would escape memory/fragments/
+// on a reverse write — a marker in a hand-edited dest is untrusted input, so a
+// "../" segment must never become an arbitrary-file-write primitive.
+func validateFragmentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty fragment name")
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(name)))
+	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "/") || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("fragment name %q escapes memory/fragments", name)
+	}
+	return nil
 }

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -1,11 +1,35 @@
 package source
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
 
 var memoryImportRe = regexp.MustCompile(`(?m)^@import\s+\./fragments/(\S+)\s*$`)
+
+// MemoryHasFragments reports whether the canonical memory at home is composed of
+// fragment files (memory/fragments/*). Write-back of memory (import / reconcile)
+// is UNSAFE when it is: the destination CLAUDE.md/AGENTS.md is the fully
+// EXPANDED memory, so persisting it back into memory/AGENTS.md would inline
+// every `@import` and strand the fragment files. Ingest cannot de-resolve the
+// expansion (which inlined text came from which fragment is unrecoverable), so
+// the only safe action is to refuse/skip the write-back — callers consult this.
+func MemoryHasFragments(home string) bool {
+	dir := filepath.Join(home, "memory", "fragments")
+	has := false
+	_ = filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		if info.Mode().IsRegular() {
+			has = true
+		}
+		return nil
+	})
+	return has
+}
 
 // maxMemoryImportDepth bounds recursive fragment expansion as a belt against
 // pathological nesting (cycles are already broken by the visiting set).

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -102,3 +102,93 @@ func TestWriteMemory_WritesWhenNoFragments(t *testing.T) {
 		t.Fatalf("memory not written: %q", got)
 	}
 }
+
+// TestMemoryMarkers_RoundTrip proves expansion is reversible: a fragmented
+// memory expands with boundary markers, and CollapseMemoryMarkers reconstructs
+// AGENTS.md (with @import restored) and the fragment content byte-for-byte.
+func TestMemoryMarkers_RoundTrip(t *testing.T) {
+	body := "# Memory\n\n@import ./fragments/style.md\n"
+	frags := map[string]string{"style.md": "Be concise.\n"}
+
+	expanded := source.ExpandMemoryImports(body, frags)
+	if !strings.Contains(expanded, "<!-- agentsync:fragment style.md -->") ||
+		!strings.Contains(expanded, "<!-- /agentsync:fragment style.md -->") {
+		t.Fatalf("markers not emitted: %q", expanded)
+	}
+	if strings.Contains(expanded, "@import") {
+		t.Fatalf("literal @import leaked into rendered output: %q", expanded)
+	}
+
+	mem, had, err := source.CollapseMemoryMarkers(expanded)
+	if err != nil || !had {
+		t.Fatalf("collapse: had=%v err=%v", had, err)
+	}
+	if mem.Body != body {
+		t.Fatalf("body round-trip: got %q want %q", mem.Body, body)
+	}
+	if mem.Fragments["style.md"] != "Be concise.\n" {
+		t.Fatalf("fragment round-trip: got %q", mem.Fragments["style.md"])
+	}
+}
+
+// TestMemoryMarkers_Nested covers a fragment that itself @imports another: the
+// inner block is restored as an @import inside the outer fragment, not inlined.
+func TestMemoryMarkers_Nested(t *testing.T) {
+	body := "# M\n@import ./fragments/outer.md\n"
+	frags := map[string]string{
+		"outer.md": "Outer top\n@import ./fragments/inner.md\nOuter bottom\n",
+		"inner.md": "Inner\n",
+	}
+	mem, had, err := source.CollapseMemoryMarkers(source.ExpandMemoryImports(body, frags))
+	if err != nil || !had {
+		t.Fatalf("collapse: had=%v err=%v", had, err)
+	}
+	if mem.Body != body {
+		t.Fatalf("body: got %q", mem.Body)
+	}
+	if mem.Fragments["outer.md"] != frags["outer.md"] {
+		t.Fatalf("outer fragment: got %q want %q", mem.Fragments["outer.md"], frags["outer.md"])
+	}
+	if mem.Fragments["inner.md"] != frags["inner.md"] {
+		t.Fatalf("inner fragment: got %q", mem.Fragments["inner.md"])
+	}
+}
+
+// TestCollapseMemoryMarkers_Errors covers the refuse-not-guess cases.
+func TestCollapseMemoryMarkers_Errors(t *testing.T) {
+	cases := map[string]string{
+		"unbalanced": "# M\n<!-- agentsync:fragment a.md -->\nx\n",
+		"mismatched": "<!-- agentsync:fragment a.md -->\nx\n<!-- /agentsync:fragment b.md -->\n",
+		"traversal":  "<!-- agentsync:fragment ../evil -->\nx\n<!-- /agentsync:fragment ../evil -->\n",
+		"ambiguous":  "<!-- agentsync:fragment a.md -->\nx\n<!-- /agentsync:fragment a.md -->\n<!-- agentsync:fragment a.md -->\ny\n<!-- /agentsync:fragment a.md -->\n",
+	}
+	for name, dest := range cases {
+		_, had, err := source.CollapseMemoryMarkers(dest)
+		if !had || err == nil {
+			t.Fatalf("%s: expected (had=true, err!=nil), got had=%v err=%v", name, had, err)
+		}
+	}
+}
+
+// TestCollapseMemoryMarkers_NoMarkers returns had=false so callers take the
+// plain (or guard) path.
+func TestCollapseMemoryMarkers_NoMarkers(t *testing.T) {
+	_, had, err := source.CollapseMemoryMarkers("# Memory\nplain body\n")
+	if had || err != nil {
+		t.Fatalf("expected had=false err=nil, got had=%v err=%v", had, err)
+	}
+}
+
+// TestExpandMemoryImports_MarkerCollision: a fragment whose content already
+// contains the marker token disables markers entirely (plain expansion), so a
+// reverse parse can't be corrupted.
+func TestExpandMemoryImports_MarkerCollision(t *testing.T) {
+	body := "@import ./fragments/a.md\n"
+	frags := map[string]string{"a.md": "see <!-- agentsync:fragment x -->\n"}
+	expanded := source.ExpandMemoryImports(body, frags)
+	if strings.Contains(expanded, "<!-- agentsync:fragment a.md -->") {
+		t.Fatalf("markers must be suppressed on collision: %q", expanded)
+	}
+	_, had, _ := source.CollapseMemoryMarkers(expanded)
+	_ = had // content token may still trip detection; the write-back guard covers safety
+}

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -1,6 +1,8 @@
 package source_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -45,5 +47,58 @@ func TestExpandMemoryImports_UnknownFragmentLeftLiteral(t *testing.T) {
 	got := source.ExpandMemoryImports("@import ./fragments/missing.md\n", map[string]string{})
 	if !strings.Contains(got, "@import ./fragments/missing.md") {
 		t.Fatalf("unknown fragment directive should be preserved: %q", got)
+	}
+}
+
+// TestWriteMemory_RefusesWhenFragmentsExist guards the silent flatten-and-orphan
+// hazard: when canonical memory is composed of fragments, the value handed to
+// WriteMemory is the fully expanded memory (ingest can't de-resolve it), so
+// overwriting AGENTS.md would inline every @import and strand the fragment
+// files. WriteMemory must refuse and leave the source untouched.
+func TestWriteMemory_RefusesWhenFragmentsExist(t *testing.T) {
+	home := t.TempDir()
+	memDir := filepath.Join(home, "memory")
+	fragDir := filepath.Join(memDir, "fragments")
+	if err := os.MkdirAll(fragDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := "# Memory\n@import ./fragments/style.md\n"
+	if err := os.WriteFile(filepath.Join(memDir, "AGENTS.md"), []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fragDir, "style.md"), []byte("Be concise.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !source.MemoryHasFragments(home) {
+		t.Fatal("MemoryHasFragments should be true")
+	}
+
+	err := source.WriteMemory(home, source.Memory{Body: "# Memory\nBe concise.\n"})
+	if err == nil {
+		t.Fatal("WriteMemory must refuse to overwrite fragment-composed memory")
+	}
+	// Source must be untouched: AGENTS.md still has the @import, fragment intact.
+	got, _ := os.ReadFile(filepath.Join(memDir, "AGENTS.md"))
+	if string(got) != orig {
+		t.Fatalf("AGENTS.md was modified despite refusal: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(fragDir, "style.md")); err != nil {
+		t.Fatalf("fragment was orphaned/removed: %v", err)
+	}
+}
+
+// TestWriteMemory_WritesWhenNoFragments confirms the guard does not block the
+// normal (no-fragments) write.
+func TestWriteMemory_WritesWhenNoFragments(t *testing.T) {
+	home := t.TempDir()
+	if source.MemoryHasFragments(home) {
+		t.Fatal("MemoryHasFragments should be false on an empty home")
+	}
+	if err := source.WriteMemory(home, source.Memory{Body: "# Memory\n"}); err != nil {
+		t.Fatalf("WriteMemory should succeed without fragments: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(home, "memory", "AGENTS.md"))
+	if string(got) != "# Memory\n" {
+		t.Fatalf("memory not written: %q", got)
 	}
 }

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -58,6 +58,14 @@ type MCPServerSpec struct {
 	Env     map[string]string `toml:"env,omitempty"`
 	Agents  []string          `toml:"agents,omitempty"`  // ["*"] or ["claude","opencode"]
 	Enabled *bool             `toml:"enabled,omitempty"` // nil means default-on
+	// Extra carries native MCP-server fields agentsync does not model (e.g.
+	// timeout, disabled, cwd), captured on ingest and rendered back verbatim so
+	// import/reconcile/apply are not lossy for them. It is PASSTHROUGH ONLY:
+	// values are never secret-resolved (a ${secret:…} here is written literally,
+	// not substituted) and never visited by walkSecretFields — so it stays out of
+	// the secret machinery. The capture leak backstop (secrets.ResidualSecretCleartext)
+	// scans it instead, refusing a write that would persist a live secret value.
+	Extra map[string]any `toml:"extra,omitempty"`
 }
 
 // Skill mirrors a skill directory skills/<name>/. Per the Agent Skills spec a
@@ -164,6 +172,11 @@ type LSPServerSpec struct {
 	// preserve them (via source.ReadLSP) rather than reset them from the dest.
 	Agents  []string `toml:"agents,omitempty"`  // ["*"] or ["claude",...]; empty = all
 	Enabled *bool    `toml:"enabled,omitempty"` // nil means default-on
+	// Extra carries native LSP-server fields agentsync does not model, captured
+	// on ingest and rendered back verbatim. Passthrough only — see the note on
+	// MCPServerSpec.Extra (never secret-resolved or walked; the capture leak
+	// backstop scans it).
+	Extra map[string]any `toml:"extra,omitempty"`
 }
 
 // Memory mirrors memory/AGENTS.md and memory/fragments/.

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -60,11 +60,28 @@ type MCPServerSpec struct {
 	Enabled *bool             `toml:"enabled,omitempty"` // nil means default-on
 }
 
-// Skill mirrors skills/<name>/SKILL.md (frontmatter + body).
+// Skill mirrors a skill directory skills/<name>/. Per the Agent Skills spec a
+// skill is a DIRECTORY whose only required member is SKILL.md (frontmatter +
+// body); it may also bundle scripts/, references/, assets/, and arbitrary
+// nested files. Files captures everything in the directory other than SKILL.md
+// so apply/import/reconcile are not lossy for those resources.
 type Skill struct {
 	Name        string         `toml:"-"` // dirname
 	Frontmatter map[string]any `toml:"-"` // YAML frontmatter parsed
 	Body        string         `toml:"-"` // markdown body
+	Files       []SkillFile    `toml:"-"` // bundled files other than SKILL.md
+}
+
+// SkillFile is one bundled resource inside a skill directory (e.g.
+// scripts/extract.py, references/REFERENCE.md, assets/logo.png). Content is
+// captured verbatim — never secret-substituted, never frontmatter-parsed — so
+// binary assets round-trip byte-for-byte. Path is relative to the skill
+// directory and slash-separated; Mode preserves the file's permission bits so
+// executable scripts keep their +x bit.
+type SkillFile struct {
+	Path    string `toml:"-"`
+	Content []byte `toml:"-"`
+	Mode    uint32 `toml:"-"`
 }
 
 // Plugin mirrors plugins/<id>.toml.

--- a/internal/source/skill_files_test.go
+++ b/internal/source/skill_files_test.go
@@ -1,0 +1,134 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestLoad_SkillBundledFiles proves a skill is loaded as a DIRECTORY: SKILL.md
+// becomes frontmatter+body and every other file (scripts/, references/, nested,
+// binary assets) is captured verbatim into Skill.Files with a slash-separated
+// relative path, sorted deterministically. This is the guard against the
+// "only SKILL.md survives" lossiness bug.
+func TestLoad_SkillBundledFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	base := "/home/.agentsync/skills/deploy"
+	binary := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	_ = afero.WriteFile(fs, filepath.Join(base, "SKILL.md"), []byte("---\nname: deploy\ndescription: ship it\n---\nBody.\n"), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(base, "scripts", "run.sh"), []byte("#!/bin/sh\necho hi\n"), 0o755)
+	_ = afero.WriteFile(fs, filepath.Join(base, "references", "REF.md"), []byte("# Reference\n"), 0o644)
+	_ = afero.WriteFile(fs, filepath.Join(base, "assets", "logo.png"), binary, 0o644)
+
+	c, err := source.Load(fs, "/home/.agentsync")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Skills) != 1 {
+		t.Fatalf("skills = %d", len(c.Skills))
+	}
+	sk := c.Skills[0]
+	if sk.Name != "deploy" || sk.Body != "Body.\n" {
+		t.Fatalf("skill header wrong: %+v", sk)
+	}
+	want := map[string][]byte{
+		"assets/logo.png":   binary,
+		"references/REF.md": []byte("# Reference\n"),
+		"scripts/run.sh":    []byte("#!/bin/sh\necho hi\n"),
+	}
+	if len(sk.Files) != len(want) {
+		t.Fatalf("Files = %d, want %d (%+v)", len(sk.Files), len(want), sk.Files)
+	}
+	// Sorted by path.
+	gotOrder := []string{sk.Files[0].Path, sk.Files[1].Path, sk.Files[2].Path}
+	wantOrder := []string{"assets/logo.png", "references/REF.md", "scripts/run.sh"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("Files not sorted: got %v want %v", gotOrder, wantOrder)
+		}
+	}
+	for _, f := range sk.Files {
+		if string(f.Content) != string(want[f.Path]) {
+			t.Fatalf("content for %s = %q", f.Path, f.Content)
+		}
+	}
+	// SKILL.md must never appear in Files.
+	for _, f := range sk.Files {
+		if f.Path == "SKILL.md" {
+			t.Fatal("SKILL.md leaked into Files")
+		}
+	}
+}
+
+// TestWriteSkill_RoundTripsBundledFiles writes a skill (incl. an executable
+// script and a binary asset) to a real home, reloads it, and asserts the bundled
+// files survive byte-for-byte with their executable bit preserved.
+func TestWriteSkill_RoundTripsBundledFiles(t *testing.T) {
+	home := t.TempDir()
+	binary := []byte{0x00, 0x10, 0x7f, 0x80, 0xff}
+	in := source.Skill{
+		Name:        "deploy",
+		Frontmatter: map[string]any{"name": "deploy", "description": "ship it"},
+		Body:        "Body.\n",
+		Files: []source.SkillFile{
+			{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\necho hi\n"), Mode: 0o755},
+			{Path: "assets/logo.png", Content: binary, Mode: 0o644},
+		},
+	}
+	if err := source.WriteSkill(home, in); err != nil {
+		t.Fatalf("WriteSkill: %v", err)
+	}
+
+	// Executable bit preserved on disk.
+	st, err := os.Stat(filepath.Join(home, "skills", "deploy", "scripts", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("scripts/run.sh lost its executable bit: %v", st.Mode())
+	}
+
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Skills) != 1 || len(c.Skills[0].Files) != 2 {
+		t.Fatalf("round-trip lost bundled files: %+v", c.Skills)
+	}
+	for _, f := range c.Skills[0].Files {
+		switch f.Path {
+		case "scripts/run.sh":
+			if f.Mode&0o100 == 0 {
+				t.Fatalf("run.sh mode not preserved on reload: %o", f.Mode)
+			}
+		case "assets/logo.png":
+			if string(f.Content) != string(binary) {
+				t.Fatalf("binary asset corrupted: %v", f.Content)
+			}
+		default:
+			t.Fatalf("unexpected bundled file %s", f.Path)
+		}
+	}
+}
+
+// TestWriteSkill_RejectsTraversalBundledPath ensures a malicious bundled path
+// (e.g. captured from a foreign native config) cannot escape the skill dir and
+// clobber an arbitrary file.
+func TestWriteSkill_RejectsTraversalBundledPath(t *testing.T) {
+	home := t.TempDir()
+	for _, bad := range []string{"../escape.txt", "/etc/passwd", "../../x"} {
+		in := source.Skill{
+			Name:        "deploy",
+			Frontmatter: map[string]any{"name": "deploy", "description": "x"},
+			Body:        "b\n",
+			Files:       []source.SkillFile{{Path: bad, Content: []byte("x"), Mode: 0o644}},
+		}
+		if err := source.WriteSkill(home, in); err == nil {
+			t.Fatalf("WriteSkill accepted traversal path %q", bad)
+		}
+	}
+}

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -272,23 +272,40 @@ func WriteLSP(home string, ls LSPServer) error {
 	return iox.AtomicWrite(filepath.Join(dir, ls.ID+".toml"), body, 0o644)
 }
 
-// WriteMemory writes memory/AGENTS.md from m into home. Overwrites atomically.
+// WriteMemory writes memory/AGENTS.md (m.Body) plus every fragment in
+// m.Fragments (memory/fragments/<name>, traversal-checked) into home. It is the
+// faithful inverse of loadMemory — a reverse-collapse (CollapseMemoryMarkers)
+// populates Fragments, so import/reconcile can restore a fragmented memory.
 //
-// It REFUSES when the canonical memory is fragment-composed (MemoryHasFragments)
-// because m.Body here is the fully EXPANDED memory (ingest cannot de-resolve the
-// `@import` expansion), so writing it would inline every fragment and orphan the
-// fragment files. This is the single chokepoint that makes the loss loud rather
-// than silent; the only caller (`import`) checks MemoryHasFragments first and
-// skips with a warning, so this refusal is defense-in-depth for future callers.
+// It still REFUSES the one dangerous shape: a flattened body (no Fragments)
+// over a source that IS fragment-composed. That only happens when a native
+// memory edit could not be reversed (markers absent/disabled), where writing the
+// expanded body would inline every @import and orphan the fragment files; the
+// caller surfaces it rather than flatten silently.
 func WriteMemory(home string, m Memory) error {
-	if MemoryHasFragments(home) {
-		return fmt.Errorf("refusing to overwrite memory/AGENTS.md: canonical memory is composed of fragments/ and the value to write is the expanded memory — persisting it would inline every @import and orphan the fragment files; edit memory/ directly")
+	if len(m.Fragments) == 0 && MemoryHasFragments(home) {
+		return fmt.Errorf("refusing to overwrite memory/AGENTS.md: canonical memory is composed of fragments/ and the value to write carries none (the expanded memory could not be reversed) — persisting it would inline every @import and orphan the fragment files; edit memory/ directly")
 	}
 	dir := filepath.Join(home, "memory")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir memory: %w", err)
 	}
-	return iox.AtomicWrite(filepath.Join(dir, "AGENTS.md"), []byte(m.Body), 0o644)
+	if err := iox.AtomicWrite(filepath.Join(dir, "AGENTS.md"), []byte(m.Body), 0o644); err != nil {
+		return err
+	}
+	for name, content := range m.Fragments {
+		if err := validateFragmentName(name); err != nil {
+			return fmt.Errorf("memory: %w", err)
+		}
+		dest := filepath.Join(dir, "fragments", filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("mkdir for memory/fragments/%s: %w", name, err)
+		}
+		if err := iox.AtomicWrite(dest, []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // renderFrontmatter serialises a frontmatter map as a YAML block enclosed in

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -273,7 +273,17 @@ func WriteLSP(home string, ls LSPServer) error {
 }
 
 // WriteMemory writes memory/AGENTS.md from m into home. Overwrites atomically.
+//
+// It REFUSES when the canonical memory is fragment-composed (MemoryHasFragments)
+// because m.Body here is the fully EXPANDED memory (ingest cannot de-resolve the
+// `@import` expansion), so writing it would inline every fragment and orphan the
+// fragment files. This is the single chokepoint that makes the loss loud rather
+// than silent; the only caller (`import`) checks MemoryHasFragments first and
+// skips with a warning, so this refusal is defense-in-depth for future callers.
 func WriteMemory(home string, m Memory) error {
+	if MemoryHasFragments(home) {
+		return fmt.Errorf("refusing to overwrite memory/AGENTS.md: canonical memory is composed of fragments/ and the value to write is the expanded memory — persisting it would inline every @import and orphan the fragment files; edit memory/ directly")
+	}
 	dir := filepath.Join(home, "memory")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir memory: %w", err)

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -135,7 +135,10 @@ func WriteMarketplace(home, name string, m Marketplace) error {
 	return iox.AtomicWrite(filepath.Join(home, "marketplaces", name+".toml"), body, 0o644)
 }
 
-// WriteSkill writes skills/<name>/SKILL.md from sk into home. Overwrites atomically.
+// WriteSkill writes skills/<name>/SKILL.md plus every bundled file (scripts/,
+// references/, assets/, …) from sk into home. Each file is written atomically
+// with its preserved permission bits; bundled content is written verbatim
+// (never frontmatter-encoded), so binary assets round-trip byte-for-byte.
 func WriteSkill(home string, sk Skill) error {
 	if err := ValidateComponentID("skill", sk.Name); err != nil {
 		return err
@@ -145,7 +148,45 @@ func WriteSkill(home string, sk Skill) error {
 		return fmt.Errorf("mkdir skills/%s: %w", sk.Name, err)
 	}
 	content := renderFrontmatter(sk.Frontmatter) + sk.Body
-	return iox.AtomicWrite(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	if err := iox.AtomicWrite(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		return err
+	}
+	for _, f := range sk.Files {
+		if err := validateSkillFilePath(f.Path); err != nil {
+			return fmt.Errorf("skill %s: %w", sk.Name, err)
+		}
+		dest := filepath.Join(dir, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("mkdir for skills/%s/%s: %w", sk.Name, f.Path, err)
+		}
+		mode := os.FileMode(f.Mode)
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := iox.AtomicWrite(dest, f.Content, mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSkillFilePath rejects a bundled-file path that would escape the skill
+// directory. Bundled paths derive from a directory walk (loader / ingest) or a
+// foreign native config, so a "../" segment must never be joined into an
+// arbitrary-file-write primitive — mirrors ValidateComponentID at the bundled
+// granularity.
+func validateSkillFilePath(rel string) error {
+	if rel == "" {
+		return fmt.Errorf("empty bundled-file path")
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(rel)))
+	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "/") || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("bundled-file path %q escapes the skill directory", rel)
+	}
+	if clean == "SKILL.md" {
+		return fmt.Errorf("bundled-file path %q collides with SKILL.md", rel)
+	}
+	return nil
 }
 
 // WriteSubagent writes agents/<name>.md from sa into home. Overwrites atomically.

--- a/test/bdd/features/06_marketplace_plugins.feature
+++ b/test/bdd/features/06_marketplace_plugins.feature
@@ -48,6 +48,8 @@ Feature: Marketplaces and plugins
     Then the command succeeds
     And the file ".claude/skills/proj-skill/SKILL.md" exists
     And the file ".claude/skills/proj-skill/SKILL.md" contains "BODY_TOKEN_skill_proj-skill"
+    And the file ".claude/skills/proj-skill/scripts/run.sh" exists
+    And the file ".claude/skills/proj-skill/scripts/run.sh" contains "BODY_TOKEN_skill_script"
     And the file ".claude/agents/proj-agent.md" exists
     And the file ".claude/agents/proj-agent.md" contains "BODY_TOKEN_agent_proj-agent"
     And the file ".claude/commands/proj-cmd.md" exists

--- a/test/bdd/support/steps.go
+++ b/test/bdd/support/steps.go
@@ -198,6 +198,15 @@ func (w *World) whenICreateProjectionTestMarketplace(dirRel, pluginID string) er
 	if err := os.WriteFile(filepath.Join(skillPath, "SKILL.md"), []byte(skillMD), 0o644); err != nil {
 		return err
 	}
+	// A skill is a DIRECTORY: a bundled script must project to the destination
+	// alongside SKILL.md, not be dropped. Written executable to also lock the
+	// +x-preservation path through projection → render → apply.
+	if err := os.MkdirAll(filepath.Join(skillPath, "scripts"), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(skillPath, "scripts", "run.sh"), []byte("#!/bin/sh\necho BODY_TOKEN_skill_script\n"), 0o755); err != nil {
+		return err
+	}
 
 	// agents/proj-agent.md
 	agentPath := filepath.Join(pluginRoot, "agents")

--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -39,13 +39,17 @@ updates on the next `apply`.
 	everywhere.
 </Aside>
 
-<Aside type="caution" title="Memory write-back is one-way when you use fragments">
-	The agent's native memory file is the *expanded* memory (every `@import` already
-	inlined), and that expansion can't be reversed into the original fragments. So
-	when `memory/fragments/` is in use, `import` skips memory (with a warning) and
-	`reconcile` refuses to write a native memory edit back — otherwise it would
-	flatten `AGENTS.md` and orphan your fragment files. A drifted native memory
-	still surfaces in `status`/`diff`; fold the change into `memory/` by hand.
+<Aside type="tip" title="Fragments round-trip both ways">
+	On `apply`, agentsync wraps each inlined fragment in HTML-comment boundary
+	markers in the native file (`<!-- agentsync:fragment style.md -->` …
+	`<!-- /agentsync:fragment style.md -->`). They read as metadata, not
+	instructions, and let `import`/`reconcile` **reverse** the expansion: a native
+	memory edit made *inside* a fragment block is captured back into that fragment
+	file, with the `@import` structure preserved — never flattened into `AGENTS.md`.
+	If the markers are absent (a fragment whose text contains the marker token
+	disables them) or were hand-mangled into an unbalanced/ambiguous state,
+	agentsync refuses the write-back rather than guess; the drift still shows in
+	`status`/`diff` and you fold it in by hand.
 </Aside>
 
 ## Per-agent rendering

--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -39,6 +39,15 @@ updates on the next `apply`.
 	everywhere.
 </Aside>
 
+<Aside type="caution" title="Memory write-back is one-way when you use fragments">
+	The agent's native memory file is the *expanded* memory (every `@import` already
+	inlined), and that expansion can't be reversed into the original fragments. So
+	when `memory/fragments/` is in use, `import` skips memory (with a warning) and
+	`reconcile` refuses to write a native memory edit back — otherwise it would
+	flatten `AGENTS.md` and orphan your fragment files. A drifted native memory
+	still surfaces in `status`/`diff`; fold the change into `memory/` by hand.
+</Aside>
+
 ## Per-agent rendering
 
 | Agent | Native memory file |

--- a/website/src/content/docs/internals/security.mdx
+++ b/website/src/content/docs/internals/security.mdx
@@ -21,7 +21,7 @@ several tiers of defense, in increasing distance from the danger:
 | Tier | Guarantee |
 | --- | --- |
 | **Compile-enforced** | Secret substitution returns a `secrets.Resolved` wrapper that is *not* assignable to `source.Canonical`. Source writers and the capture path accept only the templated `source.Canonical`. Passing resolved data to a writer is a **compile error**, not a review check. |
-| **Value-invariant** | Substitution clones the model before resolving (no aliasing back to your templated copy), and the field walker only visits secret-bearing fields — so text components (memory, skills, commands) physically cannot carry a substituted secret. |
+| **Value-invariant** | Substitution clones the model before resolving (no aliasing back to your templated copy), and the field walker only visits secret-bearing fields — so text components (memory, skills incl. their bundled files, commands) physically cannot carry a substituted secret. |
 | **Lint fence** | A `forbidigo` rule forbids unwrapping a `Resolved` outside the two adapter render egress sites. |
 | **Capture backstop** | The dest→source path re-references secrets to `${secret:…}`, then **re-scans** the about-to-be-written model and **refuses to write** if a resolved secret would persist (or a referenced key vanished) — rather than guess. |
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -19,6 +19,14 @@ parse these files *are* the canonical model.
   - agentsync.toml agents, update defaults, secrets backend
   - mcp/
     - **github.toml** one MCP server per file
+  - lsp/
+    - **gopls.toml** one LSP server per file
+  - agents/
+    - **reviewer.md** one subagent per file
+  - commands/
+    - **review.md** one slash command per file
+  - hooks/
+    - **PreToolUse.toml** one hook per file
   - marketplaces/
     - **anthropic.toml** one marketplace per file
   - plugins/
@@ -75,6 +83,10 @@ identity_file = "${env:HOME}/.config/agentsync/age.key"  # private key, per-mach
 | File | Holds |
 | --- | --- |
 | `mcp/<name>.toml` | one MCP server ([guide](/guides/mcp-servers/)) |
+| `lsp/<name>.toml` | one LSP server |
+| `agents/<name>.md` | one subagent |
+| `commands/<name>.md` | one slash command |
+| `hooks/<event>.toml` | one hook |
 | `marketplaces/<name>.toml` | one marketplace ([guide](/guides/plugins/)) |
 | `plugins/<id>.toml` | one plugin enablement ([guide](/guides/plugins/)) |
 | `memory/AGENTS.md` + `fragments/` | canonical memory ([guide](/guides/memory/)) |

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -27,8 +27,11 @@ parse these files *are* the canonical model.
     - AGENTS.md canonical memory
     - fragments/ reusable `@import` pieces
   - skills/
-    - my-skill/
-      - SKILL.md standalone skills
+    - my-skill/ a skill is a directory, not just SKILL.md
+      - SKILL.md required metadata + instructions
+      - scripts/ optional bundled code (kept verbatim, +x preserved)
+      - references/ optional bundled docs
+      - assets/ optional templates / data (binary OK)
   - secrets/
     - secrets.age age-encrypted vault
   - ignore.toml paths reconcile should stop tracking
@@ -75,7 +78,7 @@ identity_file = "${env:HOME}/.config/agentsync/age.key"  # private key, per-mach
 | `marketplaces/<name>.toml` | one marketplace ([guide](/guides/plugins/)) |
 | `plugins/<id>.toml` | one plugin enablement ([guide](/guides/plugins/)) |
 | `memory/AGENTS.md` + `fragments/` | canonical memory ([guide](/guides/memory/)) |
-| `skills/<name>/SKILL.md` | standalone skills |
+| `skills/<name>/` | one skill *directory* per the [Agent Skills](https://agentskills.io) spec — `SKILL.md` plus any bundled `scripts/`/`references/`/`assets/`/nested files, all carried verbatim |
 | `secrets/secrets.age` | the age-encrypted vault ([guide](/guides/secrets/)) |
 
 ## Project overlay


### PR DESCRIPTION
## Summary

Started as a fix for skills being modeled as only their `SKILL.md`. Because the same failure mode — **a model that represents a subset of its on-disk artifact and silently drops the rest** — turned out to be a *class*, it grew into a guardrail plus an audit that surfaced and fixed two sibling bugs (memory fragments, MCP/LSP fields).

Six commits, smallest-blast-radius first:

### 1. `feat(skills)` — honor the full Agent Skills directory spec
A skill is a **directory** ([agentskills.io](https://agentskills.io/specification)): `SKILL.md` is the only required member, but it may bundle `scripts/`, `references/`, `assets/`, and nested files. Previously every bundled file was silently dropped.
- `source.Skill` gains `Files []SkillFile`; a shared `source.ReadSkillFiles` walker captures every regular file except `SKILL.md` (slash-relative path, mode preserved); `WriteSkill` persists them.
- `claude.SkillFileOps` emits one verbatim `FileOp` per bundled file; Claude/OpenCode/Codex render **and** ingest the whole directory; marketplace/plugin projection captures plugin-bundled files (symlinks skipped — fetched repos are untrusted); reconcile write-back honors `op.Mode`.
- Bundled content is verbatim (never secret-substituted / frontmatter-parsed) so **binary assets round-trip byte-for-byte**; paths are containment-checked against `../` traversal.
- Decisions (confirmed): **preserve mode** (executable bit survives) and **store binary verbatim**.

### 2. `feat(render)` — reclaim orphaned skill files on apply
Removing a skill, or one bundled file within it, now deletes the leftover destination file on the next `apply` (previously only key-merge sections were auto-cleaned). A dest that **drifted** from what agentsync last wrote is **backed up before removal**, and now-empty skill dirs are pruned up to — never including — the skills root. Scoped to skills; subagents/commands keep their reconcile-driven cleanup. Shared by `apply` + `update`.

### 3. `docs(claude)` — the guardrail (prevention)
A non-negotiable `CLAUDE.md` section, *"Models must stay faithful to their on-disk artifacts"*: fidelity tests anchor to a spec-complete on-disk fixture (not the parsed model); unrepresentable parts must be acknowledged (translation report / `Skip` / `◐` / guard), never dropped silently; a prose capability claim must be backed by a test.

### 4. `feat(memory)` — bidirectional fragments + full layout docs (audit finding)
Memory composed of `memory/fragments/` renders to a fully **expanded** native file. `import` previously overwrote `AGENTS.md` with that expanded text — flattening every `@import` and orphaning the fragments. Now **fragments round-trip both ways**: `apply` wraps each inlined fragment in HTML-comment boundary markers (`<!-- agentsync:fragment <name> -->` …), and `CollapseMemoryMarkers` reverses them at capture time, so a native edit *inside* a fragment block is written back into that **fragment file** with the `@import` structure preserved.
- Default-on; markers read as metadata, not instructions.
- **Refuses rather than guesses** on unbalanced/mismatched/ambiguous markers or a traversing path; **content-collision fallback** (a fragment whose own text contains the marker token disables markers → falls back to the apply-only guard); reverse writes are traversal-checked; `WriteMemory` still refuses a flattened body over a fragment-composed source.
- Nested fragments and multi-import reuse handled.
- Also: the `~/.agentsync/` layout docs were missing `agents/`, `commands/`, `hooks/`, `lsp/` (all loaded by the source loader) — added.

### 5. `feat(adapter)` — preserve unmodeled native MCP/LSP fields (`Extra`) (audit finding)
MCP/LSP specs were closed structs, so ingest dropped any native field agentsync doesn't model (`timeout`, `disabled`, `cwd`, …) — and `overlayOwned` then erased it from the dest on re-apply. Added `MCPServerSpec.Extra` / `LSPServerSpec.Extra` (`map[string]any`), captured on ingest (claude/opencode/codex + the claude reconcile write-back path) and rendered back verbatim via a `[server.extra]` TOML sub-table. `Extra` is **passthrough only** — never secret-resolved or walked (a deliberate, documented exception to the one-field-list invariant); the capture leak backstop scans it (`scanExtraResidual`) and refuses any write that would persist a live secret value.

*(Commit ordering note: #4 landed first as a refuse-only guard, then commit 6 upgraded it to the bidirectional marker round-trip.)*

### 6. `feat(memory)` — bidirectional fragments via reversible boundary markers
The upgrade described in §4: replaces the apply-only guard with the marker round-trip (`ExpandMemoryImports` emits markers, `CollapseMemoryMarkers` reverses), wires it through `import`/`reconcile`, and reworks `WriteMemory` to write `AGENTS.md` + fragments.

## Docs
Synced in the same commits (repo's docs-as-contract rule): concepts, architecture, capability matrix, user-guide, configuration reference, memory guide, security page, `CLAUDE.md`, `CHANGELOG`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] Full `go test ./internal/...` green; BDD green (plugin-projection scenario applies a bundled `scripts/run.sh` end-to-end)
- [x] **Skills:** source loader/writer round-trip (executable bit + binary + `../` rejection), Claude render+ingest round-trip, marketplace projection of plugin-bundled files
- [x] **Orphan reclamation:** end-to-end `TestApply_SkillOrphanCleanup` (single-file removal + empty-dir prune, whole-skill removal, skills-root preservation, drift-backup) + prune-boundary unit tests
- [x] **Memory fragments:** expand↔collapse round-trip incl. nested; refuse cases (unbalanced/mismatched/ambiguous/traversal); collision fallback; end-to-end `TestImport_MemoryReversesFragmentEdit` (apply → edit a block in the dest → import → edit lands in the fragment file, `@import` preserved)
- [x] **`Extra`:** MCP round-trip preserves unmodeled fields (no modeled-field duplication) + leak backstop refuses a live secret value in `Extra`

https://claude.ai/code/session_01VohQtrQeH5AmP3i682rjb4