### PR TITLE
feat(cli): pretty-style `import` output (sections, ⚠️ warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   (real) or cyan `→` (dry-run) prefix; the full-agent walk groups items under
   faint section headers (`mcp servers`, `skills`, …) printed lazily so an empty
   component is invisible; the summary line is bold (`imported N items from
-  claude`) with a faint per-component breakdown underneath; the
-  foreign-collision and plugin-resolution warnings use the same yellow
-  `warning:` prefix `apply` does. Wording is preserved (`imported X` /
-  `would import X`) so scripts grepping the output keep working.
+  claude`) with a faint per-component breakdown underneath. Every `warning:`
+  label — whether emitted by `import` itself, by an adapter's `Ingest` (the
+  lenient-YAML notices that used to lead the screen as plain text), or by
+  `capture`'s re-reference path — is restyled to a bold-yellow `⚠️ warning:`
+  by a single line-buffered writer (`ui.WarnWriter`) wrapping stderr; adapters
+  pick it up via a new optional `SetStderr(io.Writer)` setter so the routing
+  is invisible to non-CLI callers. Wording is preserved (`imported X` /
+  `would import X`, `warning: …`) so scripts grepping the output keep working.
 - **`status` explains its drift classes inline** — the formatted dashboard
   now prints a brief "What `apply` will do:" legend after the summary footer,
   with one action-focused line per drift class actually present (`new` → will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 ### Added
 
 - **Styled CLI output and a `--color` flag** — `agentsync status`, `diff`,
-  `doctor`, and `apply` now render through a single presentation layer
+  `doctor`, `apply`, and `import` now render through a single presentation layer
   (`internal/ui`) with a curated semantic palette (green=synced, cyan=pending,
   red=drift, yellow=needs-decision) and the same `✓ ◐ ✗ → •` glyph vocabulary
   the capability matrix already uses. `status` gains a one-line summary footer
@@ -28,6 +28,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   bold "plugin:" labels, semantic color on the coverage marks (green=full,
   yellow=partial, red=none), faint trailing counts. With color disabled the
   output is byte-identical to before, so existing fixtures hold.
+- **`import` joins the styled-output set** — per-item lines carry a green `✓`
+  (real) or cyan `→` (dry-run) prefix; the full-agent walk groups items under
+  faint section headers (`mcp servers`, `skills`, …) printed lazily so an empty
+  component is invisible; the summary line is bold (`imported N items from
+  claude`) with a faint per-component breakdown underneath; the
+  foreign-collision and plugin-resolution warnings use the same yellow
+  `warning:` prefix `apply` does. Wording is preserved (`imported X` /
+  `would import X`) so scripts grepping the output keep working.
 - **`status` explains its drift classes inline** — the formatted dashboard
   now prints a brief "What `apply` will do:" legend after the summary footer,
   with one action-focused line per drift class actually present (`new` → will

--- a/internal/adapter/claude/claude.go
+++ b/internal/adapter/claude/claude.go
@@ -27,6 +27,13 @@ func (a *Adapter) stderr() io.Writer {
 	return os.Stderr
 }
 
+// SetStderr replaces the warning sink the adapter writes Ingest warnings to,
+// so a CLI command can route adapter warnings through the same styled writer
+// it uses for its own output. Adapters built via the registry default to
+// os.Stderr; commands that wrap stderr (e.g. `import` styling "warning:"
+// labels) call this to redirect.
+func (a *Adapter) SetStderr(w io.Writer) { a.opts.Stderr = w }
+
 // Adapter implements adapter.Adapter for Claude Code.
 type Adapter struct {
 	opts Options

--- a/internal/adapter/codex/codex.go
+++ b/internal/adapter/codex/codex.go
@@ -40,6 +40,11 @@ func (a *Adapter) stderr() io.Writer {
 	return os.Stderr
 }
 
+// SetStderr replaces the warning sink the adapter writes Ingest warnings to,
+// so a CLI command can route adapter warnings through the same styled writer
+// it uses for its own output. See claude.Adapter.SetStderr for the contract.
+func (a *Adapter) SetStderr(w io.Writer) { a.opts.Stderr = w }
+
 func (a *Adapter) Name() string { return "codex" }
 
 // KeyMergeStrategy is codex's single key-merge strategy: TOML (config.toml),

--- a/internal/adapter/opencode/opencode.go
+++ b/internal/adapter/opencode/opencode.go
@@ -33,6 +33,11 @@ func (a *Adapter) stderr() io.Writer {
 	return os.Stderr
 }
 
+// SetStderr replaces the warning sink the adapter writes Ingest warnings to,
+// so a CLI command can route adapter warnings through the same styled writer
+// it uses for its own output. See claude.Adapter.SetStderr for the contract.
+func (a *Adapter) SetStderr(w io.Writer) { a.opts.Stderr = w }
+
 func (a *Adapter) Name() string { return "opencode" }
 
 // KeyMergeStrategy is opencode's single key-merge strategy: JSONC

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -207,13 +207,25 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	if perr != nil {
 		return perr
 	}
-	io := &importIO{p: p, out: p.Out, err: p.Err, dryRun: dryRun}
+	// Wrap stderr once so every "warning: …" line — ours, the adapter's
+	// Ingest, capture's re-reference, etc. — picks up the same bold-yellow
+	// "⚠️ warning:" styling. Lines that don't start with "warning: " pass
+	// through unchanged, so indented continuations and "agentsync:" notes
+	// look the same as before.
+	warnW := ui.NewWarnWriter(p.Err, p)
+	io := &importIO{p: p, out: p.Out, err: warnW, dryRun: dryRun}
 
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	reg := registryFactory()
 	a := reg.Lookup(agentName)
 	if a == nil {
 		return fmt.Errorf("adapter %q not registered; valid agents: %s", agentName, validAgents)
+	}
+	// Route the adapter's Ingest warnings through the same styled writer.
+	// Adapters that don't implement the setter (the noop adapter today) keep
+	// writing to os.Stderr — fine, they emit no Ingest warnings anyway.
+	if s, ok := a.(adapterStderrSetter); ok {
+		s.SetStderr(warnW)
 	}
 	// Gate codex/cursor the same way `agent add` does: they're registered as
 	// noop adapters, so Ingest returns an empty canonical and import would
@@ -531,6 +543,11 @@ func importVerb(dryRun bool) string {
 	return "imported"
 }
 
+// adapterStderrSetter is the optional setter each concrete adapter
+// (claude/opencode/codex) implements, letting CLI commands route the
+// adapter's Ingest warnings through a styled writer.
+type adapterStderrSetter interface{ SetStderr(io.Writer) }
+
 // importIO bundles the styled printer, the streams it writes to, and the
 // dry-run flag so every importXxx function emits its per-item lines, section
 // headers, and warnings through one consistent shape — the same green ✓ /
@@ -572,10 +589,13 @@ func (i *importIO) flushSection() {
 	i.sectionShown = true
 }
 
-// warn prints a yellow "warning:" prefix followed by msg. msg should not be
-// trailing-newline'd; warn always appends \n.
+// warn emits a "warning: …" line. Styling (bold-yellow "⚠️ warning:") is
+// applied by the ui.WarnWriter wrapping i.err — emitting the plain prefix
+// here means adapter Ingest, capture, and importIO all share one styling
+// point, and no caller has to know about it. msg should not include a
+// trailing newline; warn appends one.
 func (i *importIO) warn(msg string) {
-	fmt.Fprintf(i.err, "%s %s\n", i.p.Yellow("warning:"), msg)
+	fmt.Fprintf(i.err, "warning: %s\n", msg)
 }
 
 // warnf is warn + fmt.Sprintf for the common "%v / %q" formatting.

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -299,7 +299,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// own) are out of scope by design, and the merge-keys writer's per-
 	// pointer OwnedKeys check preserves them on apply rather than colliding.
 	if warnings := unimportedDestPointers(home, agentName, reg); len(warnings) > 0 {
-		fmt.Fprintln(io.err, "note: these items exist in the destination but agentsync did not capture them:")
+		io.note("these items exist in the destination but agentsync did not capture them:")
 		for _, w := range warnings {
 			fmt.Fprintf(io.err, "  %s\n", w)
 		}
@@ -633,6 +633,14 @@ func (i *importIO) flushSection() {
 // trailing newline; warn appends one.
 func (i *importIO) warn(msg string) {
 	fmt.Fprintf(i.err, "warning: %s\n", msg)
+}
+
+// note prints a cyan "note:" prefix followed by msg, for informational lines
+// that aren't problems — matches the styling status.go uses for the same
+// "this is FYI, not a warning" tier. msg should not include a trailing
+// newline; note appends one.
+func (i *importIO) note(msg string) {
+	fmt.Fprintf(i.err, "%s %s\n", i.p.Cyan("note:"), msg)
 }
 
 // warnf is warn + fmt.Sprintf for the common "%v / %q" formatting.

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // loaderFsForState returns an afero.Fs suitable for re-loading the
@@ -201,6 +203,12 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		return err
 	}
 
+	p, perr := newPrinter(cmd)
+	if perr != nil {
+		return perr
+	}
+	io := &importIO{p: p, out: p.Out, err: p.Err, dryRun: dryRun}
+
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	reg := registryFactory()
 	a := reg.Lookup(agentName)
@@ -234,16 +242,16 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	var importErr error
 	switch component {
 	case "":
-		imp, importErr = importAllComponents(cmd, home, a, agentName, c, dryRun)
+		imp, importErr = importAllComponents(io, home, a, agentName, c)
 	default:
-		ids, err := importComponent(cmd, home, a, agentName, c, component, name, dryRun)
+		ids, err := importComponent(io, home, a, agentName, c, component, name)
 		importErr = err
 		imp.add(component, ids)
 		// A bulk component import (no name) that matched nothing is not an
 		// error — report it and exit cleanly. A named import that matched
 		// nothing already returned a "not found" error above.
 		if err == nil && len(ids) == 0 && name == "" {
-			fmt.Fprintf(cmd.OutOrStdout(), "no %s found in %s native config\n", component, agentName)
+			io.infof("no %s found in %s native config", component, agentName)
 		}
 	}
 
@@ -269,7 +277,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// imp (the items actually imported), so a partial failure seeds exactly what
 	// was written and an un-imported sibling's state is never re-stamped.
 	if seedErr := seedStateFromCurrentDest(home, agentName, reg, imp); seedErr != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "warning: import state seed failed: %v\n", seedErr)
+		io.warnf("import state seed failed: %v", seedErr)
 	}
 
 	// Warn if the destination file has additional pointers / files
@@ -277,12 +285,11 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// ForeignCollision on the next apply and the user often expects
 	// import to have captured everything — not just the one named item.
 	if warnings := unimportedDestPointers(home, agentName, reg); len(warnings) > 0 {
-		ew := cmd.ErrOrStderr()
-		fmt.Fprintln(ew, "warning: the following destination items are NOT in the canonical source and will trigger ForeignCollision on next apply:")
+		io.warn("the following destination items are NOT in the canonical source and will trigger ForeignCollision on next apply:")
 		for _, w := range warnings {
-			fmt.Fprintf(ew, "  %s\n", w)
+			fmt.Fprintf(io.err, "  %s\n", w)
 		}
-		fmt.Fprintf(ew, "  Run `agentsync import %s` to capture the agent's full config, or accept the backup on next apply.\n", agentName)
+		fmt.Fprintf(io.err, "  Run `agentsync import %s` to capture the agent's full config, or accept the backup on next apply.\n", agentName)
 	}
 	// Surface a partial-import error after seeding so the command still exits
 	// non-zero, but the components that were written are now owned.
@@ -524,6 +531,92 @@ func importVerb(dryRun bool) string {
 	return "imported"
 }
 
+// importIO bundles the styled printer, the streams it writes to, and the
+// dry-run flag so every importXxx function emits its per-item lines, section
+// headers, and warnings through one consistent shape — the same green ✓ /
+// cyan → vocabulary `apply` and `status` use. The lazy `section` header keeps
+// component groups from showing a name with no rows under it.
+type importIO struct {
+	p      *ui.Printer
+	out    io.Writer
+	err    io.Writer
+	dryRun bool
+	// section is the component label printed once just before the first item
+	// in a full-agent walk (e.g. "mcp servers", "skills"). Empty for a named
+	// or single-component import, where the indented item lines stand alone.
+	section      string
+	sectionShown bool
+}
+
+// item prints one "imported X" / "would import X" line, prefixed with a glyph
+// and indented for readability. suffix is appended after path (e.g.
+// " (3 entries)" for hooks). Calling this lazily flushes the section header
+// the first time, so an empty component prints nothing.
+func (i *importIO) item(path, suffix string) {
+	i.flushSection()
+	if i.dryRun {
+		fmt.Fprintf(i.out, "  %s would import %s%s\n", i.p.Cyan(ui.GlyphArrow), path, suffix)
+		return
+	}
+	fmt.Fprintf(i.out, "  %s imported %s%s\n", i.p.Green(ui.GlyphOK), path, suffix)
+}
+
+// flushSection prints the pending section header (if any) once. Callers should
+// not need to invoke this directly — item() and warn() do it for the writer
+// side; the full-agent walker resets section state between components.
+func (i *importIO) flushSection() {
+	if i.section == "" || i.sectionShown {
+		return
+	}
+	fmt.Fprintln(i.out, i.p.Faint(i.section))
+	i.sectionShown = true
+}
+
+// warn prints a yellow "warning:" prefix followed by msg. msg should not be
+// trailing-newline'd; warn always appends \n.
+func (i *importIO) warn(msg string) {
+	fmt.Fprintf(i.err, "%s %s\n", i.p.Yellow("warning:"), msg)
+}
+
+// warnf is warn + fmt.Sprintf for the common "%v / %q" formatting.
+func (i *importIO) warnf(format string, args ...any) {
+	i.warn(fmt.Sprintf(format, args...))
+}
+
+// note prints a yellow "agentsync:" prefix (matching apply.go) for diagnostics
+// that aren't warnings about user data but about how agentsync is proceeding.
+func (i *importIO) notef(format string, args ...any) {
+	fmt.Fprintf(i.err, "%s ", i.p.Yellow("agentsync:"))
+	fmt.Fprintf(i.err, format, args...)
+	if !strings.HasSuffix(format, "\n") {
+		fmt.Fprintln(i.err)
+	}
+}
+
+// info prints a faint informational line on stdout — for "nothing to do"
+// outcomes the user still wants confirmed, like "no importable items found".
+func (i *importIO) infof(format string, args ...any) {
+	fmt.Fprintf(i.out, "%s ", i.p.Faint(ui.GlyphInfo))
+	fmt.Fprintf(i.out, format, args...)
+	if !strings.HasSuffix(format, "\n") {
+		fmt.Fprintln(i.out)
+	}
+}
+
+// sectionLabel maps the internal component key to the friendly header shown in
+// a full-agent walk. Plural / two-word forms make the header scan as a heading,
+// not as a tag.
+var sectionLabel = map[string]string{
+	"mcp":     "mcp servers",
+	"lsp":     "lsp servers",
+	"skill":   "skills",
+	"agent":   "subagents",
+	"command": "commands",
+	"hook":    "hooks",
+	"memory":  "memory",
+	"plugin":  "plugins",
+}
+
 // importedSet records which component identities an import actually captured,
 // so the state seeder can scope itself to exactly those items and not re-stamp
 // (and thereby mask drift on) un-imported siblings.
@@ -561,44 +654,51 @@ func (s *importedSet) add(component string, ids []string) {
 
 // importComponent imports one component class from c. When name is empty it
 // imports every entry of that component (the bulk form); when name is set it
-// imports just that entry and errors if it is absent. When dryRun is set it
-// writes nothing and only reports what it would write. It returns the identities
+// imports just that entry and errors if it is absent. The io carries the
+// dry-run flag (which writes nothing and only reports what it would write) and
+// the styled writers per-item lines go through. It returns the identities
 // (server id, skill/subagent/command name, hook event) that were (or would be)
 // imported; len is the item count.
-func importComponent(cmd *cobra.Command, home string, a adapter.Adapter, agentName string, c source.Canonical, component, name string, dryRun bool) ([]string, error) {
+func importComponent(io *importIO, home string, a adapter.Adapter, agentName string, c source.Canonical, component, name string) ([]string, error) {
 	switch component {
 	case "mcp":
-		return importMCP(cmd, home, c, name, dryRun)
+		return importMCP(io, home, c, name)
 	case "skill":
-		return importSkill(cmd, home, c, name, dryRun)
+		return importSkill(io, home, c, name)
 	case "agent", "subagent":
-		return importSubagent(cmd, home, c, name, dryRun)
+		return importSubagent(io, home, c, name)
 	case "command":
-		return importCommand(cmd, home, c, name, dryRun)
+		return importCommand(io, home, c, name)
 	case "hook":
-		return importHook(cmd, home, c, name, dryRun)
+		return importHook(io, home, c, name)
 	case "lsp":
-		return importLSP(cmd, home, c, name, dryRun)
+		return importLSP(io, home, c, name)
 	case "memory":
-		return importMemory(cmd, home, c, dryRun)
+		return importMemory(io, home, c)
 	case "plugin":
-		return importPlugins(cmd, home, agentName, a, name, dryRun)
+		return importPlugins(io, home, agentName, a, name)
 	default:
 		return nil, fmt.Errorf("unknown component %q; valid: mcp, skill, agent, command, hook, lsp, memory, plugin", component)
 	}
 }
 
-// importAllComponents imports every importable component for the agent and
-// prints a one-line summary. Empty components are skipped silently; an agent
-// with nothing to import reports that and exits cleanly. dryRun is threaded
-// through so the preview writes nothing. The returned set names everything
-// captured, so the caller can scope state seeding to it.
-func importAllComponents(cmd *cobra.Command, home string, a adapter.Adapter, agentName string, c source.Canonical, dryRun bool) (importedSet, error) {
+// importAllComponents imports every importable component for the agent. Each
+// non-empty component gets a faint section header above its items (printed
+// lazily so an empty component prints nothing), followed by a bold summary
+// line and a faint breakdown. dryRun is carried on the io so the preview
+// writes nothing. The returned set names everything captured, so the caller
+// can scope state seeding to it.
+func importAllComponents(io *importIO, home string, a adapter.Adapter, agentName string, c source.Canonical) (importedSet, error) {
 	var imp importedSet
 	counts := map[string]int{}
 	total := 0
 	for _, comp := range importComponentOrder {
-		ids, err := importComponent(cmd, home, a, agentName, c, comp, "", dryRun)
+		// Set up the lazy section header for this component. The header is
+		// printed by io.item() on the first row; if there are no rows, the
+		// header is silently dropped — so an empty component is invisible.
+		io.section = sectionLabel[comp]
+		io.sectionShown = false
+		ids, err := importComponent(io, home, a, agentName, c, comp, "")
 		// Seed whatever WAS written even on error: a component can fail partway
 		// after writing earlier items, and those must be owned or the next apply
 		// foreign-collides on a file just imported from.
@@ -611,25 +711,44 @@ func importAllComponents(cmd *cobra.Command, home string, a adapter.Adapter, age
 			total += len(ids)
 		}
 	}
+	// Clear the section state so any later non-walk caller (none today, but the
+	// io is reused for the seed/foreign-pointer warnings below) doesn't pick up
+	// a stale header.
+	io.section = ""
+	io.sectionShown = false
+
 	if total == 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "no importable items found in %s native config\n", agentName)
+		io.infof("no importable items found in %s native config", agentName)
 		return imp, nil
 	}
+
+	noun := "items"
+	if total == 1 {
+		noun = "item"
+	}
+	verb := importVerb(io.dryRun)
+	glyph := io.p.Green(ui.GlyphOK)
+	if io.dryRun {
+		glyph = io.p.Cyan(ui.GlyphArrow)
+	}
+	fmt.Fprintln(io.out, "")
+	fmt.Fprintf(io.out, "%s %s\n", glyph,
+		io.p.Bold(fmt.Sprintf("%s %d %s from %s", verb, total, noun, agentName)))
 	var parts []string
 	for _, comp := range importComponentOrder {
 		if counts[comp] > 0 {
 			parts = append(parts, fmt.Sprintf("%d %s", counts[comp], comp))
 		}
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s %d item(s) from %s: %s\n", importVerb(dryRun), total, agentName, strings.Join(parts, ", "))
+	fmt.Fprintf(io.out, "  %s\n", io.p.Faint(strings.Join(parts, "  ·  ")))
 	return imp, nil
 }
 
 // importMCP captures the MCP server named name (or all of them when name is
 // empty). Capture.Capture batches the whole slice in one call, so it
 // re-references secrets and preserves source-only fields for every server.
-// When dryRun is set it reports the targets without writing.
-func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+// When io.dryRun is set it reports the targets without writing.
+func importMCP(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.MCPServer
 	for _, m := range c.MCPServers {
 		if name == "" || m.ID == name {
@@ -649,9 +768,9 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 			return nil, err
 		}
 	}
-	if !dryRun {
+	if !io.dryRun {
 		single := source.Canonical{MCPServers: matched}
-		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: io.err}); err != nil {
 			// Seed the servers capture DID write before failing, so a partial
 			// import doesn't leave them foreign-collided on the next apply.
 			return idsFromWritten(res.Written), err
@@ -659,7 +778,7 @@ func importMCP(cmd *cobra.Command, home string, c source.Canonical, name string,
 	}
 	ids := make([]string, len(matched))
 	for i, m := range matched {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s mcp/%s.toml\n", importVerb(dryRun), m.ID)
+		io.item(fmt.Sprintf("mcp/%s.toml", m.ID), "")
 		ids[i] = m.ID
 	}
 	return ids, nil
@@ -676,7 +795,7 @@ func idsFromWritten(written []string) []string {
 	return out
 }
 
-func importSkill(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+func importSkill(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.Skill
 	for _, sk := range c.Skills {
 		if name == "" || sk.Name == name {
@@ -696,20 +815,20 @@ func importSkill(cmd *cobra.Command, home string, c source.Canonical, name strin
 	}
 	names := make([]string, 0, len(matched))
 	for _, sk := range matched {
-		if !dryRun {
+		if !io.dryRun {
 			if err := source.WriteSkill(home, sk); err != nil {
 				// Return the names already written so the caller seeds them;
 				// otherwise the next apply foreign-collides on a file just imported.
 				return names, fmt.Errorf("write skill %s: %w", sk.Name, err)
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s skills/%s/SKILL.md\n", importVerb(dryRun), sk.Name)
+		io.item(fmt.Sprintf("skills/%s/SKILL.md", sk.Name), "")
 		names = append(names, sk.Name)
 	}
 	return names, nil
 }
 
-func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+func importSubagent(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.Subagent
 	for _, sa := range c.Subagents {
 		if name == "" || sa.Name == name {
@@ -729,18 +848,18 @@ func importSubagent(cmd *cobra.Command, home string, c source.Canonical, name st
 	}
 	names := make([]string, 0, len(matched))
 	for _, sa := range matched {
-		if !dryRun {
+		if !io.dryRun {
 			if err := source.WriteSubagent(home, sa); err != nil {
 				return names, fmt.Errorf("write subagent %s: %w", sa.Name, err)
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s agents/%s.md\n", importVerb(dryRun), sa.Name)
+		io.item(fmt.Sprintf("agents/%s.md", sa.Name), "")
 		names = append(names, sa.Name)
 	}
 	return names, nil
 }
 
-func importCommand(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+func importCommand(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.Command
 	for _, cm := range c.Commands {
 		if name == "" || cm.Name == name {
@@ -760,12 +879,12 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 	}
 	names := make([]string, 0, len(matched))
 	for _, cm := range matched {
-		if !dryRun {
+		if !io.dryRun {
 			if err := source.WriteCommand(home, cm); err != nil {
 				return names, fmt.Errorf("write command %s: %w", cm.Name, err)
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s commands/%s.md\n", importVerb(dryRun), cm.Name)
+		io.item(fmt.Sprintf("commands/%s.md", cm.Name), "")
 		names = append(names, cm.Name)
 	}
 	return names, nil
@@ -774,9 +893,9 @@ func importCommand(cmd *cobra.Command, home string, c source.Canonical, name str
 // importHook captures hooks for the named event (or all events when name is
 // empty). name addresses an event, not an individual hook. It returns the
 // DISTINCT events captured (one source file per event); the per-event line
-// still reports the entry count. When dryRun is set it reports the target event
-// files without writing.
-func importHook(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+// still reports the entry count. When io.dryRun is set it reports the target
+// event files without writing.
+func importHook(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.Hook
 	for _, h := range c.Hooks {
 		if name == "" || h.Event == name {
@@ -794,9 +913,9 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 			return nil, err
 		}
 	}
-	if !dryRun {
+	if !io.dryRun {
 		single := source.Canonical{Hooks: matched}
-		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: io.err}); err != nil {
 			return idsFromWritten(res.Written), err
 		}
 	}
@@ -810,12 +929,12 @@ func importHook(cmd *cobra.Command, home string, c source.Canonical, name string
 		perEvent[h.Event]++
 	}
 	for _, ev := range order {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s hooks/%s.toml (%d entries)\n", importVerb(dryRun), ev, perEvent[ev])
+		io.item(fmt.Sprintf("hooks/%s.toml", ev), fmt.Sprintf(" (%d entries)", perEvent[ev]))
 	}
 	return order, nil
 }
 
-func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string, dryRun bool) ([]string, error) {
+func importLSP(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.LSPServer
 	for _, ls := range c.LSPServers {
 		if name == "" || ls.ID == name {
@@ -833,21 +952,21 @@ func importLSP(cmd *cobra.Command, home string, c source.Canonical, name string,
 			return nil, err
 		}
 	}
-	if !dryRun {
+	if !io.dryRun {
 		single := source.Canonical{LSPServers: matched}
-		if res, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
+		if res, err := capture.Capture(home, &single, capture.Opts{Warn: io.err}); err != nil {
 			return idsFromWritten(res.Written), err
 		}
 	}
 	ids := make([]string, 0, len(matched))
 	for _, ls := range matched {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s lsp/%s.toml\n", importVerb(dryRun), ls.ID)
+		io.item(fmt.Sprintf("lsp/%s.toml", ls.ID), "")
 		ids = append(ids, ls.ID)
 	}
 	return ids, nil
 }
 
-func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bool) ([]string, error) {
+func importMemory(io *importIO, home string, c source.Canonical) ([]string, error) {
 	// Memory is a single block, not a named collection; nothing to write when
 	// the agent carries no memory (the common case during a full-agent import).
 	if strings.TrimSpace(c.Memory.Body) == "" {
@@ -860,10 +979,10 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 	switch {
 	case err != nil:
 		// Markers present but malformed/ambiguous — skip rather than guess.
-		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — fragment markers could not be reversed (%v). Reconcile memory/ by hand, then apply.\n", err)
+		io.notef("skipping memory import — fragment markers could not be reversed (%v). Reconcile memory/ by hand, then apply.", err)
 		return nil, nil
 	case hadMarkers:
-		if !dryRun {
+		if !io.dryRun {
 			if werr := source.WriteMemory(home, mem); werr != nil {
 				return nil, fmt.Errorf("write memory: %w", werr)
 			}
@@ -872,16 +991,16 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 		// No markers (collision/legacy) but the source is fragment-composed:
 		// writing the expanded body would inline the @imports and orphan the
 		// fragment files — skip with a warning rather than flatten silently.
-		fmt.Fprintf(cmd.ErrOrStderr(), "agentsync: skipping memory import — canonical memory uses fragments/ and the imported memory has no reversible markers; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.\n")
+		io.notef("skipping memory import — canonical memory uses fragments/ and the imported memory has no reversible markers; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.")
 		return nil, nil
 	default:
-		if !dryRun {
+		if !io.dryRun {
 			if werr := source.WriteMemory(home, c.Memory); werr != nil {
 				return nil, fmt.Errorf("write memory: %w", werr)
 			}
 		}
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s memory/AGENTS.md\n", importVerb(dryRun))
+	io.item("memory/AGENTS.md", "")
 	// A non-empty marker so importedSet.add flags memory was captured (it has no
 	// id; the seeder includes c.Memory when this is set).
 	return []string{"memory"}, nil
@@ -910,7 +1029,7 @@ func importMemory(cmd *cobra.Command, home string, c source.Canonical, dryRun bo
 // does not strand the rest. Plugins are NOT dest-seeded into state (unlike the
 // file components): they are a source-side declaration whose projected
 // components materialise as new dest files on the next apply.
-func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter, name string, dryRun bool) ([]string, error) {
+func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name string) ([]string, error) {
 	pi, ok := a.(adapter.PluginIngester)
 	if !ok {
 		return nil, nil
@@ -942,10 +1061,6 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 		return nil, nil
 	}
 
-	out := cmd.OutOrStdout()
-	ew := cmd.ErrOrStderr()
-	verb := importVerb(dryRun)
-
 	// Resolve (and, on a real run, fetch) each needed marketplace exactly once.
 	// The cached value is the agentsync marketplace name a plugin installs from;
 	// "" marks an unresolvable marketplace already warned about.
@@ -970,32 +1085,32 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 		// fetch it, and register it.
 		nm, known := mpByID[mpID]
 		if !known {
-			fmt.Fprintf(ew, "warning: skipping plugins from marketplace %q: registered in neither %s's "+
-				"native config nor agentsync; run `agentsync marketplace add <source>` then re-import\n",
+			io.warnf("skipping plugins from marketplace %q: registered in neither %s's "+
+				"native config nor agentsync; run `agentsync marketplace add <source>` then re-import",
 				mpID, agentName)
 			resolved[mpID] = ""
 			return "", false
 		}
 		src, rawURL, mappable := claudeSourceToAgentsync(nm.Source)
 		if !mappable {
-			fmt.Fprintf(ew, "warning: skipping marketplace %q: unsupported source type %q\n", mpID, nm.Source.Type)
+			io.warnf("skipping marketplace %q: unsupported source type %q", mpID, nm.Source.Type)
 			resolved[mpID] = ""
 			return "", false
 		}
-		if dryRun {
+		if io.dryRun {
 			// No fetch, so the declared agentsync name is unknown; preview by the
 			// native id. The real run resolves and prints the actual filename.
-			fmt.Fprintf(out, "%s marketplaces/%s.toml\n", verb, mpID)
+			io.item(fmt.Sprintf("marketplaces/%s.toml", mpID), "")
 			resolved[mpID] = mpID
 			return mpID, true
 		}
 		mpName, _, ferr := addMarketplaceSource(home, src, rawURL)
 		if ferr != nil {
-			fmt.Fprintf(ew, "warning: skipping marketplace %q: %v\n", mpID, ferr)
+			io.warnf("skipping marketplace %q: %v", mpID, ferr)
 			resolved[mpID] = ""
 			return "", false
 		}
-		fmt.Fprintf(out, "%s marketplaces/%s.toml\n", verb, mpName)
+		io.item(fmt.Sprintf("marketplaces/%s.toml", mpName), "")
 		resolved[mpID] = mpName
 		return mpName, true
 	}
@@ -1003,30 +1118,30 @@ func importPlugins(cmd *cobra.Command, home, agentName string, a adapter.Adapter
 	var ids []string
 	for _, pl := range want {
 		if pl.MarketplaceID == "" {
-			fmt.Fprintf(ew, "warning: skipping plugin %q: native config records no marketplace for it\n", pl.Name)
+			io.warnf("skipping plugin %q: native config records no marketplace for it", pl.Name)
 			continue
 		}
 		// The plugin name becomes plugins/<name>.toml; validate it up front (and
 		// in dry-run) so a hostile native id can't escape the source dir and the
 		// preview matches a real import.
 		if verr := source.ValidateComponentID("plugin", pl.Name); verr != nil {
-			fmt.Fprintf(ew, "warning: skipping plugin %q: %v\n", pl.Name, verr)
+			io.warnf("skipping plugin %q: %v", pl.Name, verr)
 			continue
 		}
 		mpName, mpOK := resolveMp(pl.MarketplaceID)
 		if !mpOK {
 			continue
 		}
-		if dryRun {
-			fmt.Fprintf(out, "%s plugins/%s.toml\n", verb, pl.Name)
+		if io.dryRun {
+			io.item(fmt.Sprintf("plugins/%s.toml", pl.Name), "")
 			ids = append(ids, pl.Name)
 			continue
 		}
 		if _, ierr := installPluginInto(home, pl.Name, mpName); ierr != nil {
-			fmt.Fprintf(ew, "warning: skipping plugin %q from %q: %v\n", pl.Name, mpName, ierr)
+			io.warnf("skipping plugin %q from %q: %v", pl.Name, mpName, ierr)
 			continue
 		}
-		fmt.Fprintf(out, "%s plugins/%s.toml\n", verb, pl.Name)
+		io.item(fmt.Sprintf("plugins/%s.toml", pl.Name), "")
 		ids = append(ids, pl.Name)
 	}
 	return ids, nil

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -20,6 +20,7 @@
 package ui
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -157,6 +158,72 @@ func Pad(s string, width int) string {
 		return s
 	}
 	return s + spaces(width-n)
+}
+
+// WarnWriter wraps a destination writer and styles "warning: " line prefixes
+// as a bold-yellow "⚠️ warning:" so every warning — whether emitted by the
+// CLI itself, by an adapter's Ingest, or by capture's re-reference path —
+// reads consistently. Lines that do not start with the literal "warning: "
+// prefix (e.g. pre-styled ANSI lines, indented continuation lines, or
+// "agentsync:" notes) pass through verbatim. The writer is line-buffered so a
+// callers' partial Write is held until a newline arrives — fmt.Fprintf in
+// practice always finishes a line per call, but buffering keeps a chunked
+// writer correct.
+type WarnWriter struct {
+	w   io.Writer
+	p   *Printer
+	buf []byte
+}
+
+// NewWarnWriter returns a *WarnWriter that flushes styled lines to w using p.
+// p's color decision is honored: with color off, the prefix becomes a plain
+// "⚠️ warning:" (the glyph is content, not decoration — same rule as the
+// curated glyph vocabulary above).
+func NewWarnWriter(w io.Writer, p *Printer) *WarnWriter {
+	return &WarnWriter{w: w, p: p}
+}
+
+const warnLinePrefix = "warning: "
+
+// Write line-buffers data, emitting completed lines through emit. Partial
+// trailing bytes are retained for the next Write. Always returns len(p), nil
+// (the contract callers like fmt.Fprintf expect).
+func (s *WarnWriter) Write(p []byte) (int, error) {
+	s.buf = append(s.buf, p...)
+	for {
+		idx := bytes.IndexByte(s.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		s.emit(s.buf[:idx+1])
+		s.buf = s.buf[idx+1:]
+	}
+	return len(p), nil
+}
+
+// Flush emits any buffered partial line (no trailing \n) as-is. Call at end of
+// command if you've routed a writer that may not always end in \n; the import
+// path does always terminate, so this is defensive.
+func (s *WarnWriter) Flush() {
+	if len(s.buf) > 0 {
+		s.emit(s.buf)
+		s.buf = nil
+	}
+}
+
+// GlyphWarnEmoji is the colourful warning sign (with VS16) used as the warning
+// label prefix. Wider than one column in some terminals, which is fine — the
+// warning lines are not part of any padded layout.
+const GlyphWarnEmoji = "⚠️"
+
+func (s *WarnWriter) emit(line []byte) {
+	if !bytes.HasPrefix(line, []byte(warnLinePrefix)) {
+		_, _ = s.w.Write(line)
+		return
+	}
+	rest := line[len(warnLinePrefix):]
+	label := s.p.Yellow(s.p.Bold(GlyphWarnEmoji + " warning:"))
+	fmt.Fprintf(s.w, "%s %s", label, rest)
 }
 
 func spaces(n int) string {


### PR DESCRIPTION
## Summary

Route `import` through `internal/ui` like the other styled commands and clean up the warning labels everywhere they appear during an import:

- **Per-item lines** carry a green `✓` (real) or cyan `→` (dry-run) prefix and a 2-space indent — same vocabulary `apply` already uses.
- **Full-agent walks** group items under faint section headers (`mcp servers`, `skills`, `subagents`, `commands`, `memory`, `plugins`). Headers print lazily on the first row, so an empty component is invisible.
- **Summary line** is bold (`imported N items from claude`) with a faint per-component breakdown underneath (`2 mcp  ·  4 skill  ·  1 memory`).
- **Every `warning:` label is bold-yellow `⚠️ warning:`** — `import`'s own warnings (foreign-collision, plugin/marketplace skips, seed failures), `capture`'s re-reference warnings, AND the adapter's `Ingest` warnings (the lenient-YAML notices that used to lead the screen as plain text). Continuation lines and `agentsync:` notes pass through unchanged.
- Wording is preserved (`imported X` / `would import X`, `warning: …`) so existing output assertions and any user scripts grepping the lines keep working.

## How

- New `ui.WarnWriter`: a line-buffered writer that detects `warning: ` at line start and rewrites the prefix. One styling point for everyone.
- New optional `SetStderr(io.Writer)` on `claude.Adapter` / `opencode.Adapter` / `codex.Adapter` — type-asserted in `import.go` so the noop adapter just keeps writing to `os.Stderr`.
- `importIO` helper in `import.go` bundles the printer + dry-run flag + the `section` lazy header so each `importXxx` function calls `io.item(...)` / `io.warn(...)` and the rest is automatic.
- No CLI surface change, no schema change, no test fixture changes; `CHANGELOG.md` updated.

## Visual

Before — flat list, plain `warning:` labels:
```
warning: skill "build-tools" frontmatter is not strict YAML; ...
warning: skill "render-glb" frontmatter is not strict YAML; ...
imported mcp/github.toml
imported skills/build-tools/SKILL.md
imported skills/render-glb/SKILL.md
imported memory/AGENTS.md
imported 9 item(s) from claude: 2 mcp, 4 skill, 1 agent, 1 command, 1 memory
```

After — `import claude`:
```
⚠️ warning:  skill "build-tools" frontmatter is not strict YAML; ...   (bold yellow)
⚠️ warning:  skill "render-glb" frontmatter is not strict YAML; ...    (bold yellow)
mcp servers                                                            (faint)
  ✓ imported mcp/github.toml                                           (green)
  ✓ imported mcp/linear.toml
skills
  ✓ imported skills/build-tools/SKILL.md
  ✓ imported skills/render-glb/SKILL.md
memory
  ✓ imported memory/AGENTS.md

✓ imported 9 items from claude                                          (bold)
  2 mcp  ·  4 skill  ·  1 agent  ·  1 command  ·  1 memory              (faint)
```

`--dry-run` swaps green ✓ for cyan → and "imported" for "would import"; a named single-item import (`import claude:mcp:github`) skips the section header.

## Test plan

- [x] `just test-fast` / `go test ./internal/cli/... ./internal/ui/... ./internal/adapter/...` — all green locally.
- [x] Manual `agentsync import claude` against a fixture with skills, MCPs, subagent, command, memory → screenshots in chat.
- [x] Manual `--dry-run` and named-import variants → screenshots in chat.
- [x] Verified `--color=never` (test path) emits no ANSI; existing `TestColorFlag` still green.
- [x] Verified the existing `TestImport_*` assertions (`imported`, `from claude`, `would import mcp/github.toml`, `no importable items found`) still match.
- [ ] Eyeball in a real terminal that supports color emoji (iTerm2 / kitty / Windows Terminal) to confirm the ⚠️ renders colorfully — done in the screenshot session via `--color=always` capture; in-environment PIL renderer shows the plain ⚠ glyph because there's no emoji font, but the ANSI is correct.


---
_Generated by [Claude Code](https://claude.ai/code/session_019oU2mskFW9aJvdNCq4DFcQ)_