### PR TITLE
fix(ingest): lenient YAML frontmatter + surface silently-dropped components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,19 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **`import` no longer silently drops skills/subagents/commands with loose
+  frontmatter** — a component `.md` whose `description:` carried an unquoted
+  `Triggers on: X, Y` colon-space sequence broke `sigs.k8s.io/yaml` ("mapping
+  values are not allowed in this context"), and the `continue` in every
+  adapter's Ingest dropped the whole component without warning. The parser now
+  falls back to a line-oriented "key: rest-of-line" read on strict-YAML failure,
+  matching how Claude Code itself reads these files; the canonical write-back
+  re-emits a quoted, strict-YAML form, so the next `apply` round-trips cleanly.
+  A `warning: ... frontmatter is not strict YAML; parsed leniently` line is
+  printed to stderr for each lenient parse so the source of the leak is visible.
+  A structurally-broken file (e.g. unterminated fence) is still skipped, but now
+  with an explicit `warning: skipping skill "<name>": <reason>` instead of a
+  silent drop.
 - **`agent disable --purge` validates the name; `doctor` names a half-init** —
   `disable <bogus> --purge` reported a misleading "purged 0 files" success for
   any string; it now rejects an unknown agent like the other subcommands (a

--- a/internal/adapter/claude/claude.go
+++ b/internal/adapter/claude/claude.go
@@ -2,6 +2,7 @@
 package claude
 
 import (
+	"io"
 	"os"
 	"os/exec"
 
@@ -13,6 +14,17 @@ type Options struct {
 	TargetRoot string // honors AGENTSYNC_TARGET_ROOT (real "/Users/x" in production)
 	// LookPath overrides exec.LookPath for testing. nil means use exec.LookPath.
 	LookPath func(file string) (string, error)
+	// Stderr receives Ingest warnings (lenient-YAML notices, dropped components).
+	// nil means os.Stderr. Tests inject a bytes.Buffer to assert on warnings.
+	Stderr io.Writer
+}
+
+// stderr returns the configured warning sink, defaulting to os.Stderr.
+func (a *Adapter) stderr() io.Writer {
+	if a.opts.Stderr != nil {
+		return a.opts.Stderr
+	}
+	return os.Stderr
 }
 
 // Adapter implements adapter.Adapter for Claude Code.

--- a/internal/adapter/claude/frontmatter.go
+++ b/internal/adapter/claude/frontmatter.go
@@ -12,8 +12,31 @@ import (
 
 // ParseFrontmatter extracts the YAML frontmatter and the markdown body. If
 // the input doesn't begin with "---\n", returns an empty map and the entire
-// input as body.
+// input as body. Returns an error on any YAML decode failure; callers that
+// want to accept Claude Code's looser "key: value-with-colons" frontmatter
+// should use ParseFrontmatterWithReport instead.
 func ParseFrontmatter(data []byte) (map[string]any, string, error) {
+	fm, body, _, err := parseFrontmatter(data, false)
+	return fm, body, err
+}
+
+// ParseFrontmatterWithReport is the lenient-fallback variant. It first tries
+// strict YAML; on decode failure it falls back to a line-oriented "key: rest-
+// of-line" parser that accepts bare colon-space inside values. lenient is true
+// iff the strict parse failed but the lenient one succeeded — Ingest callers
+// surface a warning in that case so the user knows their SKILL.md (or other
+// component .md) is not strict YAML.
+//
+// The lenient parser exists because Claude Code itself reads frontmatter that
+// way: a SKILL.md whose description contains an unquoted "Triggers on: X, Y"
+// parses fine in claude.ai but breaks sigs.k8s.io/yaml ("mapping values are
+// not allowed in this context"). Without this fallback, the silent `continue`
+// in adapter Ingest dropped any skill with such a description.
+func ParseFrontmatterWithReport(data []byte) (fm map[string]any, body string, lenient bool, err error) {
+	return parseFrontmatter(data, true)
+}
+
+func parseFrontmatter(data []byte, allowLenient bool) (fm map[string]any, body string, lenient bool, err error) {
 	// Normalize CRLF → LF so a .md saved by a Windows editor ("---\r\n") is
 	// recognized as having frontmatter. Without this the literal "---\n" check
 	// fails, the whole file is treated as body, and description/model/mode
@@ -23,22 +46,73 @@ func ParseFrontmatter(data []byte) (map[string]any, string, error) {
 		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	}
 	if !bytes.HasPrefix(data, []byte("---\n")) {
-		return map[string]any{}, string(data), nil
+		return map[string]any{}, string(data), false, nil
 	}
 	rest := data[len("---\n"):]
-	yml, body, ok := splitFrontmatterBody(rest)
+	yml, bodyBytes, ok := splitFrontmatterBody(rest)
 	if !ok {
-		return nil, "", fmt.Errorf("unterminated frontmatter")
+		return nil, "", false, fmt.Errorf("unterminated frontmatter")
 	}
 	// An empty frontmatter block ("---\n---\n…") is a valid empty mapping.
 	if len(bytes.TrimSpace(yml)) == 0 {
-		return map[string]any{}, string(body), nil
+		return map[string]any{}, string(bodyBytes), false, nil
 	}
-	fm, err := jsonkeys.DecodeYAML(yml)
-	if err != nil {
-		return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
+	fm, strictErr := jsonkeys.DecodeYAML(yml)
+	if strictErr == nil {
+		return fm, string(bodyBytes), false, nil
 	}
-	return fm, string(body), nil
+	if !allowLenient {
+		return nil, "", false, fmt.Errorf("parse yaml frontmatter: %w", strictErr)
+	}
+	lfm, lerr := parseFrontmatterLenient(yml)
+	if lerr != nil {
+		// Both parsers failed — return the strict error since it's typically
+		// more informative ("mapping values are not allowed in this context"
+		// vs. our generic lenient error).
+		return nil, "", false, fmt.Errorf("parse yaml frontmatter: %w", strictErr)
+	}
+	return lfm, string(bodyBytes), true, nil
+}
+
+// parseFrontmatterLenient parses YAML frontmatter as a flat string-string map
+// using "key: rest-of-line" semantics: the first ": " on each line splits the
+// key from the value, the value is taken verbatim to end-of-line, and any
+// further colons (the failure mode strict YAML rejects) are preserved.
+//
+// This is intentionally narrow — it does NOT support nested mappings, arrays,
+// multi-line scalars, or quoting. The lenient path exists only to recover skill
+// frontmatter whose description contains bare colon-space, which is by far the
+// dominant real-world breakage. Anything more structured belongs in strict YAML.
+func parseFrontmatterLenient(yml []byte) (map[string]any, error) {
+	out := map[string]any{}
+	lines := bytes.Split(yml, []byte("\n"))
+	for _, line := range lines {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 || trimmed[0] == '#' || bytes.Equal(trimmed, []byte("---")) {
+			continue
+		}
+		idx := bytes.Index(line, []byte(": "))
+		if idx < 0 {
+			// A line ending with ": " (no value) is rare but valid YAML for an
+			// empty value; accept it.
+			if bytes.HasSuffix(bytes.TrimRight(line, " \t"), []byte(":")) {
+				key := strings.TrimSpace(string(bytes.TrimSuffix(bytes.TrimRight(line, " \t"), []byte(":"))))
+				if key == "" {
+					return nil, fmt.Errorf("lenient parse: malformed line %q", string(line))
+				}
+				out[key] = ""
+				continue
+			}
+			return nil, fmt.Errorf("lenient parse: no key/value separator on line %q", string(line))
+		}
+		key := strings.TrimSpace(string(line[:idx]))
+		if key == "" {
+			return nil, fmt.Errorf("lenient parse: empty key on line %q", string(line))
+		}
+		val := strings.TrimRight(string(line[idx+2:]), " \t")
+		out[key] = val
+	}
+	return out, nil
 }
 
 // splitFrontmatterBody splits the bytes AFTER the opening "---\n" into YAML

--- a/internal/adapter/claude/frontmatter_test.go
+++ b/internal/adapter/claude/frontmatter_test.go
@@ -104,3 +104,101 @@ func TestParseFrontmatter_CRLF(t *testing.T) {
 		t.Fatalf("frontmatter not stripped; whole file returned as body: %q", body)
 	}
 }
+
+// TestParseFrontmatterWithReport_BadYAMLDescription is the regression for skill
+// SKILL.md files whose unquoted description contains a "Triggers on: X, Y" colon-
+// space sequence — that bare ": " makes sigs.k8s.io/yaml bail with "mapping
+// values are not allowed in this context", and Ingest's silent `continue`
+// dropped the whole skill. The lenient fallback succeeds on these files, returns
+// the full description as a single string, and reports Lenient=true so callers
+// can warn.
+func TestParseFrontmatterWithReport_BadYAMLDescription(t *testing.T) {
+	// Verbatim frontmatter from ~/.claude/skills/gltf-transform/SKILL.md.
+	input := []byte(`---
+name: gltf-transform
+description: Optimize and post-process GLB/glTF 3D models. Use when compressing models for web delivery, reducing file size, simplifying geometry, inspecting model stats, merging models, or converting textures. Triggers on: optimize GLB, compress model, reduce file size, simplify mesh, draco compression, meshopt, webp textures, inspect model, merge GLB, model optimization.
+---
+body text
+`)
+	// Strict parser MUST still fail (backward-compat: callers that don't opt in
+	// to lenient parsing get the same behavior they had before).
+	if _, _, err := claude.ParseFrontmatter(input); err == nil {
+		t.Fatalf("ParseFrontmatter accepted bad-YAML description; lenient fallback must be opt-in")
+	}
+	fm, body, lenient, err := claude.ParseFrontmatterWithReport(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatterWithReport: %v", err)
+	}
+	if !lenient {
+		t.Fatalf("Lenient must be true when strict YAML fails and lenient succeeds")
+	}
+	if fm["name"] != "gltf-transform" {
+		t.Fatalf("name not parsed leniently: %+v", fm)
+	}
+	desc, ok := fm["description"].(string)
+	if !ok {
+		t.Fatalf("description not a string: %T %v", fm["description"], fm["description"])
+	}
+	// The lenient parser must keep the FULL description (including the colon-
+	// space that broke strict YAML). Truncating at the colon would silently
+	// corrupt the field — the very failure mode we're trying to stop.
+	if !strings.Contains(desc, "Triggers on: optimize GLB") {
+		t.Fatalf("lenient description truncated at colon-space: %q", desc)
+	}
+	if !strings.Contains(desc, "model optimization.") {
+		t.Fatalf("lenient description missing tail: %q", desc)
+	}
+	if body != "body text\n" {
+		t.Fatalf("body mismatch: %q", body)
+	}
+}
+
+// TestParseFrontmatterWithReport_StrictSuccess: a clean YAML frontmatter must
+// parse via the strict path (Lenient=false), so we don't silently mask bugs
+// in callers that only want strict input.
+func TestParseFrontmatterWithReport_StrictSuccess(t *testing.T) {
+	input := []byte(`---
+name: x
+description: simple value
+---
+body
+`)
+	fm, body, lenient, err := claude.ParseFrontmatterWithReport(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lenient {
+		t.Fatalf("Lenient must be false when strict YAML succeeds")
+	}
+	if fm["name"] != "x" || fm["description"] != "simple value" {
+		t.Fatalf("strict parse data lost: %+v", fm)
+	}
+	if body != "body\n" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+// TestParseFrontmatterWithReport_UnterminatedFrontmatter: an unterminated "---"
+// block is a structural error the lenient parser cannot recover from — it must
+// still return an error.
+func TestParseFrontmatterWithReport_UnterminatedFrontmatter(t *testing.T) {
+	input := []byte("---\nname: x\nbody without closing fence\n")
+	if _, _, _, err := claude.ParseFrontmatterWithReport(input); err == nil {
+		t.Fatalf("unterminated frontmatter must error")
+	}
+}
+
+// TestParseFrontmatterWithReport_NoFrontmatter: a file with no leading "---"
+// is returned as body, identical to the strict ParseFrontmatter behavior.
+func TestParseFrontmatterWithReport_NoFrontmatter(t *testing.T) {
+	fm, body, lenient, err := claude.ParseFrontmatterWithReport([]byte("plain\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lenient {
+		t.Fatalf("no-frontmatter is not a lenient parse")
+	}
+	if len(fm) != 0 || body != "plain\n" {
+		t.Fatalf("unexpected: fm=%v body=%q", fm, body)
+	}
+}

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -51,6 +51,8 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
+	warn := a.stderr()
+
 	// Skills from ~/.claude/skills/<name>/ (SKILL.md + bundled files)
 	if entries, err := os.ReadDir(p.SkillsDir); err == nil {
 		for _, e := range entries {
@@ -62,12 +64,19 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := ParseFrontmatter(data)
+			fm, body, lenient, err := ParseFrontmatterWithReport(data)
 			if err != nil {
+				// A parse error used to silently drop the skill. Warn so the
+				// user knows their skill is being skipped and can fix the file.
+				fmt.Fprintf(warn, "warning: skipping skill %q: %v\n", e.Name(), err)
 				continue
+			}
+			if lenient {
+				fmt.Fprintf(warn, "warning: skill %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", e.Name())
 			}
 			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping skill %q: read bundled files: %v\n", e.Name(), err)
 				continue
 			}
 			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
@@ -84,11 +93,15 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := ParseFrontmatter(data)
+			name := e.Name()[:len(e.Name())-len(".md")]
+			fm, body, lenient, err := ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping subagent %q: %v\n", name, err)
 				continue
 			}
-			name := e.Name()[:len(e.Name())-len(".md")]
+			if lenient {
+				fmt.Fprintf(warn, "warning: subagent %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", name)
+			}
 			c.Subagents = append(c.Subagents, source.Subagent{Name: name, Frontmatter: fm, Body: body})
 		}
 	}
@@ -103,11 +116,15 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := ParseFrontmatter(data)
+			name := e.Name()[:len(e.Name())-len(".md")]
+			fm, body, lenient, err := ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping command %q: %v\n", name, err)
 				continue
 			}
-			name := e.Name()[:len(e.Name())-len(".md")]
+			if lenient {
+				fmt.Fprintf(warn, "warning: command %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", name)
+			}
 			c.Commands = append(c.Commands, source.Command{Name: name, Frontmatter: fm, Body: body})
 		}
 	}

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -1,6 +1,10 @@
 package claude_test
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -186,5 +190,76 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 	}
 	if out.Memory.Body != in.Memory.Body {
 		t.Fatalf("Memory roundtrip: got %q, want %q", out.Memory.Body, in.Memory.Body)
+	}
+}
+
+// TestIngest_LenientSkillNotSilentlyDropped is the regression for the bug
+// `agentsync import claude` exhibited: a SKILL.md whose description carries an
+// unquoted "Triggers on: X, Y" colon-space sequence broke sigs.k8s.io/yaml and
+// the silent `continue` in Ingest dropped the whole skill. Now: it loads via
+// the lenient fallback AND emits a warning to the configured Stderr so the
+// user is notified.
+func TestIngest_LenientSkillNotSilentlyDropped(t *testing.T) {
+	tmp := t.TempDir()
+	skillsDir := filepath.Join(tmp, ".claude", "skills")
+
+	// Three skills covering each path:
+	//   ok       — strict YAML, no warning
+	//   bad-yaml — colon-space in description, lenient succeeds → warning
+	//   broken   — actually malformed (unterminated fence), both parsers fail
+	//              → warning + dropped
+	if err := os.MkdirAll(filepath.Join(skillsDir, "ok"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(skillsDir, "bad-yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(skillsDir, "broken"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "ok", "SKILL.md"),
+		[]byte("---\nname: ok\ndescription: simple\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "bad-yaml", "SKILL.md"),
+		[]byte("---\nname: bad-yaml\ndescription: Does the thing. Triggers on: foo, bar, baz.\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "broken", "SKILL.md"),
+		[]byte("---\nname: broken\nno closing fence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: &warn})
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, s := range out.Skills {
+		names[s.Name] = true
+	}
+	if !names["ok"] {
+		t.Errorf("strict-YAML skill 'ok' missing from Ingest: %v", names)
+	}
+	if !names["bad-yaml"] {
+		t.Errorf("bad-yaml skill silently dropped — lenient fallback didn't run: %v", names)
+	}
+	if names["broken"] {
+		t.Errorf("a structurally-broken skill should NOT load: %v", names)
+	}
+
+	got := warn.String()
+	if !strings.Contains(got, "bad-yaml") {
+		t.Errorf("Stderr missing warning for lenient skill 'bad-yaml':\n%s", got)
+	}
+	if !strings.Contains(got, "broken") {
+		t.Errorf("Stderr missing warning for dropped skill 'broken':\n%s", got)
+	}
+	// The 'ok' skill must NOT trigger a warning — strict YAML is silent.
+	if strings.Contains(got, "skill ok") || strings.Contains(got, "skill \"ok\"") {
+		t.Errorf("strict-YAML skill incorrectly produced a warning:\n%s", got)
 	}
 }

--- a/internal/adapter/codex/codex.go
+++ b/internal/adapter/codex/codex.go
@@ -9,6 +9,7 @@
 package codex
 
 import (
+	"io"
 	"os"
 	"os/exec"
 
@@ -20,6 +21,9 @@ type Options struct {
 	TargetRoot string // honors AGENTSYNC_TARGET_ROOT (real "/Users/x" in production)
 	// LookPath overrides exec.LookPath for testing. nil means use exec.LookPath.
 	LookPath func(file string) (string, error)
+	// Stderr receives Ingest warnings (lenient-YAML notices, dropped components).
+	// nil means os.Stderr.
+	Stderr io.Writer
 }
 
 // Adapter implements adapter.Adapter (and adapter.PluginIngester) for Codex CLI.
@@ -27,6 +31,14 @@ type Adapter struct{ opts Options }
 
 // New constructs a Codex adapter.
 func New(opts Options) *Adapter { return &Adapter{opts: opts} }
+
+// stderr returns the configured warning sink, defaulting to os.Stderr.
+func (a *Adapter) stderr() io.Writer {
+	if a.opts.Stderr != nil {
+		return a.opts.Stderr
+	}
+	return os.Stderr
+}
 
 func (a *Adapter) Name() string { return "codex" }
 

--- a/internal/adapter/codex/ingest.go
+++ b/internal/adapter/codex/ingest.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -42,6 +43,8 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
+	warn := a.stderr()
+
 	// Skills from ~/.agents/skills/<name>/ (SKILL.md + bundled files)
 	if entries, err := os.ReadDir(p.SkillsDir); err == nil {
 		for _, e := range entries {
@@ -53,12 +56,17 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := claude.ParseFrontmatter(data)
+			fm, body, lenient, err := claude.ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping skill %q: %v\n", e.Name(), err)
 				continue
+			}
+			if lenient {
+				fmt.Fprintf(warn, "warning: skill %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", e.Name())
 			}
 			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping skill %q: read bundled files: %v\n", e.Name(), err)
 				continue
 			}
 			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
@@ -105,11 +113,15 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 				if err != nil {
 					continue
 				}
-				fm, body, err := claude.ParseFrontmatter(data)
+				name := e.Name()[:len(e.Name())-len(".md")]
+				fm, body, lenient, err := claude.ParseFrontmatterWithReport(data)
 				if err != nil {
+					fmt.Fprintf(warn, "warning: skipping command %q: %v\n", name, err)
 					continue
 				}
-				name := e.Name()[:len(e.Name())-len(".md")]
+				if lenient {
+					fmt.Fprintf(warn, "warning: command %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", name)
+				}
 				c.Commands = append(c.Commands, source.Command{Name: name, Frontmatter: fm, Body: body})
 			}
 		}

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -2,6 +2,7 @@ package opencode
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -46,6 +47,8 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
+	warn := a.stderr()
+
 	// Skills from ~/.claude/skills/<name>/ (SKILL.md + bundled files; shared with Claude)
 	if entries, err := os.ReadDir(p.ClaudeSkillsDir); err == nil {
 		for _, e := range entries {
@@ -57,12 +60,17 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := claude.ParseFrontmatter(data)
+			fm, body, lenient, err := claude.ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping skill %q: %v\n", e.Name(), err)
 				continue
+			}
+			if lenient {
+				fmt.Fprintf(warn, "warning: skill %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", e.Name())
 			}
 			files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping skill %q: read bundled files: %v\n", e.Name(), err)
 				continue
 			}
 			c.Skills = append(c.Skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
@@ -80,13 +88,17 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := claude.ParseFrontmatter(data)
+			name := e.Name()[:len(e.Name())-len(".md")]
+			fm, body, lenient, err := claude.ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping subagent %q: %v\n", name, err)
 				continue
+			}
+			if lenient {
+				fmt.Fprintf(warn, "warning: subagent %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", name)
 			}
 			// Drop OpenCode-specific `mode` key; it is not canonical.
 			delete(fm, "mode")
-			name := e.Name()[:len(e.Name())-len(".md")]
 			c.Subagents = append(c.Subagents, source.Subagent{Name: name, Frontmatter: fm, Body: body})
 		}
 	}
@@ -101,11 +113,15 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 			if err != nil {
 				continue
 			}
-			fm, body, err := claude.ParseFrontmatter(data)
+			name := e.Name()[:len(e.Name())-len(".md")]
+			fm, body, lenient, err := claude.ParseFrontmatterWithReport(data)
 			if err != nil {
+				fmt.Fprintf(warn, "warning: skipping command %q: %v\n", name, err)
 				continue
 			}
-			name := e.Name()[:len(e.Name())-len(".md")]
+			if lenient {
+				fmt.Fprintf(warn, "warning: command %q frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')\n", name)
+			}
 			c.Commands = append(c.Commands, source.Command{Name: name, Frontmatter: fm, Body: body})
 		}
 	}

--- a/internal/adapter/opencode/opencode.go
+++ b/internal/adapter/opencode/opencode.go
@@ -2,6 +2,7 @@
 package opencode
 
 import (
+	"io"
 	"os"
 	"os/exec"
 
@@ -13,6 +14,9 @@ type Options struct {
 	TargetRoot string // honors AGENTSYNC_TARGET_ROOT (real "/Users/x" in production)
 	// LookPath overrides exec.LookPath for testing. nil means use exec.LookPath.
 	LookPath func(file string) (string, error)
+	// Stderr receives Ingest warnings (lenient-YAML notices, dropped components).
+	// nil means os.Stderr.
+	Stderr io.Writer
 }
 
 // Adapter implements adapter.Adapter for OpenCode.
@@ -20,6 +24,14 @@ type Adapter struct{ opts Options }
 
 // New constructs an OpenCode adapter.
 func New(opts Options) *Adapter { return &Adapter{opts: opts} }
+
+// stderr returns the configured warning sink, defaulting to os.Stderr.
+func (a *Adapter) stderr() io.Writer {
+	if a.opts.Stderr != nil {
+		return a.opts.Stderr
+	}
+	return os.Stderr
+}
 
 func (a *Adapter) Name() string { return "opencode" }
 

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -201,7 +201,11 @@ func loadSkills(fs afero.Fs, home string) ([]Skill, error) {
 			}
 			return nil, fmt.Errorf("read SKILL.md for %s: %w", e.Name(), err)
 		}
-		fm, body, err := ParseFrontmatter(raw)
+		// Lenient fallback: a canonical SKILL.md authored by hand may carry an
+		// unquoted "Triggers on: …" colon-space sequence in `description:`.
+		// Strict YAML rejects it; we coerce to valid YAML on render anyway, so
+		// the load is silent.
+		fm, body, _, err := ParseFrontmatterWithReport(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -272,7 +276,7 @@ func loadSubagents(fs afero.Fs, home string) ([]Subagent, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
-		fm, body, err := ParseFrontmatter(raw)
+		fm, body, _, err := ParseFrontmatterWithReport(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -302,7 +306,7 @@ func loadCommands(fs afero.Fs, home string) ([]Command, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
-		fm, body, err := ParseFrontmatter(raw)
+		fm, body, _, err := ParseFrontmatterWithReport(raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
@@ -399,8 +403,31 @@ func loadLSP(fs afero.Fs, home string) ([]LSPServer, error) {
 
 // ParseFrontmatter extracts YAML frontmatter and body from a markdown file.
 // If the input doesn't begin with "---\n", returns an empty map and the
-// entire input as body.
+// entire input as body. Returns an error on any YAML decode failure; callers
+// that want to accept the kind of relaxed "key: value-with-colons" frontmatter
+// that Claude Code itself reads should use ParseFrontmatterWithReport instead.
 func ParseFrontmatter(data []byte) (map[string]any, string, error) {
+	fm, body, _, err := parseFrontmatter(data, false)
+	return fm, body, err
+}
+
+// ParseFrontmatterWithReport is the lenient-fallback variant: it first tries
+// strict YAML; on a YAML decode failure it falls back to a line-oriented
+// "key: rest-of-line" parser that accepts bare colons inside values. lenient
+// is true iff the strict parse failed but the lenient one succeeded — callers
+// (typically Ingest paths) can then surface a warning so the user knows their
+// SKILL.md is not strict YAML.
+//
+// The lenient parser exists because Claude Code itself reads frontmatter that
+// way: a SKILL.md whose description contains a bare "Triggers on: X, Y" parses
+// fine in claude.ai but breaks sigs.k8s.io/yaml. Without this fallback, `import`
+// silently dropped any skill with such a description (the call site swallowed
+// the parse error with `continue`).
+func ParseFrontmatterWithReport(data []byte) (fm map[string]any, body string, lenient bool, err error) {
+	return parseFrontmatter(data, true)
+}
+
+func parseFrontmatter(data []byte, allowLenient bool) (fm map[string]any, body string, lenient bool, err error) {
 	// Normalize CRLF → LF so a component .md saved by a Windows editor
 	// ("---\r\n"), or shipped CRLF inside a fetched plugin, is recognized as
 	// having frontmatter. Without this the literal "---\n" check fails and the
@@ -410,22 +437,77 @@ func ParseFrontmatter(data []byte) (map[string]any, string, error) {
 		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	}
 	if !bytes.HasPrefix(data, []byte("---\n")) {
-		return map[string]any{}, string(data), nil
+		return map[string]any{}, string(data), false, nil
 	}
 	rest := data[len("---\n"):]
-	yml, body, ok := splitFrontmatterBody(rest)
+	yml, bodyBytes, ok := splitFrontmatterBody(rest)
 	if !ok {
-		return nil, "", fmt.Errorf("unterminated frontmatter")
+		return nil, "", false, fmt.Errorf("unterminated frontmatter")
 	}
 	// An empty frontmatter block ("---\n---\n…") is a valid empty mapping.
 	if len(bytes.TrimSpace(yml)) == 0 {
-		return map[string]any{}, string(body), nil
+		return map[string]any{}, string(bodyBytes), false, nil
 	}
-	fm, err := jsonkeys.DecodeYAML(yml)
-	if err != nil {
-		return nil, "", fmt.Errorf("parse yaml frontmatter: %w", err)
+	fm, strictErr := jsonkeys.DecodeYAML(yml)
+	if strictErr == nil {
+		return fm, string(bodyBytes), false, nil
 	}
-	return fm, string(body), nil
+	if !allowLenient {
+		return nil, "", false, fmt.Errorf("parse yaml frontmatter: %w", strictErr)
+	}
+	lfm, lerr := parseFrontmatterLenient(yml)
+	if lerr != nil {
+		// Both parsers failed — return the strict error since it's typically
+		// more informative ("mapping values are not allowed in this context"
+		// vs. our generic lenient error).
+		return nil, "", false, fmt.Errorf("parse yaml frontmatter: %w", strictErr)
+	}
+	return lfm, string(bodyBytes), true, nil
+}
+
+// parseFrontmatterLenient parses YAML frontmatter as a flat string-string map
+// using "key: rest-of-line" semantics: the first ": " on each line splits the
+// key from the value, the value is taken verbatim to end-of-line, and any
+// further colons (the failure mode strict YAML rejects) are preserved.
+//
+// This is intentionally narrow — it does NOT support nested mappings, arrays,
+// multi-line scalars, or quoting. The lenient path exists only to recover skill
+// frontmatter whose `description:` contains bare colon-space, which is by far
+// the dominant real-world breakage. Anything more structured belongs in strict
+// YAML; if a future component frontmatter needs richer leniency, extend here.
+func parseFrontmatterLenient(yml []byte) (map[string]any, error) {
+	out := map[string]any{}
+	lines := bytes.Split(yml, []byte("\n"))
+	for _, line := range lines {
+		// Skip blank lines and YAML comments. A document marker ("---")
+		// shouldn't appear inside the frontmatter block (we already stripped
+		// the fences), but treat it defensively as a separator.
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 || trimmed[0] == '#' || bytes.Equal(trimmed, []byte("---")) {
+			continue
+		}
+		idx := bytes.Index(line, []byte(": "))
+		if idx < 0 {
+			// A line ending with ": " (no value) is rare but valid YAML for an
+			// empty value; accept it.
+			if bytes.HasSuffix(bytes.TrimRight(line, " \t"), []byte(":")) {
+				key := strings.TrimSpace(string(bytes.TrimSuffix(bytes.TrimRight(line, " \t"), []byte(":"))))
+				if key == "" {
+					return nil, fmt.Errorf("lenient parse: malformed line %q", string(line))
+				}
+				out[key] = ""
+				continue
+			}
+			return nil, fmt.Errorf("lenient parse: no key/value separator on line %q", string(line))
+		}
+		key := strings.TrimSpace(string(line[:idx]))
+		if key == "" {
+			return nil, fmt.Errorf("lenient parse: empty key on line %q", string(line))
+		}
+		val := strings.TrimRight(string(line[idx+2:]), " \t")
+		out[key] = val
+	}
+	return out, nil
 }
 
 // splitFrontmatterBody splits the bytes AFTER the opening "---\n" into the YAML

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -60,6 +60,74 @@ func TestParseFrontmatter_ClosingFenceAtEOF(t *testing.T) {
 	}
 }
 
+// TestParseFrontmatterWithReport_BadYAMLDescription is the source-pkg twin of
+// the claude-adapter regression: a SKILL.md whose unquoted description contains
+// "Triggers on: X, Y" (bare ": ") makes sigs.k8s.io/yaml bail. The lenient
+// fallback must succeed, keep the full description string, and report Lenient.
+func TestParseFrontmatterWithReport_BadYAMLDescription(t *testing.T) {
+	input := []byte(`---
+name: gltf-transform
+description: Optimize and post-process GLB/glTF 3D models. Use when compressing models for web delivery, reducing file size, simplifying geometry, inspecting model stats, merging models, or converting textures. Triggers on: optimize GLB, compress model, reduce file size, simplify mesh, draco compression, meshopt, webp textures, inspect model, merge GLB, model optimization.
+---
+body
+`)
+	// Strict ParseFrontmatter must still fail — backward compat for callers that
+	// rely on the strict error to surface bad input.
+	if _, _, err := source.ParseFrontmatter(input); err == nil {
+		t.Fatalf("strict ParseFrontmatter accepted bad-YAML description; lenient must be opt-in")
+	}
+	fm, body, lenient, err := source.ParseFrontmatterWithReport(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatterWithReport: %v", err)
+	}
+	if !lenient {
+		t.Fatalf("Lenient must be true when strict YAML fails and lenient succeeds")
+	}
+	if fm["name"] != "gltf-transform" {
+		t.Fatalf("name not parsed leniently: %+v", fm)
+	}
+	desc, ok := fm["description"].(string)
+	if !ok {
+		t.Fatalf("description not a string: %T %v", fm["description"], fm["description"])
+	}
+	if !contains(desc, "Triggers on: optimize GLB") {
+		t.Fatalf("lenient description truncated at colon-space: %q", desc)
+	}
+	if !contains(desc, "model optimization.") {
+		t.Fatalf("lenient description missing tail: %q", desc)
+	}
+	if body != "body\n" {
+		t.Fatalf("body mismatch: %q", body)
+	}
+}
+
+// TestLoad_SkillWithBadYAMLDescription is the integration: source.Load with a
+// SKILL.md whose description carries a bare colon-space MUST NOT silently drop
+// the skill. With the lenient fallback wired into the loader, it loads with the
+// full description preserved.
+func TestLoad_SkillWithBadYAMLDescription(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(""), 0o644)
+	_ = afero.WriteFile(fs, "/home/.agentsync/skills/gltf-transform/SKILL.md",
+		[]byte(`---
+name: gltf-transform
+description: Optimize and post-process GLB/glTF 3D models. Triggers on: optimize GLB, compress model.
+---
+body
+`), 0o644)
+	c, err := source.Load(fs, "/home/.agentsync")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Skills) != 1 || c.Skills[0].Name != "gltf-transform" {
+		t.Fatalf("skill silently dropped: %+v", c.Skills)
+	}
+	desc, _ := c.Skills[0].Frontmatter["description"].(string)
+	if !contains(desc, "Triggers on: optimize GLB") {
+		t.Fatalf("description truncated: %q", desc)
+	}
+}
+
 // TestLoad_SkillWithFenceAtEOF proves the parser bug's blast radius: source.Load
 // is the entry point for every command, so a single benign SKILL.md whose
 // closing fence sits at EOF must not abort the whole load.


### PR DESCRIPTION
## Summary

- `agentsync import claude` silently dropped any skill/subagent/command whose unquoted `description:` carried a bare `Triggers on: X, Y` colon-space — `sigs.k8s.io/yaml` rejected it (`mapping values are not allowed in this context`) and the `continue` in every adapter's Ingest swallowed the error. Real-world repro: 4 of 6 local Claude skills (`build123d`, `gltf-transform`, `model-compare`, `render-glb`) vanished on import with no warning.
- Adds `ParseFrontmatterWithReport` (both `internal/source` and `internal/adapter/claude`) that tries strict YAML first and falls back to a narrow "key: rest-of-line" parser, returning a `lenient bool` so callers can warn.
- Wires Claude / OpenCode / Codex `Ingest` to the lenient variant. The silent `continue` on parse error is replaced with `warning: skipping <kind> "<name>": <reason>`. A successful lenient parse warns too. Warnings route through a new `Options.Stderr` (default `os.Stderr`) so tests can capture them.
- `source.Load` also uses the lenient variant silently — the canonical write-back through `EncodeFrontmatter` auto-quotes values containing `: `, so the canonical `SKILL.md` becomes strict YAML on disk after one round-trip.

## Workflow

```
SKILL.md on disk
  └─ Adapter.Ingest (claude/opencode/codex)
       ├─ ParseFrontmatterWithReport(data)
       │     ├─ strict YAML succeeds → silent ✓
       │     ├─ strict fails, lenient succeeds → warn "parsed leniently" ✓
       │     └─ both fail → warn "skipping <kind>" + drop
       └─ → source.Canonical → capture.Capture → ~/.agentsync/skills/X/SKILL.md
              (EncodeFrontmatter auto-quotes ": " values → strict YAML on disk)
```

## Files changed

- `internal/source/loader.go`, `internal/source/loader_test.go` — new `ParseFrontmatterWithReport`, lenient line-oriented parser; loader call sites switched
- `internal/adapter/claude/{frontmatter,ingest,claude,frontmatter_test,ingest_test}.go` — mirror parser; `Options.Stderr`; Ingest warnings
- `internal/adapter/opencode/{ingest,opencode}.go` — `Options.Stderr`; Ingest warnings
- `internal/adapter/codex/{ingest,codex}.go` — `Options.Stderr`; Ingest warnings
- `CHANGELOG.md` — `[Unreleased] Fixed` entry

## Test plan

- [x] `just test-fast` — pure-unit packages green on host
- [x] Full hermetic gate (`go test -race -count=1 ./...` in container) — green across all packages
- [x] `just lint` — 0 issues
- [x] TDD red→green for all new tests (failed first with the expected error, then passed):
  - `claude.TestParseFrontmatterWithReport_*` — strict-success, lenient-success on verbatim `gltf-transform` description, unterminated, no-frontmatter
  - `source.TestParseFrontmatterWithReport_BadYAMLDescription` + `TestLoad_SkillWithBadYAMLDescription`
  - `claude.TestIngest_LenientSkillNotSilentlyDropped` — covers ok / lenient-warn / dropped-warn paths
- [x] Manual end-to-end against the actual `~/.claude/skills` that exhibited the bug: all 6 skills now import; the 4 previously-dropped ones produce a `warning: skill "<name>" frontmatter is not strict YAML; parsed leniently` line and write to `~/.agentsync/skills/<name>/SKILL.md` with a strict-YAML (quoted) description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)