### PR TITLE
feat(adapter): formalise WarnSink + ui.WarnWriter.RouteTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Added
 
+- **`adapter.WarnSink` extension interface** — formalises the optional
+  `SetStderr(io.Writer)` setter the claude / opencode / codex adapters added
+  alongside the `import` styling work, so future Ingest-using commands can
+  redirect adapter warnings through the styled `ui.WarnWriter` (bold-yellow
+  `⚠️ warning:`) without duplicating the type-assertion boilerplate. The
+  contract requires `nil` to reset to the default (`os.Stderr`). A new
+  `ui.WarnWriter.RouteTo(any)` helper handles the wiring in one line and
+  is a no-op for adapters that don't implement the sink, so callers pass
+  any `adapter.Adapter` and let the structural match decide. `import`
+  now uses the helper; an end-to-end regression test
+  (`TestImport_StyledAdapterWarnings`) forces `--color=always` and asserts
+  the adapter's own YAML-frontmatter warnings reach the buffer with the
+  styled prefix — locking the contract against silent regressions.
 - **`explain` accepts multiple plugins, `--all`, and `--list`** —
   `agentsync explain` now takes a space-separated list of plugin ids
   (`agentsync explain notion@official superpowers@obra`), and gains two flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,35 +15,52 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Added
 
