### PR TITLE
feat(cli): styled output, --color flag, and --json for status/diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Added
 
+- **Styled CLI output and a `--color` flag** — `agentsync status`, `diff`,
+  `doctor`, and `apply` now render through a single presentation layer
+  (`internal/ui`) with a curated semantic palette (green=synced, cyan=pending,
+  red=drift, yellow=needs-decision) and the same `✓ ◐ ✗ → •` glyph vocabulary
+  the capability matrix already uses. `status` gains a one-line summary footer
+  ("`5 clean · 2 drift`"). Color is TTY-gated by default — `--color=auto`
+  enables it only when stdout is a terminal and `NO_COLOR` is unset, while
+  `--color=always|never` overrides. Glyphs are unconditional Unicode (matching
+  the existing report output); piped output is byte-stable and never leaks raw
+  ANSI.
+- **`status --json` and `diff --json`** — emit machine-readable structured
+  output (per-agent drift items + summary tally; per-hunk source/dest with
+  pointer) for CI gates, dashboards, and scripts. Advisory diagnostics still
+  go to stderr so the JSON payload stays cleanly parseable.  `diff --json`
+  reuses the same redaction the formatted diff does, so resolved secrets are
+  masked in both modes.
 - **Canonical source model** in `~/.agentsync/` — hand-editable TOML + markdown
   for agents, MCP servers, marketplaces, plugins, memory, and skills.
 - **Full Agent Skills directory support** — a skill is treated as a *directory*
