### PR TITLE
docs(memory): show the rendered native file in the fragments guide

### DIFF
--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -29,9 +29,32 @@ Keep the top-level file small and pull in reusable pieces with `@import`:
     └── security-rules.md
 ```
 
+…where each fragment holds a focused piece:
+
+```markdown title="~/.agentsync/memory/fragments/style.md"
+Prefer clarity over cleverness.
+```
+
+```markdown title="~/.agentsync/memory/fragments/security-rules.md"
+Never log secrets.
+```
+
 At apply time agentsync expands the imports and writes the fully-composed memory
-into each agent's native file. Edit a fragment once and every agent's memory
-updates on the next `apply`.
+into each agent's native file, wrapping each fragment in HTML-comment boundary
+markers (so the expansion can be reversed — see below):
+
+```markdown title="~/.claude/CLAUDE.md (rendered by apply)"
+# Coding conventions
+
+<!-- agentsync:fragment style.md -->
+Prefer clarity over cleverness.
+<!-- /agentsync:fragment style.md -->
+<!-- agentsync:fragment security-rules.md -->
+Never log secrets.
+<!-- /agentsync:fragment security-rules.md -->
+```
+
+Edit a fragment once and every agent's memory updates on the next `apply`.
 
 <Aside type="tip" title="Fragments are reusable">
 	A fragment like `security-rules.md` can be imported by several memory files (for


### PR DESCRIPTION
## Summary

The [Compose from fragments](https://agentsync.cc/guides/memory/#compose-from-fragments) guide showed the canonical `AGENTS.md` and the directory layout, but never the **resulting native file** — leaving the loop open. This adds:

- brief example contents for the two fragment files (`style.md`, `security-rules.md`), and
- the exact rendered `~/.claude/CLAUDE.md`, **including the HTML-comment boundary markers** `apply` now emits:

```markdown
# Coding conventions

<!-- agentsync:fragment style.md -->
Prefer clarity over cleverness.
<!-- /agentsync:fragment style.md -->
<!-- agentsync:fragment security-rules.md -->
Never log secrets.
<!-- /agentsync:fragment security-rules.md -->
```

So a reader sees what expansion produces and how it ties into the "Fragments round-trip both ways" callout immediately below (the markers are what make the reverse capture possible).

Docs-only change to the authored `guides/memory.mdx` page (not a generated contract page).

## Test plan
- [x] Rendered output verified byte-for-byte against `source.ExpandMemoryImports` (two adjacent `@import`s, last-line newline handling) — the example is the real output, not a hand-drawn approximation.
- [x] Markers shown inside a fenced code block (not parsed as MDX/HTML).

https://claude.ai/code/session_01VohQtrQeH5AmP3i682rjb4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VohQtrQeH5AmP3i682rjb4)_