### PR TITLE
feat(cli): friendlier `explain` — multi-plugin args, --all, --list, styled output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Added
 
+- **`explain` accepts multiple plugins, `--all`, and `--list`** —
+  `agentsync explain` now takes a space-separated list of plugin ids
+  (`agentsync explain notion@official superpowers@obra`), and gains two flags:
+  `--all` renders coverage for every installed plugin, and `--list` prints just
+  the set of installed ids (a quick reminder of what you can pass without
+  jumping to `agentsync plugin list`). The text output is also rendered through
+  the styled UI: a bold header summarises how many plugins are being explained,
+  each plugin gets a `▸` section header (with version + a yellow `(disabled)`
+  marker when applicable), and per-agent rows use the same semantic glyph +
+  color vocabulary as `apply` and the capability matrix
+  (`✓ full` / `◐ partial` / `✗ none`). `--json` is unchanged in shape for the
+  default rows mode; with `--list` it emits a `plugins` array.
 - **Styled CLI output and a `--color` flag** — `agentsync status`, `diff`,
   `doctor`, and `apply` now render through a single presentation layer
   (`internal/ui`) with a curated semantic palette (green=synced, cyan=pending,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -340,8 +340,11 @@ plugin: atlassian@anthropic
 Inspect any plugin's coverage without applying:
 
 ```bash
-agentsync explain atlassian@anthropic
-agentsync explain atlassian@anthropic --json
+agentsync explain atlassian@anthropic                   # one plugin
+agentsync explain atlassian@anthropic superpowers@obra  # space-separated
+agentsync explain --all                                 # every installed plugin
+agentsync explain --list                                # just the ids (skip rendering)
+agentsync explain atlassian@anthropic --json            # machine-readable
 ```
 
 Control fan-out per plugin with `agents = [...]` in the plugin's TOML file. (A
@@ -507,7 +510,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project --json` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. | `--dry-run` |
-| `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
+| `explain [<plugin>...]` | Show per-agent translation coverage for one or more plugins. | `--all --list --json` |
 
 Global: `-v/--verbose` for verbose logging on any command. `--color=auto|always|never`
 controls whether output is styled with ANSI color and bold (default `auto` — on

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -14,16 +16,37 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newExplainCmd() *cobra.Command {
-	var jsonOut bool
+	var (
+		jsonOut bool
+		list    bool
+		all     bool
+	)
 	cmd := &cobra.Command{
-		Use:   "explain <plugin-id>",
-		Args:  cobra.ExactArgs(1),
-		Short: "show per-agent translation for one plugin",
+		Use:   "explain [<plugin-id>...]",
+		Short: "show per-agent translation for one or more plugins",
+		Long: "Show per-agent translation coverage for installed plugins.\n\n" +
+			"Pass one or more plugin ids (space-separated) to explain just those,\n" +
+			"--all to explain every installed plugin, or --list to print the set of\n" +
+			"installed plugin ids without rendering coverage.",
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pluginID := args[0]
+			if list && all {
+				return fmt.Errorf("--list and --all are mutually exclusive")
+			}
+			if list && len(args) > 0 {
+				return fmt.Errorf("--list does not take plugin ids")
+			}
+			if all && len(args) > 0 {
+				return fmt.Errorf("--all does not take plugin ids; it explains every installed plugin")
+			}
+			if !list && !all && len(args) == 0 {
+				return fmt.Errorf("explain needs at least one plugin id, --all, or --list")
+			}
+
 			home := paths.AgentsyncHome(paths.OSEnv{})
 			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
 			// Read-only: a strict plugin.json/entry conflict degrades to a
@@ -33,70 +56,298 @@ func newExplainCmd() *cobra.Command {
 				return err
 			}
 
-			// Find the plugin in the canonical model.
-			var found bool
-			for _, pl := range c.Plugins {
-				label := pl.Plugin.ID
-				if label == "" {
-					label = pl.ID
-				}
-				if label == pluginID || pl.ID == pluginID {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("plugin %q not found; run 'agentsync plugin list' to see installed plugins", pluginID)
-			}
-
-			// Build a single-plugin canonical by filtering the Plugins slice.
-			filtered := c
-			var matchedPlugins []source.Plugin
-			for _, pl := range c.Plugins {
-				label := pl.Plugin.ID
-				if label == "" {
-					label = pl.ID
-				}
-				if label == pluginID || pl.ID == pluginID {
-					matchedPlugins = append(matchedPlugins, pl)
-				}
-			}
-			filtered.Plugins = matchedPlugins
-
-			// Collect enabled agents. Sort so `explain --json` row order is
-			// deterministic — PrintJSON emits rows in this slice order verbatim
-			// (unlike PrintText, which sorts), so an unsorted map walk here
-			// leaked nondeterministic ordering into the JSON output.
-			var agents []string
-			for name, ag := range c.Config.Agents {
-				if ag.Enabled {
-					agents = append(agents, name)
-				}
-			}
-			sort.Strings(agents)
-
-			reg := registryFactory()
-			statePath := filepath.Join(home, ".state", "targets.json")
-			s, err := state.Load(statePath)
+			p, err := newPrinter(cmd)
 			if err != nil {
 				return err
 			}
 
-			plan, err := render.Plan(secrets.ForRender(filtered), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
-			if err != nil {
-				return err
+			if list {
+				return runExplainList(p, c, jsonOut)
 			}
 
-			report := render.BuildReport(filtered, plan, agents)
-
-			w := cmd.OutOrStdout()
-			if jsonOut {
-				return report.PrintJSON(w)
+			// Resolve the requested plugin ids (--all expands to every installed
+			// plugin id; otherwise we keep argv order so the user sees rows in
+			// the order they asked for).
+			wanted, missing := resolveExplainTargets(c, args, all)
+			if len(missing) > 0 {
+				return fmt.Errorf("plugin(s) not installed: %s; run 'agentsync plugin list' to see installed plugins",
+					strings.Join(missing, ", "))
 			}
-			report.PrintText(w)
-			return nil
+			if len(wanted) == 0 {
+				// --all with no installed plugins is an honest empty state.
+				return runExplainEmpty(p, jsonOut)
+			}
+
+			return runExplain(cmd.OutOrStdout(), p, c, wanted, home, jsonOut)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "structured JSON output")
+	cmd.Flags().BoolVar(&list, "list", false, "list installed plugin ids and exit")
+	cmd.Flags().BoolVar(&all, "all", false, "explain every installed plugin")
 	return cmd
+}
+
+// resolveExplainTargets matches user-supplied plugin ids against the canonical
+// model's installed plugins. With all=true the args are ignored and every
+// installed plugin is returned in id order. Missing ids are reported separately
+// so the caller can emit one combined error rather than one per typo.
+func resolveExplainTargets(c source.Canonical, args []string, all bool) (matched []source.Plugin, missing []string) {
+	if all {
+		matched = append(matched, c.Plugins...)
+		sort.Slice(matched, func(i, j int) bool { return explainLabel(matched[i]) < explainLabel(matched[j]) })
+		return matched, nil
+	}
+	// Index installed plugins by both labels they may be referenced as
+	// (the @marketplace form and the short id).
+	byID := map[string]source.Plugin{}
+	for _, pl := range c.Plugins {
+		if pl.Plugin.ID != "" {
+			byID[pl.Plugin.ID] = pl
+		}
+		if pl.ID != "" {
+			byID[pl.ID] = pl
+		}
+	}
+	seen := map[string]bool{}
+	for _, want := range args {
+		pl, ok := byID[want]
+		if !ok {
+			missing = append(missing, want)
+			continue
+		}
+		key := explainLabel(pl)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		matched = append(matched, pl)
+	}
+	return matched, missing
+}
+
+// runExplainList prints the set of installed plugin ids so users don't have to
+// jump to `plugin list` just to remember what they can explain.
+func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
+	type listRow struct {
+		ID       string `json:"id"`
+		Version  string `json:"version,omitempty"`
+		Disabled bool   `json:"disabled,omitempty"`
+	}
+	plugins := make([]source.Plugin, len(c.Plugins))
+	copy(plugins, c.Plugins)
+	sort.Slice(plugins, func(i, j int) bool { return explainLabel(plugins[i]) < explainLabel(plugins[j]) })
+
+	if jsonOut {
+		rows := make([]listRow, 0, len(plugins))
+		for _, pl := range plugins {
+			rows = append(rows, listRow{
+				ID:       explainLabel(pl),
+				Version:  pl.Plugin.Version,
+				Disabled: pl.Plugin.Disabled,
+			})
+		}
+		return emitJSON(p.Out, struct {
+			Plugins []listRow `json:"plugins"`
+		}{Plugins: rows})
+	}
+
+	if len(plugins) == 0 {
+		fmt.Fprintf(p.Out, "%s\n", p.Faint("no plugins installed — try `agentsync plugin install <id@marketplace>`"))
+		return nil
+	}
+
+	fmt.Fprintf(p.Out, "%s %s\n", p.Bold("Installed plugins"),
+		p.Faint(fmt.Sprintf("(%d)", len(plugins))))
+	maxLabel := 0
+	for _, pl := range plugins {
+		if n := visibleLen(explainLabel(pl)); n > maxLabel {
+			maxLabel = n
+		}
+	}
+	for _, pl := range plugins {
+		label := explainLabel(pl)
+		hasTrail := pl.Plugin.Version != "" || pl.Plugin.Disabled
+		// Only pad the label when something follows it — a bare row with
+		// trailing spaces just leaves visible whitespace at end-of-line.
+		shown := label
+		if hasTrail {
+			shown = ui.Pad(label, maxLabel)
+		}
+		line := fmt.Sprintf("  %s %s", p.Cyan(ui.GlyphInfo), shown)
+		if pl.Plugin.Version != "" {
+			line += "  " + p.Faint("v"+pl.Plugin.Version)
+		}
+		if pl.Plugin.Disabled {
+			line += "  " + p.Yellow("(disabled)")
+		}
+		fmt.Fprintln(p.Out, line)
+	}
+	fmt.Fprintln(p.Out, "")
+	fmt.Fprintf(p.Out, "%s %s\n",
+		p.Faint(ui.GlyphArrow),
+		p.Faint("explain coverage: `agentsync explain <plugin>` or `--all`"))
+	return nil
+}
+
+// runExplainEmpty handles `--all` when no plugins are installed.
+func runExplainEmpty(p *ui.Printer, jsonOut bool) error {
+	if jsonOut {
+		return emitJSON(p.Out, render.TranslationReport{})
+	}
+	fmt.Fprintf(p.Out, "%s\n", p.Faint("no plugins installed — try `agentsync plugin install <id@marketplace>`"))
+	return nil
+}
+
+// runExplain renders translation coverage for the matched plugins. Each plugin
+// is reported under a styled header (id, version, disabled marker); the per-
+// agent rows reuse the same PrintTextStyled body apply uses, so the visual
+// vocabulary stays consistent.
+func runExplain(w io.Writer, p *ui.Printer, c source.Canonical, wanted []source.Plugin, home string, jsonOut bool) error {
+	// Collect enabled agents. Sort so `--json` row order is deterministic
+	// (PrintJSON emits rows in this slice order verbatim).
+	var agents []string
+	for name, ag := range c.Config.Agents {
+		if ag.Enabled {
+			agents = append(agents, name)
+		}
+	}
+	sort.Strings(agents)
+
+	reg := registryFactory()
+	statePath := filepath.Join(home, ".state", "targets.json")
+	s, err := state.Load(statePath)
+	if err != nil {
+		return err
+	}
+
+	// One shared plan over the full canonical: every plugin-row in the
+	// report already reads from the same per-agent op set today (BuildReport
+	// attributes counts globally — see its doc-comment). Planning per
+	// plugin would not change a row's numbers and would multiply work.
+	plan, err := render.Plan(secrets.ForRender(c), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		// Build one combined report whose rows cover exactly the requested
+		// plugins, in the order resolveExplainTargets returned them.
+		filtered := c
+		filtered.Plugins = wanted
+		report := render.BuildReport(filtered, plan, agents)
+		return report.PrintJSON(w)
+	}
+
+	// Text path: render plugin-by-plugin so each gets its own styled section
+	// header (with version + disabled marker), separated by a blank line.
+	fmt.Fprintf(w, "%s %s\n",
+		p.Bold("agentsync explain"),
+		p.Faint(fmt.Sprintf("— translation coverage for %s", pluralize(len(wanted), "plugin"))))
+	fmt.Fprintln(w, "")
+
+	for i, pl := range wanted {
+		if i > 0 {
+			fmt.Fprintln(w, "")
+		}
+		emitPluginHeader(w, p, pl)
+
+		filtered := c
+		filtered.Plugins = []source.Plugin{pl}
+		report := render.BuildReport(filtered, plan, agents)
+		// The report already groups by plugin and renders one row per
+		// agent — emit it stripped of its own "plugin: …" header to avoid
+		// duplicating the one we just printed.
+		emitReportBody(w, p, report)
+	}
+	return nil
+}
+
+// emitPluginHeader prints a styled "▸ <id>  v<version>  (disabled)" line.
+func emitPluginHeader(w io.Writer, p *ui.Printer, pl source.Plugin) {
+	label := explainLabel(pl)
+	parts := []string{p.Bold(p.Cyan("▸") + " " + label)}
+	if pl.Plugin.Version != "" {
+		parts = append(parts, p.Faint("v"+pl.Plugin.Version))
+	}
+	if pl.Plugin.Disabled {
+		parts = append(parts, p.Yellow("(disabled)"))
+	}
+	fmt.Fprintln(w, strings.Join(parts, "  "))
+}
+
+// emitReportBody emits the agent rows for a single-plugin report, without the
+// "plugin: …" header PrintTextStyled normally prints (we already drew our own
+// section header above it).
+func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
+	// Stable agent ordering matches PrintTextStyled.
+	rows := append([]render.PluginRow(nil), r.Rows...)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Agent < rows[j].Agent })
+	if len(rows) == 0 {
+		fmt.Fprintf(w, "  %s\n", p.Faint("(no enabled agents — `agentsync agent add <name>`)"))
+		return
+	}
+	for _, row := range rows {
+		if row.Disabled {
+			// BuildReport emits a single disabled-marker row (no per-agent
+			// counts) for disabled plugins; the section header above already
+			// shows "(disabled)", so this row would just duplicate that.
+			continue
+		}
+		glyph, color := coverageGlyphAndColor(p, row.Coverage)
+		// Column order matches apply's translation report: agent name (bold
+		// padded), then the colored "<glyph> <coverage>" mark (padded plain
+		// before coloring so ANSI never shifts the count column), then a
+		// faint count tail with an optional skip note.
+		mark := color(ui.Pad(glyph+" "+row.Coverage, 12))
+		tail := p.Faint(fmt.Sprintf("%d mcp · %d commands", row.MCP, row.Commands))
+		if row.Skips > 0 {
+			tail += "  " + p.Yellow(fmt.Sprintf("(%d skipped)", row.Skips))
+		}
+		fmt.Fprintf(w, "  %s %s  %s  %s\n",
+			p.Faint(ui.GlyphArrow),
+			p.Bold(ui.Pad(row.Agent, 10)),
+			mark,
+			tail)
+	}
+}
+
+// coverageGlyphAndColor maps a coverage string to a glyph + semantic color
+// helper (matches the existing translation-report vocabulary).
+func coverageGlyphAndColor(p *ui.Printer, cov string) (string, func(string) string) {
+	switch cov {
+	case "full":
+		return ui.GlyphOK, p.Green
+	case "partial":
+		return ui.GlyphPartial, p.Yellow
+	default:
+		return ui.GlyphErr, p.Red
+	}
+}
+
+// explainLabel returns the human label for a plugin (the @marketplace form,
+// falling back to the short id).
+func explainLabel(pl source.Plugin) string {
+	if pl.Plugin.ID != "" {
+		return pl.Plugin.ID
+	}
+	return pl.ID
+}
+
+// pluralize renders "1 plugin" / "2 plugins" — the trivial English-y form is
+// enough for CLI surface and beats pulling in a dependency.
+func pluralize(n int, word string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", word)
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}
+
+// visibleLen counts runes (the labels here are ASCII plugin ids; this keeps it
+// cheap and avoids a runewidth dependency for the unlikely non-ASCII case).
+func visibleLen(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
 }

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -150,6 +150,229 @@ func TestExplain_JSONAgentOrderDeterministic(t *testing.T) {
 	}
 }
 
+// TestExplain_NoArgsRequiresSomething rejects a bare `explain` invocation with
+// neither plugin ids nor --list/--all so the user gets a pointer to the new
+// flags rather than a confusing usage error.
+func TestExplain_NoArgsRequiresSomething(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "explain")
+	if err == nil {
+		t.Fatal("expected error for bare explain; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--all") || !strings.Contains(msg, "--list") {
+		t.Errorf("error should point at --all and --list; got: %s", msg)
+	}
+}
+
+// TestExplain_List prints installed plugin ids (and stays empty when none are
+// installed, with an install hint).
+func TestExplain_List(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty case: list works even with zero plugins; hints at install.
+	out, err := runCLI(t, env, "explain", "--list")
+	if err != nil {
+		t.Fatalf("--list (empty): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "no plugins installed") {
+		t.Errorf("empty list should hint at install; got:\n%s", out)
+	}
+
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "install", "demo@test-mp"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err = runCLI(t, env, "explain", "--list")
+	if err != nil {
+		t.Fatalf("--list: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "demo@test-mp") {
+		t.Errorf("--list missing plugin id; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Installed plugins") {
+		t.Errorf("--list missing header; got:\n%s", out)
+	}
+
+	// --list --json emits a `plugins` array.
+	out, err = runCLI(t, env, "explain", "--list", "--json")
+	if err != nil {
+		t.Fatalf("--list --json: %v\n%s", err, out)
+	}
+	var parsed struct {
+		Plugins []struct {
+			ID string `json:"id"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--list --json not valid JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Plugins) != 1 || parsed.Plugins[0].ID != "demo@test-mp" {
+		t.Errorf("--list --json plugins = %+v; want one demo@test-mp", parsed.Plugins)
+	}
+}
+
+// TestExplain_MultipleArgs renders coverage for each requested plugin in argv
+// order. This is the new multi-arg shape: `explain a b c`.
+func TestExplain_MultipleArgs(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainMultiFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"alpha@multi-mp", "beta@multi-mp"} {
+		if _, err := runCLI(t, env, "plugin", "install", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Note args order: beta first, then alpha — multi-arg explain must honor it.
+	out, err := runCLI(t, env, "explain", "beta@multi-mp", "alpha@multi-mp", "--json")
+	if err != nil {
+		t.Fatalf("multi-arg --json: %v\n%s", err, out)
+	}
+	var parsed struct {
+		Rows []struct {
+			Plugin string `json:"plugin"`
+			Agent  string `json:"agent"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("multi-arg not valid JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Rows) < 2 {
+		t.Fatalf("expected >=2 rows across the two plugins; got %d", len(parsed.Rows))
+	}
+	if parsed.Rows[0].Plugin != "beta@multi-mp" {
+		t.Errorf("first row plugin = %q; want beta@multi-mp (argv-order)", parsed.Rows[0].Plugin)
+	}
+	// Both plugins must appear in the rows.
+	seen := map[string]bool{}
+	for _, r := range parsed.Rows {
+		seen[r.Plugin] = true
+	}
+	for _, want := range []string{"alpha@multi-mp", "beta@multi-mp"} {
+		if !seen[want] {
+			t.Errorf("missing rows for %q; got rows: %+v", want, parsed.Rows)
+		}
+	}
+}
+
+// TestExplain_All explains every installed plugin without naming them.
+func TestExplain_All(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainMultiFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"alpha@multi-mp", "beta@multi-mp"} {
+		if _, err := runCLI(t, env, "plugin", "install", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := runCLI(t, env, "explain", "--all", "--json")
+	if err != nil {
+		t.Fatalf("--all: %v\n%s", err, out)
+	}
+	var parsed struct {
+		Rows []struct {
+			Plugin string `json:"plugin"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--all not valid JSON: %v\n%s", err, out)
+	}
+	seen := map[string]bool{}
+	for _, r := range parsed.Rows {
+		seen[r.Plugin] = true
+	}
+	for _, want := range []string{"alpha@multi-mp", "beta@multi-mp"} {
+		if !seen[want] {
+			t.Errorf("--all missing rows for %q; got rows: %+v", want, parsed.Rows)
+		}
+	}
+}
+
+// TestExplain_MultipleArgsMissingAggregated reports every missing plugin id in
+// one message — typing two bad ids should not require two roundtrips to learn.
+func TestExplain_MultipleArgsMissingAggregated(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "explain", "nope1", "nope2")
+	if err == nil {
+		t.Fatal("expected error for two missing plugins; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "nope1") || !strings.Contains(msg, "nope2") {
+		t.Errorf("error should list both missing ids; got: %s", msg)
+	}
+}
+
+// TestExplain_FlagConflicts catches mutually-exclusive flag combinations early.
+func TestExplain_FlagConflicts(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"list+all", []string{"explain", "--list", "--all"}, "mutually exclusive"},
+		{"list+id", []string{"explain", "--list", "foo"}, "--list does not take"},
+		{"all+id", []string{"explain", "--all", "foo"}, "--all does not take"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runCLI(t, env, tc.args...)
+			if err == nil {
+				t.Fatal("expected error; got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want error containing %q; got: %s", tc.want, err)
+			}
+		})
+	}
+}
+
 // setupExplainFixture creates a minimal local marketplace with a single demo plugin.
 func setupExplainFixture(t *testing.T, tmp string) string {
 	t.Helper()
@@ -170,6 +393,34 @@ func setupExplainFixture(t *testing.T, tmp string) string {
 		[]byte(`{"name":"demo","version":"1.0.0","mcpServers":{"demo-mcp":{"command":"echo","args":["hi"]}}}`),
 		0o644); err != nil {
 		t.Fatal(err)
+	}
+	return fixture
+}
+
+// setupExplainMultiFixture creates a marketplace with two installable plugins
+// (alpha + beta) used by the multi-arg / --all explain tests.
+func setupExplainMultiFixture(t *testing.T, tmp string) string {
+	t.Helper()
+	fixture := filepath.Join(tmp, "fixture-marketplace-explain-multi")
+	if err := os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+		[]byte(`{"name":"multi-mp","owner":{"name":"x"},"plugins":[`+
+			`{"name":"alpha","source":"./plugins/alpha"},`+
+			`{"name":"beta","source":"./plugins/beta"}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		plugDir := filepath.Join(fixture, "plugins", name, ".claude-plugin")
+		if err := os.MkdirAll(plugDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		manifest := `{"name":"` + name + `","version":"1.0.0","mcpServers":{"` + name + `-mcp":{"command":"echo","args":["hi"]}}}`
+		if err := os.WriteFile(filepath.Join(plugDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return fixture
 }

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `diff [<path>]` | Show pending / drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source. | `--dry-run` |
-| `explain <plugin>` | Show a plugin's per-agent translation coverage. | `--json` |
+| `explain [<plugin>...]` | Show per-agent translation coverage for one or more plugins. | `--all --list --json` |
 
 ---
 
@@ -165,9 +165,19 @@ agentsync update
 agentsync update --apply --auto-safe
 ```
 
-### `explain <plugin>`
-Prints a plugin's per-agent translation coverage without applying. Add `--json`
-for machine-readable output.
+### `explain [<plugin>...]`
+Prints per-agent translation coverage for one or more installed plugins, without
+applying. Pass space-separated plugin ids to explain just those, `--all` to
+explain every installed plugin, or `--list` to print just the set of installed
+ids (a quick reminder of what you can pass). Add `--json` for machine-readable
+output (rows for plugin/agent coverage, or a `plugins` array under `--list`).
+
+```bash
+agentsync explain atlassian@anthropic
+agentsync explain atlassian@anthropic superpowers@obra
+agentsync explain --all
+agentsync explain --list
+```
 
 ---
 
@@ -179,6 +189,6 @@ for machine-readable output.
 | `--project <path>` | apply, status, diff, reconcile, update | Apply a specific project's overlay. |
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
-| `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). |
+| `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). `explain --list --json` emits a `plugins` array; `explain` with ids/`--all` emits the translation `rows`. |
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. |


### PR DESCRIPTION
## Summary

`agentsync explain` previously took exactly one plugin id and emitted an
unstyled report. Four UX changes:

- **multi-arg**: `agentsync explain notion@official superpowers@obra` —
  any number of space-separated ids, one section per plugin in argv order
- **`--all`**: explains every installed plugin (sorted by id)
- **`--list`**: prints just the installed plugin ids — a quick reminder of
  what you can pass, no full render. JSON form emits a `plugins` array
- **styled text path**: bold header, per-plugin `▸` section header (with
  version + `(disabled)` markers), per-agent rows using the same
  `✓ ◐ ✗` glyph + green/yellow/red palette `apply` and the capability
  matrix already use. Falls back to plain when piped / `--color=never` so
  existing fixtures hold.

Bonus polish: missing ids in a multi-arg call are aggregated into one
error (no need to learn about typos one-roundtrip-at-a-time), mutually
exclusive flag combos (`--list --all`, ids alongside either flag) are
caught early, and bare `explain` now points at the new flags.

Default `--json` shape is unchanged for the rows mode.

## Visual

| | |
|---|---|
| `--list`, multi-arg, `--all` | `(disabled)` marker + aggregated error |

(Screenshots shared in the spawning chat.)

## Docs

Updated in the same commit per the docs-stay-in-sync rule:

- `docs/user-guide.md` — quickstart usage + command reference
- `website/src/content/docs/reference/cli.mdx` — `explain` section +
  cross-command `--json` row
- `CHANGELOG.md` — new entry under `[Unreleased]`

## Test plan

- [x] `go test ./...` green (unit + integration in container)
- [x] New tests: `--list` (empty + populated, JSON), multi-arg argv-order
      preservation, `--all`, aggregated missing-id error, flag-conflict
      matrix (`--list+--all`, `--list+id`, `--all+id`), bare-explain hint
- [x] Existing tests still pass byte-for-byte (no fixture churn —
      `--color=auto` keeps piped/test output plain)
- [x] Manual smoke: `--list` with disabled plugin, multi-arg with
      argv-order, single + multi `--json` outputs
- [x] `go vet ./...` clean; `gofumpt -l` clean

https://claude.ai/code/session_01ReMj14uMxDuymYxcY3bLoz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReMj14uMxDuymYxcY3bLoz)_