@@ -142,6 +158,13 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`diff` no longer leaks raw ANSI into pipes** — the previous implementation
+  called `diffmatchpatch.DiffPrettyText` unconditionally, so `agentsync diff |
+  grep` (or any redirect to a file) accumulated `\x1b[31m…\x1b[0m` escape
+  sequences instead of readable text. The new color-aware renderer emits ANSI
+  only when stdout is a TTY (and `NO_COLOR` is unset), and falls back to
+  `[-…-]` / `{+…+}` text markers in plain mode so a piped diff is still legible
+  and `grep`-friendly.
 - **`agent disable --purge` validates the name; `doctor` names a half-init** —
   `disable <bogus> --purge` reported a misleading "purged 0 files" success for
   any string; it now rejects an unknown agent like the other subcommands (a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,17 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   enables it only when stdout is a terminal and `NO_COLOR` is unset, while
   `--color=always|never` overrides. Glyphs are unconditional Unicode (matching
   the existing report output); piped output is byte-stable and never leaks raw
-  ANSI.
+  ANSI. The `apply` translation report is rendered through the same Printer:
+  bold "plugin:" labels, semantic color on the coverage marks (green=full,
+  yellow=partial, red=none), faint trailing counts. With color disabled the
+  output is byte-identical to before, so existing fixtures hold.
+- **Spinners on slow network ops** — `agentsync update` and `agentsync
+  marketplace add` animate a braille-frame spinner on stderr while
+  marketplace fetches and plugin-manifest pulls are in flight. The spinner is
+  a complete no-op on a non-terminal (CI logs, piped stderr, captured-output
+  tests) — no animation, no static fallback line — so byte-stable fixtures
+  stay byte-stable and grep'd output stays clean; the success line each
+  command already prints carries the result.
 - **`status --json` and `diff --json`** — emit machine-readable structured
   output (per-agent drift items + summary tally; per-hunk source/dest with
   pointer) for CI gates, dashboards, and scripts. Advisory diagnostics still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   bold "plugin:" labels, semantic color on the coverage marks (green=full,
   yellow=partial, red=none), faint trailing counts. With color disabled the
   output is byte-identical to before, so existing fixtures hold.
+- **`status` explains its drift classes inline** — the formatted dashboard
+  now prints a brief "What `apply` will do:" legend after the summary footer,
+  with one action-focused line per drift class actually present (`new` → will
+  be created; `pending` → will be updated to match source; `drift` → will be
+  overwritten, use `reconcile` to keep the dest edit; `foreign-collision` →
+  will be backed up and overwritten; etc.). Each line uses the same glyph and
+  color as the per-item rows above so you can scan from a row to its meaning
+  by shape and color. Suppressed entirely when only `clean` items exist (the
+  word is self-evident) and excluded from `--json` (the class field is the
+  machine contract).
 - **Spinners on slow network ops** — `agentsync update` and `agentsync
   marketplace add` animate a braille-frame spinner on stderr while
   marketplace fetches and plugin-manifest pulls are in flight. The spinner is

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -503,13 +503,18 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. | `--scope --project` |
-| `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project` |
+| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. | `--scope --project --json` |
+| `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project --json` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. | `--dry-run` |
 | `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
 
-Global: `-v/--verbose` for verbose logging on any command.
+Global: `-v/--verbose` for verbose logging on any command. `--color=auto|always|never`
+controls whether output is styled with ANSI color and bold (default `auto` — on
+for a TTY, off when piped/redirected; honors `NO_COLOR`). `status --json` and
+`diff [<path>] --json` emit the structured report instead of the formatted one,
+suitable for CI gates and dashboards (`diff --json` masks the same resolved
+secrets the formatted diff does).
 
 ---
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -160,7 +160,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		report := render.BuildReport(c, plan, agents)
 		if len(report.Rows) > 0 {
 			fmt.Fprintln(w)
-			report.PrintText(w)
+			report.PrintTextStyled(w, p)
 		}
 		return nil
 	}
@@ -230,7 +230,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	report := render.BuildReport(c, plan, agents)
 	if len(report.Rows) > 0 {
 		fmt.Fprintln(w)
-		report.PrintText(w)
+		report.PrintTextStyled(w, p)
 	}
 	return nil
 }

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newApplyCmd() *cobra.Command {
@@ -50,6 +51,10 @@ func newApplyCmd() *cobra.Command {
 // applyRun is the lock-protected body of the apply command. It is split
 // out from newApplyCmd so the lock acquisition lives in one obvious place.
 func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFlag string) error {
+	p, err := newPrinter(cmd)
+	if err != nil {
+		return err
+	}
 	c, sc, projectRoot, err := loadProjectedForScope(afero.NewOsFs(), home, scopeFlag, projectFlag, false)
 	if err != nil {
 		return err
@@ -61,9 +66,9 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// project tree the user didn't expect. The dry-run lists paths; the real
 	// apply otherwise printed only an op count.
 	if sc == adapter.ScopeProject {
-		fmt.Fprintf(cmd.ErrOrStderr(), "scope: project (%s)\n", projectRoot)
+		fmt.Fprintf(p.Err, "%s project (%s)\n", p.Faint("scope:"), projectRoot)
 	} else {
-		fmt.Fprintln(cmd.ErrOrStderr(), "scope: user")
+		fmt.Fprintf(p.Err, "%s user\n", p.Faint("scope:"))
 	}
 
 	// Resolve ${secret:...} and ${env:...} references before rendering. The
@@ -90,13 +95,13 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		// marker `agents` allowlist that intersects to nothing, so point
 		// there instead of at `agent add`.
 		if sc == adapter.ScopeProject {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"agentsync: no agents are enabled after applying the project marker at %s; nothing to apply.\n"+
-					"  Check the [agents] allowlist in that project's .agentsync.toml.\n", projectRoot)
+			fmt.Fprintf(p.Err,
+				"%s no agents are enabled after applying the project marker at %s; nothing to apply.\n"+
+					"  Check the [agents] allowlist in that project's .agentsync.toml.\n", p.Yellow("agentsync:"), projectRoot)
 		} else {
-			fmt.Fprintln(cmd.ErrOrStderr(),
-				"agentsync: no agents are enabled in agentsync.toml; nothing to apply.\n"+
-					"  Run `agentsync agent add claude` (or opencode) to register an agent.")
+			fmt.Fprintf(p.Err,
+				"%s no agents are enabled in agentsync.toml; nothing to apply.\n"+
+					"  Run `agentsync agent add claude` (or opencode) to register an agent.\n", p.Yellow("agentsync:"))
 		}
 		return nil
 	}
@@ -115,24 +120,24 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		if err != nil {
 			return err
 		}
-		w := cmd.OutOrStdout()
-		fmt.Fprintf(w, "Plan: %d ops total across %d agent(s)\n", plan.Total(), len(plan.PerAgent))
+		w := p.Out
+		fmt.Fprintf(w, "%s %d ops total across %d agent(s)\n", p.Bold("Plan:"), plan.Total(), len(plan.PerAgent))
 		for _, name := range reg.Names() {
 			res, ok := plan.PerAgent[name]
 			if !ok {
 				continue
 			}
-			fmt.Fprintf(w, "  %-10s %d ops, %d skips\n", name, len(res.Ops), len(res.Skips))
+			fmt.Fprintf(w, "  %s %d ops, %d skips\n", p.Bold(ui.Pad(name, 10)), len(res.Ops), len(res.Skips))
 			// List every destination path so the user can see exactly
 			// what apply will touch. Without this the dry-run hides the
 			// most useful piece of information (which files will be
 			// written) behind an op count.
 			for _, op := range res.Ops {
-				if op.Action == "" || op.Action == "write" {
-					fmt.Fprintf(w, "    write %s\n", op.Path)
-				} else {
-					fmt.Fprintf(w, "    %-5s %s\n", op.Action, op.Path)
+				action := op.Action
+				if action == "" {
+					action = "write"
 				}
+				fmt.Fprintf(w, "    %s %s %s\n", p.Cyan(ui.GlyphArrow), p.Cyan(ui.Pad(action, 5)), op.Path)
 			}
 		}
 		// Foreign-collision preview: which destinations contain content
@@ -146,7 +151,8 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		}
 		if len(previews) > 0 {
 			fmt.Fprintln(w)
-			fmt.Fprintf(w, "Foreign collisions: %d (the real apply will back these up before overwriting)\n", len(previews))
+			fmt.Fprintf(w, "%s %d (the real apply will back these up before overwriting)\n",
+				p.Yellow(ui.GlyphWarn+" Foreign collisions:"), len(previews))
 			for _, r := range previews {
 				fmt.Fprintf(w, "  %s\n", r.String())
 			}
@@ -168,10 +174,10 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	}
 	collisions, written, unchanged, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
 	if len(collisions) > 0 {
-		ew := cmd.ErrOrStderr()
-		fmt.Fprintf(ew, "agentsync: backed up %d pre-existing target(s) before overwriting:\n", len(collisions))
+		fmt.Fprintf(p.Err, "%s backed up %d pre-existing target(s) before overwriting:\n",
+			p.Yellow("agentsync:"), len(collisions))
 		for _, r := range collisions {
-			fmt.Fprintf(ew, "  %s\n", r.String())
+			fmt.Fprintf(p.Err, "  %s\n", r.String())
 		}
 	}
 
@@ -212,14 +218,14 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// of a pre-existing native file). Best-effort; never fails the apply.
 	_ = render.PruneBackups(home, render.DefaultBackupKeep)
 
-	w := cmd.OutOrStdout()
+	w := p.Out
 	// Report a clean no-op distinctly from real work: when every destination
 	// path already held our exact bytes (write skipped, no mtime churn), say so
 	// instead of the misleading "applied: N ops".
 	if len(written) > 0 && len(unchanged) == len(written) {
-		fmt.Fprintf(w, "up to date: %d ops, no changes\n", plan.Total())
+		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("up to date: %d ops, no changes", plan.Total())))
 	} else {
-		fmt.Fprintln(w, "applied:", plan.Total(), "ops")
+		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("applied: %d ops", plan.Total())))
 	}
 	report := render.BuildReport(c, plan, agents)
 	if len(report.Rows) > 0 {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -14,18 +14,38 @@ import (
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
+
+// diffHunk is one changed file or merged key. Source and Dest are the
+// secret-MASKED renderings; --json emits these verbatim, so the same redaction
+// that protects the formatted diff protects the JSON.
+type diffHunk struct {
+	Path    string `json:"path"`
+	Pointer string `json:"pointer,omitempty"`
+	Source  string `json:"source"`
+	Dest    string `json:"dest"`
+}
+
+type diffModel struct {
+	Hunks []diffHunk `json:"hunks"`
+}
 
 func newDiffCmd() *cobra.Command {
 	var (
 		scopeFlag   string
 		projectFlag string
+		jsonOut     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "diff [<path>]",
 		Short: "print unified diff between source-rendered content and destination",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			p, perr := newPrinter(cmd)
+			if perr != nil {
+				return perr
+			}
 			filterPath := ""
 			if len(args) == 1 {
 				fp, err := filepath.Abs(args[0])
@@ -59,7 +79,10 @@ func newDiffCmd() *cobra.Command {
 				}
 			}
 			if len(agents) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				if jsonOut {
+					return emitJSON(p.Out, diffModel{Hunks: []diffHunk{}})
+				}
+				fmt.Fprintln(p.Out, "no agents enabled; run `agentsync agent add claude` (or opencode)")
 				return nil
 			}
 			// diff renders the TEMPLATED canonical (it masks the destination's
@@ -95,10 +118,11 @@ func newDiffCmd() *cobra.Command {
 			}
 			redact := secrets.CollectResolved(&c, secBackend, envBackend)
 
-			dmp := diffmatchpatch.New()
-			w := cmd.OutOrStdout()
-			hasDiff := false
-
+			// Collect all hunks (masked src/dst) first, then render either the
+			// formatted diff or --json. Pretty rendering and JSON share the
+			// same masked strings, so the secret-leak guards above protect
+			// both modes.
+			var hunks []diffHunk
 			for _, name := range reg.Names() {
 				res, ok := plan.PerAgent[name]
 				if !ok {
@@ -121,18 +145,12 @@ func newDiffCmd() *cobra.Command {
 						_ = json.Unmarshal(op.Content, &ours)
 						final := readDestFile(op.MergeStrategy, op.Path)
 						for _, ptr := range render.CollectPointers(ours, "") {
-							srcVal := getPointerValue(ours, ptr)
-							dstVal := getPointerValue(final, ptr)
-							srcStr := secrets.MaskResolved(marshalPretty(srcVal), redact)
-							dstStr := secrets.MaskResolved(marshalPretty(dstVal), redact)
+							srcStr := secrets.MaskResolved(marshalPretty(getPointerValue(ours, ptr)), redact)
+							dstStr := secrets.MaskResolved(marshalPretty(getPointerValue(final, ptr)), redact)
 							if srcStr == dstStr {
 								continue
 							}
-							hasDiff = true
-							fmt.Fprintf(w, "--- source  %s#%s\n", op.Path, ptr)
-							fmt.Fprintf(w, "+++ dest    %s#%s\n", op.Path, ptr)
-							diffs := dmp.DiffMain(dstStr, srcStr, false)
-							fmt.Fprintln(w, dmp.DiffPrettyText(diffs))
+							hunks = append(hunks, diffHunk{Path: op.Path, Pointer: ptr, Source: srcStr, Dest: dstStr})
 						}
 					} else {
 						// File-level diff.
@@ -149,24 +167,67 @@ func newDiffCmd() *cobra.Command {
 						if srcStr == dstStr {
 							continue
 						}
-						hasDiff = true
-						fmt.Fprintf(w, "--- source  %s\n", op.Path)
-						fmt.Fprintf(w, "+++ dest    %s\n", op.Path)
-						diffs := dmp.DiffMain(dstStr, srcStr, false)
-						fmt.Fprintln(w, dmp.DiffPrettyText(diffs))
+						hunks = append(hunks, diffHunk{Path: op.Path, Source: srcStr, Dest: dstStr})
 					}
 				}
 			}
 
-			if !hasDiff {
-				fmt.Fprintln(w, "no diff")
+			if jsonOut {
+				return emitJSON(p.Out, diffModel{Hunks: hunks})
+			}
+
+			if len(hunks) == 0 {
+				fmt.Fprintln(p.Out, "no diff")
+				return nil
+			}
+
+			dmp := diffmatchpatch.New()
+			for _, h := range hunks {
+				label := h.Path
+				if h.Pointer != "" {
+					label = h.Path + "#" + h.Pointer
+				}
+				fmt.Fprintf(p.Out, "%s %s\n", p.Red("--- source"), label)
+				fmt.Fprintf(p.Out, "%s %s\n", p.Green("+++ dest  "), label)
+				diffs := dmp.DiffMain(h.Dest, h.Source, false)
+				fmt.Fprintln(p.Out, renderDiffText(p, diffs))
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted diff")
 	return cmd
+}
+
+// renderDiffText turns a diffmatchpatch result into a printable string. In
+// color mode, insertions and deletions are highlighted green/red inline; in
+// plain mode (NO_COLOR, --color=never, or a non-terminal), inserts wrap as
+// {+text+} and deletes as [-text-] so the change is still legible when piped
+// to a file or grep. The previous implementation emitted raw ANSI in either
+// case, leaking escape codes into redirects.
+func renderDiffText(p *ui.Printer, diffs []diffmatchpatch.Diff) string {
+	var b strings.Builder
+	for _, d := range diffs {
+		switch d.Type {
+		case diffmatchpatch.DiffInsert:
+			if p.Color() {
+				b.WriteString(p.Green(d.Text))
+			} else {
+				b.WriteString("{+" + d.Text + "+}")
+			}
+		case diffmatchpatch.DiffDelete:
+			if p.Color() {
+				b.WriteString(p.Red(d.Text))
+			} else {
+				b.WriteString("[-" + d.Text + "-]")
+			}
+		default:
+			b.WriteString(d.Text)
+		}
+	}
+	return b.String()
 }
 
 func marshalPretty(v any) string {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,5 +226,97 @@ func TestDiff_PathFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "no diff") {
 		t.Fatalf("filtered diff for non-matching path should report 'no diff'; got: %s", out)
+	}
+}
+
+// TestDiff_PlainModeUsesTextMarkers locks in the readability fix: the previous
+// diff path emitted raw ANSI unconditionally via diffmatchpatch's DiffPrettyText,
+// so piped/redirected output became "{ESC}[31m...{ESC}[0m..." gibberish.  Auto
+// color on a non-TTY pipe must instead use text markers ([-...-] / {+...+}) so
+// the change is legible without a terminal.
+func TestDiff_PlainModeUsesTextMarkers(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.ReplaceAll(string(body), `"npx"`, `"npm"`)), 0o644)
+
+	out, err := runCLI(t, env, "diff")
+	if err != nil {
+		t.Fatalf("diff: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("piped diff must not emit raw ANSI; got:\n%q", out)
+	}
+	if !strings.Contains(out, "[-") || !strings.Contains(out, "{+") {
+		t.Fatalf("plain diff should use text change markers; got:\n%s", out)
+	}
+}
+
+// TestDiff_JSONOutputMasksSecrets is the regression for diff --json leaking
+// resolved cleartext: the JSON path must mask through the SAME redaction the
+// formatted diff uses, so neither mode prints a substituted credential.
+func TestDiff_JSONOutputMasksSecrets(t *testing.T) {
+	const sentinel = "ghp_JSON_SENTINEL_DO_NOT_LEAK_456789"
+
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "GITHUB_TOKEN": sentinel}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	body := `[server]
+type = "stdio"
+command = "npx"
+
+[server.env]
+GITHUB_TOKEN = "${env:GITHUB_TOKEN}"
+`
+	_ = os.WriteFile(mcp, []byte(body), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drift the dest so there is a hunk to emit.
+	dst := filepath.Join(tmp, ".claude.json")
+	dstBytes, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.ReplaceAll(string(dstBytes), `"npx"`, `"npm"`)), 0o644)
+
+	out, err := runCLI(t, env, "diff", "--json")
+	if err != nil {
+		t.Fatalf("diff --json: %v\n%s", err, out)
+	}
+	if strings.Contains(out, sentinel) {
+		t.Fatalf("SECURITY: diff --json leaked sentinel:\n%s", out)
+	}
+	var got struct {
+		Hunks []struct {
+			Path    string `json:"path"`
+			Pointer string `json:"pointer"`
+			Source  string `json:"source"`
+			Dest    string `json:"dest"`
+		} `json:"hunks"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("diff --json output not valid JSON: %v\n%s", err, out)
+	}
+	if len(got.Hunks) == 0 {
+		t.Fatalf("expected at least one hunk; got 0\n%s", out)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -24,34 +24,37 @@ func newDoctorCmd() *cobra.Command {
 		Short: "diagnose first-run readiness: environment, schema, secrets, adapters",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			w := cmd.OutOrStdout()
+			p, err := newPrinter(cmd)
+			if err != nil {
+				return err
+			}
 			home := paths.AgentsyncHome(paths.OSEnv{})
 
-			fmt.Fprintln(w, "agentsync doctor")
-			fmt.Fprintln(w, "  AGENTSYNC_HOME:", home)
-			fmt.Fprintln(w, "  Go version:    ", runtime.Version())
-			fmt.Fprintln(w, "  OS / arch:     ", runtime.GOOS, runtime.GOARCH)
+			fmt.Fprintln(p.Out, p.Bold("agentsync doctor"))
+			fmt.Fprintln(p.Out, "  AGENTSYNC_HOME:", home)
+			fmt.Fprintln(p.Out, "  Go version:    ", runtime.Version())
+			fmt.Fprintln(p.Out, "  OS / arch:     ", runtime.GOOS, runtime.GOARCH)
 
-			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Source repo")
+			fmt.Fprintln(p.Out, "")
+			p.Section("Source repo")
 			fails := 0
-			fails += checkHomeDir(w, home)
-			fails += checkStateDir(w, home)
-			cfg, schemaOK := checkSchema(w, home)
+			fails += checkHomeDir(p, home)
+			fails += checkStateDir(p, home)
+			cfg, schemaOK := checkSchema(p, home)
 			if !schemaOK {
 				fails++
 			}
 
-			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Secrets")
+			fmt.Fprintln(p.Out, "")
+			p.Section("Secrets")
 			if schemaOK {
-				fails += checkSecrets(w, cfg.Secrets, home)
+				fails += checkSecrets(p, cfg.Secrets, home)
 			} else {
-				fmt.Fprintln(w, "  skipped (schema invalid above)")
+				fmt.Fprintln(p.Out, "  skipped (schema invalid above)")
 			}
 
-			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Adapter detection (PATH-only)")
+			fmt.Fprintln(p.Out, "")
+			p.Section("Adapter detection (PATH-only)")
 			for _, agent := range []struct {
 				name string
 				bin  string
@@ -61,47 +64,64 @@ func newDoctorCmd() *cobra.Command {
 				{"codex", "codex"},
 				{"cursor", "cursor"},
 			} {
-				p, err := exec.LookPath(agent.bin)
-				if err != nil {
-					fmt.Fprintf(w, "  %-10s not found in PATH\n", agent.name)
+				path, lookErr := exec.LookPath(agent.bin)
+				if lookErr != nil {
+					fmt.Fprintf(p.Out, "  %s %-10s %s\n", p.Faint(ui.GlyphInfo), agent.name, p.Faint("not found in PATH"))
 					continue
 				}
-				fmt.Fprintf(w, "  %-10s %s\n", agent.name, p)
+				fmt.Fprintf(p.Out, "  %s %-10s %s\n", p.Green(ui.GlyphOK), agent.name, p.Faint(path))
 			}
 
-			fmt.Fprintln(w, "")
-			fmt.Fprintln(w, "Plugins")
+			fmt.Fprintln(p.Out, "")
+			p.Section("Plugins")
 			if schemaOK {
-				checkPlugins(w, home)
+				checkPlugins(p, home)
 			} else {
-				fmt.Fprintln(w, "  skipped (schema invalid above)")
+				fmt.Fprintln(p.Out, "  skipped (schema invalid above)")
 			}
 
-			fmt.Fprintln(w, "")
+			fmt.Fprintln(p.Out, "")
 			if fails > 0 {
-				fmt.Fprintf(w, "%d issue(s) detected — fix before running `agentsync apply`\n", fails)
+				fmt.Fprintf(p.Out, "%s %s\n", p.Red(ui.GlyphErr),
+					p.Red(fmt.Sprintf("%d issue(s) detected — fix before running `agentsync apply`", fails)))
 				return fmt.Errorf("doctor: %d issue(s) detected", fails)
 			}
-			fmt.Fprintln(w, "all checks passed")
+			fmt.Fprintf(p.Out, "%s %s\n", p.Green(ui.GlyphOK), p.Green("all checks passed"))
 			return nil
 		},
 	}
 }
 
+// okCheck / failCheck / warnCheck render one readiness line. The label carries
+// its own trailing alignment padding (e.g. "home dir   ") and is printed plain
+// immediately before the colored status, so the "<label><status>" substring the
+// doctor tests pin stays contiguous when color is off.
+func okCheck(p *ui.Printer, label, status string) {
+	fmt.Fprintf(p.Out, "  %s %s%s\n", p.Green(ui.GlyphOK), label, p.Green(status))
+}
+
+func failCheck(p *ui.Printer, label, status string) {
+	fmt.Fprintf(p.Out, "  %s %s%s\n", p.Red(ui.GlyphErr), label, p.Red(status))
+}
+
+func warnCheck(p *ui.Printer, label, status string) {
+	fmt.Fprintf(p.Out, "  %s %s%s\n", p.Yellow(ui.GlyphWarn), label, p.Yellow(status))
+}
+
 // checkHomeDir verifies that AGENTSYNC_HOME exists and is a directory.
 // Returns 1 if the check fails, 0 otherwise.
-func checkHomeDir(w io.Writer, home string) int {
+func checkHomeDir(p *ui.Printer, home string) int {
 	info, err := os.Stat(home)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(w, "  home dir   missing — run `agentsync init`\n")
+			failCheck(p, "home dir   ", "missing — run `agentsync init`")
 			return 1
 		}
-		fmt.Fprintf(w, "  home dir   unreadable: %v\n", err)
+		failCheck(p, "home dir   ", fmt.Sprintf("unreadable: %v", err))
 		return 1
 	}
 	if !info.IsDir() {
-		fmt.Fprintf(w, "  home dir   exists but is not a directory: %s\n", home)
+		failCheck(p, "home dir   ", fmt.Sprintf("exists but is not a directory: %s", home))
 		return 1
 	}
 	// A home dir without agentsync.toml is half-initialized (e.g. an authoring
@@ -109,56 +129,56 @@ func checkHomeDir(w io.Writer, home string) int {
 	// avoids calling the schema "ok" on a config-less home.
 	if _, err := os.Stat(filepath.Join(home, "agentsync.toml")); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(w, "  home dir   missing agentsync.toml (half-initialized) — run `agentsync init`\n")
+			failCheck(p, "home dir   ", "missing agentsync.toml (half-initialized) — run `agentsync init`")
 			return 1
 		}
-		fmt.Fprintf(w, "  home dir   agentsync.toml unreadable: %v\n", err)
+		failCheck(p, "home dir   ", fmt.Sprintf("agentsync.toml unreadable: %v", err))
 		return 1
 	}
