### PR TITLE
fix(skills): quote review-loop description to suppress lenient YAML parse warning

### DIFF
--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-loop
-description: Multi-round adversarial code review loop — four specialized agents (correctness, adversarial, API design, test rigor) run in parallel against a PR, repeated until all four return `CLEAN — ship it` or a budgeted number of rounds (default 5) is exhausted. Use when the user wants a thorough review of a substantive PR — new interfaces, contract changes, load-bearing refactors — and has signalled they want both correctness AND polish. Heavy: up to 5 rounds × 4 agents = 20 sub-invocations, so not for tiny bug fixes, WIP sketches, or doc-only PRs. Invoke explicitly; do not auto-trigger from a generic "review this" request unless the user names the high-bar mandate.
+description: 'Multi-round adversarial code review loop — four specialized agents (correctness, adversarial, API design, test rigor) run in parallel against a PR, repeated until all four return `CLEAN — ship it` or a budgeted number of rounds (default 5) is exhausted. Use when the user wants a thorough review of a substantive PR — new interfaces, contract changes, load-bearing refactors — and has signalled they want both correctness AND polish. Heavy: up to 5 rounds × 4 agents = 20 sub-invocations, so not for tiny bug fixes, WIP sketches, or doc-only PRs. Invoke explicitly; do not auto-trigger from a generic "review this" request unless the user names the high-bar mandate.'
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

- The `review-loop` skill's frontmatter description contained `Heavy: up to 5 rounds × 4 agents` — an unquoted colon-space (`: `) that fails strict YAML parsing.
- `agentsync import claude` would fall back to the lenient line-oriented parser and emit: `⚠️ warning: skill "review-loop" frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')`.
- Fix: wrap the description value in single quotes so it parses cleanly under `sigs.k8s.io/yaml`.

## Test plan

- [ ] `agentsync import claude --scope project` completes with no YAML warning for this skill