-- **`adapter.WarnSink` extension interface** — formalises the optional
-  `SetStderr(io.Writer)` setter the claude / opencode / codex adapters added
-  alongside the `import` styling work, so future Ingest-using commands can
-  redirect adapter warnings through the styled `ui.WarnWriter` (bold-yellow
-  `⚠️ warning:`) without duplicating the type-assertion boilerplate. The
-  contract has three load-bearing pieces, all tested:
-  - `SetStderr(nil)` resets to the default (`os.Stderr`) and MUST NOT
-    panic. Pinned by `TestSetStderr_NilResetsToDefault` in the claude
-    adapter; break-verified to fail when the setter ignores nil.
-  - Each concrete adapter compile-pins itself against `adapter.WarnSink`
-    via `var _ adapter.WarnSink = a` in its identity test, so dropping
-    `SetStderr` fails the build instead of silently becoming a `RouteTo`
-    no-op.
-  - The caller owns lifetime. `ui.WarnWriter` gains a paired
-    `RouteTo(any)` / `Unroute(any)` and a `Flush()` method;
-    `internal/cli/import.go` uses `defer warnW.Unroute(a)` +
-    `defer warnW.Flush()` so a routed adapter is detached before the
-    command returns and any partial line in the line-assembly buffer is
-    drained. `WarnWriter` is documented as not safe for concurrent use
-    (one writer per command invocation, the existing pattern).
-  - `internal/ui` gains a direct unit test (`TestWarnWriter_RouteTo_AndUnroute`)
-    against a fake setter so the routing primitive is anchored
-    independent of the full `import` stack — drift on `RouteTo`/`Unroute`
-    fails there immediately, not just in the integration test.
-  - The end-to-end `TestImport_StyledAdapterWarnings` now covers both the
-    claude AND the opencode adapter via a table-driven subtest, and
-    asserts the styling loosely (`ui.GlyphWarnEmoji + " warning:"` plus
-    the SGR yellow + bold codes separately) so a correct refactor of the
-    SGR concatenation order doesn't spuriously fail.
+- **`adapter.WarnEmitter` extension interface** — formalises the optional
+  `SetStderr(io.Writer)` setter the claude / opencode / codex adapters
+  added alongside the `import` styling work, so future Ingest-using
+  commands can redirect adapter warnings through the styled `ui.WarnWriter`
+  (bold-yellow `⚠️ warning:`) without duplicating the type-assertion
+  boilerplate. Named for the implementor (a *source* of warnings that
+  accepts a sink, mirroring `PluginIngester`), not the parameter.
+  The contract has four load-bearing pieces, all tested and break-verified:
+  - **`SetStderr(nil)` resets to the default (`os.Stderr`)** and MUST NOT
+    panic. Pinned by per-adapter `TestSetStderr_NilResetsToDefault`
+    tests (claude / opencode / codex) that capture `os.Stderr` via a
+    pipe and assert the warning actually lands there — a faulty
+    `SetStderr(nil)` routing to `io.Discard` would not pass.
+  - **Configure stderr BEFORE Ingest.** Adapters snapshot the writer at
+    Ingest entry, so dynamic switching mid-Ingest is ignored. Documented
+    on the interface.
+  - **Compile-pin against the interface.** Each adapter's identity test
+    carries `var _ adapter.WarnEmitter = a`; dropping the method fails
+    the build, not a runtime no-op.
+  - **Caller owns lifetime via a restore handle.** `ui.WarnWriter.RouteTo`
+    is now `func (s *WarnWriter) RouteTo(a any) func()` — it wires the
+    writer immediately and returns a restore closure. Idiomatic
+    `defer warnW.RouteTo(a)()` evaluates the inner `RouteTo(a)` now and
+    defers the returned restore (which calls `SetStderr(nil)`).
+    `ui.WarnWriter` gains a `Flush()` method;
+    `internal/cli/import.go` pairs `defer warnW.Flush()` with the
+    routed-restore so partial lines drain on return.
+- **Routing primitive safety guards.**
+  `ui.WarnWriter.RouteTo` is a silent no-op for: untyped-`nil`,
+  typed-nil pointers (caught via `reflect.IsNil` so the type-assert
+  doesn't lead to a `SetStderr` deref panic), and any value whose
+  dynamic type doesn't implement the setter. The restore closure is
+  always callable, so `defer warnW.RouteTo(a)()` is safe regardless of
+  what `a` is. Behaviour pinned by `TestWarnWriter_RouteTo` in
+  `internal/ui/routeto_test.go` (happy path + nil + typed-nil +
+  non-implementor + repeated-restore).
+- **End-to-end same-line regex anchor.** `TestImport_StyledAdapterWarnings`
+  is now table-driven across claude AND opencode and asserts that the
+  styled `⚠️ warning:` prefix appears on the SAME line as the
+  adapter-specific `"frontmatter is not strict YAML"` phrase. The
+  prior assertion looked for the styled prefix anywhere in the
+  output, which the CLI's own `importIO.warn` could satisfy; the
+  same-line anchor catches both the os.Stderr-fallback and the
+  WarnWriter-bypass regressions. Break-verified.
+- `ui.WarnWriter` is documented as not safe for concurrent use (one
+  writer per command invocation, the existing pattern).
 - **`explain` accepts multiple plugins, `--all`, and `--list`** —
   `agentsync explain` now takes a space-separated list of plugin ids
   (`agentsync explain notion@official superpowers@obra`), and gains two flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,15 +76,27 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   Flush, and (c) a non-warning partial drains verbatim. Without
   this, Flush could silently become a no-op since every current
   emitter terminates with `\n`.
-- **Mid-Ingest snapshot contract pinned.** New
-  `TestSetStderr_SnapshotAtIngestEntry` in the claude adapter
-  package uses a custom writer that, on first emission, swaps the
-  adapter's `Stderr` to a sibling buffer; the snapshot taken at
-  Ingest entry (`warn := a.stderr()`) means subsequent warnings
-  still land in the original sink. A future refactor that re-reads
-  `a.stderr()` per warning would silently violate the documented
-  "configure stderr BEFORE Ingest" promise on `WarnEmitter`; this
-  test catches it.
+- **Mid-Ingest snapshot contract pinned per-adapter.**
+  `TestSetStderr_SnapshotAtIngestEntry` in each implementing
+  adapter's package (claude / opencode / codex) uses a custom
+  writer that, on first emission, swaps the adapter's `Stderr` to
+  a sibling buffer; the snapshot taken at Ingest entry (`warn :=
+  a.stderr()`) means subsequent warnings still land in the
+  original sink. A future refactor in ANY adapter's Ingest that
+  re-reads `a.stderr()` per warning would silently violate the
+  documented "configure stderr BEFORE Ingest" promise on
+  `WarnEmitter`; the per-adapter tests catch it independently
+  rather than relying on a single lead test + grep.
+- **Shared `internal/adapter/adaptertest` test helper package.**
+  Centralises `CaptureOsStderr(t, fn)` (the `os.Stderr`-pipe-swap
+  helper with the defer-cleanup invariants that round-3 demonstrated
+  must hold) and `SwapOnFirstWriteBuffer` (the writer that fires a
+  callback on first write, used by the snapshot tests). Follows the
+  stdlib `httptest` precedent: an ordinary package that takes
+  `*testing.T`. Eliminates three byte-identical 30-line copies
+  across the adapter test packages — a maintenance trap that
+  round-3 surfaced when the deferred-cleanup fix had to be applied
+  three times in lockstep.
 - **`explain` accepts multiple plugins, `--all`, and `--list`** —
   `agentsync explain` now takes a space-separated list of plugin ids
   (`agentsync explain notion@official superpowers@obra`), and gains two flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,30 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   alongside the `import` styling work, so future Ingest-using commands can
   redirect adapter warnings through the styled `ui.WarnWriter` (bold-yellow
   `⚠️ warning:`) without duplicating the type-assertion boilerplate. The
-  contract requires `nil` to reset to the default (`os.Stderr`). A new
-  `ui.WarnWriter.RouteTo(any)` helper handles the wiring in one line and
-  is a no-op for adapters that don't implement the sink, so callers pass
-  any `adapter.Adapter` and let the structural match decide. `import`
-  now uses the helper; an end-to-end regression test
-  (`TestImport_StyledAdapterWarnings`) forces `--color=always` and asserts
-  the adapter's own YAML-frontmatter warnings reach the buffer with the
-  styled prefix — locking the contract against silent regressions.
+  contract has three load-bearing pieces, all tested:
+  - `SetStderr(nil)` resets to the default (`os.Stderr`) and MUST NOT
+    panic. Pinned by `TestSetStderr_NilResetsToDefault` in the claude
+    adapter; break-verified to fail when the setter ignores nil.
+  - Each concrete adapter compile-pins itself against `adapter.WarnSink`
+    via `var _ adapter.WarnSink = a` in its identity test, so dropping
+    `SetStderr` fails the build instead of silently becoming a `RouteTo`
+    no-op.
+  - The caller owns lifetime. `ui.WarnWriter` gains a paired
+    `RouteTo(any)` / `Unroute(any)` and a `Flush()` method;
+    `internal/cli/import.go` uses `defer warnW.Unroute(a)` +
+    `defer warnW.Flush()` so a routed adapter is detached before the
+    command returns and any partial line in the line-assembly buffer is
+    drained. `WarnWriter` is documented as not safe for concurrent use
+    (one writer per command invocation, the existing pattern).
+  - `internal/ui` gains a direct unit test (`TestWarnWriter_RouteTo_AndUnroute`)
+    against a fake setter so the routing primitive is anchored
+    independent of the full `import` stack — drift on `RouteTo`/`Unroute`
+    fails there immediately, not just in the integration test.
+  - The end-to-end `TestImport_StyledAdapterWarnings` now covers both the
+    claude AND the opencode adapter via a table-driven subtest, and
+    asserts the styling loosely (`ui.GlyphWarnEmoji + " warning:"` plus
+    the SGR yellow + bold codes separately) so a correct refactor of the
+    SGR concatenation order doesn't spuriously fail.
 - **`explain` accepts multiple plugins, `--all`, and `--list`** —
   `agentsync explain` now takes a space-separated list of plugin ids
   (`agentsync explain notion@official superpowers@obra`), and gains two flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,30 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   WarnWriter-bypass regressions. Break-verified.
 - `ui.WarnWriter` is documented as not safe for concurrent use (one
   writer per command invocation, the existing pattern).
+- **`captureOsStderr` cleanup is panic-safe.** The per-adapter
+  `os.Stderr`-pipe-swap helpers used by the nil-reset tests now
+  defer `w.Close()` and `os.Stderr = orig` BEFORE invoking `fn`, so
+  a `t.Fatalf` inside `fn` (which calls `runtime.Goexit`) no longer
+  leaks the read goroutine or leaves `os.Stderr` swapped for later
+  tests in the same package. Each helper also carries a "do not
+  `t.Parallel`" comment naming the global-state hazard.
+- **`Flush()` coverage.** New `TestWarnWriter_Flush` in
+  `internal/ui/routeto_test.go` covers the partial-line drain
+  path the `importRun` defer relies on: a `"warning: "` Write with
+  no trailing newline is asserted to (a) sit in the buffer until
+  Flush is called, (b) get styled with the bold-yellow prefix on
+  Flush, and (c) a non-warning partial drains verbatim. Without
+  this, Flush could silently become a no-op since every current
+  emitter terminates with `\n`.
+- **Mid-Ingest snapshot contract pinned.** New
+  `TestSetStderr_SnapshotAtIngestEntry` in the claude adapter
+  package uses a custom writer that, on first emission, swaps the
+  adapter's `Stderr` to a sibling buffer; the snapshot taken at
+  Ingest entry (`warn := a.stderr()`) means subsequent warnings
+  still land in the original sink. A future refactor that re-reads
+  `a.stderr()` per warning would silently violate the documented
+  "configure stderr BEFORE Ingest" promise on `WarnEmitter`; this
+  test catches it.
 - **`explain` accepts multiple plugins, `--all`, and `--list`** —
   `agentsync explain` now takes a space-separated list of plugin ids
   (`agentsync explain notion@official superpowers@obra`), and gains two flags:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,9 +206,9 @@ See the capability matrix for source links.
 
 ### WarnSink (optional)
 
-A second optional extension lets a CLI command redirect the warnings an
-adapter's `Ingest` emits (lenient-YAML notices, dropped components, …) away
-from `os.Stderr`:
+A second optional extension lets callers redirect the warnings an adapter's
+`Ingest` emits (lenient-YAML notices, dropped components, …) away from
+`os.Stderr`:
 
 ```go
 type WarnSink interface {
@@ -216,23 +216,32 @@ type WarnSink interface {
 }
 ```
 
-Concrete adapters (claude/opencode/codex) implement it on their `Adapter`
-type; the noop adapter doesn't (it emits no warnings). `import` is the only
-caller today: it wraps `cmd.ErrOrStderr()` in a `ui.WarnWriter` that
-restyles `"warning: "` line prefixes to bold-yellow `"⚠️ warning:"`, then
-calls `warnW.RouteTo(a)` to inject the wrapper into any adapter that
-implements `WarnSink`. The same wrapper backs `capture.Opts.Warn` and the
-command's own `io.warn` calls, so every warning the user sees during an
-import — adapter, capture, or CLI — shares one styling.
+Concrete adapters (claude/opencode/codex) implement it; the noop adapter
+doesn't (it emits no warnings). Three contract rules every implementor
+honours:
 
-The setter contract requires `nil` to reset to the default
-(`os.Stderr`) — implementors must not panic on `nil`.
+1. **`SetStderr(nil)` resets to the default** (`os.Stderr`) — and MUST NOT
+   panic. Pinned by `TestSetStderr_NilResetsToDefault` in the claude
+   adapter package; future adapters add their own.
+2. **The setter must compile-pin against `adapter.WarnSink`.** Each
+   adapter's `claude_test.go` / `opencode_test.go` / `codex_test.go`
+   carries a `var _ adapter.WarnSink = a` line so dropping the method
+   fails the test build, not a runtime no-op.
+3. **The writer's lifetime is the caller's problem.** Today's caller
+   (`import`) `defer`s `WarnWriter.Unroute(a)` (which is `SetStderr(nil)`
+   via the structural type-assert) and `WarnWriter.Flush()` so partial
+   lines and dangling pointers don't escape the command.
 
-The interface is kept off the core `Adapter` for the same reason as
-`PluginIngester`: an adapter that emits no Ingest warnings shouldn't be
-forced to implement a setter it'll never use. `ui.WarnWriter.RouteTo`
-type-asserts structurally, so adding the setter to a new adapter is a
-single-method change with no caller updates required.
+`import` is the only caller today: it wraps `cmd.ErrOrStderr()` in a
+`ui.WarnWriter` that restyles `"warning: "` line prefixes to bold-yellow
+`"⚠️ warning:"`, then `warnW.RouteTo(a)` injects the wrapper. The same
+wrapper backs `capture.Opts.Warn` and the command's own `io.warn` calls,
+so every warning the user sees during an import — adapter, capture, or
+CLI — shares one styling.
+
+Kept off the core `Adapter` for the same reason as `PluginIngester`: an
+adapter that emits no Ingest warnings shouldn't be forced to implement a
+setter it'll never use.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,36 @@ components-only-on-apply rule above:
 
 See the capability matrix for source links.
 
+### WarnSink (optional)
+
+A second optional extension lets a CLI command redirect the warnings an
+adapter's `Ingest` emits (lenient-YAML notices, dropped components, …) away
+from `os.Stderr`:
+
+```go
+type WarnSink interface {
+    SetStderr(w io.Writer)
+}
+```
+
+Concrete adapters (claude/opencode/codex) implement it on their `Adapter`
+type; the noop adapter doesn't (it emits no warnings). `import` is the only
+caller today: it wraps `cmd.ErrOrStderr()` in a `ui.WarnWriter` that
+restyles `"warning: "` line prefixes to bold-yellow `"⚠️ warning:"`, then
+calls `warnW.RouteTo(a)` to inject the wrapper into any adapter that
+implements `WarnSink`. The same wrapper backs `capture.Opts.Warn` and the
+command's own `io.warn` calls, so every warning the user sees during an
+import — adapter, capture, or CLI — shares one styling.
+
+The setter contract requires `nil` to reset to the default
+(`os.Stderr`) — implementors must not panic on `nil`.
+
+The interface is kept off the core `Adapter` for the same reason as
+`PluginIngester`: an adapter that emits no Ingest warnings shouldn't be
+forced to implement a setter it'll never use. `ui.WarnWriter.RouteTo`
+type-asserts structurally, so adding the setter to a new adapter is a
+single-method change with no caller updates required.
+
 ---
 
 ## 4. The apply pipeline (Source ▶ Destination)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,40 +204,48 @@ components-only-on-apply rule above:
 
 See the capability matrix for source links.
 
-### WarnSink (optional)
+### WarnEmitter (optional)
 
 A second optional extension lets callers redirect the warnings an adapter's
 `Ingest` emits (lenient-YAML notices, dropped components, …) away from
 `os.Stderr`:
 
 ```go
-type WarnSink interface {
+type WarnEmitter interface {
     SetStderr(w io.Writer)
 }
 ```
 
 Concrete adapters (claude/opencode/codex) implement it; the noop adapter
-doesn't (it emits no warnings). Three contract rules every implementor
+doesn't (it emits no warnings). Four contract rules every implementor
 honours:
 
-1. **`SetStderr(nil)` resets to the default** (`os.Stderr`) — and MUST NOT
-   panic. Pinned by `TestSetStderr_NilResetsToDefault` in the claude
-   adapter package; future adapters add their own.
-2. **The setter must compile-pin against `adapter.WarnSink`.** Each
-   adapter's `claude_test.go` / `opencode_test.go` / `codex_test.go`
-   carries a `var _ adapter.WarnSink = a` line so dropping the method
-   fails the test build, not a runtime no-op.
-3. **The writer's lifetime is the caller's problem.** Today's caller
-   (`import`) `defer`s `WarnWriter.Unroute(a)` (which is `SetStderr(nil)`
-   via the structural type-assert) and `WarnWriter.Flush()` so partial
-   lines and dangling pointers don't escape the command.
+1. **`SetStderr(nil)` resets to the default** (`os.Stderr`) — and MUST
+   NOT panic. Pinned by per-adapter `TestSetStderr_NilResetsToDefault`
+   tests that capture `os.Stderr` via a pipe and assert the warning
+   actually lands there — a faulty `SetStderr(nil)` routing to
+   `io.Discard` would not pass.
+2. **Configure stderr BEFORE Ingest.** Adapters snapshot the writer at
+   Ingest entry (`warn := a.stderr()`), so calling `SetStderr` mid-Ingest
+   is ignored for the remainder of that call. The `RouteTo`-before-Ingest
+   pattern is the supported one; don't depend on dynamic switching.
+3. **Compile-pin against `adapter.WarnEmitter`.** Each adapter's
+   `claude_test.go` / `opencode_test.go` / `codex_test.go` carries a
+   `var _ adapter.WarnEmitter = a` line so dropping the method fails
+   the test build, not a runtime no-op.
+4. **The writer's lifetime is the caller's problem.** Today's caller
+   (`import`) uses the restore-handle pattern —
+   `defer warnW.RouteTo(a)()` evaluates the inner `RouteTo(a)` immediately
+   (wires the writer) and defers the returned restore closure (calls
+   `SetStderr(nil)` on the way out) — paired with `defer warnW.Flush()`
+   to drain any partial line in the WarnWriter's line-assembly buffer.
 
 `import` is the only caller today: it wraps `cmd.ErrOrStderr()` in a
 `ui.WarnWriter` that restyles `"warning: "` line prefixes to bold-yellow
-`"⚠️ warning:"`, then `warnW.RouteTo(a)` injects the wrapper. The same
-wrapper backs `capture.Opts.Warn` and the command's own `io.warn` calls,
-so every warning the user sees during an import — adapter, capture, or
-CLI — shares one styling.
+`"⚠️ warning:"`, then `defer warnW.RouteTo(a)()` injects the wrapper
+and arranges the restore. The same wrapper backs `capture.Opts.Warn`
+and the command's own `io.warn` calls, so every warning the user sees
+during an import — adapter, capture, or CLI — shares one styling.
 
 Kept off the core `Adapter` for the same reason as `PluginIngester`: an
 adapter that emits no Ingest warnings shouldn't be forced to implement a

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -171,20 +171,31 @@ type PluginIngester interface {
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
 }
 
-// WarnSink is an OPTIONAL extension to Adapter: an adapter that emits Ingest
-// warnings implements it to let callers redirect the stream away from the
-// default (os.Stderr). Kept off the core Adapter for the same reason as
-// PluginIngester — adapters that emit no warnings shouldn't be forced to
-// implement a setter they'll never use. ui.WarnWriter.RouteTo type-asserts
-// for it, so callers don't need to know who implements it.
+// WarnEmitter is an OPTIONAL extension to Adapter: an adapter that emits
+// Ingest warnings implements it to let callers redirect the stream away
+// from the default (os.Stderr). Implementors are SOURCES of warnings that
+// accept a sink — the name follows the PluginIngester precedent of
+// describing what the implementor does, not the parameter the method
+// takes. Kept off the core Adapter so adapters that emit no warnings
+// aren't forced to implement a setter they'll never use; ui.WarnWriter
+// type-asserts for it, so callers pass any adapter and let the structural
+// match decide.
 //
-// Implementations MUST treat a nil writer as "reset to default" rather than
-// panicking. The simplest (and current) realisation is to store the writer
-// in a field and have an accessor return os.Stderr when the field is nil;
-// any equivalent that survives SetStderr(nil) without losing future
-// warnings is fine. The behaviour is pinned by a SetStderr-nil-resets test
-// in each implementing adapter's package.
-type WarnSink interface {
+// Implementations MUST:
+//
+//   - Treat a nil writer as "reset to default" — subsequent warnings go to
+//     os.Stderr (or whatever the implementor's pre-SetStderr default was),
+//     not to io.Discard or any silent sink. Pinned per-adapter by
+//     TestSetStderr_NilResetsToDefault tests that capture os.Stderr and
+//     assert the warning lands there.
+//   - Not panic on a nil writer.
+//
+// Configuring stderr is meant to happen BEFORE Ingest runs. Today's
+// adapters snapshot the writer at Ingest entry (warn := a.stderr()), so a
+// SetStderr call mid-Ingest is ignored for the remainder of that call.
+// Use RouteTo-before-Ingest (the import pattern); don't depend on dynamic
+// switching during a single Ingest invocation.
+type WarnEmitter interface {
 	SetStderr(w io.Writer)
 }
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -4,6 +4,8 @@
 package adapter
 
 import (
+	"io"
+
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -167,6 +169,31 @@ type NativePlugin struct {
 // "PluginIngester (read-only)" for the full rationale.
 type PluginIngester interface {
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
+}
+
+// WarnSink is an OPTIONAL extension to Adapter: an adapter that emits Ingest
+// warnings (lenient-YAML notices, dropped components, "skill X frontmatter is
+// not strict YAML; parsed leniently", …) implements it so a CLI command can
+// redirect that stream away from os.Stderr — typically into a styled writer
+// like ui.WarnWriter that restyles "warning: " prefixes to bold-yellow
+// "⚠️ warning:". The contract is intentionally minimal: implementors swap the
+// destination, nothing else. A `nil` writer must reset back to the default
+// (os.Stderr) — implementations should treat `nil` as "go back to default"
+// rather than panicking. Adapters that emit no warnings can skip implementing
+// this entirely; ui.WarnWriter.RouteTo is a no-op for them, so callers don't
+// need to know who implements it.
+//
+// Kept off the core Adapter interface for the same reason as PluginIngester:
+// the canonical schema doesn't otherwise care which adapters emit warnings,
+// and third-party adapters shouldn't be forced to add a setter they don't
+// need. import is the only caller today; future Ingest-using commands
+// (reconcile, if it ever grows full-Ingest semantics) will use the same
+// helper.
+type WarnSink interface {
+	// SetStderr replaces the warning sink. The implementor MUST honor a nil
+	// argument as "reset to default" rather than panicking — callers may pass
+	// nil to undo a prior routing.
+	SetStderr(w io.Writer)
 }
 
 // DestWriter is the single funnel for any write that targets a native agent

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -172,27 +172,19 @@ type PluginIngester interface {
 }
 
 // WarnSink is an OPTIONAL extension to Adapter: an adapter that emits Ingest
-// warnings (lenient-YAML notices, dropped components, "skill X frontmatter is
-// not strict YAML; parsed leniently", …) implements it so a CLI command can
-// redirect that stream away from os.Stderr — typically into a styled writer
-// like ui.WarnWriter that restyles "warning: " prefixes to bold-yellow
-// "⚠️ warning:". The contract is intentionally minimal: implementors swap the
-// destination, nothing else. A `nil` writer must reset back to the default
-// (os.Stderr) — implementations should treat `nil` as "go back to default"
-// rather than panicking. Adapters that emit no warnings can skip implementing
-// this entirely; ui.WarnWriter.RouteTo is a no-op for them, so callers don't
-// need to know who implements it.
+// warnings implements it to let callers redirect the stream away from the
+// default (os.Stderr). Kept off the core Adapter for the same reason as
+// PluginIngester — adapters that emit no warnings shouldn't be forced to
+// implement a setter they'll never use. ui.WarnWriter.RouteTo type-asserts
+// for it, so callers don't need to know who implements it.
 //
-// Kept off the core Adapter interface for the same reason as PluginIngester:
-// the canonical schema doesn't otherwise care which adapters emit warnings,
-// and third-party adapters shouldn't be forced to add a setter they don't
-// need. import is the only caller today; future Ingest-using commands
-// (reconcile, if it ever grows full-Ingest semantics) will use the same
-// helper.
+// Implementations MUST treat a nil writer as "reset to default" rather than
+// panicking. The simplest (and current) realisation is to store the writer
+// in a field and have an accessor return os.Stderr when the field is nil;
+// any equivalent that survives SetStderr(nil) without losing future
+// warnings is fine. The behaviour is pinned by a SetStderr-nil-resets test
+// in each implementing adapter's package.
 type WarnSink interface {
-	// SetStderr replaces the warning sink. The implementor MUST honor a nil
-	// argument as "reset to default" rather than panicking — callers may pass
-	// nil to undo a prior routing.
 	SetStderr(w io.Writer)
 }
 

--- a/internal/adapter/adaptertest/stderr.go
+++ b/internal/adapter/adaptertest/stderr.go
@@ -1,0 +1,106 @@
+// Package adaptertest holds test helpers shared by the adapter packages.
+//
+// It exists for one purpose today: centralise the os.Stderr-capture pipe
+// pattern the per-adapter SetStderr-nil-resets tests use. Round-3 of the
+// PR-#50 review surfaced that the pattern had been copy-pasted to three
+// adapter test packages (claude / opencode / codex) and that the
+// deferred-cleanup fix had to be applied identically to all three — the
+// kind of triplication that silently invites drift the next time
+// something subtle changes. Sharing the helper as a normal (non-_test)
+// package follows the stdlib `httptest` precedent: ordinary code that
+// happens to take a `*testing.T`.
+//
+// This package MUST NOT depend on any concrete adapter (claude /
+// opencode / codex) — that would invert the layering, since each
+// adapter package already imports adapter, and the test helper is
+// shared across them.
+package adaptertest
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// CaptureOsStderr swaps os.Stderr for a pipe, runs fn, then restores
+// the original os.Stderr and returns whatever fn wrote to the pipe.
+// Cleanup is deferred BEFORE invoking fn so a t.Fatalf / panic (both
+// unwind via runtime.Goexit and through defers) does not leak the
+// read goroutine or leave os.Stderr swapped for the rest of the
+// process.
+//
+// Use it to verify an adapter's SetStderr(nil) actually routes back
+// to the os.Stderr default — a faulty implementation routing to
+// io.Discard would otherwise pass an "is the previous buffer empty?"
+// assertion while silently dropping every future warning.
+//
+// Not safe for concurrent use within a package: it swaps a
+// process-global. Callers MUST NOT t.Parallel a test that calls this.
+func CaptureOsStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	// Deferred cleanup for the t.Fatalf / panic path: runtime.Goexit
+	// unwinds through defers but skips bare statements AFTER fn(), so a
+	// failed assertion inside fn would otherwise (a) leak the read
+	// goroutine blocked on the open pipe and (b) leave os.Stderr
+	// pointing at our closed write end, breaking later tests in the
+	// same package. Double-Close on the happy path is harmless —
+	// *os.File.Close returns an error on second call which we ignore.
+	defer func() { os.Stderr = orig }()
+	defer func() { _ = w.Close() }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	// Explicit close on the happy path is required: the deferred close
+	// above runs only on function return, but `return <-done` blocks
+	// FIRST waiting for the goroutine's send, which itself waits for
+	// io.Copy to see EOF. Without this explicit close, the receive
+	// would deadlock against the still-open write end.
+	_ = w.Close()
+	return <-done
+}
+
+// SwapOnFirstWriteBuffer is a bytes.Buffer that, on its first Write
+// call, invokes OnFirstWrite (once) before writing. Used by per-
+// adapter snapshot tests to swap the adapter's Stderr to a sibling
+// buffer mid-Ingest. If the adapter snapshots `warn := a.stderr()`
+// at Ingest entry (the documented adapter.WarnEmitter contract),
+// subsequent warnings still land in this buffer; if the adapter
+// instead re-reads `a.stderr()` per warning, they land in the
+// sibling and the snapshot assertion catches it.
+//
+// Zero-value ready; set OnFirstWrite before passing to the adapter.
+type SwapOnFirstWriteBuffer struct {
+	bytes.Buffer
+	OnFirstWrite func()
+	fired        bool
+}
+
+// Write implements io.Writer.
+func (b *SwapOnFirstWriteBuffer) Write(p []byte) (int, error) {
+	if !b.fired {
+		b.fired = true
+		if b.OnFirstWrite != nil {
+			b.OnFirstWrite()
+		}
+	}
+	return b.Buffer.Write(p)
+}
+
+// Fired reports whether OnFirstWrite has been invoked. Tests use it
+// to fail-loudly when the fixture didn't actually trigger any write
+// (which would let the snapshot assertion pass vacuously).
+func (b *SwapOnFirstWriteBuffer) Fired() bool { return b.fired }

--- a/internal/adapter/claude/claude_test.go
+++ b/internal/adapter/claude/claude_test.go
@@ -18,6 +18,10 @@ func TestAdapter_Identity(t *testing.T) {
 		t.Fatalf("expected non-zero capabilities")
 	}
 	var _ adapter.Adapter = a
+	// Compile-time pin: a future refactor that drops SetStderr (or changes
+	// its signature) fails to build here, surfacing the drift before
+	// ui.WarnWriter.RouteTo would silently no-op the adapter at runtime.
+	var _ adapter.WarnSink = a
 }
 
 func TestAdapter_DetectsHomeDir(t *testing.T) {

--- a/internal/adapter/claude/claude_test.go
+++ b/internal/adapter/claude/claude_test.go
@@ -21,7 +21,7 @@ func TestAdapter_Identity(t *testing.T) {
 	// Compile-time pin: a future refactor that drops SetStderr (or changes
 	// its signature) fails to build here, surfacing the drift before
 	// ui.WarnWriter.RouteTo would silently no-op the adapter at runtime.
-	var _ adapter.WarnSink = a
+	var _ adapter.WarnEmitter = a
 }
 
 func TestAdapter_DetectsHomeDir(t *testing.T) {

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -2,6 +2,7 @@ package claude_test
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,27 +194,30 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 	}
 }
 
-// TestIngest_LenientSkillNotSilentlyDropped is the regression for the bug
-// `agentsync import claude` exhibited: a SKILL.md whose description carries an
-// unquoted "Triggers on: X, Y" colon-space sequence broke sigs.k8s.io/yaml and
-// the silent `continue` in Ingest dropped the whole skill. Now: it loads via
-// TestSetStderr_NilResetsToDefault pins the adapter.WarnSink contract: a
-// later SetStderr(nil) must not panic and must reset warnings away from the
-// previously-configured buffer (back to the os.Stderr default — verified
-// indirectly by asserting the previously-set buffer no longer receives the
-// warning a known-lenient skill triggers). Without this, the doc claim
-// in adapter.WarnSink is a paper promise: today's implementations satisfy
-// the contract by coincidence of the stderr() accessor's nil fallback,
-// not by the setter doing anything special, so the only thing keeping the
-// contract from silently regressing is this test.
+// TestSetStderr_NilResetsToDefault pins the adapter.WarnEmitter nil
+// contract: SetStderr(nil) MUST NOT panic AND MUST route subsequent
+// warnings back to the os.Stderr default — not to io.Discard, not to
+// the previously-set buffer, and not into the void. The test plants a
+// known-lenient skill, sets a buffer as the active sink, calls
+// SetStderr(nil), captures os.Stderr via a pipe for the duration of
+// the second Ingest, and asserts:
+//
+//   (a) the previously-set buffer no longer receives the warning, AND
+//   (b) os.Stderr DOES — proving the reset goes to the default, not
+//       silently elsewhere.
+//
+// Without (b), a faulty SetStderr(nil) that routes to io.Discard
+// would pass the (a)-only test while quietly dropping every future
+// warning the user needs to see. The behaviour is verified by the
+// break-tests recorded in the PR description; future adapters add a
+// parallel test in their own package (see opencode/ingest_test.go,
+// codex/codex_test.go).
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Same lenient-trigger fixture the LenientSkillNotSilentlyDropped test
-	// uses: a colon-space in the description.
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
 		[]byte("---\nname: bad-yaml\ndescription: Triggers on: rebase\n---\nbody\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -225,14 +229,55 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	// Reset: a panic here is itself a contract failure.
 	a.SetStderr(nil)
 
-	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
-		t.Fatalf("Ingest after SetStderr(nil): %v", err)
-	}
+	captured := captureOsStderr(t, func() {
+		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+			t.Fatalf("Ingest after SetStderr(nil): %v", err)
+		}
+	})
+
 	if warn.Len() > 0 {
 		t.Fatalf("SetStderr(nil) did not detach the previously-set buffer; got:\n%s", warn.String())
 	}
+	if !strings.Contains(captured, "frontmatter is not strict YAML") {
+		t.Fatalf("SetStderr(nil) must route to os.Stderr default; captured nothing matching the lenient-YAML notice:\n%s", captured)
+	}
 }
 