-	fmt.Fprintf(w, "  home dir   ok\n")
+	okCheck(p, "home dir   ", "ok")
 	return 0
 }
 
 // checkStateDir verifies that .state/ is writable.
-func checkStateDir(w io.Writer, home string) int {
+func checkStateDir(p *ui.Printer, home string) int {
 	stateDir := filepath.Join(home, ".state")
 	if info, err := os.Stat(stateDir); err != nil {
-		fmt.Fprintf(w, "  .state/    missing — run `agentsync init`\n")
+		failCheck(p, ".state/    ", "missing — run `agentsync init`")
 		return 1
 	} else if !info.IsDir() {
-		fmt.Fprintf(w, "  .state/    exists but is not a directory\n")
+		failCheck(p, ".state/    ", "exists but is not a directory")
 		return 1
 	}
 	probe := filepath.Join(stateDir, ".doctor-write-probe")
 	if err := os.WriteFile(probe, []byte{}, 0o600); err != nil {
-		fmt.Fprintf(w, "  .state/    not writable: %v\n", err)
+		failCheck(p, ".state/    ", fmt.Sprintf("not writable: %v", err))
 		return 1
 	}
 	_ = os.Remove(probe)
-	fmt.Fprintf(w, "  .state/    ok (writable)\n")
+	okCheck(p, ".state/    ", "ok (writable)")
 
 	// Verify targets.json parses — the same load status/apply/diff/reconcile
 	// do. A corrupt state file makes every real command exit 1, so a readiness
 	// check that ignores it would falsely report healthy. A missing file is
 	// fine (state.Load returns an empty state on a fresh install).
 	if _, err := state.Load(filepath.Join(stateDir, "targets.json")); err != nil {
-		fmt.Fprintf(w, "  state file corrupt: %v\n", err)
+		failCheck(p, "state file ", fmt.Sprintf("corrupt: %v", err))
 		return 1
 	}
-	fmt.Fprintf(w, "  state file ok\n")
+	okCheck(p, "state file ", "ok")
 	return 0
 }
 
 // checkSchema validates agentsync.toml. Returns the parsed Config plus a
 // success flag so secrets checks can reuse it.
-func checkSchema(w io.Writer, home string) (source.Config, bool) {
+func checkSchema(p *ui.Printer, home string) (source.Config, bool) {
 	c, err := source.Load(afero.NewOsFs(), home)
 	if err != nil {
-		fmt.Fprintf(w, "  schema     invalid: %v\n", err)
+		failCheck(p, "schema     ", fmt.Sprintf("invalid: %v", err))
 		return source.Config{}, false
 	}
-	fmt.Fprintf(w, "  schema     ok (%d mcp, %d plugin(s), %d marketplace(s))\n",
-		len(c.MCPServers), len(c.Plugins), len(c.Marketplaces))
+	okCheck(p, "schema     ", fmt.Sprintf("ok (%d mcp, %d plugin(s), %d marketplace(s))",
+		len(c.MCPServers), len(c.Plugins), len(c.Marketplaces)))
 	return c.Config, true
 }
 
@@ -168,16 +188,16 @@ func checkSchema(w io.Writer, home string) (source.Config, bool) {
 // brings them under management. Probes every registered adapter (not just the
 // enabled set) so a fresh user with Claude plugins but no agentsync config still
 // sees the nudge.
-func checkPlugins(w io.Writer, home string) {
+func checkPlugins(p *ui.Printer, home string) {
 	c, err := source.Load(afero.NewOsFs(), home)
 	if err != nil {
-		fmt.Fprintln(w, "  skipped (source not loadable)")
+		fmt.Fprintln(p.Out, "  skipped (source not loadable)")
 		return
 	}
 	reg := registryFactory()
 	undeclared := undeclaredNativePlugins(c, reg, reg.Names())
 	if len(undeclared) == 0 {
-		fmt.Fprintln(w, "  ok (no undeclared native plugins)")
+		okCheck(p, "", "ok (no undeclared native plugins)")
 		return
 	}
 	for _, name := range reg.Names() {
@@ -185,34 +205,34 @@ func checkPlugins(w io.Writer, home string) {
 		if len(missing) == 0 {
 			continue
 		}
-		fmt.Fprintf(w, "  %-10s %d not in source: %s — run `agentsync import %s:plugin`\n",
-			name, len(missing), strings.Join(missing, ", "), name)
+		warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf("%d not in source: %s — run `agentsync import %s:plugin`",
+			len(missing), strings.Join(missing, ", "), name))
 	}
 }
 
 // checkSecrets validates the [secrets] block: backend present, identity
 // file exists with restrictive permissions, recipient set.
-func checkSecrets(w io.Writer, cfg source.SecretsConfig, home string) int {
+func checkSecrets(p *ui.Printer, cfg source.SecretsConfig, home string) int {
 	if cfg.Backend == "" {
-		fmt.Fprintf(w, "  backend    not configured (skip — no [secrets] block)\n")
+		fmt.Fprintf(p.Out, "  %s backend    %s\n", p.Faint(ui.GlyphInfo), p.Faint("not configured (skip — no [secrets] block)"))
 		return 0
 	}
 	if cfg.Backend != "age" {
-		fmt.Fprintf(w, "  backend    unsupported: %q (want \"age\")\n", cfg.Backend)
+		failCheck(p, "backend    ", fmt.Sprintf("unsupported: %q (want \"age\")", cfg.Backend))
 		return 1
 	}
-	fmt.Fprintf(w, "  backend    age\n")
+	okCheck(p, "backend    ", "age")
 
 	fails := 0
 	if cfg.Recipient == "" {
-		fmt.Fprintf(w, "  recipient  missing — set [secrets].recipient in agentsync.toml\n")
+		failCheck(p, "recipient  ", "missing — set [secrets].recipient in agentsync.toml")
 		fails++
 	} else {
-		fmt.Fprintf(w, "  recipient  set\n")
+		okCheck(p, "recipient  ", "set")
 	}
 
 	if cfg.IdentityFile == "" {
-		fmt.Fprintf(w, "  identity   missing — set [secrets].identity_file in agentsync.toml\n")
+		failCheck(p, "identity   ", "missing — set [secrets].identity_file in agentsync.toml")
 		return fails + 1
 	}
 	// Resolve identity_file the same way apply does (expanding ${env:HOME}/~
@@ -222,25 +242,25 @@ func checkSecrets(w io.Writer, cfg source.SecretsConfig, home string) int {
 	idPath := secrets.ResolveIdentityFile(cfg, home, userHome)
 	info, err := os.Stat(idPath)
 	if err != nil {
-		fmt.Fprintf(w, "  identity   %s — not readable (%v)\n", idPath, err)
+		failCheck(p, "identity   ", fmt.Sprintf("%s — not readable (%v)", idPath, err))
 		return fails + 1
 	}
 	// Use the same check apply/verify use so doctor never disagrees: it honors
 	// AGENTSYNC_AGE_SKIP_PERM_CHECK=1 and the Windows ACL caveat, unlike the
 	// previous inline 0o077 mask which falsely failed an opted-out 0644 key.
 	if permErr := secrets.CheckIdentityPermissions(idPath); permErr != nil {
-		fmt.Fprintf(w, "  identity   %s — too permissive (%v); chmod 600 (or set AGENTSYNC_AGE_SKIP_PERM_CHECK=1)\n", idPath, info.Mode().Perm())
+		failCheck(p, "identity   ", fmt.Sprintf("%s — too permissive (%v); chmod 600 (or set AGENTSYNC_AGE_SKIP_PERM_CHECK=1)", idPath, info.Mode().Perm()))
 		return fails + 1
 	}
-	fmt.Fprintf(w, "  identity   ok (%s)\n", idPath)
+	okCheck(p, "identity   ", fmt.Sprintf("ok (%s)", idPath))
 
 	// Age-encrypted file location — warn if missing (legitimate on a
 	// fresh install where the user hasn't called `secrets set` yet).
 	agePath := secrets.ResolveAgeFile(cfg, home, userHome)
 	if _, err := os.Stat(agePath); err != nil {
-		fmt.Fprintf(w, "  age file   %s — not yet created (run `agentsync secrets edit` to author)\n", agePath)
+		warnCheck(p, "age file   ", fmt.Sprintf("%s — not yet created (run `agentsync secrets edit` to author)", agePath))
 	} else {
-		fmt.Fprintf(w, "  age file   %s\n", agePath)
+		okCheck(p, "age file   ", agePath)
 	}
 	return fails
 }

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -60,6 +60,10 @@ func newMarketplaceAddCmd() *cobra.Command {
 func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	rawURL := args[0]
 	home := paths.AgentsyncHome(paths.OSEnv{})
+	p, err := newPrinter(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Build the Source from the raw URL/path argument.
 	src, err := parseMarketplaceSource(rawURL)
@@ -67,7 +71,9 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	stopSpin := p.Spin(fmt.Sprintf("fetching marketplace %s", rawURL))
 	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL)
+	stopSpin()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,7 +3,11 @@
 package cli
 
 import (
+	"encoding/json"
+	"io"
+
 	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // version metadata; main.go injects via -ldflags. Tests use the literal
@@ -17,7 +21,10 @@ var (
 // NewRoot constructs the root command tree. Tests build their own root via
 // this constructor so flag state is isolated per test.
 func NewRoot() *cobra.Command {
-	var verbose bool
+	var (
+		verbose   bool
+		colorFlag string
+	)
 
 	cmd := &cobra.Command{
 		Use:           "agentsync",
@@ -29,6 +36,7 @@ func NewRoot() *cobra.Command {
 	cmd.SetVersionTemplate(`{{.Use}} {{.Version}} (commit ` + Commit + `, built ` + Date + `)
 `)
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
+	cmd.PersistentFlags().StringVar(&colorFlag, "color", "auto", "colorize output: auto | always | never")
 
 	cmd.AddCommand(
 		newInitCmd(),
@@ -52,3 +60,32 @@ func NewRoot() *cobra.Command {
 
 // Execute is the main.go entry point.
 func Execute() error { return NewRoot().Execute() }
+
+// newPrinter builds the presentation Printer for a command invocation, reading
+// the inherited --color flag and binding to the command's stdout/stderr. The
+// color decision (TTY + NO_COLOR + flag) is made once, here, so every command
+// styles output identically. An invalid --color value is reported as an error.
+func newPrinter(cmd *cobra.Command) (*ui.Printer, error) {
+	modeStr, err := cmd.Flags().GetString("color")
+	if err != nil {
+		// Persistent flag not merged into this command's set; read it off the
+		// inherited set explicitly.
+		if f := cmd.InheritedFlags().Lookup("color"); f != nil {
+			modeStr = f.Value.String()
+		}
+	}
+	mode, perr := ui.ParseColorMode(modeStr)
+	if perr != nil {
+		return nil, perr
+	}
+	return ui.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), mode), nil
+}
+
+// emitJSON writes v as indented JSON to w. Used by the --json output modes,
+// which print only the structured payload to stdout (diagnostics go to stderr)
+// so the result is cleanly parseable.
+func emitJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -17,20 +17,49 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 	"github.com/tailscale/hujson"
 )
+
+// statusItem is one tracked file or merged key and its drift classification.
+type statusItem struct {
+	Path string `json:"path"`
+	// Pointer is the RFC-6901 JSON pointer for a key-merge item; empty for a
+	// whole-file item.
+	Pointer string `json:"pointer,omitempty"`
+	Class   string `json:"class"`
+}
+
+// statusAgent groups one agent's tracked items.
+type statusAgent struct {
+	Agent string       `json:"agent"`
+	Items []statusItem `json:"items"`
+}
+
+// statusModel is the full drift report, rendered either as the formatted
+// dashboard or, under --json, verbatim. Summary tallies items by drift class.
+type statusModel struct {
+	Agents  []statusAgent  `json:"agents"`
+	Summary map[string]int `json:"summary"`
+}
 
 func newStatusCmd() *cobra.Command {
 	var (
 		scopeFlag   string
 		projectFlag string
+		jsonOut     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "report drift across registered agents",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			p, err := newPrinter(cmd)
+			if err != nil {
+				return err
+			}
 			home := paths.AgentsyncHome(paths.OSEnv{})
 			// Load WITH the plugin cache so drift classification sees the
 			// same plugin-projected components `apply` writes; source.Load
@@ -54,15 +83,12 @@ func newStatusCmd() *cobra.Command {
 				}
 			}
 			if len(agents) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "no agents enabled; run `agentsync agent add claude` (or opencode)")
-				// Still surface orphaned state from a removed/disabled agent, so
-				// removing the LAST agent doesn't hide its leftover native config.
-				for _, a := range orphanedStateAgents(s, agents) {
-					fmt.Fprintf(cmd.ErrOrStderr(),
-						"warning: agent %q is not enabled but still owns tracked files/keys in state; its "+
-							"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
-						a, a)
+				if jsonOut {
+					emitStatusWarnings(p, c, reg, s, agents)
+					return emitJSON(p.Out, statusModel{Agents: []statusAgent{}, Summary: map[string]int{}})
 				}
+				fmt.Fprintln(p.Out, "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				emitStatusWarnings(p, c, reg, s, agents)
 				return nil
 			}
 			// apply WRITES (and RecordOpsState HASHES) the secret-RESOLVED
@@ -83,90 +109,167 @@ func newStatusCmd() *cobra.Command {
 				return err
 			}
 
-			w := cmd.OutOrStdout()
-			for _, name := range reg.Names() {
-				res, ok := plan.PerAgent[name]
-				if !ok {
-					continue
-				}
-				fmt.Fprintf(w, "[%s]\n", name)
-				seen := map[string]bool{}
-				// file-level: for each op, classify. Only key-merge ops are
-				// handled key-by-key below; every other strategy (including
-				// "replace", used by skills/subagents/commands/memory) is a
-				// whole-file op and must be classified here. Skipping on any
-				// non-empty MergeStrategy silently dropped all replace-strategy
-				// files, so status reported no drift for them.
-				for _, op := range res.Ops {
-					if render.IsKeyMerge(op.MergeStrategy) {
-						continue // covered key-by-key below
-					}
-					if seen[op.Path] {
-						continue
-					}
-					seen[op.Path] = true
-					hsrc := hashContent(op.Content)
-					happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, op.Path)].SHA256
-					hdest := hashFile(op.Path)
-					cls := drift.Classify(hsrc, happlied, hdest)
-					fmt.Fprintf(w, "  %-20s %s\n", cls, op.Path)
-				}
-				// key-level: for each merge op, walk owned pointers
-				for _, op := range res.Ops {
-					if !render.IsKeyMerge(op.MergeStrategy) {
-						continue
-					}
-					var ours map[string]any
-					_ = json.Unmarshal(op.Content, &ours)
-					final := readDestFile(op.MergeStrategy, op.Path)
-					for _, ptr := range render.CollectPointers(ours, "") {
-						hsrc := hashAnyValue(getPointerValue(ours, ptr))
-						happlied := s.Keys[stateKeyKey(userHome, name, sc, projectRoot, op.Path, ptr)].SHA256
-						hdest := hashAnyValue(getPointerValue(final, ptr))
-						cls := drift.Classify(hsrc, happlied, hdest)
-						fmt.Fprintf(w, "  %-20s %s#%s\n", cls, op.Path, ptr)
-					}
-				}
-				// orphans: whole-file dests this agent still owns in state but no
-				// longer renders (the source component was removed). Without this,
-				// status reported nothing for them — falsely "clean" — though the
-				// file lingers and the next apply / a reconcile would act on it.
-				for _, orphan := range render.OrphanFiles(s, userHome, name, sc, projectRoot, res.Ops) {
-					happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, orphan)].SHA256
-					cls := drift.Classify("", happlied, hashFile(orphan))
-					fmt.Fprintf(w, "  %-20s %s\n", cls, orphan)
-				}
+			model := buildStatusModel(plan, reg.Names(), s, userHome, sc, projectRoot)
+			if jsonOut {
+				// JSON to stdout, advisory warnings to stderr — keeps the
+				// machine-readable payload cleanly parseable.
+				emitStatusWarnings(p, c, reg, s, agents)
+				return emitJSON(p.Out, model)
 			}
-			// Surface agents that still own tracked state (and thus orphaned
-			// native config) but are no longer enabled — a removed, or
-			// disabled-not-purged, agent. status/apply otherwise iterate only the
-			// enabled set, so these would accumulate silently with no diagnostic.
-			for _, a := range orphanedStateAgents(s, agents) {
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"warning: agent %q is not enabled but still owns tracked files/keys in state; its "+
-						"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
-					a, a)
-			}
-			// Nudge: plugins installed natively in an enabled agent but not yet
-			// declared in source. agentsync treats them as foreign-managed (never
-			// drift), so this is informational — it points at `import`.
-			undeclared := undeclaredNativePlugins(c, reg, agents)
-			for _, name := range reg.Names() {
-				missing := undeclared[name]
-				if len(missing) == 0 {
-					continue
-				}
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"note: %d plugin(s) installed in %s are not in your source (%s); "+
-						"run `agentsync import %s:plugin` to manage them.\n",
-					len(missing), name, strings.Join(missing, ", "), name)
-			}
+			renderStatusText(p, model)
+			emitStatusWarnings(p, c, reg, s, agents)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: auto-detect from cwd)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted report")
 	return cmd
+}
+
+// buildStatusModel classifies every tracked file/key/orphan across agents into
+// the structured statusModel. It is the single source of truth both the
+// formatted dashboard and --json render from.
+func buildStatusModel(plan render.RenderPlan, names []string, s *state.Targets, userHome string, sc adapter.Scope, projectRoot string) statusModel {
+	model := statusModel{Summary: map[string]int{}}
+	for _, name := range names {
+		res, ok := plan.PerAgent[name]
+		if !ok {
+			continue
+		}
+		ag := statusAgent{Agent: name}
+		seen := map[string]bool{}
+		// file-level: every non-key-merge op is a whole-file item (including the
+		// "replace" strategy used by skills/subagents/commands/memory).
+		for _, op := range res.Ops {
+			if render.IsKeyMerge(op.MergeStrategy) {
+				continue // covered key-by-key below
+			}
+			if seen[op.Path] {
+				continue
+			}
+			seen[op.Path] = true
+			hsrc := hashContent(op.Content)
+			happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, op.Path)].SHA256
+			hdest := hashFile(op.Path)
+			cls := drift.Classify(hsrc, happlied, hdest).String()
+			ag.Items = append(ag.Items, statusItem{Path: op.Path, Class: cls})
+			model.Summary[cls]++
+		}
+		// key-level: walk owned pointers for each merge op.
+		for _, op := range res.Ops {
+			if !render.IsKeyMerge(op.MergeStrategy) {
+				continue
+			}
+			var ours map[string]any
+			_ = json.Unmarshal(op.Content, &ours)
+			final := readDestFile(op.MergeStrategy, op.Path)
+			for _, ptr := range render.CollectPointers(ours, "") {
+				hsrc := hashAnyValue(getPointerValue(ours, ptr))
+				happlied := s.Keys[stateKeyKey(userHome, name, sc, projectRoot, op.Path, ptr)].SHA256
+				hdest := hashAnyValue(getPointerValue(final, ptr))
+				cls := drift.Classify(hsrc, happlied, hdest).String()
+				ag.Items = append(ag.Items, statusItem{Path: op.Path, Pointer: ptr, Class: cls})
+				model.Summary[cls]++
+			}
+		}
+		// orphans: whole-file dests this agent still owns in state but no longer
+		// renders (the source component was removed). Without these, status
+		// reports nothing for a file that lingers and the next apply/reconcile
+		// would act on.
+		for _, orphan := range render.OrphanFiles(s, userHome, name, sc, projectRoot, res.Ops) {
+			happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, orphan)].SHA256
+			cls := drift.Classify("", happlied, hashFile(orphan)).String()
+			ag.Items = append(ag.Items, statusItem{Path: orphan, Class: cls})
+			model.Summary[cls]++
+		}
+		model.Agents = append(model.Agents, ag)
+	}
+	return model
+}
+
+// classOrder is the stable display order for the summary footer and groups the
+// drift classes by severity for coloring.
+var classOrder = []string{
+	"clean", "converged", "new", "pending",
+	"drift", "conflict", "foreign-collision", "orphan", "orphan-drifted",
+}
+
+// styleClass maps a drift class to its glyph and color. Green = synced, cyan =
+// a pending change apply will make, red = unexpected/destructive drift, yellow
+// = an orphan needing a decision.
+func styleClass(p *ui.Printer, cls string) (glyph string, color func(string) string) {
+	switch cls {
+	case "clean", "converged":
+		return ui.GlyphOK, p.Green
+	case "new", "pending":
+		return ui.GlyphArrow, p.Cyan
+	case "drift", "conflict", "foreign-collision", "orphan-drifted":
+		return ui.GlyphErr, p.Red
+	case "orphan":
+		return ui.GlyphWarn, p.Yellow
+	default:
+		return ui.GlyphInfo, p.Faint
+	}
+}
+
+// renderStatusText prints the formatted drift dashboard: a bold header per
+// agent, a glyph + color-coded class per item, and a one-line summary footer.
+func renderStatusText(p *ui.Printer, model statusModel) {
+	for _, ag := range model.Agents {
+		fmt.Fprintln(p.Out, p.Bold("["+ag.Agent+"]"))
+		for _, it := range ag.Items {
+			disp := it.Path
+			if it.Pointer != "" {
+				disp = it.Path + "#" + it.Pointer
+			}
+			glyph, color := styleClass(p, it.Class)
+			// Pad the plain "glyph class" to a fixed visible width BEFORE
+			// coloring so ANSI bytes never shift the path column.
+			label := ui.Pad(glyph+" "+it.Class, 20)
+			fmt.Fprintf(p.Out, "  %s %s\n", color(label), disp)
+		}
+	}
+
+	// Summary footer lists only non-zero classes, so the words "drift" /
+	// "conflict" / "pending" never appear when there is none of that state.
+	var segs []string
+	for _, cls := range classOrder {
+		n := model.Summary[cls]
+		if n == 0 {
+			continue
+		}
+		_, color := styleClass(p, cls)
+		segs = append(segs, color(fmt.Sprintf("%d %s", n, cls)))
+	}
+	if len(segs) > 0 {
+		fmt.Fprintln(p.Out, "")
+		fmt.Fprintln(p.Out, strings.Join(segs, "  ·  "))
+	}
+}
+
+// emitStatusWarnings writes advisory diagnostics to stderr: orphaned state from
+// a removed/disabled agent, and native plugins not yet declared in source.
+// These are not part of the status model (and not the --json payload).
+func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, agents []string) {
+	for _, a := range orphanedStateAgents(s, agents) {
+		fmt.Fprintf(p.Err, "%s agent %q is not enabled but still owns tracked files/keys in state; its "+
+			"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
+			p.Yellow("warning:"), a, a)
+	}
+	// Nudge: plugins installed natively in an enabled agent but not yet declared
+	// in source. agentsync treats them as foreign-managed (never drift), so this
+	// is informational — it points at `import`.
+	undeclared := undeclaredNativePlugins(c, reg, agents)
+	for _, name := range reg.Names() {
+		missing := undeclared[name]
+		if len(missing) == 0 {
+			continue
+		}
+		fmt.Fprintf(p.Err, "%s %d plugin(s) installed in %s are not in your source (%s); "+
+			"run `agentsync import %s:plugin` to manage them.\n",
+			p.Cyan("note:"), len(missing), name, strings.Join(missing, ", "), name)
+	}
 }
 
 // orphanedStateAgents returns, sorted, the agent names that appear as a state

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -246,6 +246,55 @@ func renderStatusText(p *ui.Printer, model statusModel) {
 		fmt.Fprintln(p.Out, "")
 		fmt.Fprintln(p.Out, strings.Join(segs, "  ·  "))
 	}
