### PR TITLE
chore(lint): fold fmt+tidy into `just lint` and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,24 @@ jobs:
       - uses: extractions/setup-just@v3
       - run: just test-release
 
+  # Lint = format + tidy + golangci-lint, via the same `just lint` recipe
+  # contributors run locally, then a diff guard so an uncommitted format/tidy
+  # change fails the build (CI and local can't drift).
   lint:
+    name: lint (fmt + tidy + golangci-lint)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          # Pin a known-good golangci-lint. Its release binary must be built
-          # with a Go >= our go.mod version, or it can't parse our export
-          # data; v2.12.2 ships built with Go 1.26. Bump deliberately.
-          version: v2.12.2
+      - uses: extractions/setup-just@v3
+      # golangci-lint is pinned inside the recipe (v2.12.2 via `go run`); its
+      # build needs a Go >= our go.mod version to parse this module's export
+      # data, which setup-go guarantees.
+      - run: just lint
+      - name: Verify formatting & go.mod/go.sum are committed
+        run: git diff --exit-code
 
   goreleaser-snapshot:
     name: goreleaser-snapshot (cross-build matrix)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,13 +187,16 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 
 - `just build` / `just test-fast`; full gate `just test-release` (hermetic container).
 - FS-touching tests refuse to run on host without `AGENTSYNC_TEST_IN_CONTAINER=1`.
-- Lint with `just lint`, which runs golangci-lint via `go run
-  github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...` —
-  pinned to the version CI's `golangci-lint-action` uses, so it self-bootstraps
-  (no separate install or PATH step) and can't drift from CI. `go run pkg@version`
-  resolves the tool outside the main module, so `go.mod`/`go.sum` stay untouched;
-  it compiles with the local Go toolchain (≥ go.mod's **1.26.2**), so it parses
-  our export data natively — no `GOTOOLCHAIN` override needed.
+- Lint/format/tidy with `just lint` — the single dev entry point. It rewrites Go
+  sources (`gofmt -s` + gofumpt) and deliberately tidies `go.mod`/`go.sum`
+  (`go mod tidy`) in place, then runs golangci-lint via `go run
+  github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`. The
+  linter self-bootstraps (no separate install or PATH step); `go run pkg@version`
+  resolves gofumpt and golangci-lint outside the main module, so *those* never
+  land in `go.mod`, and golangci-lint compiles with the local Go toolchain (≥
+  go.mod's **1.26.2**) so it parses our export data natively — no `GOTOOLCHAIN`
+  override needed. CI runs this exact recipe then `git diff --exit-code`, so an
+  uncommitted format/tidy change fails the build — local and CI can't drift.
 - `just test` (full unit/integration in container), `just test-e2e`,
   `just test-bdd`, `just test-live` (network, opt-in, not in the release gate).
 - Go version is `go.mod`'s `go` directive (currently **1.26.2**); CI reads it via
@@ -215,7 +218,7 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 - **Errors** wrap with `fmt.Errorf("doing X: %w", err)`; match with `errors.Is/As`.
   No `pkg/errors`.
 - **Imports** grouped stdlib / third-party / internal; gofumpt + goimports
-  formatting (`just fmt`).
+  formatting (applied by `just lint`).
 - **`time.Now()`** in `internal/render`/`internal/state` is confined to
   informational metadata (state `AppliedAt`, backup-dir names) — it never feeds a
   content hash or the drift classifier, so it calls `time.Now().UTC()` directly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,12 @@ AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run TestApply_FirstRun
 ## Lint & format
 
 ```bash
-just lint           # golangci-lint run ./...
-just fmt            # gofmt -s + gofumpt
-just tidy           # go mod tidy
+just lint           # format (gofmt -s + gofumpt) + tidy (go mod tidy) + golangci-lint
 ```
+
+`just lint` is the single pre-commit entry point — it rewrites your Go sources
+and `go.mod`/`go.sum` in place, then runs the linter. CI runs this exact recipe
+followed by `git diff --exit-code`, so commit whatever it changes.
 
 Test conventions enforced by lint (don't fight them):
 

--- a/justfile
+++ b/justfile
@@ -62,19 +62,19 @@ test-fast:
 test-live:
     AGENTSYNC_LIVE_PLUGIN_TEST=1 go test -tags=live -count=1 -v ./internal/marketplace/...
 
-# Run golangci-lint over every package. Pinned via `go run` (matches CI's
-# golangci-lint-action version) so no separate install/PATH step is needed.
+# Rewrites Go sources (gofmt -s + gofumpt) and go.mod/go.sum (go mod tidy) in
+# place, then runs golangci-lint, pinned via `go run` (matches the version CI
+# runs) so it self-bootstraps with no separate install/PATH step. `go run
+# pkg@version` resolves gofumpt and golangci-lint outside the main module, so
+# neither lands in go.mod — only `go mod tidy`'s deliberate edits do. CI runs
+# this exact recipe and then `git diff --exit-code`, so any uncommitted
+# format/tidy change fails the build — local and CI can't drift.
+# The defacto entry point: format + tidy + lint, run before every commit.
 lint:
-    go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
-
-# Format Go sources with gofmt + gofumpt.
-fmt:
     gofmt -w -s .
     go run mvdan.cc/gofumpt@v0.10.0 -w .
-
-# Run `go mod tidy`.
-tidy:
     go mod tidy
+    go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
 
 # --- Docs website (website/, Astro Starlight → agentsync.cc) ----------------
 # The site reads no Go; it's a bun + Astro project. `docs-dev`/`docs-build`


### PR DESCRIPTION
## Summary

Makes `just lint` the single defacto entry point for keeping code in shape, and has CI enforce it.

- `just lint` now **formats** (`gofmt -s` + gofumpt), **tidies** (`go mod tidy`), then runs **golangci-lint** — all inlined into one recipe.
- The standalone `fmt` and `tidy` recipes are **removed**. `just lint` is the one command to run before committing; there's no separate `just fmt` / `just tidy` to remember.
- The CI `lint` job now runs that exact recipe and then `git diff --exit-code`, so an uncommitted format/tidy change fails the build — local and CI can't drift.

### Tradeoff (intentional)

This replaces `golangci-lint-action` with `just lint`, so CI runs the *same* thing contributors run (zero drift). The cost: we lose the action's **inline PR annotations** and its dedicated lint cache. `actions/setup-go@v5` still caches the module/build cache, so golangci-lint isn't recompiled from scratch each run; findings now appear in the job log rather than as inline PR comments.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [x] Tests / CI / tooling

## Test plan

- [x] `just lint` runs all four steps end-to-end and reports `0 issues` (also confirms the justfile still parses after removing `fmt`/`tidy`).
- [x] `gofmt -s` and `gofumpt` are no-ops across the whole tree (incl. `testdata/`), and `go mod tidy -diff` shows `go.mod`/`go.sum` already tidy → the new diff guard is green on `main`.
- [x] `ci.yml` parses; lint steps resolve to `checkout → setup-go → setup-just → just lint → git diff --exit-code`.
- [ ] `just test-release` not re-run — this change is tooling/CI only and touches no Go source.

## Checklist

- [x] Conventional commit messages with a scope.
- [ ] Tests added/updated — n/a (tooling/CI change, no Go behavior changed).
- [x] Not a secrets/capture/`source.Write*` change.
- [x] Docs updated: `CONTRIBUTING.md` ("Lint & format") and `CLAUDE.md` (lint paragraph + the formatting note in "Code conventions").

🤖 Generated with [Claude Code](https://claude.com/claude-code)