+// captureOsStderr swaps os.Stderr for a pipe, runs fn, then restores and
+// drains the pipe. Shared with the parallel SetStderr-nil tests in the
+// opencode and codex packages via a tiny per-package copy (each is a
+// `package foo_test` file, so a shared import would create cycles —
+// the cost of duplicating ~15 lines is acceptable for one test helper).
+//
+// Safe in a per-package `go test` invocation: Go's test binary runs
+// tests in a single goroutine within the package, and os.Stderr writes
+// are not interleaved with anything else during fn.
+func captureOsStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// TestIngest_LenientSkillNotSilentlyDropped is the regression for the bug
+// `agentsync import claude` exhibited: a SKILL.md whose description carries an
+// unquoted "Triggers on: X, Y" colon-space sequence broke sigs.k8s.io/yaml and
+// the silent `continue` in Ingest dropped the whole skill. Now: it loads via
 // the lenient fallback AND emits a warning to the configured Stderr so the
 // user is notified.
 func TestIngest_LenientSkillNotSilentlyDropped(t *testing.T) {

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -213,7 +213,7 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 // parallel test in their own package (see opencode/ingest_test.go,
 // codex/codex_test.go).
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
-	// Do NOT t.Parallel: captureOsStderr swaps the process-global
+	// Do NOT t.Parallel: adaptertest.CaptureOsStderr swaps the process-global
 	// os.Stderr. A parallel sibling running concurrently would race
 	// on the swap.
 	tmp := t.TempDir()
@@ -263,7 +263,7 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 // and the assertion fires.
 //
 // opencode and codex carry parallel snapshot tests using the same
-// SwapOnFirstWriteBuffer (and the same captureOsStderr helper), so
+// SwapOnFirstWriteBuffer (and the same adaptertest.CaptureOsStderr helper), so
 // drift in any single adapter's Ingest implementation is caught
 // per-package.
 func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -213,6 +213,9 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 // parallel test in their own package (see opencode/ingest_test.go,
 // codex/codex_test.go).
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	// Do NOT t.Parallel: captureOsStderr swaps the process-global
+	// os.Stderr. A parallel sibling running concurrently would race
+	// on the swap.
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -261,6 +264,16 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}
 	os.Stderr = w
 
+	// Deferred cleanup for the t.Fatalf / panic path: runtime.Goexit
+	// unwinds through defers but skips bare statements AFTER fn(), so a
+	// failed assertion inside fn would otherwise (a) leak the read
+	// goroutine blocked on an open pipe and (b) leave os.Stderr
+	// pointing at our closed write end, breaking later tests in the
+	// same package. The double Close on the happy path is harmless —
+	// os.File.Close returns an error on second call which we ignore.
+	defer func() { os.Stderr = orig }()
+	defer func() { _ = w.Close() }()
+
 	done := make(chan string, 1)
 	go func() {
 		var buf bytes.Buffer
@@ -269,9 +282,85 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}()
 
 	fn()
+	// Explicit close on the happy path is required: the deferred close
+	// above runs only on function return, but `return <-done` blocks
+	// FIRST waiting for the goroutine's send, which itself waits for
+	// io.Copy to see EOF. Without this explicit close, the receive
+	// deadlocks against the still-open write end.
 	_ = w.Close()
-	os.Stderr = orig
 	return <-done
+}
+
+// midIngestSwapBuffer is a writer that, on its first Write call, swaps
+// the adapter's configured Stderr to a sibling buffer. If the adapter
+// snapshots `a.stderr()` at Ingest entry (the documented behaviour),
+// subsequent warnings still land in midIngestSwapBuffer because the
+// local `warn` variable inside Ingest holds the old reference. If the
+// adapter ever re-reads `a.stderr()` per-emission, subsequent warnings
+// land in the sibling buffer and this test catches it.
+type midIngestSwapBuffer struct {
+	bytes.Buffer
+	a       *claude.Adapter
+	sibling io.Writer
+	swapped bool
+}
+
+func (m *midIngestSwapBuffer) Write(p []byte) (int, error) {
+	if !m.swapped {
+		m.a.SetStderr(m.sibling)
+		m.swapped = true
+	}
+	return m.Buffer.Write(p)
+}
+
+// TestSetStderr_SnapshotAtIngestEntry pins the documented "configure
+// stderr BEFORE Ingest; don't depend on dynamic switching mid-Ingest"
+// contract on adapter.WarnEmitter. The interface promise is that
+// adapters snapshot the writer once at Ingest entry (`warn :=
+// a.stderr()` — see internal/adapter/claude/ingest.go:54). A future
+// refactor that re-reads `a.stderr()` per warning would silently
+// violate the doc; this test makes that a build failure instead.
+//
+// The fixture plants two lenient-YAML skills so Ingest emits two
+// warnings in sequence. The first write swaps the adapter's stderr to
+// a sibling buffer — if the snapshot holds, the second warning still
+// lands in the primary; if it doesn't, the sibling receives the second
+// warning.
+func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {
+	tmp := t.TempDir()
+	for _, name := range []string{"first", "second"} {
+		dir := filepath.Join(tmp, ".claude", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + name + "\ndescription: Triggers on: rebase\n---\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var sibling bytes.Buffer
+	primary := &midIngestSwapBuffer{sibling: &sibling}
+	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: primary})
+	primary.a = a
+
+	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	if !primary.swapped {
+		t.Fatal("midIngestSwapBuffer's Write was never called — fixture didn't trigger the first warning")
+	}
+	if sibling.Len() > 0 {
+		t.Fatalf("snapshot contract violated: warnings emitted AFTER mid-Ingest SetStderr landed in the sibling buffer (%d bytes):\n%s",
+			sibling.Len(), sibling.String())
+	}
+	// Sanity: both warnings should be in primary (proving the snapshot
+	// is what protected, not that no second warning was emitted).
+	if strings.Count(primary.String(), "frontmatter is not strict YAML") < 2 {
+		t.Fatalf("expected BOTH lenient-YAML warnings in the original sink (snapshot); got:\n%s",
+			primary.String())
+	}
 }
 
 // TestIngest_LenientSkillNotSilentlyDropped is the regression for the bug

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -197,6 +197,42 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 // `agentsync import claude` exhibited: a SKILL.md whose description carries an
 // unquoted "Triggers on: X, Y" colon-space sequence broke sigs.k8s.io/yaml and
 // the silent `continue` in Ingest dropped the whole skill. Now: it loads via
