### PR TITLE
chore(lint): apply gofumpt comment-indent rewrite to fix CI on every PR

### DIFF
--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -202,9 +202,9 @@ func TestIngest_RoundTripsMemory(t *testing.T) {
 // SetStderr(nil), captures os.Stderr via a pipe for the duration of
 // the second Ingest, and asserts:
 //
-//   (a) the previously-set buffer no longer receives the warning, AND
-//   (b) os.Stderr DOES — proving the reset goes to the default, not
-//       silently elsewhere.
+//	(a) the previously-set buffer no longer receives the warning, AND
+//	(b) os.Stderr DOES — proving the reset goes to the default, not
+//	    silently elsewhere.
 //
 // Without (b), a faulty SetStderr(nil) that routes to io.Discard
 // would pass the (a)-only test while quietly dropping every future


### PR DESCRIPTION
## Summary

Mechanical lint fix: PR #51 tightened `just lint` to run `gofmt -w -s . && gofumpt -w .` and assert `git diff --exit-code` in CI. PR #50 (which landed before #51) shipped a doc comment in `internal/adapter/claude/ingest_test.go` using 3-space indent on a list continuation:

```go
//   (a) the previously-set buffer no longer receives …
//   (b) os.Stderr DOES …
//       silently elsewhere.
```

gofumpt rewrites those to tab-indent on every run, so the lint step dirties the tree and the diff-check fails. **Every PR cut from current main inherits this failure regardless of what it touches.** PR #53 (a doc-only skill add) happened to be the one that surfaced it.

## Fix

Run the formatter, commit the diff. Three lines, zero behavioural change, no Go semantics affected.

```diff
-//   (a) the previously-set buffer no longer receives the warning, AND
-//   (b) os.Stderr DOES — proving the reset goes to the default, not
-//       silently elsewhere.
+//	(a) the previously-set buffer no longer receives the warning, AND
+//	(b) os.Stderr DOES — proving the reset goes to the default, not
+//	    silently elsewhere.
```

## Why a separate PR

So this can land first and unblock every in-flight branch (PR #53 and any other open PR) without waiting on review of unrelated changes. PR #53 will rebase clean once this merges.

## Test plan

- [x] `gofmt -w -s . && gofumpt -w . && go mod tidy` — only this file changes; no other drift in the tree.
- [ ] CI's `just lint` step passes — the diff-check should be clean after this lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_019oU2mskFW9aJvdNCq4DFcQ)_