### PR TITLE
build(docs): clean website/dist before docs-publish rebuild

### DIFF
--- a/justfile
+++ b/justfile
@@ -102,11 +102,11 @@ docs-sync:
     cd website && bun run sync:docs
 
 # Publish the built docs site to the gh-pages branch — GitHub Pages "deploy from a
-# branch", which costs no GitHub Actions minutes. Builds, then force-pushes
-# website/dist as a single commit to origin/gh-pages. (.nojekyll + CNAME ship in
-# website/public/, so the output is served as-is.)
+# branch", which costs no GitHub Actions minutes. Cleans website/dist, rebuilds,
+# then force-pushes it as a single commit to origin/gh-pages. (.nojekyll + CNAME
+# ship in website/public/, so the output is served as-is.)
 docs-publish:
-    cd website && { [ -d node_modules ] || bun install; } && bun run build
+    cd website && rm -rf dist && { [ -d node_modules ] || bun install; } && bun run build
     REMOTE="$(git remote get-url origin)"; cd website/dist && git init -q && git add -A && git -c user.name="agentsync docs" -c user.email="docs@users.noreply.github.com" commit -qm "deploy agentsync.cc docs" && git push -f "$REMOTE" HEAD:gh-pages && rm -rf .git
 
 # Full CI gate: lint + the hermetic release suite + the cross-build matrix.


### PR DESCRIPTION
## What

`just docs-publish` now removes `website/dist` before rebuilding the docs site.

## Why

`docs-publish` force-pushes the contents of `website/dist` wholesale to the
`gh-pages` branch. Without a clean step, a stale `dist/` from a previous build
could carry files that no longer exist in the source — and those would get
republished. Cleaning first guarantees each publish reflects a fresh, complete
build.

The clean is scoped to `website/dist` only (not the broader `just clean`
recipe, which also removes `bin/`/coverage and is unrelated to docs).

## Changes

- `justfile`: `docs-publish` runs `rm -rf dist` before `bun run build`; comment
  updated to read "Cleans website/dist, rebuilds, then force-pushes it".

## Test plan

- [x] `just --list` parses the justfile without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)