+// TestSetStderr_NilResetsToDefault pins the adapter.WarnSink contract: a
+// later SetStderr(nil) must not panic and must reset warnings away from the
+// previously-configured buffer (back to the os.Stderr default — verified
+// indirectly by asserting the previously-set buffer no longer receives the
+// warning a known-lenient skill triggers). Without this, the doc claim
+// in adapter.WarnSink is a paper promise: today's implementations satisfy
+// the contract by coincidence of the stderr() accessor's nil fallback,
+// not by the setter doing anything special, so the only thing keeping the
+// contract from silently regressing is this test.
+func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Same lenient-trigger fixture the LenientSkillNotSilentlyDropped test
+	// uses: a colon-space in the description.
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: bad-yaml\ndescription: Triggers on: rebase\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: &warn})
+
+	// Reset: a panic here is itself a contract failure.
+	a.SetStderr(nil)
+
+	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Ingest after SetStderr(nil): %v", err)
+	}
+	if warn.Len() > 0 {
+		t.Fatalf("SetStderr(nil) did not detach the previously-set buffer; got:\n%s", warn.String())
+	}
+}
+
 // the lenient fallback AND emits a warning to the configured Stderr so the
 // user is notified.
 func TestIngest_LenientSkillNotSilentlyDropped(t *testing.T) {

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -2,13 +2,13 @@ package claude_test
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/adaptertest"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -232,7 +232,7 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	// Reset: a panic here is itself a contract failure.
 	a.SetStderr(nil)
 
-	captured := captureOsStderr(t, func() {
+	captured := adaptertest.CaptureOsStderr(t, func() {
 		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
 			t.Fatalf("Ingest after SetStderr(nil): %v", err)
 		}
@@ -246,86 +246,26 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	}
 }
 
-// captureOsStderr swaps os.Stderr for a pipe, runs fn, then restores and
-// drains the pipe. Shared with the parallel SetStderr-nil tests in the
-// opencode and codex packages via a tiny per-package copy (each is a
-// `package foo_test` file, so a shared import would create cycles —
-// the cost of duplicating ~15 lines is acceptable for one test helper).
-//
-// Safe in a per-package `go test` invocation: Go's test binary runs
-// tests in a single goroutine within the package, and os.Stderr writes
-// are not interleaved with anything else during fn.
-func captureOsStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stderr = w
-
-	// Deferred cleanup for the t.Fatalf / panic path: runtime.Goexit
-	// unwinds through defers but skips bare statements AFTER fn(), so a
-	// failed assertion inside fn would otherwise (a) leak the read
-	// goroutine blocked on an open pipe and (b) leave os.Stderr
-	// pointing at our closed write end, breaking later tests in the
-	// same package. The double Close on the happy path is harmless —
-	// os.File.Close returns an error on second call which we ignore.
-	defer func() { os.Stderr = orig }()
-	defer func() { _ = w.Close() }()
-
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		done <- buf.String()
-	}()
-
-	fn()
-	// Explicit close on the happy path is required: the deferred close
-	// above runs only on function return, but `return <-done` blocks
-	// FIRST waiting for the goroutine's send, which itself waits for
-	// io.Copy to see EOF. Without this explicit close, the receive
-	// deadlocks against the still-open write end.
-	_ = w.Close()
-	return <-done
-}
-
-// midIngestSwapBuffer is a writer that, on its first Write call, swaps
-// the adapter's configured Stderr to a sibling buffer. If the adapter
-// snapshots `a.stderr()` at Ingest entry (the documented behaviour),
-// subsequent warnings still land in midIngestSwapBuffer because the
-// local `warn` variable inside Ingest holds the old reference. If the
-// adapter ever re-reads `a.stderr()` per-emission, subsequent warnings
-// land in the sibling buffer and this test catches it.
-type midIngestSwapBuffer struct {
-	bytes.Buffer
-	a       *claude.Adapter
-	sibling io.Writer
-	swapped bool
-}
-
-func (m *midIngestSwapBuffer) Write(p []byte) (int, error) {
-	if !m.swapped {
-		m.a.SetStderr(m.sibling)
-		m.swapped = true
-	}
-	return m.Buffer.Write(p)
-}
-
 // TestSetStderr_SnapshotAtIngestEntry pins the documented "configure
 // stderr BEFORE Ingest; don't depend on dynamic switching mid-Ingest"
 // contract on adapter.WarnEmitter. The interface promise is that
 // adapters snapshot the writer once at Ingest entry (`warn :=
 // a.stderr()` — see internal/adapter/claude/ingest.go:54). A future
 // refactor that re-reads `a.stderr()` per warning would silently
-// violate the doc; this test makes that a build failure instead.
+// violate the doc; this test makes that a test failure instead.
 //
 // The fixture plants two lenient-YAML skills so Ingest emits two
-// warnings in sequence. The first write swaps the adapter's stderr to
-// a sibling buffer — if the snapshot holds, the second warning still
-// lands in the primary; if it doesn't, the sibling receives the second
-// warning.
+// warnings in sequence. The first write to the primary buffer triggers
+// adaptertest.SwapOnFirstWriteBuffer.OnFirstWrite, which swaps the
+// adapter's stderr to a sibling buffer mid-emission. If the snapshot
+// holds, the second warning still lands in the primary; if the adapter
+// instead re-reads `a.stderr()` per warning, the sibling receives it
+// and the assertion fires.
+//
+// opencode and codex carry parallel snapshot tests using the same
+// SwapOnFirstWriteBuffer (and the same captureOsStderr helper), so
+// drift in any single adapter's Ingest implementation is caught
+// per-package.
 func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {
 	tmp := t.TempDir()
 	for _, name := range []string{"first", "second"} {
@@ -340,16 +280,16 @@ func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {
 	}
 
 	var sibling bytes.Buffer
-	primary := &midIngestSwapBuffer{sibling: &sibling}
+	primary := &adaptertest.SwapOnFirstWriteBuffer{}
 	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: primary})
-	primary.a = a
+	primary.OnFirstWrite = func() { a.SetStderr(&sibling) }
 
 	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
 
-	if !primary.swapped {
-		t.Fatal("midIngestSwapBuffer's Write was never called — fixture didn't trigger the first warning")
+	if !primary.Fired() {
+		t.Fatal("OnFirstWrite was never called — fixture didn't trigger any warning")
 	}
 	if sibling.Len() > 0 {
 		t.Fatalf("snapshot contract violated: warnings emitted AFTER mid-Ingest SetStderr landed in the sibling buffer (%d bytes):\n%s",

--- a/internal/adapter/codex/codex_test.go
+++ b/internal/adapter/codex/codex_test.go
@@ -25,7 +25,7 @@ func TestAdapter_Identity(t *testing.T) {
 	var _ adapter.PluginIngester = a
 	// Compile-time pin: drift on SetStderr fails the build before RouteTo
 	// would silently no-op us at runtime.
-	var _ adapter.WarnSink = a
+	var _ adapter.WarnEmitter = a
 }
 
 func TestAdapter_Capabilities_HasExpected(t *testing.T) {

--- a/internal/adapter/codex/codex_test.go
+++ b/internal/adapter/codex/codex_test.go
@@ -23,6 +23,9 @@ func TestAdapter_Identity(t *testing.T) {
 	// Must satisfy both interfaces.
 	var _ adapter.Adapter = a
 	var _ adapter.PluginIngester = a
+	// Compile-time pin: drift on SetStderr fails the build before RouteTo
+	// would silently no-op us at runtime.
+	var _ adapter.WarnSink = a
 }
 
 func TestAdapter_Capabilities_HasExpected(t *testing.T) {

--- a/internal/adapter/codex/setstderr_test.go
+++ b/internal/adapter/codex/setstderr_test.go
@@ -19,6 +19,8 @@ import (
 // skills from the cross-agent ~/.agents/skills/ directory (see
 // codex.ResolvePaths → SkillsDir).
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	// Do NOT t.Parallel: captureOsStderr swaps the process-global
+	// os.Stderr.
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".agents", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -62,6 +64,13 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}
 	os.Stderr = w
 
+	// Deferred cleanup so a t.Fatalf / panic inside fn doesn't leak
+	// the read goroutine and leave os.Stderr swapped — see the lead
+	// captureOsStderr in internal/adapter/claude/ingest_test.go for
+	// the full rationale. Double-close on the happy path is harmless.
+	defer func() { os.Stderr = orig }()
+	defer func() { _ = w.Close() }()
+
 	done := make(chan string, 1)
 	go func() {
 		var buf bytes.Buffer
@@ -70,7 +79,7 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}()
 
 	fn()
+	// Explicit close on the happy path: <-done blocks before defers run.
 	_ = w.Close()
-	os.Stderr = orig
 	return <-done
 }

--- a/internal/adapter/codex/setstderr_test.go
+++ b/internal/adapter/codex/setstderr_test.go
@@ -1,0 +1,76 @@
+package codex_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/codex"
+)
+
+// TestSetStderr_NilResetsToDefault is the codex adapter's mirror of the
+// claude package's nil-reset test. Same contract, same shape: after
+// SetStderr(nil), warnings emitted during Ingest must (a) NOT reach the
+// previously-set buffer, and (b) reach os.Stderr instead. codex reads
+// skills from the cross-agent ~/.agents/skills/ directory (see
+// codex.ResolvePaths → SkillsDir).
+func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, ".agents", "skills", "bad-yaml")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: bad-yaml\ndescription: Triggers on: rebase\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	a := codex.New(codex.Options{TargetRoot: tmp, Stderr: &warn})
+
+	// Reset: a panic here is itself a contract failure.
+	a.SetStderr(nil)
+
+	captured := captureOsStderr(t, func() {
+		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+			t.Fatalf("Ingest after SetStderr(nil): %v", err)
+		}
+	})
+
+	if warn.Len() > 0 {
+		t.Fatalf("SetStderr(nil) did not detach the previously-set buffer; got:\n%s", warn.String())
+	}
+	if !strings.Contains(captured, "frontmatter is not strict YAML") {
+		t.Fatalf("SetStderr(nil) must route to os.Stderr default; captured nothing matching the lenient-YAML notice:\n%s", captured)
+	}
+}
+
+// captureOsStderr — see internal/adapter/claude/ingest_test.go for the
+// shared shape. Per-package copy because `package foo_test` files can't
+// share without introducing an extra helper package; ~15 duplicated
+// lines is the lighter cost.
+func captureOsStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}

--- a/internal/adapter/codex/setstderr_test.go
+++ b/internal/adapter/codex/setstderr_test.go
@@ -2,13 +2,13 @@ package codex_test
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/adaptertest"
 	"github.com/spxrogers/agentsync/internal/adapter/codex"
 )
 
@@ -19,8 +19,8 @@ import (
 // skills from the cross-agent ~/.agents/skills/ directory (see
 // codex.ResolvePaths → SkillsDir).
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
-	// Do NOT t.Parallel: captureOsStderr swaps the process-global
-	// os.Stderr.
+	// Do NOT t.Parallel: adaptertest.CaptureOsStderr swaps the
+	// process-global os.Stderr.
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".agents", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -37,7 +37,7 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	// Reset: a panic here is itself a contract failure.
 	a.SetStderr(nil)
 
-	captured := captureOsStderr(t, func() {
+	captured := adaptertest.CaptureOsStderr(t, func() {
 		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
 			t.Fatalf("Ingest after SetStderr(nil): %v", err)
 		}
@@ -51,35 +51,44 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	}
 }
 
-// captureOsStderr — see internal/adapter/claude/ingest_test.go for the
-// shared shape. Per-package copy because `package foo_test` files can't
-// share without introducing an extra helper package; ~15 duplicated
-// lines is the lighter cost.
-func captureOsStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
+// TestSetStderr_SnapshotAtIngestEntry mirrors the claude package's
+// snapshot test for codex. The contract is interface-level on
+// adapter.WarnEmitter, but the implementation property — `warn :=
+// a.stderr()` snapshot at Ingest entry — lives in each adapter's
+// ingest.go (codex: ingest.go:46). A future re-read-per-warning
+// refactor in codex's Ingest would silently violate the documented
+// contract without this test.
+func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {
+	tmp := t.TempDir()
+	for _, name := range []string{"first", "second"} {
+		dir := filepath.Join(tmp, ".agents", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + name + "\ndescription: Triggers on: rebase\n---\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	os.Stderr = w
 
-	// Deferred cleanup so a t.Fatalf / panic inside fn doesn't leak
-	// the read goroutine and leave os.Stderr swapped — see the lead
-	// captureOsStderr in internal/adapter/claude/ingest_test.go for
-	// the full rationale. Double-close on the happy path is harmless.
-	defer func() { os.Stderr = orig }()
-	defer func() { _ = w.Close() }()
+	var sibling bytes.Buffer
+	primary := &adaptertest.SwapOnFirstWriteBuffer{}
+	a := codex.New(codex.Options{TargetRoot: tmp, Stderr: primary})
+	primary.OnFirstWrite = func() { a.SetStderr(&sibling) }
 
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		done <- buf.String()
-	}()
+	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
 
-	fn()
-	// Explicit close on the happy path: <-done blocks before defers run.
-	_ = w.Close()
-	return <-done
+	if !primary.Fired() {
+		t.Fatal("OnFirstWrite was never called — fixture didn't trigger any warning")
+	}
+	if sibling.Len() > 0 {
+		t.Fatalf("snapshot contract violated: warnings emitted AFTER mid-Ingest SetStderr landed in the sibling buffer (%d bytes):\n%s",
+			sibling.Len(), sibling.String())
+	}
+	if strings.Count(primary.String(), "frontmatter is not strict YAML") < 2 {
+		t.Fatalf("expected BOTH lenient-YAML warnings in the original sink (snapshot); got:\n%s",
+			primary.String())
+	}
 }

--- a/internal/adapter/opencode/opencode_test.go
+++ b/internal/adapter/opencode/opencode_test.go
@@ -19,6 +19,9 @@ func TestAdapter_Identity(t *testing.T) {
 	}
 	// Must satisfy the interface.
 	var _ adapter.Adapter = a
+	// Compile-time pin: same drift-detection as the claude adapter — drops
+	// of SetStderr fail the build before RouteTo would silently no-op us.
+	var _ adapter.WarnSink = a
 }
 
 func TestAdapter_Capabilities_HasExpected(t *testing.T) {

--- a/internal/adapter/opencode/opencode_test.go
+++ b/internal/adapter/opencode/opencode_test.go
@@ -21,7 +21,7 @@ func TestAdapter_Identity(t *testing.T) {
 	var _ adapter.Adapter = a
 	// Compile-time pin: same drift-detection as the claude adapter — drops
 	// of SetStderr fail the build before RouteTo would silently no-op us.
-	var _ adapter.WarnSink = a
+	var _ adapter.WarnEmitter = a
 }
 
 func TestAdapter_Capabilities_HasExpected(t *testing.T) {

--- a/internal/adapter/opencode/setstderr_test.go
+++ b/internal/adapter/opencode/setstderr_test.go
@@ -1,0 +1,81 @@
+package opencode_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/opencode"
+)
+
+// TestSetStderr_NilResetsToDefault is the opencode adapter's mirror of
+// the claude package's nil-reset test. Same contract, same shape: after
+// SetStderr(nil), warnings emitted during Ingest must (a) NOT reach the
+// previously-set buffer, and (b) reach os.Stderr instead. opencode reads
+// skills from the shared ~/.claude/skills/ directory (see
+// opencode.ResolvePaths → ClaudeSkillsDir), so the fixture lives there.
+//
+// The contract (adapter.WarnEmitter) is interface-level; one test per
+// implementing adapter is the agreed-upon coverage. See
+// internal/adapter/claude/ingest_test.go for the lead test.
+func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: bad-yaml\ndescription: Triggers on: rebase\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	a := opencode.New(opencode.Options{TargetRoot: tmp, Stderr: &warn})
+
+	// Reset: a panic here is itself a contract failure.
+	a.SetStderr(nil)
+
+	captured := captureOsStderr(t, func() {
+		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+			t.Fatalf("Ingest after SetStderr(nil): %v", err)
+		}
+	})
+
+	if warn.Len() > 0 {
+		t.Fatalf("SetStderr(nil) did not detach the previously-set buffer; got:\n%s", warn.String())
+	}
+	if !strings.Contains(captured, "frontmatter is not strict YAML") {
+		t.Fatalf("SetStderr(nil) must route to os.Stderr default; captured nothing matching the lenient-YAML notice:\n%s", captured)
+	}
+}
+
+// captureOsStderr swaps os.Stderr for a pipe, runs fn, then restores and
+// drains the pipe. Per-package copy of the helper in
+// internal/adapter/claude/ingest_test.go — sharing it across `package
+// foo_test` files would require a new exported helper package; ~15
+// lines duplicated keeps the test contract local to each adapter.
+func captureOsStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}