+	renderStatusLegend(p, model.Summary)
+}
+
+// classLegend gives a one-line, action-focused explanation of what `apply`
+// will do for an item in each drift class. Phrased so each line reads as a
+// continuation of "apply will…". "clean" is intentionally omitted: the word
+// is self-evident and adding "no action" would just be noise; the legend
+// itself is also skipped entirely when the summary contains nothing but
+// "clean" items, so a fully-synced status report stays as terse as today.
+var classLegend = map[string]string{
+	"converged":         "no action (source and dest now match)",
+	"new":               "will be created",
+	"pending":           "will be updated to match source",
+	"drift":             "will be overwritten (use reconcile to keep the dest edit)",
+	"conflict":          "will be overwritten (use reconcile to merge the dest edit)",
+	"foreign-collision": "will be backed up and overwritten",
+	"orphan":            "will be deleted",
+	"orphan-drifted":    "will be deleted (a local edit will be lost)",
+}
+
+// renderStatusLegend prints a brief glossary of the drift classes that
+// actually appear in the summary. Each line is colored to match the per-item
+// dashboard above and prefixed with the same glyph, so the user can scan
+// from a body row to its meaning by shape and color, not just by word.
+func renderStatusLegend(p *ui.Printer, summary map[string]int) {
+	type entry struct {
+		cls, msg string
+	}
+	var rows []entry
+	for _, cls := range classOrder {
+		if summary[cls] == 0 {
+			continue
+		}
+		msg, ok := classLegend[cls]
+		if !ok {
+			continue
+		}
+		rows = append(rows, entry{cls, msg})
+	}
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Fprintln(p.Out, "")
+	fmt.Fprintln(p.Out, p.Faint("What `apply` will do:"))
+	for _, r := range rows {
+		glyph, color := styleClass(p, r.cls)
+		label := ui.Pad(glyph+" "+r.cls, 20)
+		fmt.Fprintf(p.Out, "  %s %s\n", color(label), p.Faint(r.msg))
+	}
 }
 
 // emitStatusWarnings writes advisory diagnostics to stderr: orphaned state from

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -222,3 +222,56 @@ func TestStatus_JSONOutput(t *testing.T) {
 		t.Errorf("expected one agent 'claude'; got %#v", got.Agents)
 	}
 }
