### PR TITLE
fix(render): apply --scope project writes only project-scope items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   project`/`--project` with no `.agentsync/` tree is a hard error pointing at
   `init --scope project`, never a silent downgrade to user scope.
 
+### Fixed
+
+- **`apply --scope project` now renders only project-scope items.** Previously
+  `project.Merge` never populated `Canonical.Project`, so all three adapter
+  `Render` methods wrote the full merged canonical (user + project items) into
+  the project directory. `apply --scope project` now correctly writes only the
+  project-overlay items (`<root>/.agentsync/` content) to `<root>/.claude/`,
+  mirroring how Claude Code, OpenCode, and Codex each read user-scope config
+  from their own global directories at runtime. This also fixes `status`,
+  `diff`, and `reconcile` at project scope, which use the same render path.
+
 ### Changed
 
 - **The M5 single-file `.agentsync.toml` project marker is retired** (one project

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -16,53 +16,61 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	paths := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 
+	// At project scope render only the project-overlay items; the merged
+	// canonical includes user-scope items that Claude Code already reads from
+	// ~/.claude/ and must not be duplicated into <project>/.claude/.
+	renderC := c
+	if scope == adapter.ScopeProject && c.Project != nil {
+		renderC = *c.Project
+	}
+
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 
 	// 1. MCP -> .claude.json (user) or settings.json (project)
-	if mcpOps, err := a.renderMCP(c, paths, scope); err != nil {
+	if mcpOps, err := a.renderMCP(renderC, paths, scope); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, mcpOps...)
 	}
 
 	// 2. Memory -> CLAUDE.md
-	if memOps, err := a.renderMemory(c, paths); err != nil {
+	if memOps, err := a.renderMemory(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, memOps...)
 	}
 
 	// 3. Skills -> ~/.claude/skills/<name>/SKILL.md
-	if skillOps, err := a.renderSkills(c, paths); err != nil {
+	if skillOps, err := a.renderSkills(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, skillOps...)
 	}
 
 	// 4. Subagents -> ~/.claude/agents/<name>.md
-	if subagentOps, err := a.renderSubagents(c, paths); err != nil {
+	if subagentOps, err := a.renderSubagents(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, subagentOps...)
 	}
 
 	// 5. Commands -> ~/.claude/commands/<name>.md
-	if cmdOps, err := a.renderCommands(c, paths); err != nil {
+	if cmdOps, err := a.renderCommands(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, cmdOps...)
 	}
 
 	// 6. Hooks -> settings.json /hooks/<event>
-	if hookOps, err := a.renderHooks(c, paths); err != nil {
+	if hookOps, err := a.renderHooks(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, hookOps...)
 	}
 
 	// 7. LSP servers -> settings.json /lspServers/<id>
-	if lspOps, err := a.renderLSP(c, paths); err != nil {
+	if lspOps, err := a.renderLSP(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, lspOps...)

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -207,6 +207,56 @@ func TestRender_LSP_EmptyProducesNoOp(t *testing.T) {
 	}
 }
 
+// TestRender_ProjectScope_OnlyProjectItems verifies that apply --scope project
+// writes only the project-overlay items (c.Project) to the project directory,
+// not the merged canonical that also includes user-scope items.
+func TestRender_ProjectScope_OnlyProjectItems(t *testing.T) {
+	projSkill := source.Skill{
+		Name:        "proj-review",
+		Frontmatter: map[string]any{"name": "proj-review", "description": "project skill"},
+		Body:        "Project review.\n",
+	}
+	projRoot := t.TempDir()
+	projCanon := source.Canonical{
+		Skills: []source.Skill{projSkill},
+	}
+	// Merged canonical has both a user skill and the project skill, with
+	// Project set to the project-only canonical — exactly what project.Merge
+	// produces after the fix.
+	merged := source.Canonical{
+		Skills: []source.Skill{
+			{Name: "user-skill", Frontmatter: map[string]any{"name": "user-skill"}, Body: "User skill.\n"},
+			projSkill,
+		},
+		Project: &projCanon,
+	}
+
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, projRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	skillPaths := map[string]bool{}
+	for _, op := range ops {
+		if strings.Contains(op.Path, "/skills/") {
+			skillPaths[op.Path] = true
+		}
+	}
+	if skillPaths[strings.Join([]string{projRoot, ".claude", "skills", "user-skill", "SKILL.md"}, "/")] {
+		t.Fatalf("user-scope skill must not be written at project scope: %v", skillPaths)
+	}
+	found := false
+	for p := range skillPaths {
+		if strings.Contains(p, "proj-review") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("project skill not rendered at project scope: ops=%+v", ops)
+	}
+}
+
 func TestRender_Hooks_WritesSettingsJSON(t *testing.T) {
 	c := source.Canonical{
 		Hooks: []source.Hook{

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -2,6 +2,7 @@ package claude_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -237,23 +238,20 @@ func TestRender_ProjectScope_OnlyProjectItems(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	skillPaths := map[string]bool{}
+	wantUserSkill := filepath.Join(projRoot, ".claude", "skills", "user-skill", "SKILL.md")
+	wantProjSkill := filepath.Join(projRoot, ".claude", "skills", "proj-review", "SKILL.md")
+
+	var gotProjSkill bool
 	for _, op := range ops {
-		if strings.Contains(op.Path, "/skills/") {
-			skillPaths[op.Path] = true
+		if op.Path == wantUserSkill {
+			t.Fatalf("user-scope skill must not be written at project scope: %s", op.Path)
+		}
+		if op.Path == wantProjSkill {
+			gotProjSkill = true
 		}
 	}
-	if skillPaths[strings.Join([]string{projRoot, ".claude", "skills", "user-skill", "SKILL.md"}, "/")] {
-		t.Fatalf("user-scope skill must not be written at project scope: %v", skillPaths)
-	}
-	found := false
-	for p := range skillPaths {
-		if strings.Contains(p, "proj-review") {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("project skill not rendered at project scope: ops=%+v", ops)
+	if !gotProjSkill {
+		t.Fatalf("project skill not rendered at project scope; want op at %s, ops=%+v", wantProjSkill, ops)
 	}
 }
 

--- a/internal/adapter/codex/render.go
+++ b/internal/adapter/codex/render.go
@@ -20,44 +20,52 @@ import (
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+
+	// At project scope render only the project-overlay items so user-scope
+	// items are not duplicated into the project directory.
+	renderC := c
+	if scope == adapter.ScopeProject && c.Project != nil {
+		renderC = *c.Project
+	}
+
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 
-	if mcpOps, err := a.renderMCP(c, p); err != nil {
+	if mcpOps, err := a.renderMCP(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, mcpOps...)
 	}
-	if memOps, err := a.renderMemory(c, p); err != nil {
+	if memOps, err := a.renderMemory(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, memOps...)
 	}
-	if skOps, err := a.renderSkills(c, p); err != nil {
+	if skOps, err := a.renderSkills(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, skOps...)
 	}
-	if saOps, saSkips, err := a.renderSubagents(c, p); err != nil {
+	if saOps, saSkips, err := a.renderSubagents(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, saOps...)
 		skips = append(skips, saSkips...)
 	}
-	if cmdOps, cmdSkips, err := a.renderCommands(c, p, scope); err != nil {
+	if cmdOps, cmdSkips, err := a.renderCommands(renderC, p, scope); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, cmdOps...)
 		skips = append(skips, cmdSkips...)
 	}
-	if hookOps, hookSkips, err := a.renderHooks(c, p); err != nil {
+	if hookOps, hookSkips, err := a.renderHooks(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, hookOps...)
 		skips = append(skips, hookSkips...)
 	}
 	// LSP: Codex has no LSP concept — skip with explanation.
-	for _, l := range c.LSPServers {
+	for _, l := range renderC.LSPServers {
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "Codex has no LSP configuration concept",

--- a/internal/adapter/codex/render_test.go
+++ b/internal/adapter/codex/render_test.go
@@ -2,6 +2,7 @@ package codex_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -287,6 +288,49 @@ func TestRender_Hooks_KnownAndUnknownEvents(t *testing.T) {
 // ---------------------------------------------------------------------------
 // LSP — always skipped
 // ---------------------------------------------------------------------------
+
+// TestRender_ProjectScope_OnlyProjectItems verifies that at project scope the
+// adapter renders only the project-overlay items (c.Project), not the merged
+// canonical that also includes user-scope items.
+func TestRender_ProjectScope_OnlyProjectItems(t *testing.T) {
+	projSkill := source.Skill{
+		Name:        "proj-skill",
+		Frontmatter: map[string]any{"name": "proj-skill", "description": "project skill"},
+		Body:        "Project skill.\n",
+	}
+	projRoot := t.TempDir()
+	projCanon := source.Canonical{Skills: []source.Skill{projSkill}}
+	merged := source.Canonical{
+		Skills: []source.Skill{
+			{Name: "user-skill", Frontmatter: map[string]any{"name": "user-skill"}, Body: "User skill.\n"},
+			projSkill,
+		},
+		Project: &projCanon,
+	}
+
+	a := codex.New(codex.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, projRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Codex skills live under <project>/.agents/skills/ at project scope.
+	wantUserSkill := filepath.Join(projRoot, ".agents", "skills", "user-skill", "SKILL.md")
+	wantProjSkill := filepath.Join(projRoot, ".agents", "skills", "proj-skill", "SKILL.md")
+
+	var gotProjSkill bool
+	for _, op := range ops {
+		if op.Path == wantUserSkill {
+			t.Fatalf("user-scope skill must not be written at project scope: %s", op.Path)
+		}
+		if op.Path == wantProjSkill {
+			gotProjSkill = true
+		}
+	}
+	if !gotProjSkill {
+		t.Fatalf("project skill not rendered; want op at %s, ops=%+v", wantProjSkill, ops)
+	}
+}
 
 func TestRender_LSP_Skipped(t *testing.T) {
 	c := source.Canonical{LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}}}

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -14,45 +14,53 @@ import (
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
+
+	// At project scope render only the project-overlay items so user-scope
+	// items are not duplicated into the project directory.
+	renderC := c
+	if scope == adapter.ScopeProject && c.Project != nil {
+		renderC = *c.Project
+	}
+
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 
-	if mcpOps, err := a.renderMCP(c, p); err != nil {
+	if mcpOps, err := a.renderMCP(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, mcpOps...)
 	}
-	if memOps, err := a.renderMemory(c, p); err != nil {
+	if memOps, err := a.renderMemory(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, memOps...)
 	}
-	if skOps, err := a.renderSkills(c, p); err != nil {
+	if skOps, err := a.renderSkills(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, skOps...)
 	}
-	if saOps, saSkips, err := a.renderSubagents(c, p); err != nil {
+	if saOps, saSkips, err := a.renderSubagents(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, saOps...)
 		skips = append(skips, saSkips...)
 	}
-	if cmdOps, cmdSkips, err := a.renderCommands(c, p); err != nil {
+	if cmdOps, cmdSkips, err := a.renderCommands(renderC, p); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, cmdOps...)
 		skips = append(skips, cmdSkips...)
 	}
 	// Hooks: skip with explanation.
-	for _, h := range c.Hooks {
+	for _, h := range renderC.Hooks {
 		skips = append(skips, adapter.Skip{
 			Component: "hook", Name: h.Event,
 			Reason: "OpenCode hooks are JS/TS plugins; shim generation deferred to post-v1",
 		})
 	}
 	// LSP: skip with explanation.
-	for _, l := range c.LSPServers {
+	for _, l := range renderC.LSPServers {
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "OpenCode LSP projection deferred to v1.x",

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -396,12 +396,13 @@ func TestRender_ProjectScope_OnlyProjectItems(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantUserSkill := filepath.Join(projRoot, ".claude", "skills", "user-skill", "SKILL.md")
+	// OpenCode shares Claude's skills dir (.claude/skills/) at project scope.
+	wantExcluded := filepath.Join(projRoot, ".claude", "skills", "user-skill", "SKILL.md")
 	wantProjSkill := filepath.Join(projRoot, ".claude", "skills", "proj-skill", "SKILL.md")
 
 	var gotProjSkill bool
 	for _, op := range ops {
-		if op.Path == wantUserSkill {
+		if op.Path == wantExcluded {
 			t.Fatalf("user-scope skill must not be written at project scope: %s", op.Path)
 		}
 		if op.Path == wantProjSkill {

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -2,6 +2,7 @@ package opencode_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -363,6 +364,52 @@ func TestRender_Command_BodyPreserved(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("lint.md op missing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Project scope — only project items rendered
+// ---------------------------------------------------------------------------
+
+// TestRender_ProjectScope_OnlyProjectItems verifies that at project scope the
+// adapter renders only the project-overlay items (c.Project), not the merged
+// canonical that also includes user-scope items.
+func TestRender_ProjectScope_OnlyProjectItems(t *testing.T) {
+	projSkill := source.Skill{
+		Name:        "proj-skill",
+		Frontmatter: map[string]any{"name": "proj-skill", "description": "project skill"},
+		Body:        "Project skill.\n",
+	}
+	projRoot := t.TempDir()
+	projCanon := source.Canonical{Skills: []source.Skill{projSkill}}
+	merged := source.Canonical{
+		Skills: []source.Skill{
+			{Name: "user-skill", Frontmatter: map[string]any{"name": "user-skill"}, Body: "User skill.\n"},
+			projSkill,
+		},
+		Project: &projCanon,
+	}
+
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, projRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantUserSkill := filepath.Join(projRoot, ".claude", "skills", "user-skill", "SKILL.md")
+	wantProjSkill := filepath.Join(projRoot, ".claude", "skills", "proj-skill", "SKILL.md")
+
+	var gotProjSkill bool
+	for _, op := range ops {
+		if op.Path == wantUserSkill {
+			t.Fatalf("user-scope skill must not be written at project scope: %s", op.Path)
+		}
+		if op.Path == wantProjSkill {
+			gotProjSkill = true
+		}
+	}
+	if !gotProjSkill {
+		t.Fatalf("project skill not rendered; want op at %s, ops=%+v", wantProjSkill, ops)
 	}
 }
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -157,7 +157,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 				fmt.Fprintf(w, "  %s\n", r.String())
 			}
 		}
-		report := render.BuildReport(c, plan, agents)
+		report := render.BuildReport(reportCanonical(c, sc), plan, agents)
 		if len(report.Rows) > 0 {
 			fmt.Fprintln(w)
 			report.PrintTextStyled(w, p)
@@ -227,7 +227,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	} else {
 		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("applied: %d ops", plan.Total())))
 	}
-	report := render.BuildReport(c, plan, agents)
+	report := render.BuildReport(reportCanonical(c, sc), plan, agents)
 	if len(report.Rows) > 0 {
 		fmt.Fprintln(w)
 		report.PrintTextStyled(w, p)
@@ -527,4 +527,15 @@ func sameDir(a, b string) bool {
 		cb = rb
 	}
 	return ca == cb
+}
+
+// reportCanonical returns the canonical to pass to render.BuildReport. At
+// project scope the report should reflect what was actually rendered (the
+// project-only overlay), not the merged canonical which includes user-scope
+// items the adapters never wrote to the project directory.
+func reportCanonical(c source.Canonical, sc adapter.Scope) source.Canonical {
+	if sc == adapter.ScopeProject && c.Project != nil {
+		return *c.Project
+	}
+	return c
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -111,6 +111,7 @@ func Merge(base, proj source.Canonical) source.Canonical {
 	// also writing user-scope items there. secretFields/cloneForResolve already
 	// handle c.Project; this was simply never set.
 	projCopy := proj
+	projCopy.Project = nil // prevent accidental nesting if proj itself came from a Merge
 	out.Project = &projCopy
 
 	return out

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -105,6 +105,14 @@ func Merge(base, proj source.Canonical) source.Canonical {
 	out.Commands = overlayByKey(base.Commands, proj.Commands, func(c source.Command) string { return c.Name })
 	out.Hooks = overlayHooks(base.Hooks, proj.Hooks)
 	out.Memory = overlayMemory(base.Memory, proj.Memory)
+
+	// Store the project-only canonical so scope-aware render paths (apply
+	// --scope project) can render proj items to the project directory without
+	// also writing user-scope items there. secretFields/cloneForResolve already
+	// handle c.Project; this was simply never set.
+	projCopy := proj
+	out.Project = &projCopy
+
 	return out
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -271,3 +271,37 @@ func TestMerge_DoesNotMutateBase(t *testing.T) {
 		t.Fatal("Merge mutated base MCPServers slice")
 	}
 }
+
+// TestMerge_StoresProjectOverlay verifies that Merge populates out.Project with
+// the project-only canonical so scope-aware render paths can distinguish which
+// items originated from the project vs the user.
+func TestMerge_StoresProjectOverlay(t *testing.T) {
+	base := source.Canonical{
+		Skills:     []source.Skill{{Name: "user-skill", Body: "user"}},
+		MCPServers: []source.MCPServer{{ID: "user-mcp", Server: source.MCPServerSpec{Command: "user-cmd"}}},
+	}
+	proj := source.Canonical{
+		Skills:     []source.Skill{{Name: "proj-skill", Body: "proj"}},
+		MCPServers: []source.MCPServer{{ID: "proj-mcp", Server: source.MCPServerSpec{Command: "proj-cmd"}}},
+	}
+	out := project.Merge(base, proj)
+
+	// Merged result contains items from both scopes.
+	if len(out.Skills) != 2 {
+		t.Fatalf("expected 2 merged skills, got %d", len(out.Skills))
+	}
+	if len(out.MCPServers) != 2 {
+		t.Fatalf("expected 2 merged MCP servers, got %d", len(out.MCPServers))
+	}
+
+	// out.Project must be non-nil and hold only the project-scope items.
+	if out.Project == nil {
+		t.Fatal("Merge must set out.Project to the project-only canonical")
+	}
+	if len(out.Project.Skills) != 1 || out.Project.Skills[0].Name != "proj-skill" {
+		t.Fatalf("Project.Skills should contain only project skills: %+v", out.Project.Skills)
+	}
+	if len(out.Project.MCPServers) != 1 || out.Project.MCPServers[0].ID != "proj-mcp" {
+		t.Fatalf("Project.MCPServers should contain only project servers: %+v", out.Project.MCPServers)
+	}
+}

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -16,7 +16,12 @@ type Canonical struct {
 	Plugins      []Plugin
 	Marketplaces []Marketplace
 	Memory       Memory
-	Project      *Canonical // nil for user-scope canonical; populated by M5 overlay
+	// Project holds the project-only canonical set by project.Merge. It is nil
+	// for a user-scope canonical (one loaded directly from ~/.agentsync/ without
+	// a project overlay). Scope-aware render paths (apply/status/diff/reconcile
+	// --scope project) render from Project instead of the merged canonical so
+	// user-scope items are not duplicated into the project directory.
+	Project *Canonical
 }
 
 // Config mirrors agentsync.toml at the root of ~/.agentsync/.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `apply --scope project` was writing all merged (user + project) items into the project directory. Claude Code, OpenCode, and Codex each read user-scope config from their own global directories at runtime, so duplicating user items into the project dir was both wrong and redundant.
- Root cause: `project.Merge` built the merged canonical but never populated `Canonical.Project` — the field that exists precisely to hold the project-only overlay for scope-aware render paths.
- Fix: `Merge` now sets `out.Project = &projCopy` (with `projCopy.Project = nil` to prevent nesting). All three adapter `Render` methods switch to `renderC = *c.Project` when `scope == ScopeProject && c.Project != nil`. The translation report (`BuildReport`) is also fixed to use the project-only canonical at project scope via a new `reportCanonical` helper in `apply.go`.

## What changed

- **`internal/project/project.go`** — `Merge` stores the project-only canonical in `out.Project`
- **`internal/adapter/claude/render.go`**, **`opencode/render.go`**, **`codex/render.go`** — render from `c.Project` at project scope
- **`internal/cli/apply.go`** — `reportCanonical(c, sc)` ensures the translation report counts project-only items at project scope
- **`internal/source/schema.go`** — `Canonical.Project` field comment updated (was stale "M5 overlay" language)
- **Tests** — `TestMerge_StoresProjectOverlay`; `TestRender_ProjectScope_OnlyProjectItems` for all three adapters (with `filepath.Join`-anchored path assertions and load-bearing negative assertions)

## Test plan

- [ ] `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/project/... ./internal/adapter/claude/... ./internal/adapter/opencode/... ./internal/adapter/codex/... ./internal/cli/... ./internal/render/...` — all green
- [ ] `GOTOOLCHAIN=go1.26.2 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...` — 0 issues
- [ ] Manually: `agentsync import claude --scope project` followed by `agentsync apply --scope project --dry-run` should show only project-scoped items (not 626 merged ops)

https://claude.ai/code/session_01HKutfkaB4JYtXixumquhhF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKutfkaB4JYtXixumquhhF)_