--- a/internal/adapter/opencode/setstderr_test.go
+++ b/internal/adapter/opencode/setstderr_test.go
@@ -2,13 +2,13 @@ package opencode_test
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/adaptertest"
 	"github.com/spxrogers/agentsync/internal/adapter/opencode"
 )
 
@@ -21,10 +21,11 @@ import (
 //
 // The contract (adapter.WarnEmitter) is interface-level; one test per
 // implementing adapter is the agreed-upon coverage. See
-// internal/adapter/claude/ingest_test.go for the lead test.
+// internal/adapter/claude/ingest_test.go for the lead test and the
+// shared helpers in internal/adapter/adaptertest.
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
-	// Do NOT t.Parallel: captureOsStderr swaps the process-global
-	// os.Stderr.
+	// Do NOT t.Parallel: adaptertest.CaptureOsStderr swaps the
+	// process-global os.Stderr.
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -41,7 +42,7 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	// Reset: a panic here is itself a contract failure.
 	a.SetStderr(nil)
 
-	captured := captureOsStderr(t, func() {
+	captured := adaptertest.CaptureOsStderr(t, func() {
 		if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
 			t.Fatalf("Ingest after SetStderr(nil): %v", err)
 		}
@@ -55,36 +56,44 @@ func TestSetStderr_NilResetsToDefault(t *testing.T) {
 	}
 }
 
-// captureOsStderr swaps os.Stderr for a pipe, runs fn, then restores and
-// drains the pipe. Per-package copy of the helper in
-// internal/adapter/claude/ingest_test.go — sharing it across `package
-// foo_test` files would require a new exported helper package; ~15
-// lines duplicated keeps the test contract local to each adapter.
-func captureOsStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
+// TestSetStderr_SnapshotAtIngestEntry mirrors the claude package's
+// snapshot test for opencode. The contract is interface-level on
+// adapter.WarnEmitter, but the implementation property — `warn :=
+// a.stderr()` snapshot at Ingest entry — lives in each adapter's
+// ingest.go (opencode: ingest.go:50). A future re-read-per-warning
+// refactor in opencode's Ingest would silently violate the documented
+// contract without this test.
+func TestSetStderr_SnapshotAtIngestEntry(t *testing.T) {
+	tmp := t.TempDir()
+	for _, name := range []string{"first", "second"} {
+		dir := filepath.Join(tmp, ".claude", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + name + "\ndescription: Triggers on: rebase\n---\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	os.Stderr = w
 
-	// Deferred cleanup so a t.Fatalf / panic inside fn doesn't leak
-	// the read goroutine and leave os.Stderr swapped — see the lead
-	// captureOsStderr in internal/adapter/claude/ingest_test.go for
-	// the full rationale. Double-close on the happy path is harmless.
-	defer func() { os.Stderr = orig }()
-	defer func() { _ = w.Close() }()
+	var sibling bytes.Buffer
+	primary := &adaptertest.SwapOnFirstWriteBuffer{}
+	a := opencode.New(opencode.Options{TargetRoot: tmp, Stderr: primary})
+	primary.OnFirstWrite = func() { a.SetStderr(&sibling) }
 
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		done <- buf.String()
-	}()
+	if _, err := a.Ingest(adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
 
-	fn()
-	// Explicit close on the happy path: <-done blocks before defers run.
-	_ = w.Close()
-	return <-done
+	if !primary.Fired() {
+		t.Fatal("OnFirstWrite was never called — fixture didn't trigger any warning")
+	}
+	if sibling.Len() > 0 {
+		t.Fatalf("snapshot contract violated: warnings emitted AFTER mid-Ingest SetStderr landed in the sibling buffer (%d bytes):\n%s",
+			sibling.Len(), sibling.String())
+	}
+	if strings.Count(primary.String(), "frontmatter is not strict YAML") < 2 {
+		t.Fatalf("expected BOTH lenient-YAML warnings in the original sink (snapshot); got:\n%s",
+			primary.String())
+	}
 }

--- a/internal/adapter/opencode/setstderr_test.go
+++ b/internal/adapter/opencode/setstderr_test.go
@@ -23,6 +23,8 @@ import (
 // implementing adapter is the agreed-upon coverage. See
 // internal/adapter/claude/ingest_test.go for the lead test.
 func TestSetStderr_NilResetsToDefault(t *testing.T) {
+	// Do NOT t.Parallel: captureOsStderr swaps the process-global
+	// os.Stderr.
 	tmp := t.TempDir()
 	skillDir := filepath.Join(tmp, ".claude", "skills", "bad-yaml")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -67,6 +69,13 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}
 	os.Stderr = w
 
+	// Deferred cleanup so a t.Fatalf / panic inside fn doesn't leak
+	// the read goroutine and leave os.Stderr swapped — see the lead
+	// captureOsStderr in internal/adapter/claude/ingest_test.go for
+	// the full rationale. Double-close on the happy path is harmless.
+	defer func() { os.Stderr = orig }()
+	defer func() { _ = w.Close() }()
+
 	done := make(chan string, 1)
 	go func() {
 		var buf bytes.Buffer
@@ -75,7 +84,7 @@ func captureOsStderr(t *testing.T, fn func()) string {
 	}()
 
 	fn()
+	// Explicit close on the happy path: <-done blocks before defers run.
 	_ = w.Close()
-	os.Stderr = orig
 	return <-done
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -221,18 +221,21 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	if a == nil {
 		return fmt.Errorf("adapter %q not registered; valid agents: %s", agentName, validAgents)
 	}
-	// Route the adapter's Ingest warnings through the same styled writer.
-	// Adapters that don't implement adapter.WarnSink (the noop adapter today)
-	// are silently no-op'd by RouteTo — fine, they emit no Ingest warnings
-	// anyway. The deferred Unroute detaches the writer from the adapter on
-	// return — defensive against any caller that ever caches adapters
-	// across commands (today registryFactory() builds fresh each run). Flush
+	// Route the adapter's Ingest warnings through the same styled writer,
+	// and defer the restore so the adapter is detached before importRun
+	// returns. Idiomatic Go pair (mirrors log.SetOutput-via-defer and
+	// signal.Notify/Stop): the inner RouteTo(a) call runs now, returns a
+	// restore closure, and the outer () gets deferred. Adapters that don't
+	// implement adapter.WarnEmitter (the noop adapter today) yield a no-op
+	// restore closure, so the deferred call is always safe. Flush
 	// surrenders any partial unterminated line still in the WarnWriter's
-	// line-assembly buffer; all emitters terminate with \n today, so this is
-	// belt-and-suspenders.
-	warnW.RouteTo(a)
-	defer warnW.Unroute(a)
+	// line-assembly buffer; all emitters terminate with \n today, so this
+	// is belt-and-suspenders. Deferred order (LIFO): Flush first while the
+	// route is still live, then restore — though Flush writes through
+	// warnW.w directly, not via the adapter setter, so the two are order-
+	// independent in practice.
 	defer warnW.Flush()
+	defer warnW.RouteTo(a)()
 	// Gate codex/cursor the same way `agent add` does: they're registered as
 	// noop adapters, so Ingest returns an empty canonical and import would
 	// otherwise fail with a misleading "<component> not found in native config".

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -224,8 +224,15 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// Route the adapter's Ingest warnings through the same styled writer.
 	// Adapters that don't implement adapter.WarnSink (the noop adapter today)
 	// are silently no-op'd by RouteTo — fine, they emit no Ingest warnings
-	// anyway.
+	// anyway. The deferred Unroute detaches the writer from the adapter on
+	// return — defensive against any caller that ever caches adapters
+	// across commands (today registryFactory() builds fresh each run). Flush
+	// surrenders any partial unterminated line still in the WarnWriter's
+	// line-assembly buffer; all emitters terminate with \n today, so this is
+	// belt-and-suspenders.
 	warnW.RouteTo(a)
+	defer warnW.Unroute(a)
+	defer warnW.Flush()
 	// Gate codex/cursor the same way `agent add` does: they're registered as
 	// noop adapters, so Ingest returns an empty canonical and import would
 	// otherwise fail with a misleading "<component> not found in native config".

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -230,10 +230,14 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// restore closure, so the deferred call is always safe. Flush
 	// surrenders any partial unterminated line still in the WarnWriter's
 	// line-assembly buffer; all emitters terminate with \n today, so this
-	// is belt-and-suspenders. Deferred order (LIFO): Flush first while the
-	// route is still live, then restore — though Flush writes through
-	// warnW.w directly, not via the adapter setter, so the two are order-
-	// independent in practice.
+	// is belt-and-suspenders.
+	//
+	// LIFO execution: the RouteTo defer (registered second) runs FIRST —
+	// the restore closure detaches the adapter — and Flush (registered
+	// first) runs SECOND, draining any partial line the WarnWriter held.
+	// The two are order-independent in practice because Flush writes
+	// through warnW.w directly (not via the adapter setter the restore
+	// just detached), but the order is worth knowing.
 	defer warnW.Flush()
 	defer warnW.RouteTo(a)()
 	// Gate codex/cursor the same way `agent add` does: they're registered as

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -222,11 +222,10 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		return fmt.Errorf("adapter %q not registered; valid agents: %s", agentName, validAgents)
 	}
 	// Route the adapter's Ingest warnings through the same styled writer.
-	// Adapters that don't implement the setter (the noop adapter today) keep
-	// writing to os.Stderr — fine, they emit no Ingest warnings anyway.
-	if s, ok := a.(adapterStderrSetter); ok {
-		s.SetStderr(warnW)
-	}
+	// Adapters that don't implement adapter.WarnSink (the noop adapter today)
+	// are silently no-op'd by RouteTo — fine, they emit no Ingest warnings
+	// anyway.
+	warnW.RouteTo(a)
 	// Gate codex/cursor the same way `agent add` does: they're registered as
 	// noop adapters, so Ingest returns an empty canonical and import would
 	// otherwise fail with a misleading "<component> not found in native config".
@@ -579,11 +578,6 @@ func importVerb(dryRun bool) string {
 	}
 	return "imported"
 }
-
-// adapterStderrSetter is the optional setter each concrete adapter
-// (claude/opencode/codex) implements, letting CLI commands route the
-// adapter's Ingest warnings through a styled writer.
-type adapterStderrSetter interface{ SetStderr(io.Writer) }
 
 // importIO bundles the styled printer, the streams it writes to, and the
 // dry-run flag so every importXxx function emits its per-item lines, section

--- a/internal/cli/import_warn_routing_test.go
+++ b/internal/cli/import_warn_routing_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -14,40 +15,54 @@ import (
 // emitted into the adapter's configured Stderr from inside
 // internal/adapter/<name>/ingest.go — must come out of the captured CLI
 // buffer with the bold-yellow "⚠️ warning:" prefix the user sees on every
-// other warning, NOT as plain "warning: …".
+// other warning, NOT as plain "warning: …", and NOT only as a styled
+// "warning:" that the CLI itself could have emitted.
 //
 // Three load-bearing pieces:
 //
-//	internal/adapter/adapter.go   — WarnSink extension interface
+//	internal/adapter/adapter.go   — WarnEmitter extension interface
 //	internal/ui/ui.go             — WarnWriter + RouteTo helper
 //	internal/cli/import.go        — wires them together once per run
 //
-// The routing primitive itself (RouteTo against a fake setter) is unit-tested
-// in internal/ui/routeto_test.go. This integration test is what proves the
-// wiring works end-to-end through a real adapter; it covers both the claude
-// and opencode WarnSink implementations.
+// The routing primitive itself (RouteTo against a fake setter, restore
+// closure, typed-nil guard, non-implementor) is unit-tested in
+// internal/ui/routeto_test.go. This integration test is what proves the
+// wiring works end-to-end through a real adapter; the per-adapter
+// behavioural nil-reset contract is pinned by TestSetStderr_NilResetsToDefault
+// in each adapter package.
 //
-// **Which assertion is load-bearing?** The negative one. The CLI's own
-// `importIO.warn` also writes through the same WarnWriter, so seeing a
-// styled `⚠️ warning:` somewhere in `out` doesn't by itself prove the
-// adapter line was routed — it could be a CLI-emitted warning being styled
-// independently. The substring `warning: skill "…"` is emitted EXCLUSIVELY
-// by the adapter's ingest path (claude/ingest.go's lenient-YAML notice for
-// skills, opencode/ingest.go's equivalent). If routing breaks, that plain
-// substring appears verbatim in the buffer; if routing works, the line
-// starts with the styled prefix and the plain form is byte-for-byte absent.
+// **Which assertion is load-bearing?** The same-line regex below
+// (styled "⚠️ warning:" prefix appearing on the same line as a
+// lenient-YAML-specific token). Reasoning:
 //
-// The styled-prefix positive check is kept as a smoke signal but is asserted
-// loosely on the user-visible token (⚠️ + "warning:") + the presence of the
-// two SGR codes (yellow + bold) — not on the exact concatenated ANSI byte
-// sequence, which is an implementation detail of ui.Printer's wrap order
-// that a correct refactor could shuffle.
+//   - A plain `"warning: …"` substring is not a sufficient negative: if
+//     the adapter's stderr falls back to the test-process's real
+//     os.Stderr (the failure mode the routing is meant to prevent), the
+//     warning would be invisible to the captured buffer, and a
+//     looser-positive ("the styled prefix appears anywhere in out")
+//     would pass for the wrong reason — the CLI's own importIO.warn
+//     writes through the SAME WarnWriter and emits its own styled
+//     prefixes for unrelated warnings.
+//   - The lenient-YAML notice ("frontmatter is not strict YAML; parsed
+//     leniently") is emitted ONLY by the adapter's Ingest path. Requiring
+//     it on the SAME line as the styled prefix proves the adapter line
+//     was both received AND styled — neither a CLI-only styled warning
+//     nor a routing-bypassed adapter warning matches the regex.
 func TestImport_StyledAdapterWarnings(t *testing.T) {
+	// Built once: the same-line regex requires the bold-yellow "⚠️ warning:"
+	// prefix (verbatim — the user-visible bytes) followed by anything up to
+	// the lenient-YAML phrase the adapter emits. ANSI byte order is not
+	// pinned, just the presence and the same-line locality.
+	styledAdapterWarn := regexp.MustCompile(
+		regexp.QuoteMeta(ui.GlyphWarnEmoji+" warning:") +
+			`[^\n]*frontmatter is not strict YAML`,
+	)
+
 	for _, agent := range []string{"claude", "opencode"} {
 		t.Run(agent, func(t *testing.T) {
 			tmp, env := importTestEnv(t)
 			if _, err := runCLI(t, env, "agent", "add", agent); err != nil {
-				t.Fatalf("agent add %s: %v", agent, err)
+				t.Fatalf("[%s] agent add: %v", agent, err)
 			}
 
 			// Both adapters emit a lenient-YAML warning when a skill's
@@ -63,52 +78,54 @@ func TestImport_StyledAdapterWarnings(t *testing.T) {
 			}
 
 			// --color=always forces ANSI on a non-TTY (the runCLI buffer is
-			// not a terminal). --color=auto would degrade to plain and the
-			// styling assertions below would pass for the wrong reason.
+			// not a terminal). Without it, --color=auto would degrade to
+			// plain and the styling assertion below would pass for the
+			// wrong reason.
 			out, err := runCLI(t, env, "import", agent+":skill:rebaser", "--color=always")
 			if err != nil {
-				t.Fatalf("import: %v\n%s", err, out)
+				t.Fatalf("[%s] import: %v\n%s", agent, err, out)
 			}
 
-			// LOAD-BEARING negative: the plain `warning: skill "rebaser"`
-			// substring originates only in the adapter's Ingest path. If it
-			// appears verbatim, routing was bypassed.
+			// LOAD-BEARING positive: the styled prefix and the
+			// adapter-specific lenient-YAML token must appear on the
+			// SAME line. This rules out two ways the routing could be
+			// silently broken:
+			//   1. Adapter Stderr falls back to the test-process's real
+			//      os.Stderr (so the warning is invisible to `out`) —
+			//      the regex wouldn't match because the lenient-YAML
+			//      phrase wouldn't be present at all.
+			//   2. Adapter writes plain "warning: …" to the captured
+			//      buffer somehow without going through the WarnWriter
+			//      restyle — the regex wouldn't match because the
+			//      styled prefix wouldn't lead the line.
+			if !styledAdapterWarn.MatchString(out) {
+				t.Fatalf("[%s] expected same-line styled prefix + adapter lenient-YAML phrase; got:\n%q",
+					agent, out)
+			}
+
+			// LOAD-BEARING negative: the plain `warning: skill "…"`
+			// substring originates only in the adapter's Ingest path. If
+			// it appears verbatim in `out`, routing wasn't bypassed via
+			// os.Stderr (the warning DID reach `out`) but was bypassed
+			// via the WarnWriter restyle (no prefix swap). This catches
+			// regressions in WarnWriter.emit or the line-buffer flush.
 			plainPrefix := "warning: skill \"rebaser\""
 			if strings.Contains(out, plainPrefix) {
-				t.Fatalf("plain %q appeared — adapter stderr is not being routed through the styled writer:\n%q",
-					plainPrefix, out)
-			}
-
-			// Smoke positive: the styled token shows up (user-visible glyph
-			// + word), and the two SGR codes the WarnWriter applies are both
-			// present. Asserted loosely so the test doesn't pin the exact
-			// SGR concatenation order — `Yellow(Bold(…))` produces a
-			// different byte sequence from `Bold(Yellow(…))` but is
-			// visually identical and equally correct.
-			styledToken := ui.GlyphWarnEmoji + " warning:"
-			if !strings.Contains(out, styledToken) {
-				t.Fatalf("expected the user-visible styled token %q in output; got:\n%q", styledToken, out)
-			}
-			const sgrYellow, sgrBold = "\x1b[33m", "\x1b[1m"
-			if !strings.Contains(out, sgrYellow) || !strings.Contains(out, sgrBold) {
-				t.Fatalf("expected both yellow (%q) and bold (%q) SGR codes in output; got:\n%q",
-					sgrYellow, sgrBold, out)
-			}
-			// And the adapter's specific warning body must survive the
-			// styling — otherwise the routing ate the line.
-			if !strings.Contains(out, "rebaser") {
-				t.Fatalf("styled prefix present but adapter warning body missing; routing may be malformed:\n%q", out)
+				t.Fatalf("[%s] plain %q appeared — adapter stderr reached the buffer but the WarnWriter restyle didn't fire:\n%q",
+					agent, plainPrefix, out)
 			}
 		})
 	}
 }
 
 // skillsRoot returns the on-disk directory each adapter scans for a
-// user-scope skill named "rebaser". Kept here rather than reaching into the
-// adapter packages so a future adapter that joins this test only needs one
-// case added. opencode intentionally shares ~/.claude/skills/ with claude —
-// see opencode.ResolvePaths → ClaudeSkillsDir; both adapters surface the
-// lenient-YAML warning from the same on-disk file.
+// user-scope skill named "rebaser". Kept here rather than reaching into
+// the adapter packages so a future adapter joining the table only needs
+// one case added. opencode intentionally shares ~/.claude/skills/ with
+// claude — see opencode.ResolvePaths → ClaudeSkillsDir; both adapters
+// surface the lenient-YAML warning from the same on-disk file. (codex
+// reads skills from ~/.agents/skills/, but the integration test gates
+// codex behind v1Supported so it isn't included today.)
 func skillsRoot(t *testing.T, tmp, agent string) string {
 	t.Helper()
 	switch agent {

--- a/internal/cli/import_warn_routing_test.go
+++ b/internal/cli/import_warn_routing_test.go
@@ -1,0 +1,69 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestImport_StyledAdapterWarnings is the regression for the warning-styling
+// plumbing: an adapter's Ingest warnings — physically emitted by the claude
+// adapter into its configured Stderr — must be routed through the same
+// styled writer the CLI uses for its own warnings, picking up the bold-yellow
+// "⚠️ warning:" prefix the user sees on every other warning.
+//
+// The contract has three load-bearing pieces:
+//
+//	internal/adapter/adapter.go     — WarnSink extension interface
+//	internal/ui/ui.go               — WarnWriter + RouteTo helper
+//	internal/cli/import.go          — wires them together once per run
+//
+// If any of those silently regresses (RouteTo no longer type-asserts, or
+// import.go forgets to wrap stderr, or the adapter stops implementing
+// SetStderr), the YAML-frontmatter notices the claude adapter emits would
+// fall back to plain "warning: …" on os.Stderr — invisible to the test
+// buffer, but jarring next to the styled "⚠️ warning:" lines in real use.
+// This test forces --color=always (the runCLI buffer is not a TTY) and asserts
+// the ANSI-prefixed form appears in the captured output.
+func TestImport_StyledAdapterWarnings(t *testing.T) {
+	tmp, env := importTestEnv(t)
+
+	// Plant a skill with a lenient-YAML description ('Triggers on: rebase'
+	// — the colon-space is what trips strict YAML and triggers the
+	// lenient-parse warning the claude adapter emits during Ingest).
+	skillDir := filepath.Join(tmp, ".claude", "skills", "rebaser")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: rebaser\ndescription: Triggers on: rebase\n---\nRebase helper.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --color=always forces ANSI even off a TTY (the test buffer is not a
+	// terminal). Without this, --color=auto would degrade to plain and the
+	// assertion would pass for the wrong reason.
+	out, err := runCLI(t, env, "import", "claude:skill:rebaser", "--color=always")
+	if err != nil {
+		t.Fatalf("import: %v\n%s", err, out)
+	}
+
+	// The adapter emits exactly: warning: skill "rebaser" frontmatter is not
+	// strict YAML; parsed leniently (consider quoting values containing ': ')
+	// The WarnWriter rewrites the line-start "warning: " into a bold-yellow
+	// "⚠️ warning:" sequence. We assert (a) the rewritten prefix appears,
+	// (b) the original "rebaser" content survives so we know it's the same
+	// line, and (c) the plain "warning: skill" form does NOT appear (which
+	// would mean the routing was bypassed).
+	const styledPrefix = "\x1b[33m\x1b[1m⚠️ warning:\x1b[0m\x1b[0m"
+	if !strings.Contains(out, styledPrefix) {
+		t.Fatalf("expected adapter warnings to be styled as bold-yellow ⚠️ warning:; got:\n%q", out)
+	}
+	if !strings.Contains(out, "rebaser") {
+		t.Fatalf("styled prefix present but the rebaser-skill warning content is missing; routing may have eaten it:\n%q", out)
+	}
+	if strings.Contains(out, "warning: skill \"rebaser\"") {
+		t.Fatalf("plain 'warning: skill \"rebaser\"' appeared — adapter stderr is not being routed through the styled writer:\n%q", out)
+	}
+}

--- a/internal/cli/import_warn_routing_test.go
+++ b/internal/cli/import_warn_routing_test.go
@@ -5,65 +5,117 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
-// TestImport_StyledAdapterWarnings is the regression for the warning-styling
-// plumbing: an adapter's Ingest warnings — physically emitted by the claude
-// adapter into its configured Stderr — must be routed through the same
-// styled writer the CLI uses for its own warnings, picking up the bold-yellow
-// "⚠️ warning:" prefix the user sees on every other warning.
+// TestImport_StyledAdapterWarnings is the integration regression for the
+// warning-styling plumbing: a real adapter's Ingest warning — physically
+// emitted into the adapter's configured Stderr from inside
+// internal/adapter/<name>/ingest.go — must come out of the captured CLI
+// buffer with the bold-yellow "⚠️ warning:" prefix the user sees on every
+// other warning, NOT as plain "warning: …".
 //
-// The contract has three load-bearing pieces:
+// Three load-bearing pieces:
 //
-//	internal/adapter/adapter.go     — WarnSink extension interface
-//	internal/ui/ui.go               — WarnWriter + RouteTo helper
-//	internal/cli/import.go          — wires them together once per run
+//	internal/adapter/adapter.go   — WarnSink extension interface
+//	internal/ui/ui.go             — WarnWriter + RouteTo helper
+//	internal/cli/import.go        — wires them together once per run
 //
-// If any of those silently regresses (RouteTo no longer type-asserts, or
-// import.go forgets to wrap stderr, or the adapter stops implementing
-// SetStderr), the YAML-frontmatter notices the claude adapter emits would
-// fall back to plain "warning: …" on os.Stderr — invisible to the test
-// buffer, but jarring next to the styled "⚠️ warning:" lines in real use.
-// This test forces --color=always (the runCLI buffer is not a TTY) and asserts
-// the ANSI-prefixed form appears in the captured output.
+// The routing primitive itself (RouteTo against a fake setter) is unit-tested
+// in internal/ui/routeto_test.go. This integration test is what proves the
+// wiring works end-to-end through a real adapter; it covers both the claude
+// and opencode WarnSink implementations.
+//
+// **Which assertion is load-bearing?** The negative one. The CLI's own
+// `importIO.warn` also writes through the same WarnWriter, so seeing a
+// styled `⚠️ warning:` somewhere in `out` doesn't by itself prove the
+// adapter line was routed — it could be a CLI-emitted warning being styled
+// independently. The substring `warning: skill "…"` is emitted EXCLUSIVELY
+// by the adapter's ingest path (claude/ingest.go's lenient-YAML notice for
+// skills, opencode/ingest.go's equivalent). If routing breaks, that plain
+// substring appears verbatim in the buffer; if routing works, the line
+// starts with the styled prefix and the plain form is byte-for-byte absent.
+//
+// The styled-prefix positive check is kept as a smoke signal but is asserted
+// loosely on the user-visible token (⚠️ + "warning:") + the presence of the
+// two SGR codes (yellow + bold) — not on the exact concatenated ANSI byte
+// sequence, which is an implementation detail of ui.Printer's wrap order
+// that a correct refactor could shuffle.
 func TestImport_StyledAdapterWarnings(t *testing.T) {
-	tmp, env := importTestEnv(t)
+	for _, agent := range []string{"claude", "opencode"} {
+		t.Run(agent, func(t *testing.T) {
+			tmp, env := importTestEnv(t)
+			if _, err := runCLI(t, env, "agent", "add", agent); err != nil {
+				t.Fatalf("agent add %s: %v", agent, err)
+			}
 
-	// Plant a skill with a lenient-YAML description ('Triggers on: rebase'
-	// — the colon-space is what trips strict YAML and triggers the
-	// lenient-parse warning the claude adapter emits during Ingest).
-	skillDir := filepath.Join(tmp, ".claude", "skills", "rebaser")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	body := "---\nname: rebaser\ndescription: Triggers on: rebase\n---\nRebase helper.\n"
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
+			// Both adapters emit a lenient-YAML warning when a skill's
+			// description carries an unquoted colon-space. We plant the
+			// fixture under each agent's native skills root.
+			skillDir := skillsRoot(t, tmp, agent)
+			if err := os.MkdirAll(skillDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := "---\nname: rebaser\ndescription: Triggers on: rebase\n---\nRebase helper.\n"
+			if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	// --color=always forces ANSI even off a TTY (the test buffer is not a
-	// terminal). Without this, --color=auto would degrade to plain and the
-	// assertion would pass for the wrong reason.
-	out, err := runCLI(t, env, "import", "claude:skill:rebaser", "--color=always")
-	if err != nil {
-		t.Fatalf("import: %v\n%s", err, out)
-	}
+			// --color=always forces ANSI on a non-TTY (the runCLI buffer is
+			// not a terminal). --color=auto would degrade to plain and the
+			// styling assertions below would pass for the wrong reason.
+			out, err := runCLI(t, env, "import", agent+":skill:rebaser", "--color=always")
+			if err != nil {
+				t.Fatalf("import: %v\n%s", err, out)
+			}
 
-	// The adapter emits exactly: warning: skill "rebaser" frontmatter is not
-	// strict YAML; parsed leniently (consider quoting values containing ': ')
-	// The WarnWriter rewrites the line-start "warning: " into a bold-yellow
-	// "⚠️ warning:" sequence. We assert (a) the rewritten prefix appears,
-	// (b) the original "rebaser" content survives so we know it's the same
-	// line, and (c) the plain "warning: skill" form does NOT appear (which
-	// would mean the routing was bypassed).
-	const styledPrefix = "\x1b[33m\x1b[1m⚠️ warning:\x1b[0m\x1b[0m"
-	if !strings.Contains(out, styledPrefix) {
-		t.Fatalf("expected adapter warnings to be styled as bold-yellow ⚠️ warning:; got:\n%q", out)
+			// LOAD-BEARING negative: the plain `warning: skill "rebaser"`
+			// substring originates only in the adapter's Ingest path. If it
+			// appears verbatim, routing was bypassed.
+			plainPrefix := "warning: skill \"rebaser\""
+			if strings.Contains(out, plainPrefix) {
+				t.Fatalf("plain %q appeared — adapter stderr is not being routed through the styled writer:\n%q",
+					plainPrefix, out)
+			}
+
+			// Smoke positive: the styled token shows up (user-visible glyph
+			// + word), and the two SGR codes the WarnWriter applies are both
+			// present. Asserted loosely so the test doesn't pin the exact
+			// SGR concatenation order — `Yellow(Bold(…))` produces a
+			// different byte sequence from `Bold(Yellow(…))` but is
+			// visually identical and equally correct.
+			styledToken := ui.GlyphWarnEmoji + " warning:"
+			if !strings.Contains(out, styledToken) {
+				t.Fatalf("expected the user-visible styled token %q in output; got:\n%q", styledToken, out)
+			}
+			const sgrYellow, sgrBold = "\x1b[33m", "\x1b[1m"
+			if !strings.Contains(out, sgrYellow) || !strings.Contains(out, sgrBold) {
+				t.Fatalf("expected both yellow (%q) and bold (%q) SGR codes in output; got:\n%q",
+					sgrYellow, sgrBold, out)
+			}
+			// And the adapter's specific warning body must survive the
+			// styling — otherwise the routing ate the line.
+			if !strings.Contains(out, "rebaser") {
+				t.Fatalf("styled prefix present but adapter warning body missing; routing may be malformed:\n%q", out)
+			}
+		})
 	}
-	if !strings.Contains(out, "rebaser") {
-		t.Fatalf("styled prefix present but the rebaser-skill warning content is missing; routing may have eaten it:\n%q", out)
-	}
-	if strings.Contains(out, "warning: skill \"rebaser\"") {
-		t.Fatalf("plain 'warning: skill \"rebaser\"' appeared — adapter stderr is not being routed through the styled writer:\n%q", out)
+}
+
+// skillsRoot returns the on-disk directory each adapter scans for a
+// user-scope skill named "rebaser". Kept here rather than reaching into the
+// adapter packages so a future adapter that joins this test only needs one
+// case added. opencode intentionally shares ~/.claude/skills/ with claude —
+// see opencode.ResolvePaths → ClaudeSkillsDir; both adapters surface the
+// lenient-YAML warning from the same on-disk file.
+func skillsRoot(t *testing.T, tmp, agent string) string {
+	t.Helper()
+	switch agent {
+	case "claude", "opencode":
+		return filepath.Join(tmp, ".claude", "skills", "rebaser")
+	default:
+		t.Fatalf("no skills root mapping for agent %q", agent)
+		return ""
 	}
 }

--- a/internal/cli/import_warn_routing_test.go
+++ b/internal/cli/import_warn_routing_test.go
@@ -53,9 +53,17 @@ func TestImport_StyledAdapterWarnings(t *testing.T) {
 	// prefix (verbatim — the user-visible bytes) followed by anything up to
 	// the lenient-YAML phrase the adapter emits. ANSI byte order is not
 	// pinned, just the presence and the same-line locality.
+	//
+	// `[^\n\r]*` rather than `[^\n]*`: rejects both newline AND carriage-
+	// return between the prefix and the phrase. SGR bytes don't contain
+	// either, so this only matters as defence-in-depth against a future
+	// styling change that emits stray CRs — without the \r in the
+	// negated class, a `\r` between the prefix and the phrase would let
+	// the regex match across what the terminal would render as separate
+	// lines.
 	styledAdapterWarn := regexp.MustCompile(
 		regexp.QuoteMeta(ui.GlyphWarnEmoji+" warning:") +
-			`[^\n]*frontmatter is not strict YAML`,
+			`[^\n\r]*frontmatter is not strict YAML`,
 	)
 
 	for _, agent := range []string{"claude", "opencode"} {

--- a/internal/ui/routeto_test.go
+++ b/internal/ui/routeto_test.go
@@ -21,58 +21,84 @@ func (f *fakeSetter) SetStderr(w io.Writer) {
 	f.lastNil = (w == nil)
 }
 
-// nonSetter has no SetStderr method; RouteTo/Unroute must silently no-op on
-// it (the "adapter doesn't implement WarnSink" path).
+// nonSetter has no SetStderr method; RouteTo must silently no-op on it
+// (the "adapter doesn't implement WarnEmitter" path).
 type nonSetter struct{}
 
-// TestWarnWriter_RouteTo_AndUnroute pins the routing primitive directly so
-// the contract is not piggy-backed on the import command's full setup. If
+// TestWarnWriter_RouteTo pins the routing primitive directly so the
+// contract is not piggy-backed on the import command's full setup. If
 // RouteTo ever drops its type-assert (or its structural interface drifts
-// from adapter.WarnSink in signature), this test fails immediately —
+// from adapter.WarnEmitter in signature), this test fails immediately —
 // independent of any --color flag, lenient-YAML fixture, or printer state.
-func TestWarnWriter_RouteTo_AndUnroute(t *testing.T) {
+// The restore-closure shape is also tested here: every RouteTo call
+// returns a callable closure, even on the no-op paths, so callers can
+// safely `defer warnW.RouteTo(a)()` without nil-checking.
+func TestWarnWriter_RouteTo(t *testing.T) {
 	p := New(&bytes.Buffer{}, &bytes.Buffer{}, ColorNever)
 	w := NewWarnWriter(&bytes.Buffer{}, p)
 
 	t.Run("RouteTo passes the writer to a SetStderr implementor", func(t *testing.T) {
 		var s fakeSetter
-		w.RouteTo(&s)
+		restore := w.RouteTo(&s)
 		if s.calls != 1 {
 			t.Fatalf("RouteTo: SetStderr should be called exactly once; got %d", s.calls)
 		}
 		if s.got != w {
 			t.Fatalf("RouteTo: SetStderr should receive the *WarnWriter; got %T", s.got)
 		}
+		if restore == nil {
+			t.Fatal("RouteTo must always return a non-nil restore closure")
+		}
+		restore()
+		if s.calls != 2 || !s.lastNil {
+			t.Fatalf("restore must call SetStderr(nil); got calls=%d lastNil=%v", s.calls, s.lastNil)
+		}
 	})
 
-	t.Run("Unroute passes nil to reset to default", func(t *testing.T) {
+	t.Run("restore is idempotent enough to defer safely", func(t *testing.T) {
 		var s fakeSetter
-		w.RouteTo(&s)
-		w.Unroute(&s)
-		if s.calls != 2 {
-			t.Fatalf("Unroute should issue a second SetStderr call; got total %d", s.calls)
-		}
-		if !s.lastNil {
-			t.Fatalf("Unroute must call SetStderr(nil); got non-nil writer %T", s.got)
+		restore := w.RouteTo(&s)
+		restore()
+		restore() // second call sends another SetStderr(nil); same end state.
+		if s.calls != 3 || !s.lastNil {
+			t.Fatalf("repeated restore should keep the setter at nil; got calls=%d lastNil=%v",
+				s.calls, s.lastNil)
 		}
 	})
 
-	t.Run("RouteTo on a non-implementor is a silent no-op", func(t *testing.T) {
-		// If the type assertion ever changes (e.g. someone replaces the
-		// structural setter with a named adapter.WarnSink and forgets to
-		// import-cycle-break), this case will fail because non-implementors
-		// would no longer compile, or RouteTo would panic on the assertion.
-		// Today: pure no-op.
-		w.RouteTo(&nonSetter{})
-		w.Unroute(&nonSetter{})
-		// No panic, no observable effect — the test passing IS the assertion.
+	t.Run("RouteTo on a non-implementor is a silent no-op with a callable restore", func(t *testing.T) {
+		// Restore is a no-op closure for non-implementors; callers can
+		// always `defer warnW.RouteTo(a)()` without checking.
+		restore := w.RouteTo(&nonSetter{})
+		if restore == nil {
+			t.Fatal("restore closure must be non-nil even on the no-op path")
+		}
+		restore() // must not panic.
 	})
 
-	t.Run("RouteTo with nil receiver-arg is a silent no-op", func(t *testing.T) {
-		// any(nil) carries no concrete type; the type-assert misses. Important
-		// because Adapter implementations may legitimately be nil during error
-		// paths (e.g. reg.Lookup of an unregistered agent).
-		w.RouteTo(nil)
-		w.Unroute(nil)
+	t.Run("RouteTo on untyped nil is a silent no-op", func(t *testing.T) {
+		// any(nil) carries no concrete type; the type-assert misses.
+		// Important because adapter implementations may legitimately be
+		// nil during error paths (e.g. reg.Lookup of an unregistered
+		// agent — though the actual caller short-circuits earlier).
+		restore := w.RouteTo(nil)
+		if restore == nil {
+			t.Fatal("restore closure must be non-nil even for nil arg")
+		}
+		restore()
+	})
+
+	t.Run("RouteTo on typed-nil pointer is a silent no-op (no panic)", func(t *testing.T) {
+		// var a *fakeSetter = nil; w.RouteTo(a) — the interface value
+		// carries the method set of *fakeSetter, so the type assertion
+		// SUCCEEDS, but calling SetStderr on a nil pointer would
+		// dereference and panic. RouteTo's reflect guard catches this.
+		// Without the guard, this test panics.
+		var nilSetter *fakeSetter
+		restore := w.RouteTo(nilSetter)
+		if restore == nil {
+			t.Fatal("restore closure must be non-nil even for typed-nil arg")
+		}
+		restore() // must not panic.
 	})
 }

--- a/internal/ui/routeto_test.go
+++ b/internal/ui/routeto_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -55,11 +56,15 @@ func TestWarnWriter_RouteTo(t *testing.T) {
 		}
 	})
 
-	t.Run("restore is idempotent enough to defer safely", func(t *testing.T) {
+	t.Run("restore is safe to call twice", func(t *testing.T) {
+		// Strictly not idempotent — each restore call DOES invoke
+		// SetStderr(nil) — but the end state is unchanged, which is
+		// what makes `defer warnW.RouteTo(a)()` safe even if the
+		// caller ever explicitly restored earlier in the function.
 		var s fakeSetter
 		restore := w.RouteTo(&s)
 		restore()
-		restore() // second call sends another SetStderr(nil); same end state.
+		restore()
 		if s.calls != 3 || !s.lastNil {
 			t.Fatalf("repeated restore should keep the setter at nil; got calls=%d lastNil=%v",
 				s.calls, s.lastNil)
@@ -100,5 +105,58 @@ func TestWarnWriter_RouteTo(t *testing.T) {
 			t.Fatal("restore closure must be non-nil even for typed-nil arg")
 		}
 		restore() // must not panic.
+	})
+}
+
+// TestWarnWriter_Flush pins the partial-line drain: a Write without a
+// terminating newline sits in the line-assembly buffer until either a
+// later newline arrives or Flush surrenders it. importRun does
+// `defer warnW.Flush()` so a partial line a panicking adapter left in
+// the buffer still reaches the user's terminal. Without this test,
+// Flush could silently become a no-op and every other test would still
+// pass (all current emitters terminate lines with \n).
+func TestWarnWriter_Flush(t *testing.T) {
+	var dest bytes.Buffer
+	p := New(&bytes.Buffer{}, &dest, ColorNever)
+	w := NewWarnWriter(&dest, p)
+
+	t.Run("partial 'warning: ' line drains and gets styled on Flush", func(t *testing.T) {
+		dest.Reset()
+		_, _ = w.Write([]byte("warning: partial line no newline"))
+		// Before Flush: nothing yet emitted because the line is incomplete.
+		if dest.Len() != 0 {
+			t.Fatalf("partial line should sit in the buffer until Flush; got: %q", dest.String())
+		}
+		w.Flush()
+		got := dest.String()
+		// Color is off (ColorNever), so the styled prefix is the bare
+		// glyph + "warning:" — emit's HasPrefix("warning: ") still
+		// triggers the prefix rewrite even without a trailing newline.
+		const wantPrefix = GlyphWarnEmoji + " warning:"
+		if !strings.HasPrefix(got, wantPrefix) {
+			t.Fatalf("Flush should style the partial warning prefix; got: %q", got)
+		}
+		if !strings.Contains(got, "partial line no newline") {
+			t.Fatalf("Flush should drain the body too; got: %q", got)
+		}
+	})
+
+	t.Run("partial non-warning line drains verbatim", func(t *testing.T) {
+		dest.Reset()
+		w2 := NewWarnWriter(&dest, p)
+		_, _ = w2.Write([]byte("note: agentsync did things"))
+		w2.Flush()
+		if got := dest.String(); got != "note: agentsync did things" {
+			t.Fatalf("non-warning partial line should drain verbatim; got: %q", got)
+		}
+	})
+
+	t.Run("Flush on empty buffer is a no-op", func(t *testing.T) {
+		dest.Reset()
+		w3 := NewWarnWriter(&dest, p)
+		w3.Flush()
+		if dest.Len() != 0 {
+			t.Fatalf("Flush on empty buffer should not write; got: %q", dest.String())
+		}
 	})
 }

--- a/internal/ui/routeto_test.go
+++ b/internal/ui/routeto_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// fakeSetter records the most recent SetStderr argument so the routing
+// primitive can be exercised in isolation, without standing up an adapter,
+// a printer, or the import command.
+type fakeSetter struct {
+	got     io.Writer
+	calls   int
+	lastNil bool
+}
+
+func (f *fakeSetter) SetStderr(w io.Writer) {
+	f.got = w
+	f.calls++
+	f.lastNil = (w == nil)
+}
+
+// nonSetter has no SetStderr method; RouteTo/Unroute must silently no-op on
+// it (the "adapter doesn't implement WarnSink" path).
+type nonSetter struct{}
+
+// TestWarnWriter_RouteTo_AndUnroute pins the routing primitive directly so
+// the contract is not piggy-backed on the import command's full setup. If
+// RouteTo ever drops its type-assert (or its structural interface drifts
+// from adapter.WarnSink in signature), this test fails immediately —
+// independent of any --color flag, lenient-YAML fixture, or printer state.
+func TestWarnWriter_RouteTo_AndUnroute(t *testing.T) {
+	p := New(&bytes.Buffer{}, &bytes.Buffer{}, ColorNever)
+	w := NewWarnWriter(&bytes.Buffer{}, p)
+
+	t.Run("RouteTo passes the writer to a SetStderr implementor", func(t *testing.T) {
+		var s fakeSetter
+		w.RouteTo(&s)
+		if s.calls != 1 {
+			t.Fatalf("RouteTo: SetStderr should be called exactly once; got %d", s.calls)
+		}
+		if s.got != w {
+			t.Fatalf("RouteTo: SetStderr should receive the *WarnWriter; got %T", s.got)
+		}
+	})
+
+	t.Run("Unroute passes nil to reset to default", func(t *testing.T) {
+		var s fakeSetter
+		w.RouteTo(&s)
+		w.Unroute(&s)
+		if s.calls != 2 {
+			t.Fatalf("Unroute should issue a second SetStderr call; got total %d", s.calls)
+		}
+		if !s.lastNil {
+			t.Fatalf("Unroute must call SetStderr(nil); got non-nil writer %T", s.got)
+		}
+	})
+
+	t.Run("RouteTo on a non-implementor is a silent no-op", func(t *testing.T) {
+		// If the type assertion ever changes (e.g. someone replaces the
+		// structural setter with a named adapter.WarnSink and forgets to
+		// import-cycle-break), this case will fail because non-implementors
+		// would no longer compile, or RouteTo would panic on the assertion.
+		// Today: pure no-op.
+		w.RouteTo(&nonSetter{})
+		w.Unroute(&nonSetter{})
+		// No panic, no observable effect — the test passing IS the assertion.
+	})
+
+	t.Run("RouteTo with nil receiver-arg is a silent no-op", func(t *testing.T) {
+		// any(nil) carries no concrete type; the type-assert misses. Important
+		// because Adapter implementations may legitimately be nil during error
+		// paths (e.g. reg.Lookup of an unregistered agent).
+		w.RouteTo(nil)
+		w.Unroute(nil)
+	})
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -266,19 +266,32 @@ func (s *WarnWriter) RouteTo(a any) func() {
 }
 
 // noopRestore is the restore function returned when RouteTo can't wire
-// anything. Shared so the non-implementor path doesn't allocate per call.
+// anything. Shared so the non-implementor path doesn't allocate per
+// call. Keep stateless: a future addition that captures state would
+// silently share that state across every no-op RouteTo call (every
+// command that runs against the noop adapter, every nil-setter test).
 var noopRestore = func() {}
 
-// setterOf returns the SetStderr setter on a, or (nil, false) when:
-//   - a is untyped nil,
-//   - a's dynamic type doesn't implement SetStderr, or
-//   - a is a typed-nil pointer (the interface holds a method set but
-//     calling on it would panic).
+// setterOf returns the SetStderr setter on a, or (nil, false) when a
+// cannot be safely called. The three rejection paths are distinct:
 //
-// The reflect check on the typed-nil case is the only non-trivial bit:
-// today's caller (import) always passes a real adapter from
-// registry.Lookup, which is never typed-nil — the guard is defence in
-// depth for future callers passing through error paths.
+//  1. `a == nil`: an UNTYPED nil any-value (no concrete type behind it).
+//     The bare `nil` check catches this; the later type-assert would
+//     also fail, but doing it explicitly documents the case.
+//  2. `a.(stderrSetter)` failure: a's dynamic type doesn't implement
+//     SetStderr — this is the "noop adapter" path. Today's caller
+//     can pass any adapter.Adapter; non-implementors get this path.
+//  3. `rv.IsNil()` on a Pointer kind: a TYPED-nil pointer (e.g.
+//     `var p *Adapter = nil`). The interface value carries *Adapter's
+//     method set, so the type-assert in (2) SUCCEEDS, but calling
+//     SetStderr on the nil pointer would dereference and panic. The
+//     reflect guard is the only check that catches this.
+//
+// Scope of the reflect guard: Pointer kind only. Map/Chan/Func/Slice/
+// Interface kinds can also be typed-nil and would panic similarly, but
+// no implementor today (all *Adapter) uses them, and the unidiomatic
+// shape would be a louder review signal than a runtime no-op. Widen
+// the guard if a non-pointer implementor ever lands.
 func (s *WarnWriter) setterOf(a any) (stderrSetter, bool) {
 	if a == nil {
 		return nil, false

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -216,6 +216,28 @@ func (s *WarnWriter) Flush() {
 // warning lines are not part of any padded layout.
 const GlyphWarnEmoji = "⚠️"
 
+// RouteTo wires the writer into anything that exposes a `SetStderr(io.Writer)`
+// setter (matching adapter.WarnSink, though ui does not import the adapter
+// package — the interface is structural). Adapters that don't implement the
+// setter are silently no-ops, so callers don't have to type-assert before
+// calling this; pass any adapter.Adapter and let the structural match decide.
+//
+// Typical use from a CLI command:
+//
+//	warnW := ui.NewWarnWriter(p.Err, p)
+//	warnW.RouteTo(a) // a is the Adapter returned from registry.Lookup
+//	c, err := a.Ingest(...)
+//
+// Every "warning: …" line the adapter writes during Ingest then picks up the
+// bold-yellow "⚠️ warning:" styling, identical to warnings the command emits
+// itself.
+func (s *WarnWriter) RouteTo(a any) {
+	type setter interface{ SetStderr(io.Writer) }
+	if v, ok := a.(setter); ok {
+		v.SetStderr(s)
+	}
+}
+
 func (s *WarnWriter) emit(line []byte) {
 	if !bytes.HasPrefix(line, []byte(warnLinePrefix)) {
 		_, _ = s.w.Write(line)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 
 	"golang.org/x/term"
 )
@@ -219,32 +220,78 @@ func (s *WarnWriter) Flush() {
 // warning lines are not part of any padded layout.
 const GlyphWarnEmoji = "⚠️"
 
-// stderrSetter is the structural shape of adapter.WarnSink. Duplicated here
-// so ui doesn't depend on the adapter package; the adapter-package test
-// suites pin each concrete adapter to adapter.WarnSink at compile time, so
-// drift between the two definitions fails to build.
+// stderrSetter is the structural shape of adapter.WarnEmitter. Duplicated
+// here so ui doesn't depend on the adapter package; each concrete adapter's
+// test suite pins itself against adapter.WarnEmitter at compile time, and
+// internal/cli/import_warn_routing_test.go pins a real adapter through
+// RouteTo at runtime, so drift between the two definitions fails the
+// build or the test rather than silently regressing to a no-op.
+//
+// TODO: when WarnEmitter grows a second method (a structured-diagnostic
+// sink, a `Verbose(io.Writer)`, etc.), the structural-duplicate-with-
+// compile-pin pattern stops being free. Move the interface to a neutral
+// package (e.g. internal/cliio) so ui and adapter both import one
+// definition.
 type stderrSetter interface{ SetStderr(w io.Writer) }
 
 // RouteTo wires this writer into anything that exposes a
-// `SetStderr(io.Writer)` setter (matching adapter.WarnSink). Non-implementors
-// are silently no-op'd, so callers can pass any adapter.Adapter without
-// type-asserting first. Pair with a deferred Unroute to detach on return.
-func (s *WarnWriter) RouteTo(a any) {
-	if v, ok := a.(stderrSetter); ok {
-		v.SetStderr(s)
+// SetStderr(io.Writer) setter (matching adapter.WarnEmitter) and returns a
+// restore function that detaches the writer when invoked. Idiomatic use
+// pairs with defer:
+//
+//	defer warnW.RouteTo(a)()
+//
+// The inner RouteTo(a) call evaluates immediately (wires the writer); the
+// outer () is the deferred restore. The returned function is always
+// safe to call — it's a no-op when the target doesn't implement the
+// setter, when the target is a typed-nil pointer, or when the target was
+// an untyped nil — so callers never need to type-assert or nil-check.
+//
+// Non-implementor cases that resolve to a silent no-op:
+//
+//   - untyped nil (`any(nil)`): the type-assert misses because the
+//     interface value carries no concrete type.
+//   - typed nil (`var a *T = nil; RouteTo(a)`): the type-assert SUCCEEDS
+//     because the interface value holds the method set of *T, but calling
+//     SetStderr would dereference the nil pointer. RouteTo guards
+//     against this via reflect.
+//   - any value whose dynamic type doesn't implement SetStderr.
+func (s *WarnWriter) RouteTo(a any) func() {
+	v, ok := s.setterOf(a)
+	if !ok {
+		return noopRestore
 	}
+	v.SetStderr(s)
+	return func() { v.SetStderr(nil) }
 }
 
-// Unroute reverses a prior RouteTo by passing nil to the same setter, which
-// per the adapter.WarnSink contract resets the implementor to its default
-// sink (os.Stderr). Defensive: today's adapters are constructed fresh per
-// command via registryFactory(), but a caller that ever caches adapters
-// shouldn't leak this WarnWriter past the command's lifetime. No-op when the
-// target doesn't implement the setter, mirroring RouteTo.
-func (s *WarnWriter) Unroute(a any) {
-	if v, ok := a.(stderrSetter); ok {
-		v.SetStderr(nil)
+// noopRestore is the restore function returned when RouteTo can't wire
+// anything. Shared so the non-implementor path doesn't allocate per call.
+var noopRestore = func() {}
+
+// setterOf returns the SetStderr setter on a, or (nil, false) when:
+//   - a is untyped nil,
+//   - a's dynamic type doesn't implement SetStderr, or
+//   - a is a typed-nil pointer (the interface holds a method set but
+//     calling on it would panic).
+//
+// The reflect check on the typed-nil case is the only non-trivial bit:
+// today's caller (import) always passes a real adapter from
+// registry.Lookup, which is never typed-nil — the guard is defence in
+// depth for future callers passing through error paths.
+func (s *WarnWriter) setterOf(a any) (stderrSetter, bool) {
+	if a == nil {
+		return nil, false
 	}
+	v, ok := a.(stderrSetter)
+	if !ok {
+		return nil, false
+	}
+	rv := reflect.ValueOf(a)
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return nil, false
+	}
+	return v, true
 }
 
 func (s *WarnWriter) emit(line []byte) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -169,6 +169,9 @@ func Pad(s string, width int) string {
 // callers' partial Write is held until a newline arrives — fmt.Fprintf in
 // practice always finishes a line per call, but buffering keeps a chunked
 // writer correct.
+//
+// Not safe for concurrent use: the line-assembly buffer is unsynchronized.
+// One *WarnWriter per command invocation is the intended pattern.
 type WarnWriter struct {
 	w   io.Writer
 	p   *Printer
@@ -216,25 +219,31 @@ func (s *WarnWriter) Flush() {
 // warning lines are not part of any padded layout.
 const GlyphWarnEmoji = "⚠️"
 
-// RouteTo wires the writer into anything that exposes a `SetStderr(io.Writer)`
-// setter (matching adapter.WarnSink, though ui does not import the adapter
-// package — the interface is structural). Adapters that don't implement the
-// setter are silently no-ops, so callers don't have to type-assert before
-// calling this; pass any adapter.Adapter and let the structural match decide.
-//
-// Typical use from a CLI command:
-//
-//	warnW := ui.NewWarnWriter(p.Err, p)
-//	warnW.RouteTo(a) // a is the Adapter returned from registry.Lookup
-//	c, err := a.Ingest(...)
-//
-// Every "warning: …" line the adapter writes during Ingest then picks up the
-// bold-yellow "⚠️ warning:" styling, identical to warnings the command emits
-// itself.
+// stderrSetter is the structural shape of adapter.WarnSink. Duplicated here
+// so ui doesn't depend on the adapter package; the adapter-package test
+// suites pin each concrete adapter to adapter.WarnSink at compile time, so
+// drift between the two definitions fails to build.
+type stderrSetter interface{ SetStderr(w io.Writer) }
+
+// RouteTo wires this writer into anything that exposes a
+// `SetStderr(io.Writer)` setter (matching adapter.WarnSink). Non-implementors
+// are silently no-op'd, so callers can pass any adapter.Adapter without
+// type-asserting first. Pair with a deferred Unroute to detach on return.
 func (s *WarnWriter) RouteTo(a any) {
-	type setter interface{ SetStderr(io.Writer) }
-	if v, ok := a.(setter); ok {
+	if v, ok := a.(stderrSetter); ok {
 		v.SetStderr(s)
+	}
+}
+
+// Unroute reverses a prior RouteTo by passing nil to the same setter, which
+// per the adapter.WarnSink contract resets the implementor to its default
+// sink (os.Stderr). Defensive: today's adapters are constructed fresh per
+// command via registryFactory(), but a caller that ever caches adapters
+// shouldn't leak this WarnWriter past the command's lifetime. No-op when the
+// target doesn't implement the setter, mirroring RouteTo.
+func (s *WarnWriter) Unroute(a any) {
+	if v, ok := a.(stderrSetter); ok {
+		v.SetStderr(nil)
 	}
 }
 


### PR DESCRIPTION
## Summary

Formalises the `SetStderr` plumbing the `import` styling work (#49) introduced on the concrete adapters, so future Ingest-using commands can reuse it in one line instead of redeclaring a private type-assertion interface each time. No behaviour change for users.

## What changed

| File | Change |
|---|---|
| `internal/adapter/adapter.go` | New `WarnSink` optional extension interface (sits beside `PluginIngester`). Implementors expose `SetStderr(io.Writer)`; `nil` MUST reset to the default (`os.Stderr`). |
| `internal/ui/ui.go` | New `WarnWriter.RouteTo(any)` helper — wires the styled writer into anything that satisfies the setter via a structural interface, so `ui` doesn't import `adapter`. Silently no-ops on adapters that don't implement it. |
| `internal/cli/import.go` | Drops the duplicated private `adapterStderrSetter` interface; replaces the four-line type assertion with `warnW.RouteTo(a)`. |
| `internal/cli/import_warn_routing_test.go` | New end-to-end test (`TestImport_StyledAdapterWarnings`): forces `--color=always`, plants a lenient-YAML skill, and asserts the adapter's own YAML-frontmatter warning reaches the buffer with the bold-yellow `⚠️ warning:` prefix. Three-way assertion (styled prefix present + content present + plain prefix absent) catches any single regression in the chain. |
| `docs/architecture.md` | Adds a `WarnSink (optional)` subsection next to `PluginIngester (read-only)`, documenting the contract and `nil`-resets-to-default rule for future adapter authors. |
| `CHANGELOG.md` | Entry under `[Unreleased]`. |

## Why now (and not before)

When #49 added the styling, each concrete adapter grew a `SetStderr(io.Writer)` method and `import.go` defined a private `adapterStderrSetter` interface to type-assert against it. That worked but lived in three places, was nowhere documented, and had no test locking it in — exactly the kind of plumbing that would silently regress the next time someone touched adapter construction. This change consolidates it before a second caller (e.g. a future reconcile that grows full-Ingest semantics) has to re-derive it.

## Why the test is load-bearing

Break-verified: removing `warnW.RouteTo(a)` from `import.go` fails the test with a clear message ("expected adapter warnings to be styled as bold-yellow ⚠️ warning:") — the YAML-frontmatter notice falls back to `os.Stderr`, doesn't reach the cobra-captured buffer, and the styled-prefix assertion catches it. Today the routing is invisible in CI because the captured-output tests never previously inspected the styled prefix; this test is the contract.

## Test plan

- [x] `go test ./internal/cli/... ./internal/ui/... ./internal/adapter/...` — all green.
- [x] Break-test: comment out `warnW.RouteTo(a)` → `TestImport_StyledAdapterWarnings` fails cleanly. Restore → green.
- [x] `go build ./...` clean.
- [x] No CLI surface change; no canonical schema change; no fixture changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_019oU2mskFW9aJvdNCq4DFcQ)_