+
+// TestStatus_LegendExplainsDriftClasses locks in the legend contract: status
+// emits a brief "What `apply` will do:" glossary for every drift class that
+// actually appears in the summary, so a newcomer can scan from a row to its
+// meaning without leaving the terminal. The legend is suppressed entirely
+// when everything is clean (the word is self-evident) and entirely from
+// --json output (the class field is the machine-readable contract).
+func TestStatus_LegendExplainsDriftClasses(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Drift the dest so the summary contains a non-clean class.
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.ReplaceAll(string(body), `"npx"`, `"npm"`)), 0o644)
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "What `apply` will do:") {
+		t.Errorf("expected the legend header; got:\n%s", out)
+	}
+	// The drift class is present in the summary, so its explanation must appear.
+	if !strings.Contains(out, "will be overwritten") {
+		t.Errorf("expected the 'drift' legend line; got:\n%s", out)
+	}
+	// "clean" is self-evident and the legend must NOT list it (even though
+	// the summary footer counts clean items).
+	if strings.Contains(out, "clean ") && strings.Count(out, "clean") > 1 &&
+		strings.Contains(out, "no action") {
+		t.Errorf("legend should not list 'clean'; got:\n%s", out)
+	}
+	// --json must stay legend-free so the payload is parseable.
+	jsonOut, err := runCLI(t, env, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, jsonOut)
+	}
+	if strings.Contains(jsonOut, "What `apply` will do:") {
+		t.Errorf("--json must not include the legend; got:\n%s", jsonOut)
+	}
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,5 +170,55 @@ func TestStatus_CleanAfterApply(t *testing.T) {
 	// After clean apply, should report clean or new (state recorded).
 	if strings.Contains(out, "drift") || strings.Contains(out, "conflict") {
 		t.Fatalf("status reported unexpected drift after clean apply: %s", out)
+	}
+}
+
+// TestStatus_JSONOutput locks in the contract that --json emits the structured
+// drift model: a per-agent items list keyed by drift class plus a summary
+// tally. Scripts (CI gates, dashboards) consume this — its shape and the
+// drift-class vocabulary are public.
+func TestStatus_JSONOutput(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Drift the dest so the model has a non-zero "drift" tally.
+	dst := filepath.Join(tmp, ".claude.json")
+	body, _ := os.ReadFile(dst)
+	_ = os.WriteFile(dst, []byte(strings.ReplaceAll(string(body), `"npx"`, `"npm"`)), 0o644)
+
+	out, err := runCLI(t, env, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	var got struct {
+		Agents []struct {
+			Agent string `json:"agent"`
+			Items []struct {
+				Path    string `json:"path"`
+				Pointer string `json:"pointer"`
+				Class   string `json:"class"`
+			} `json:"items"`
+		} `json:"agents"`
+		Summary map[string]int `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("status --json: output not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if got.Summary["drift"] != 1 {
+		t.Errorf("expected summary.drift=1; got %v\noutput:%s", got.Summary, out)
+	}
+	if len(got.Agents) != 1 || got.Agents[0].Agent != "claude" {
+		t.Errorf("expected one agent 'claude'; got %#v", got.Agents)
 	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -63,6 +63,10 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	if autoSafe && !doApply {
 		return fmt.Errorf("--auto-safe requires --apply (it only filters which bumps are applied)")
 	}
+	p, err := newPrinter(cmd)
+	if err != nil {
+		return err
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")
@@ -96,7 +100,9 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		}
 
 		fetcher := marketplace.Dispatch(src)
+		stopSpin := p.Spin(fmt.Sprintf("fetching marketplace %s", mpName))
 		result, err := fetcher.Fetch(src, cacheDir)
+		stopSpin()
 		if err != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", mpName, err)
 			continue
@@ -127,7 +133,9 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	}
 
 	// Compute fresh manifest SHAs for installed plugins (for SHA drift detection).
+	stopSpin := p.Spin("checking plugin manifests")
 	freshSHAs := computeFreshPluginSHAs(home, c.Plugins, fetched, cmd.OutOrStdout())
+	stopSpin()
 
 	// Detect re-uploaded (same version, different SHA) plugins.
 	shaWarnings := marketplace.DetectSHADrift(c.Plugins, freshSHAs)

--- a/internal/cli/ux_color_test.go
+++ b/internal/cli/ux_color_test.go
@@ -1,0 +1,46 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestColorFlag locks in the --color flag's three modes:
+//   - auto (the default) on a non-TTY pipe → no color, so captured tests stay
+//     byte-stable and piped output never leaks raw ANSI.
+//   - always forces color even off a terminal.
+//   - never disables color even when the flag's auto path would have enabled it.
+//
+// We probe via `doctor`, which always renders glyphs and (under color) wraps
+// the status token in ANSI; --version on its own emits no styled tokens.
+func TestColorFlag(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	// auto + non-TTY → plain
+	autoOut, _ := runCLI(t, env, "doctor")
+	if strings.Contains(autoOut, "\x1b[") {
+		t.Fatalf("auto color on a captured (non-TTY) buffer must produce no ANSI; got:\n%s", autoOut)
+	}
+
+	// always forces color, even off a terminal.
+	alwaysOut, _ := runCLI(t, env, "doctor", "--color=always")
+	if !strings.Contains(alwaysOut, "\x1b[") {
+		t.Fatalf("--color=always should emit ANSI even on a non-TTY; got plain:\n%s", alwaysOut)
+	}
+
+	// never disables color unconditionally.
+	neverOut, _ := runCLI(t, env, "doctor", "--color=never")
+	if strings.Contains(neverOut, "\x1b[") {
+		t.Fatalf("--color=never must emit no ANSI; got:\n%s", neverOut)
+	}
+
+	// Bogus mode value reports a clear error.
+	bogusOut, err := runCLI(t, env, "doctor", "--color=psychedelic")
+	if err == nil {
+		t.Fatalf("--color=psychedelic should error; got success:\n%s", bogusOut)
+	}
+}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // PluginRow is one row in the translation report — one plugin × one agent.
@@ -47,12 +48,28 @@ func coverageMark(cov string) string {
 	}
 }
 
-// PrintText writes the human-readable report to w.
+// PrintText writes the human-readable report to w in its plain form.
 //
 //	plugin: demo@test-mp
 //	  claude    ✓ full   (1 mcp, 0 commands)
 //	  opencode  ✓ full   (1 mcp, 0 commands)
+//
+// Use PrintTextStyled to render the same report with semantic color via a
+// *ui.Printer. Plain output is byte-stable so existing test fixtures hold.
 func (r TranslationReport) PrintText(w io.Writer) {
+	r.printText(w, nil)
+}
+
+// PrintTextStyled writes the report with the same layout as PrintText, but
+// styled via p: bold "plugin:" labels, semantically colored coverage marks
+// (green=full, yellow=partial, red=none), and faint trailing counts. When p
+// has color disabled (non-TTY, NO_COLOR, --color=never), the output is
+// visually identical to PrintText — only ANSI is suppressed.
+func (r TranslationReport) PrintTextStyled(w io.Writer, p *ui.Printer) {
+	r.printText(w, p)
+}
+
+func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 	// Group rows by plugin.
 	byPlugin := map[string][]PluginRow{}
 	pluginOrder := []string{}
@@ -67,17 +84,44 @@ func (r TranslationReport) PrintText(w io.Writer) {
 	sort.Strings(pluginOrder)
 
 	for _, plug := range pluginOrder {
-		fmt.Fprintf(w, "plugin: %s\n", plug)
+		if p != nil {
+			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), plug)
+		} else {
+			fmt.Fprintf(w, "plugin: %s\n", plug)
+		}
 		rows := byPlugin[plug]
 		sort.Slice(rows, func(i, j int) bool { return rows[i].Agent < rows[j].Agent })
 		for _, row := range rows {
 			if row.Disabled {
-				fmt.Fprintf(w, "  (disabled by project)\n")
+				if p != nil {
+					fmt.Fprintf(w, "  %s\n", p.Faint("(disabled by project)"))
+				} else {
+					fmt.Fprintf(w, "  (disabled by project)\n")
+				}
 				continue
 			}
-			fmt.Fprintf(w, "  %-10s %s (%d mcp, %d commands)\n",
-				row.Agent, coverageMark(row.Coverage), row.MCP, row.Commands)
+			mark := coverageMark(row.Coverage)
+			tail := fmt.Sprintf("(%d mcp, %d commands)", row.MCP, row.Commands)
+			if p != nil {
+				mark = colorCoverage(p, row.Coverage, mark)
+				tail = p.Faint(tail)
+			}
+			fmt.Fprintf(w, "  %-10s %s %s\n", row.Agent, mark, tail)
 		}
+	}
+}
+
+// colorCoverage maps a coverage string to its semantic color. The mark itself
+// (with trailing alignment padding) is colored as one unit, so a colored space
+// run doesn't shift the column that follows.
+func colorCoverage(p *ui.Printer, cov, mark string) string {
+	switch cov {
+	case "full":
+		return p.Green(mark)
+	case "partial":
+		return p.Yellow(mark)
+	default:
+		return p.Red(mark)
 	}
 }
 

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func TestBuildReport_NoPlugins(t *testing.T) {
@@ -169,6 +170,46 @@ func TestTranslationReport_PrintText(t *testing.T) {
 	}
 	if !strings.Contains(out, "✓ full") {
 		t.Errorf("missing full mark; got:\n%s", out)
+	}
+}
+
+// TestTranslationReport_PrintTextStyled locks in two contracts:
+//   - with color disabled, the styled renderer produces byte-identical output
+//     to PrintText (so the same fixture passes through either path), and
+//   - with color enabled, semantic ANSI is emitted around the right tokens
+//     (green for "full", bold for "plugin:").
+func TestTranslationReport_PrintTextStyled(t *testing.T) {
+	c := source.Canonical{
+		Plugins: []source.Plugin{
+			{ID: "demo", Plugin: source.PluginSpec{ID: "demo@test-mp", Version: "1.0.0"}},
+		},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude":   {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+			"opencode": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"claude", "opencode"})
+
+	var plainBuf, plainStyledBuf, coloredBuf bytes.Buffer
+	report.PrintText(&plainBuf)
+	report.PrintTextStyled(&plainStyledBuf, ui.New(&plainStyledBuf, &plainStyledBuf, ui.ColorNever))
+	report.PrintTextStyled(&coloredBuf, ui.New(&coloredBuf, &coloredBuf, ui.ColorAlways))
+
+	if plainBuf.String() != plainStyledBuf.String() {
+		t.Errorf("PrintTextStyled under ColorNever must equal PrintText byte-for-byte\nPrintText:\n%q\nStyled:\n%q",
+			plainBuf.String(), plainStyledBuf.String())
+	}
+	colored := coloredBuf.String()
+	if !strings.Contains(colored, "\x1b[1m") {
+		t.Errorf("styled report should bold the 'plugin:' label; got:\n%s", colored)
+	}
+	if !strings.Contains(colored, "\x1b[32m") {
+		t.Errorf("a 'full' coverage row should render green; got:\n%s", colored)
+	}
+	if !strings.Contains(colored, "✓ full") {
+		t.Errorf("styled report should still carry the ✓ full glyph; got:\n%s", colored)
 	}
 }
 

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// spinnerInterval is the animation frame rate. 100ms ≈ 10Hz, slow enough that
+// the CPU cost is negligible and fast enough to feel live.
+const spinnerInterval = 100 * time.Millisecond
+
+// spinnerFrames is a 10-step braille cycle — single-display-column, supported
+// by every modern terminal, and visually consistent with the rest of the glyph
+// vocabulary.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Spinner is a lightweight in-place progress indicator for slow network ops
+// (marketplace fetch, plugin pull). It animates only when its writer is a
+// terminal; off a terminal (CI logs, piped stderr, captured-output tests) it
+// is a complete no-op — no animation, no static fallback line — so byte-stable
+// fixtures stay byte-stable and grep'd output stays clean. The success line a
+// caller already prints carries the result.
+type Spinner struct {
+	w       io.Writer
+	label   string
+	animate bool
+	color   bool
+
+	mu      sync.Mutex
+	started bool
+	stopped bool
+
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// Spinner builds a Spinner bound to p.Err and inheriting p's color decision.
+// Call Start to begin and Stop to end; both are idempotent and safe to call
+// in either order (a Stop without Start is a no-op).
+func (p *Printer) Spinner(label string) *Spinner {
+	return &Spinner{
+		w:       p.Err,
+		label:   label,
+		animate: isTerminal(p.Err),
+		color:   p.color,
+		stopCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+}
+
+// Spin is the one-call helper: it starts a Spinner and returns the stop
+// function. Typical use:
+//
+//	stop := p.Spin("fetching marketplace github")
+//	result, err := fetcher.Fetch(src, cacheDir)
+//	stop()
+//	if err != nil { ... }
+func (p *Printer) Spin(label string) func() {
+	s := p.Spinner(label)
+	s.Start()
+	return s.Stop
+}
+
+// Start begins the animation. Idempotent; no-op on a non-terminal writer.
+func (s *Spinner) Start() {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+	if !s.animate {
+		return
+	}
+	go s.loop()
+}
+
+func (s *Spinner) loop() {
+	defer close(s.doneCh)
+	t := time.NewTicker(spinnerInterval)
+	defer t.Stop()
+	i := 0
+	for {
+		select {
+		case <-s.stopCh:
+			// Erase the spinner line (\r to col 0, \x1b[K to clear to EOL) so the
+			// caller's next write starts on a fresh, blank line.
+			fmt.Fprint(s.w, "\r\x1b[K")
+			return
+		case <-t.C:
+			frame := spinnerFrames[i%len(spinnerFrames)]
+			if s.color {
+				fmt.Fprintf(s.w, "\r%s%s%s %s", codeCyan, frame, codeReset, s.label)
+			} else {
+				fmt.Fprintf(s.w, "\r%s %s", frame, s.label)
+			}
+			i++
+		}
+	}
+}
+
+// Stop ends the animation, clears the spinner line, and blocks until the
+// animation goroutine has flushed. Idempotent; safe to call before Start
+// (in which case it is a no-op).
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	started := s.started
+	s.mu.Unlock()
+	if !s.animate || !started {
+		return
+	}
+	close(s.stopCh)
+	<-s.doneCh
+}

--- a/internal/ui/spinner_test.go
+++ b/internal/ui/spinner_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+)
+
+// A *bytes.Buffer is never a terminal, so the spinner must be a complete
+// no-op: no animation frames, no static fallback line, no escape codes. This
+// is what keeps captured-output tests of `update` / `marketplace add`
+// byte-stable when we wrap their network calls.
+func TestSpinnerNoOpOffTerminal(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorAuto)
+
+	stop := p.Spin("fetching marketplace x")
+	stop()
+
+	if buf.Len() != 0 {
+		t.Fatalf("spinner on a non-terminal writer must produce no output; got %q", buf.String())
+	}
+}
+
+// Stop must be safe to call twice (typical pattern is a manual stop followed
+// by a deferred stop on the error path) and Start must be safe to skip.
+func TestSpinnerIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorAuto)
+
+	s := p.Spinner("x")
+	s.Stop() // before Start — must not block or panic
+	s.Stop() // again
+	s.Start()
+	s.Start() // again
+	s.Stop()
+	s.Stop()
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output; got %q", buf.String())
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,175 @@
+// Package ui centralizes agentsync's terminal presentation: semantic color, a
+// curated glyph vocabulary, and small layout primitives (sections, status
+// lines, aligned labels). It is the single place that decides whether to emit
+// ANSI, so every command renders through a *Printer and the color/glyph/spacing
+// language stays consistent across `status`, `diff`, `doctor`, and `apply`.
+//
+// Two independent axes:
+//
+//   - Color is TTY-gated. `--color=always|never` forces it; `auto` (the
+//     default) enables color only when the output is a terminal and NO_COLOR
+//     (https://no-color.org) is unset. Non-TTY output (pipes, files, tests) is
+//     therefore byte-for-byte plain — color never leaks into a redirect.
+//   - Glyphs are always Unicode. The ✓ / ◐ / ✗ vocabulary already appears in the
+//     translation report and the capability matrix; keeping it unconditional
+//     means piped output reads the same as the screen and existing fixtures
+//     hold. Color, not glyph choice, is what degrades.
+//
+// Color is reserved for state: a green ✓ means synced, a red ✗ means drift. It
+// is never decoration. Everything still parses with color stripped.
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// ANSI SGR codes, restricted to the basic 16-color palette so any terminal
+// that supports color at all renders them faithfully — semantic status
+// coloring never needs 256-color or truecolor.
+const (
+	codeReset  = "\x1b[0m"
+	codeBold   = "\x1b[1m"
+	codeFaint  = "\x1b[2m"
+	codeRed    = "\x1b[31m"
+	codeGreen  = "\x1b[32m"
+	codeYellow = "\x1b[33m"
+	codeBlue   = "\x1b[34m"
+	codeCyan   = "\x1b[36m"
+)
+
+// Curated glyph vocabulary. Always Unicode; each is one display column wide, so
+// callers can align around them with plain rune/space counting (no runewidth).
+const (
+	GlyphOK      = "✓" // success / synced / clean
+	GlyphPartial = "◐" // partial coverage (mirrors the capability matrix)
+	GlyphErr     = "✗" // failure / drift / missing
+	GlyphWarn    = "⚠" // warning / needs attention
+	GlyphInfo    = "•" // neutral bullet
+	GlyphArrow   = "→" // transition / "see"
+)
+
+// ColorMode is the resolved value of the global --color flag.
+type ColorMode int
+
+const (
+	ColorAuto ColorMode = iota
+	ColorAlways
+	ColorNever
+)
+
+// ParseColorMode maps the --color flag string to a ColorMode. An empty string
+// defaults to auto so callers can pass the raw flag value.
+func ParseColorMode(s string) (ColorMode, error) {
+	switch s {
+	case "", "auto":
+		return ColorAuto, nil
+	case "always":
+		return ColorAlways, nil
+	case "never":
+		return ColorNever, nil
+	default:
+		return ColorAuto, fmt.Errorf("unknown --color value %q; want auto, always, or never", s)
+	}
+}
+
+// Printer renders styled output to a pair of writers. Construct one per command
+// invocation via New; the color decision is frozen at construction.
+type Printer struct {
+	Out   io.Writer
+	Err   io.Writer
+	color bool
+}
+
+// New builds a Printer bound to out/err, resolving whether to emit color from
+// mode, the NO_COLOR environment variable, and whether out is a terminal.
+func New(out, err io.Writer, mode ColorMode) *Printer {
+	return &Printer{Out: out, Err: err, color: resolveColor(out, mode)}
+}
+
+// Color reports whether this Printer emits ANSI. Commands that hand a writer to
+// a third-party renderer (e.g. the diff library's own colorizer) consult this
+// to gate that output through the same decision.
+func (p *Printer) Color() bool { return p.color }
+
+func resolveColor(out io.Writer, mode ColorMode) bool {
+	switch mode {
+	case ColorAlways:
+		return true
+	case ColorNever:
+		return false
+	default:
+		// NO_COLOR: any value, even empty, disables color per the standard.
+		if _, ok := os.LookupEnv("NO_COLOR"); ok {
+			return false
+		}
+		return isTerminal(out)
+	}
+}
+
+// isTerminal reports whether w is backed by a terminal. A *bytes.Buffer / pipe
+// (tests, redirects) has no Fd and is therefore plain — which is exactly what
+// keeps captured-output tests byte-stable.
+func isTerminal(w io.Writer) bool {
+	type fdWriter interface{ Fd() uintptr }
+	f, ok := w.(fdWriter)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+func (p *Printer) wrap(code, s string) string {
+	if !p.color || s == "" {
+		return s
+	}
+	return code + s + codeReset
+}
+
+// Semantic style helpers. Each returns s unchanged when color is disabled, so
+// callers can compose them freely without branching.
+func (p *Printer) Bold(s string) string   { return p.wrap(codeBold, s) }
+func (p *Printer) Faint(s string) string  { return p.wrap(codeFaint, s) }
+func (p *Printer) Red(s string) string    { return p.wrap(codeRed, s) }
+func (p *Printer) Green(s string) string  { return p.wrap(codeGreen, s) }
+func (p *Printer) Yellow(s string) string { return p.wrap(codeYellow, s) }
+func (p *Printer) Blue(s string) string   { return p.wrap(codeBlue, s) }
+func (p *Printer) Cyan(s string) string   { return p.wrap(codeCyan, s) }
+
+// Section prints a heading (bold when colored, plain text otherwise) to Out.
+func (p *Printer) Section(title string) {
+	fmt.Fprintln(p.Out, p.Bold(title))
+}
+
+// Pad left-justifies s to a fixed visible width, counting runes (the glyph set
+// is single-width) rather than bytes, then returns the padded plain string.
+// Callers color the RESULT so that ANSI bytes never throw off the column —
+// padding is applied before any escape codes exist.
+func Pad(s string, width int) string {
+	n := 0
+	for range s {
+		n++
+	}
+	if n >= width {
+		return s
+	}
+	return s + spaces(width-n)
+}
+
+func spaces(n int) string {
+	const blanks = "                                                                "
+	if n <= 0 {
+		return ""
+	}
+	if n <= len(blanks) {
+		return blanks[:n]
+	}
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = ' '
+	}
+	return string(out)
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseColorMode(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    ColorMode
+		wantErr bool
+	}{
+		{"", ColorAuto, false},
+		{"auto", ColorAuto, false},
+		{"always", ColorAlways, false},
+		{"never", ColorNever, false},
+		{"bogus", ColorAuto, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseColorMode(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseColorMode(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseColorMode(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// A *bytes.Buffer is never a terminal, so auto must resolve to no-color — this
+// is the property that keeps every captured-output test byte-stable.
+func TestColorResolution(t *testing.T) {
+	var buf bytes.Buffer
+
+	if p := New(&buf, &buf, ColorAuto); p.Color() {
+		t.Error("auto color on a non-terminal writer should be off")
+	}
+	if p := New(&buf, &buf, ColorAlways); !p.Color() {
+		t.Error("always should force color even on a non-terminal")
+	}
+	if p := New(&buf, &buf, ColorNever); p.Color() {
+		t.Error("never should disable color")
+	}
+}
+
+// NO_COLOR (any value, even empty) disables auto color, but an explicit
+// --color=always still wins.
+func TestNoColorEnv(t *testing.T) {
+	var buf bytes.Buffer
+	t.Setenv("NO_COLOR", "")
+	if p := New(&buf, &buf, ColorAuto); p.Color() {
+		t.Error("NO_COLOR set should disable auto color")
+	}
+	if p := New(&buf, &buf, ColorAlways); !p.Color() {
+		t.Error("--color=always should override NO_COLOR")
+	}
+}
+
+func TestStyleHelpers(t *testing.T) {
+	var buf bytes.Buffer
+
+	plain := New(&buf, &buf, ColorNever)
+	if got := plain.Green("ok"); got != "ok" {
+		t.Errorf("plain Green(ok) = %q, want unchanged", got)
+	}
+	if got := plain.Bold(""); got != "" {
+		t.Errorf("empty string must never be wrapped, got %q", got)
+	}
+
+	colored := New(&buf, &buf, ColorAlways)
+	got := colored.Red("drift")
+	if !strings.HasPrefix(got, codeRed) || !strings.HasSuffix(got, codeReset) || !strings.Contains(got, "drift") {
+		t.Errorf("colored Red(drift) = %q, want wrapped in red + reset", got)
+	}
+}
+
+func TestSection(t *testing.T) {
+	var buf bytes.Buffer
+	New(&buf, &buf, ColorNever).Section("Source repo")
+	if got := buf.String(); got != "Source repo\n" {
+		t.Errorf("plain Section = %q, want %q", got, "Source repo\n")
+	}
+}
+
+// Pad must count display columns (runes), not bytes, so a multi-byte glyph
+// doesn't blow the alignment of the following column.
+func TestPad(t *testing.T) {
+	tests := []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"drift", 10, "drift     "},
+		{"clean", 5, "clean"},
+		{"toolong", 3, "toolong"},
+		{"✓ ok", 6, "✓ ok  "}, // 4 runes (glyph counts as one) padded to 6
+	}
+	for _, tc := range tests {
+		got := Pad(tc.in, tc.width)
+		if got != tc.want {
+			t.Errorf("Pad(%q,%d) = %q, want %q", tc.in, tc.width, got, tc.want)
+		}
+	}
+}

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -122,11 +122,16 @@ agentsync apply
 
 ### `status`
 Summarizes what's out of sync across all agents — pending source changes and
-destination drift.
+destination drift. Pass `--json` to emit the structured drift report (per-agent
+items + a summary tally keyed by drift class) for CI gates or dashboards;
+advisory diagnostics still flow to stderr so the JSON payload stays clean.
 
 ### `diff [<path>]`
 Shows the pending / drift changes in detail. **Resolved secrets are redacted**, so
-a piped diff can't leak credentials. Pass a path to scope the diff.
+a piped diff can't leak credentials. Pass a path to scope the diff. Color is
+TTY-gated — piped output uses `[-…-]` / `{+…+}` text markers instead of raw
+ANSI. Pass `--json` for a structured hunk list (the same masked source/dest
+strings, so the redaction protects both modes).
 
 ### `reconcile`
 The interactive merge UX for drift and conflicts. Full guide:
@@ -168,4 +173,6 @@ for machine-readable output.
 | `--project <path>` | apply, status, diff, reconcile, update | Apply a specific project's overlay. |
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
+| `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). |
+| `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. |

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -122,9 +122,15 @@ agentsync apply
 
 ### `status`
 Summarizes what's out of sync across all agents — pending source changes and
-destination drift. Pass `--json` to emit the structured drift report (per-agent
-items + a summary tally keyed by drift class) for CI gates or dashboards;
-advisory diagnostics still flow to stderr so the JSON payload stays clean.
+destination drift. A one-line summary footer tallies items by drift class, and
+a brief "What `apply` will do:" legend follows it, explaining each class
+present (`new` will be created, `pending` will be updated to match source,
+`drift` will be overwritten — use `reconcile` to keep the edit, etc.). Clean
+items are tallied but never glossed. Pass `--json` to emit the structured
+drift report (per-agent items + a summary tally keyed by drift class) for CI
+gates or dashboards; advisory diagnostics still flow to stderr so the JSON
+payload stays clean. `--json` output omits the legend (the class field is the
+machine contract).
 
 ### `diff [<path>]`
 Shows the pending / drift changes in detail. **Resolved secrets are redacted**, so


### PR DESCRIPTION
## Summary

Introduces `internal/ui` as the single source for terminal presentation: semantic color (green=synced, cyan=pending, red=drift, yellow=needs-decision), the curated `✓ ◐ ✗ → •` glyph vocabulary the capability matrix already uses, and small layout primitives. **Zero new deps** — raw ANSI + `golang.org/x/term` (already in `go.mod`).

- `status`, `doctor`, `apply`, `diff` retrofit through the Printer. Color is TTY-gated (`--color=auto` enables ANSI only when stdout is a terminal and `NO_COLOR` is unset; `--color=always|never` overrides). Glyphs stay Unicode in all modes, matching existing report output, so piped output is byte-stable and never leaks raw ANSI.
- `status` gains a one-line summary footer that omits zero categories — the words "drift"/"conflict" never appear when there is none of that state, preserving the existing test contracts.
- `doctor` lines get `✓`/`✗`/`⚠` + colored status tokens, with the `label+pad+status` substring preserved so existing fixtures hold.
- **Fixes a latent leak**: `diff` previously called `diffmatchpatch.DiffPrettyText` unconditionally, so `agentsync diff | grep` accumulated raw `\x1b[…]` escape sequences. The new renderer emits ANSI only on a TTY, and falls back to git-style `[-…-]` / `{+…+}` text markers in plain mode so a piped diff stays legible.
- `status --json` and `diff --json` emit structured payloads to stdout for CI gates and dashboards (advisory diagnostics still flow to stderr so the JSON stays cleanly parseable). `diff --json` reuses the same masking the formatted diff does — a sentinel test (`TestDiff_JSONOutputMasksSecrets`) locks that in.

Design rationale + the brainstorm that produced this scope: kept the foundation zero-dep to match the project's lean + security-conscious `go.mod`, since semantic color + a curated single-width glyph set don't need terminfo, runewidth, or a TUI runtime. Bubble Tea is a separate, deferred decision tied solely to an interactive `reconcile`.

### Sample output

`status` (clean) — `1 clean` summary in green, `✓ clean` per item.
`status` (drifted) — color-coded class + a `1 drift` footer.
`diff` (piped/plain) — `{+npx+}` / `[-npm-]` markers; no ANSI in the redirect.
`diff` (TTY) — inline green/red highlighting through the Printer.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (all packages, including new tests)
- [x] **New tests** lock the contracts:
  - `TestStatus_JSONOutput` — JSON parses, summary tally + agent items present
  - `TestDiff_JSONOutputMasksSecrets` — sentinel never appears under `--json`
  - `TestDiff_PlainModeUsesTextMarkers` — no `\x1b[` in piped diff; `[-` / `{+` present
  - `TestColorFlag` — `auto` plain in tests, `always` emits ANSI, `never` strips, bogus value errors
  - `ui` package: `TestColorResolution`, `TestNoColorEnv`, `TestStyleHelpers`, `TestPad`, etc.
- [x] Existing fixtures untouched (doctor's `home dir   ok`, status's `drift`/`clean`/`orphan` keywords, apply's `Foreign collisions`/`0 ops`/`backed up`/`no agents`/`agent add`, diff's `no diff`/`.claude.json` + secret-leak guards)
- [x] Manual visual: `doctor`/`status`/`apply`/`diff` under `--color=always` and `--color=never`, plus default `auto` over a pipe
- [x] Docs updated in the same commit per the CLAUDE.md contract: `docs/user-guide.md` (command reference + global flags note), `website/src/content/docs/reference/cli.mdx` (status/diff sections + cross-command flags table), `CHANGELOG.md` (Added entry for the styled output + `--json`, Fixed entry for the diff ANSI leak)

### Known non-issue

`go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2` errors locally with `Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`. Pre-existing on `main` — `.golangci.yml` targets Go 1.26 but the pinned binary was built with 1.25 — unrelated to this diff. CI's `golangci-lint-action` resolves binaries differently.

https://claude.ai/code/session_011Vyzq3wQbiHqzLbhggnJYH

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vyzq3wQbiHqzLbhggnJYH)_