### PR TITLE
fix(adapter): place project-scope MCP/config where Claude & OpenCode actually read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Claude project-scope MCP servers now target `<root>/.mcp.json`, not
+  `<root>/.claude/settings.json`.** Per the upstream Claude Code MCP-scope docs,
+  project-scope servers live in a repo-root `.mcp.json` (the file `claude mcp add
+  --scope project` writes and the team checks in); `settings.json` holds
+  hooks/LSP/permissions, never project MCP. The Claude adapter previously both
+  rendered and ingested project MCP at `settings.json`, so `apply --scope
+  project` wrote to a file Claude Code does not read project MCP from, and
+  `import claude:mcp --scope project` missed servers added via Claude's own
+  `--scope project` flow. Render and ingest now use `.mcp.json` at project scope
+  (top-level `mcpServers`, `merge-json-keys` so a hand-authored file's foreign
+  keys and unmodeled per-server fields like `timeout` survive); user scope
+  (`~/.claude.json`) is unchanged. A stale `mcpServers` block a prior version
+  wrote into a project `settings.json` is left untouched — remove it by hand.
 - **`apply --scope project` now renders only project-scope items.** Previously
   `project.Merge` never populated `Canonical.Project`, so all three adapter
   `Render` methods wrote the full merged canonical (user + project items) into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   adapter's `ResolvePaths` falls through to *user*-scope paths when the project
   root is empty, so a `(ScopeProject, "")` reaching an adapter would silently
   write the project overlay into the user's global config (or read it from
-  there). `Render` and `Ingest` on all three adapters (claude, opencode, codex)
-  now call the shared `adapter.RequireProjectRoot` first and return
-  `ErrProjectRootRequired` instead. The CLI already guarantees a non-empty root
-  for project scope, so this is defense-in-depth against a future or non-CLI
-  caller — turning a silent wrong-scope I/O into a loud error.
+  there). Every scope-resolving adapter method — `Render`, `Ingest`, and
+  `IngestPlugins` (claude, opencode, codex) — now calls the shared
+  `adapter.RequireProjectRoot` first and returns `ErrProjectRootRequired`
+  instead. The CLI already guarantees a non-empty root for project scope, so
+  this is defense-in-depth against a future or non-CLI caller — turning a silent
+  wrong-scope I/O into a loud error.
 - **Claude project-scope MCP servers now target `<root>/.mcp.json`, not
   `<root>/.claude/settings.json`.** Per the upstream Claude Code MCP-scope docs,
   project-scope servers live in a repo-root `.mcp.json` (the file `claude mcp add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,12 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   `--scope project` flow. Render and ingest now use `.mcp.json` at project scope
   (top-level `mcpServers`, `merge-json-keys` so a hand-authored file's foreign
   keys and unmodeled per-server fields like `timeout` survive); user scope
-  (`~/.claude.json`) is unchanged. A stale `mcpServers` block a prior version
-  wrote into a project `settings.json` is left untouched — remove it by hand.
+  (`~/.claude.json`) is unchanged. If a prior version already wrote project MCP
+  into a project `settings.json`, the next `apply --scope project` of an
+  in-place upgrade removes that stale `mcpServers` block automatically via
+  orphan-key cleanup — agentsync still owns those keys in state, and foreign
+  keys in the file are preserved; if the state was not carried over (e.g. a
+  fresh clone), remove the block by hand.
 - **OpenCode project-scope config now targets `<root>/opencode.json`, not
   `<root>/.opencode/opencode.json`.** Per the upstream OpenCode config docs, a
   repo's JSON config is `opencode.json` at the project **root**; OpenCode does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   keys and unmodeled per-server fields like `timeout` survive); user scope
   (`~/.claude.json`) is unchanged. A stale `mcpServers` block a prior version
   wrote into a project `settings.json` is left untouched — remove it by hand.
+- **OpenCode project-scope config now targets `<root>/opencode.json`, not
+  `<root>/.opencode/opencode.json`.** Per the upstream OpenCode config docs, a
+  repo's JSON config is `opencode.json` at the project **root**; OpenCode does
+  not read `.opencode/opencode.json` (the `.opencode/` directory holds only the
+  `agents/`/`commands/`/`skills/` subdirs, which were already correct). The
+  adapter previously rendered/ingested project-scope MCP servers (the only
+  structured config it writes) at `.opencode/opencode.json`, so `apply --scope
+  project` wrote them where OpenCode never looks and `import`/`reconcile --scope
+  project` read the wrong file. Same class of bug as the Claude project-MCP fix
+  above; user scope (`~/.config/opencode/opencode.json`) is unchanged.
 - **`apply --scope project` now renders only project-scope items.** Previously
   `project.Merge` never populated `Canonical.Project`, so all three adapter
   `Render` methods wrote the full merged canonical (user + project items) into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Fixed
 
+- **Adapters fail loud on a project-scope call with no project root.** Every
+  adapter's `ResolvePaths` falls through to *user*-scope paths when the project
+  root is empty, so a `(ScopeProject, "")` reaching an adapter would silently
+  write the project overlay into the user's global config (or read it from
+  there). `Render` and `Ingest` on all three adapters (claude, opencode, codex)
+  now call the shared `adapter.RequireProjectRoot` first and return
+  `ErrProjectRootRequired` instead. The CLI already guarantees a non-empty root
+  for project scope, so this is defense-in-depth against a future or non-CLI
+  caller — turning a silent wrong-scope I/O into a loud error.
 - **Claude project-scope MCP servers now target `<root>/.mcp.json`, not
   `<root>/.claude/settings.json`.** Per the upstream Claude Code MCP-scope docs,
   project-scope servers live in a repo-root `.mcp.json` (the file `claude mcp add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   adapter's `ResolvePaths` falls through to *user*-scope paths when the project
   root is empty, so a `(ScopeProject, "")` reaching an adapter would silently
   write the project overlay into the user's global config (or read it from
-  there). Every scope-resolving adapter method — `Render`, `Ingest`, and
-  `IngestPlugins` (claude, opencode, codex) — now calls the shared
+  there). Every scope-resolving adapter method — `Render` and `Ingest` (claude,
+  opencode, codex), plus `IngestPlugins` (claude, codex) — now calls the shared
   `adapter.RequireProjectRoot` first and returns `ErrProjectRootRequired`
   instead. The CLI already guarantees a non-empty root for project scope, so
   this is defense-in-depth against a future or non-CLI caller — turning a silent

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,12 +99,12 @@ Two design points worth internalizing:
 - **Project scope requires a project root.** Each adapter's `ResolvePaths` falls
   through to *user*-scope paths when the project root is empty, so a
   `(ScopeProject, "")` call would silently write the project overlay into the
-  user's global config. Every path-resolving adapter calls
-  `adapter.RequireProjectRoot` first thing in `Render`/`Ingest` and returns
-  `ErrProjectRootRequired` instead — a loud failure at the narrowest waist rather
-  than a silent wrong-scope write. The CLI's `resolveScope` already guarantees a
-  non-empty root for project scope, so this is defense-in-depth against a future
-  or non-CLI caller.
+  user's global config. Every scope-resolving adapter method —
+  `Render`, `Ingest`, and `IngestPlugins` — calls `adapter.RequireProjectRoot`
+  first thing and returns `ErrProjectRootRequired` instead — a loud failure at
+  the narrowest waist rather than a silent wrong-scope I/O. The CLI's
+  `resolveScope` already guarantees a non-empty root for project scope, so this
+  is defense-in-depth against a future or non-CLI caller.
 
 `Capability` is a bitmask, so the OpenCode adapter simply omits `CapHook` and
 `CapLSP` (and the Codex adapter omits `CapLSP` — Codex has no LSP concept) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,15 @@ Two design points worth internalizing:
   doesn't yet own, before overwriting). A `forbidigo` lint rule fails any direct
   write outside the allowed packages, so a new adapter can't regress the backup
   guarantee.
+- **Project scope requires a project root.** Each adapter's `ResolvePaths` falls
+  through to *user*-scope paths when the project root is empty, so a
+  `(ScopeProject, "")` call would silently write the project overlay into the
+  user's global config. Every path-resolving adapter calls
+  `adapter.RequireProjectRoot` first thing in `Render`/`Ingest` and returns
+  `ErrProjectRootRequired` instead — a loud failure at the narrowest waist rather
+  than a silent wrong-scope write. The CLI's `resolveScope` already guarantees a
+  non-empty root for project scope, so this is defense-in-depth against a future
+  or non-CLI caller.
 
 `Capability` is a bitmask, so the OpenCode adapter simply omits `CapHook` and
 `CapLSP` (and the Codex adapter omits `CapLSP` — Codex has no LSP concept) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,8 @@ the pipeline reports those components as skipped.
 
 **Key-merge strategies and on-disk format.** `KeyMergeStrategy` /
 `FileOp.MergeStrategy` name how an adapter co-owns keys inside a shared config
-file: `merge-json-keys` (Claude's `.claude.json`/`settings.json`),
+file: `merge-json-keys` (Claude's `.claude.json`/`settings.json`, and a
+project's repo-root `.mcp.json` for project-scope MCP servers),
 `merge-jsonc-keys` (OpenCode's comment-tolerant `opencode.json`), and
 `merge-toml-keys` (Codex's `config.toml`). The merge *currency* is always a
 `map[string]any` decoded from the rendered op's JSON `Content`, so the

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -63,7 +63,7 @@ Component support across agents.
 
 | Component | Claude | OpenCode | Codex | Cursor[^planned] |
 |---|:--:|:--:|:--:|:--:|
-| **MCP server** | ✓ `~/.claude.json` | ✓ `opencode.json` | ✓ `config.toml` | ✓ `.cursor/mcp.json` |
+| **MCP server** | ✓ `~/.claude.json` (user) · `.mcp.json` (project) | ✓ `opencode.json` | ✓ `config.toml` | ✓ `.cursor/mcp.json` |
 | **Memory** | ✓ `CLAUDE.md` | ✓ `AGENTS.md` | ✓ `~/.codex/AGENTS.md` | ◐ `AGENTS.md` |
 | **Skill** | ✓ `~/.claude/skills/X/` (dir) | ✓ shared `.claude/skills/` | ✓ `~/.agents/skills/` | ✓ `.cursor/skills/` |
 | **Subagent** | ✓ `~/.claude/agents/X.md` | ◐ frontmatter munged | ◐ markdown → TOML | ◐ `.cursor/agents/` |

--- a/docs/components.md
+++ b/docs/components.md
@@ -101,8 +101,9 @@ interface funnels all destination writes through the foreign-collision backup.
 
 ### `internal/adapter/claude`
 The reference adapter — all seven components including LSP, with per-key merge
-into shared JSON files (`~/.claude.json`, `settings.json`) that preserves
-foreign keys. `IngestPlugins` reads `enabledPlugins` / `extraKnownMarketplaces`
+into shared JSON files (`~/.claude.json`, `settings.json`, and a project's
+repo-root `.mcp.json` for project-scope MCP servers) that preserves foreign
+keys. `IngestPlugins` reads `enabledPlugins` / `extraKnownMarketplaces`
 to discover plugins on `import`; Render projects each plugin's components to
 Claude's native paths (`~/.claude/skills/<name>/`, `mcpServers` in
 `.claude.json`, …) and deliberately leaves the enablement keys themselves

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -474,7 +474,7 @@ user config:
 ```bash
 cd ~/code/myrepo
 agentsync apply --scope project   # walks up from cwd to the .agentsync/ tree
-ls .claude/settings.json          # project-scope config landed
+ls .mcp.json                      # project-scope MCP servers landed (repo root)
 ```
 
 Commands default to **user** scope. Project scope is never auto-applied: pass

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -4,11 +4,32 @@
 package adapter
 
 import (
+	"errors"
 	"io"
 
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// ErrProjectRootRequired is returned by RequireProjectRoot (and thus by every
+// adapter's Render/Ingest) when a project-scope call supplies no project root.
+var ErrProjectRootRequired = errors.New("adapter: project scope requires a non-empty project root")
+
+// RequireProjectRoot guards the adapter boundary against a project-scope call
+// with an empty project root. Every adapter resolves its destinations via a
+// ResolvePaths that falls through to USER-scope paths when project == "" — so a
+// caller reaching an adapter with (ScopeProject, "") would SILENTLY write the
+// project overlay into the user's global config (or read it from there). The
+// CLI's resolveScope already guarantees a non-empty root for project scope; this
+// is the belt-and-suspenders that turns a future caller's mistake into a loud
+// error at the narrowest waist every read/write funnels through, instead of a
+// silent wrong-scope I/O. Adapters MUST call it first thing in Render and Ingest.
+func RequireProjectRoot(scope Scope, project string) error {
+	if scope == ScopeProject && project == "" {
+		return ErrProjectRootRequired
+	}
+	return nil
+}
 
 // Capability is a bitmask of components an adapter can produce. M1's Claude
 // adapter is full-spectrum; M2's OpenCode adapter omits Hook + LSP.
@@ -88,6 +109,13 @@ type Adapter interface {
 	// cleartext, or wrapped templated for a preview) into destination FileOps.
 	// It accepts only secrets.Resolved — never a raw source.Canonical — so the
 	// render egress is type-distinct from the dest->source write path.
+	//
+	// CONTRACT — at ScopeProject the project root MUST be non-empty. Any adapter
+	// that resolves scope-dependent destinations MUST call RequireProjectRoot
+	// first thing in Render and Ingest and return ErrProjectRootRequired for an
+	// empty root, so a project-scope call can never silently fall through to
+	// user-scope destinations (the three real adapters do; a pure no-op adapter
+	// that resolves no paths has nothing to fall through to). See RequireProjectRoot.
 	Render(r secrets.Resolved, scope Scope, project string) ([]FileOp, []Skip, error)
 	Ingest(scope Scope, project string) (source.Canonical, error)
 	// KeyMergeStrategy returns this adapter's single JSON-key-merge strategy

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -12,7 +12,8 @@ import (
 )
 
 // ErrProjectRootRequired is returned by RequireProjectRoot (and thus by every
-// adapter's Render/Ingest) when a project-scope call supplies no project root.
+// scope-resolving adapter method — Render, Ingest, and IngestPlugins) when a
+// project-scope call supplies no project root.
 var ErrProjectRootRequired = errors.New("adapter: project scope requires a non-empty project root")
 
 // RequireProjectRoot guards the adapter boundary against a project-scope call
@@ -23,7 +24,8 @@ var ErrProjectRootRequired = errors.New("adapter: project scope requires a non-e
 // CLI's resolveScope already guarantees a non-empty root for project scope; this
 // is the belt-and-suspenders that turns a future caller's mistake into a loud
 // error at the narrowest waist every read/write funnels through, instead of a
-// silent wrong-scope I/O. Adapters MUST call it first thing in Render and Ingest.
+// silent wrong-scope I/O. Adapters MUST call it first thing in every method that
+// resolves scope-dependent paths: Render, Ingest, and IngestPlugins.
 func RequireProjectRoot(scope Scope, project string) error {
 	if scope == ScopeProject && project == "" {
 		return ErrProjectRootRequired

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -111,11 +111,13 @@ type Adapter interface {
 	// render egress is type-distinct from the dest->source write path.
 	//
 	// CONTRACT — at ScopeProject the project root MUST be non-empty. Any adapter
-	// that resolves scope-dependent destinations MUST call RequireProjectRoot
-	// first thing in Render and Ingest and return ErrProjectRootRequired for an
+	// method that resolves scope-dependent destinations MUST call
+	// RequireProjectRoot first thing and return ErrProjectRootRequired for an
 	// empty root, so a project-scope call can never silently fall through to
-	// user-scope destinations (the three real adapters do; a pure no-op adapter
-	// that resolves no paths has nothing to fall through to). See RequireProjectRoot.
+	// user-scope destinations. That covers Render and Ingest here, and
+	// IngestPlugins on the PluginIngester extension below; the three real
+	// adapters do all of these. (A pure no-op adapter that resolves no paths has
+	// nothing to fall through to.) See RequireProjectRoot.
 	Render(r secrets.Resolved, scope Scope, project string) ([]FileOp, []Skip, error)
 	Ingest(scope Scope, project string) (source.Canonical, error)
 	// KeyMergeStrategy returns this adapter's single JSON-key-merge strategy
@@ -196,6 +198,11 @@ type NativePlugin struct {
 // enable-state location is undocumented). See `docs/architecture.md` §
 // "PluginIngester (read-only)" for the full rationale.
 type PluginIngester interface {
+	// IngestPlugins resolves scope-dependent paths (it reads the agent's native
+	// config, which differs per scope), so — like Render/Ingest — it MUST call
+	// RequireProjectRoot first and return ErrProjectRootRequired for a
+	// project-scope call with no root, even though import only ever calls it at
+	// user scope today (plugins are a user-scope concept).
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
 }
 

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -20,13 +20,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	var c source.Canonical
 
 	// MCP from ~/.claude.json (user) or <proj>/.mcp.json (project — the file
-	// `claude mcp add --scope project` writes; settings.json is never project MCP)
-	var mcpFile string
-	if scope == adapter.ScopeProject {
-		mcpFile = p.MCPProject
-	} else {
-		mcpFile = p.DotClaude
-	}
+	// `claude mcp add --scope project` writes; settings.json is never project MCP).
+	// mcpDest centralizes the scope→file choice shared with renderMCP.
+	mcpFile := p.mcpDest(scope)
 	if data, err := os.ReadFile(mcpFile); err == nil {
 		var top map[string]any
 		if err := json.Unmarshal(data, &top); err != nil {

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -16,6 +16,9 @@ import (
 // It is the inverse of Render: Ingest(Apply(Render(c))) round-trips to c
 // for the components agentsync manages.
 func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return source.Canonical{}, err
+	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var c source.Canonical
 

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -19,10 +19,11 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var c source.Canonical
 
-	// MCP from .claude.json (user) or settings.json (project)
+	// MCP from ~/.claude.json (user) or <proj>/.mcp.json (project — the file
+	// `claude mcp add --scope project` writes; settings.json is never project MCP)
 	var mcpFile string
 	if scope == adapter.ScopeProject {
-		mcpFile = p.Settings
+		mcpFile = p.MCPProject
 	} else {
 		mcpFile = p.DotClaude
 	}

--- a/internal/adapter/claude/ingest_plugins.go
+++ b/internal/adapter/claude/ingest_plugins.go
@@ -27,6 +27,9 @@ import (
 // whole import (matching the hooks/LSP blocks in Ingest). Only a genuine read
 // error (e.g. a permission problem) is surfaced.
 func (a *Adapter) IngestPlugins(scope adapter.Scope, project string) ([]adapter.NativeMarketplace, []adapter.NativePlugin, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return nil, nil, err
+	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	data, err := os.ReadFile(p.Settings)
 	if err != nil {

--- a/internal/adapter/claude/ingest_test.go
+++ b/internal/adapter/claude/ingest_test.go
@@ -2,6 +2,7 @@ package claude_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,6 +99,96 @@ func TestIngest_RoundTripsMCPExtra(t *testing.T) {
 		if _, dup := ex[k]; dup {
 			t.Fatalf("modeled key %q duplicated into Extra: %+v", k, ex)
 		}
+	}
+}
+
+// TestIngest_ProjectScopeMCP_ReadsMCPJSONNotSettings is artifact-anchored: it
+// writes a real <project>/.mcp.json (the upstream project-MCP location) AND a
+// <project>/.claude/settings.json carrying a different mcpServers block, then
+// ingests at project scope and asserts ONLY the .mcp.json server is captured —
+// settings.json's mcpServers is not read as project MCP.
+func TestIngest_ProjectScopeMCP_ReadsMCPJSONNotSettings(t *testing.T) {
+	proj := t.TempDir()
+	// Project MCP lives at the repo root in .mcp.json.
+	if err := os.WriteFile(filepath.Join(proj, ".mcp.json"),
+		[]byte(`{"mcpServers":{"projapi":{"command":"node","args":["s.js"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A settings.json mcpServers block is a trap: it must NOT be read at project
+	// scope (settings.json holds hooks/LSP/permissions, never project MCP).
+	claudeDir := filepath.Join(proj, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"mcpServers":{"shouldNotImport":{"command":"trap"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	out, err := a.Ingest(adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("want exactly 1 MCP server (from .mcp.json), got %d: %+v", len(out.MCPServers), out.MCPServers)
+	}
+	if out.MCPServers[0].ID != "projapi" {
+		t.Fatalf("want %q from .mcp.json, got %q (settings.json mcpServers wrongly read?)", "projapi", out.MCPServers[0].ID)
+	}
+}
+
+// TestIngest_ProjectScopeMCP_PreservesExtra is artifact-anchored on a real
+// <project>/.mcp.json carrying an unmodeled native key (`timeout` — a
+// documented per-server .mcp.json field). It must survive ingest→render
+// verbatim via the passthrough Extra map, landing back in <project>/.mcp.json.
+func TestIngest_ProjectScopeMCP_PreservesExtra(t *testing.T) {
+	proj := t.TempDir()
+	if err := os.WriteFile(filepath.Join(proj, ".mcp.json"),
+		[]byte(`{"mcpServers":{"api":{"command":"node","timeout":600000}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	out, err := a.Ingest(adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("mcp = %d", len(out.MCPServers))
+	}
+	if got := out.MCPServers[0].Server.Extra["timeout"]; got != float64(600000) {
+		t.Fatalf("unmodeled timeout not captured into Extra: %+v", out.MCPServers[0].Server.Extra)
+	}
+
+	// Render the ingested overlay back at project scope; timeout must reappear
+	// in <project>/.mcp.json via MergeExtra.
+	projCanon := source.Canonical{MCPServers: out.MCPServers}
+	merged := source.Canonical{MCPServers: out.MCPServers, Project: &projCanon}
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMCP := filepath.Join(proj, ".mcp.json")
+	var content []byte
+	for _, op := range ops {
+		if op.Path == wantMCP {
+			content = op.Content
+		}
+	}
+	if content == nil {
+		t.Fatalf("no <project>/.mcp.json render op; ops=%+v", ops)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(content, &got); err != nil {
+		t.Fatal(err)
+	}
+	api, ok := got["mcpServers"].(map[string]any)["api"].(map[string]any)
+	if !ok {
+		t.Fatalf("api server missing on re-render: %v", got)
+	}
+	if api["timeout"] != float64(600000) {
+		t.Fatalf("timeout dropped on re-render: %+v", api)
 	}
 }
 

--- a/internal/adapter/claude/paths.go
+++ b/internal/adapter/claude/paths.go
@@ -50,11 +50,11 @@ func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
 }
 
 // mcpDest returns the destination file for MCP servers at the given scope: the
-// user-global ~/.claude.json, or a project's repo-root .mcp.json. It returns ""
-// only for ScopeProject with no project root resolved (MCPProject unset);
-// callers MUST treat "" as "no MCP destination" — renderMCP skips it and Ingest's
-// ReadFile of "" simply finds nothing. Centralizing the scope→file choice keeps
-// renderMCP and Ingest from drifting apart on where project MCP lives.
+// user-global ~/.claude.json, or a project's repo-root .mcp.json. Centralizing
+// the scope→file choice keeps renderMCP and Ingest from drifting apart on where
+// project MCP lives. It would return "" for ScopeProject with no project root
+// (MCPProject unset), but Render and Ingest reject that case up front via
+// adapter.RequireProjectRoot, so callers never observe an empty result.
 func (p Paths) mcpDest(scope adapter.Scope) string {
 	if scope == adapter.ScopeProject {
 		return p.MCPProject

--- a/internal/adapter/claude/paths.go
+++ b/internal/adapter/claude/paths.go
@@ -6,7 +6,8 @@ import "path/filepath"
 type Paths struct {
 	Home            string // ~/.claude
 	Settings        string // ~/.claude/settings.json
-	DotClaude       string // ~/.claude.json (mcpServers + plugin enables live here)
+	DotClaude       string // ~/.claude.json (user-scope mcpServers + plugin enables live here)
+	MCPProject      string // <proj>/.mcp.json (project-scope mcpServers; empty at user scope)
 	SkillsDir       string // ~/.claude/skills
 	AgentsDir       string // ~/.claude/agents
 	CommandsDir     string // ~/.claude/commands
@@ -27,10 +28,15 @@ func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
 		PluginsCacheDir: filepath.Join(home, "plugins", "cache"),
 	}
 	if projectScope && project != "" {
-		// project-scope settings live under <project>/.claude/
+		// project-scope settings live under <project>/.claude/, but project-scope
+		// MCP servers live in <project>/.mcp.json at the repo root — the file
+		// `claude mcp add --scope project` writes and the team checks in (per
+		// https://code.claude.com/docs/ MCP scopes). settings.json holds
+		// hooks/LSP/permissions, never project MCP.
 		projHome := filepath.Join(project, ".claude")
 		p.Home = projHome
 		p.Settings = filepath.Join(projHome, "settings.json")
+		p.MCPProject = filepath.Join(project, ".mcp.json")
 		p.SkillsDir = filepath.Join(projHome, "skills")
 		p.AgentsDir = filepath.Join(projHome, "agents")
 		p.CommandsDir = filepath.Join(projHome, "commands")

--- a/internal/adapter/claude/paths.go
+++ b/internal/adapter/claude/paths.go
@@ -1,6 +1,10 @@
 package claude
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
 
 // Paths resolves the destination paths for a given (scope, project, target-root).
 type Paths struct {
@@ -43,4 +47,17 @@ func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
 		p.Memory = filepath.Join(project, "CLAUDE.md")
 	}
 	return p
+}
+
+// mcpDest returns the destination file for MCP servers at the given scope: the
+// user-global ~/.claude.json, or a project's repo-root .mcp.json. It returns ""
+// only for ScopeProject with no project root resolved (MCPProject unset);
+// callers MUST treat "" as "no MCP destination" — renderMCP skips it and Ingest's
+// ReadFile of "" simply finds nothing. Centralizing the scope→file choice keeps
+// renderMCP and Ingest from drifting apart on where project MCP lives.
+func (p Paths) mcpDest(scope adapter.Scope) string {
+	if scope == adapter.ScopeProject {
+		return p.MCPProject
+	}
+	return p.DotClaude
 }

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -133,18 +133,20 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([
 		return nil, nil
 	}
 
+	dest := p.mcpDest(scope)
+	if dest == "" {
+		// Defensive: ScopeProject with no resolved project root yields no MCP
+		// destination (MCPProject unset). The CLI never reaches here —
+		// resolveScope guarantees a non-empty project root — but guard the
+		// library boundary rather than emit a write op targeting "".
+		return nil, nil
+	}
+
 	ours := map[string]any{"mcpServers": targeted}
 
 	body, err := json.MarshalIndent(ours, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal mcp: %w", err)
-	}
-
-	var dest string
-	if scope == adapter.ScopeProject {
-		dest = p.MCPProject
-	} else {
-		dest = p.DotClaude
 	}
 
 	return []adapter.FileOp{{

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -13,6 +13,9 @@ import (
 // Pure function: returns the same output for the same input (disk reads are
 // treated as fixed inputs for the purposes of the merge-json-keys strategy).
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return nil, nil, err
+	}
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	paths := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 
@@ -133,14 +136,10 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([
 		return nil, nil
 	}
 
+	// dest is always non-empty here: Render rejects ScopeProject with an empty
+	// project root up front (adapter.RequireProjectRoot), so mcpDest cannot
+	// return "" by the time renderMCP runs.
 	dest := p.mcpDest(scope)
-	if dest == "" {
-		// Defensive: ScopeProject with no resolved project root yields no MCP
-		// destination (MCPProject unset). The CLI never reaches here —
-		// resolveScope guarantees a non-empty project root — but guard the
-		// library boundary rather than emit a write op targeting "".
-		return nil, nil
-	}
 
 	ours := map[string]any{"mcpServers": targeted}
 

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -27,7 +27,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 
-	// 1. MCP -> .claude.json (user) or settings.json (project)
+	// 1. MCP -> ~/.claude.json (user) or <proj>/.mcp.json (project)
 	if mcpOps, err := a.renderMCP(renderC, paths, scope); err != nil {
 		return nil, nil, err
 	} else {
@@ -94,9 +94,10 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 	return ops, skips, nil
 }
 
-// renderMCP converts canonical MCPServers to a FileOp targeting .claude.json
-// (user scope) or settings.json (project scope). The FileOp carries
-// MergeStrategy "merge-json-keys" so Apply can preserve foreign keys.
+// renderMCP converts canonical MCPServers to a FileOp targeting ~/.claude.json
+// (user scope) or <project>/.mcp.json (project scope — the upstream Claude Code
+// project-MCP location, NOT settings.json). The FileOp carries MergeStrategy
+// "merge-json-keys" so Apply preserves foreign keys in a hand-authored .mcp.json.
 func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([]adapter.FileOp, error) {
 	targeted := map[string]any{}
 	for _, m := range c.MCPServers {
@@ -141,7 +142,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths, scope adapter.Scope) ([
 
 	var dest string
 	if scope == adapter.ScopeProject {
-		dest = p.Settings
+		dest = p.MCPProject
 	} else {
 		dest = p.DotClaude
 	}

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -136,6 +136,11 @@ func TestProjectScope_EmptyProjectErrors(t *testing.T) {
 	if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
 		t.Fatalf("Ingest: want ErrProjectRootRequired, got %v", err)
 	}
+	// IngestPlugins resolves scope-dependent paths too (reads settings.json), so
+	// it carries the same guard.
+	if _, _, err := a.IngestPlugins(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("IngestPlugins: want ErrProjectRootRequired, got %v", err)
+	}
 }
 
 func TestRender_MCP_AgentsAllowlist(t *testing.T) {

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -58,6 +58,64 @@ func TestRender_MCP_UserScope(t *testing.T) {
 	}
 }
 
+// TestRender_MCP_ProjectScope verifies project-scope MCP servers target
+// <project>/.mcp.json — the upstream Claude Code project-MCP location — NOT
+// <project>/.claude/settings.json. The content keeps the {"mcpServers": …}
+// top-level shape and merge-json-keys strategy so a hand-authored .mcp.json's
+// foreign keys survive.
+func TestRender_MCP_ProjectScope(t *testing.T) {
+	enabled := true
+	projRoot := t.TempDir()
+	srv := source.MCPServer{
+		ID: "company-api",
+		Server: source.MCPServerSpec{
+			Type:    "stdio",
+			Command: "npx",
+			Args:    []string{"-y", "@company/mcp"},
+			Enabled: &enabled,
+		},
+	}
+	// At project scope apply renders only the project overlay (c.Project) —
+	// exactly what project.Merge produces. Mirror that here.
+	projCanon := source.Canonical{MCPServers: []source.MCPServer{srv}}
+	merged := source.Canonical{MCPServers: []source.MCPServer{srv}, Project: &projCanon}
+
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, projRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantMCP := filepath.Join(projRoot, ".mcp.json")
+	wantSettings := filepath.Join(projRoot, ".claude", "settings.json")
+	var found *adapter.FileOp
+	for i, op := range ops {
+		if op.Path == wantSettings && strings.Contains(string(op.Content), "mcpServers") {
+			t.Fatalf("project MCP must not land in settings.json: %s", op.Path)
+		}
+		if op.Path == wantMCP {
+			found = &ops[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no <project>/.mcp.json op produced; ops=%+v", ops)
+	}
+	if found.MergeStrategy != "merge-json-keys" {
+		t.Fatalf("MergeStrategy = %q, want merge-json-keys", found.MergeStrategy)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(found.Content, &got); err != nil {
+		t.Fatalf("not valid json: %v", err)
+	}
+	servers, ok := got["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("top-level mcpServers missing: %v", got)
+	}
+	if _, ok := servers["company-api"].(map[string]any); !ok {
+		t.Fatalf("company-api server missing under mcpServers: %v", servers)
+	}
+}
+
 func TestRender_MCP_AgentsAllowlist(t *testing.T) {
 	enabled := true
 	c := source.Canonical{

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -2,6 +2,7 @@ package claude_test
 
 import (
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -116,25 +117,24 @@ func TestRender_MCP_ProjectScope(t *testing.T) {
 	}
 }
 
-// TestRender_MCP_ProjectScope_EmptyProjectNoMCPOp pins the library-boundary
-// guard: ScopeProject with an empty project root (which the CLI never produces —
-// resolveScope guarantees a non-empty root) must NOT emit an MCP FileOp with an
-// empty Path. Without the guard renderMCP would write to "".
-func TestRender_MCP_ProjectScope_EmptyProjectNoMCPOp(t *testing.T) {
+// TestProjectScope_EmptyProjectErrors pins the adapter-boundary guard: a
+// project-scope Render or Ingest with no project root must fail loudly with
+// adapter.ErrProjectRootRequired rather than silently fall through to USER-scope
+// paths (which would write the project overlay into the user's global config).
+// The CLI's resolveScope guarantees a non-empty root, so this guards a future or
+// non-CLI caller.
+func TestProjectScope_EmptyProjectErrors(t *testing.T) {
 	enabled := true
 	c := source.Canonical{MCPServers: []source.MCPServer{{
 		ID:     "x",
 		Server: source.MCPServerSpec{Command: "y", Enabled: &enabled},
 	}}}
 	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
-	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, "")
-	if err != nil {
-		t.Fatal(err)
+	if _, _, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Render: want ErrProjectRootRequired, got %v", err)
 	}
-	for _, op := range ops {
-		if op.Path == "" {
-			t.Fatalf("emitted a FileOp with empty Path (no MCP dest at project scope): %+v", op)
-		}
+	if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Ingest: want ErrProjectRootRequired, got %v", err)
 	}
 }
 

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -116,6 +116,28 @@ func TestRender_MCP_ProjectScope(t *testing.T) {
 	}
 }
 
+// TestRender_MCP_ProjectScope_EmptyProjectNoMCPOp pins the library-boundary
+// guard: ScopeProject with an empty project root (which the CLI never produces —
+// resolveScope guarantees a non-empty root) must NOT emit an MCP FileOp with an
+// empty Path. Without the guard renderMCP would write to "".
+func TestRender_MCP_ProjectScope_EmptyProjectNoMCPOp(t *testing.T) {
+	enabled := true
+	c := source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "x",
+		Server: source.MCPServerSpec{Command: "y", Enabled: &enabled},
+	}}}
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range ops {
+		if op.Path == "" {
+			t.Fatalf("emitted a FileOp with empty Path (no MCP dest at project scope): %+v", op)
+		}
+	}
+}
+
 func TestRender_MCP_AgentsAllowlist(t *testing.T) {
 	enabled := true
 	c := source.Canonical{

--- a/internal/adapter/codex/ingest.go
+++ b/internal/adapter/codex/ingest.go
@@ -22,6 +22,9 @@ import (
 // from `developer_instructions`. Project-scope slash commands are never written
 // (global-only), so they don't ingest at project scope either.
 func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return source.Canonical{}, err
+	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var c source.Canonical
 

--- a/internal/adapter/codex/ingest_plugins.go
+++ b/internal/adapter/codex/ingest_plugins.go
@@ -30,6 +30,9 @@ import (
 // one is treated as "no plugins discovered" rather than failing the whole
 // import. Only a genuine read error (e.g. a permission problem) is surfaced.
 func (a *Adapter) IngestPlugins(scope adapter.Scope, project string) ([]adapter.NativeMarketplace, []adapter.NativePlugin, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return nil, nil, err
+	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	data, err := os.ReadFile(p.Config)
 	if err != nil {

--- a/internal/adapter/codex/render.go
+++ b/internal/adapter/codex/render.go
@@ -18,6 +18,9 @@ import (
 // set in Codex's UI are preserved by config.toml's merge-toml-keys writer
 // because this render claims no keys under that section.
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return nil, nil, err
+	}
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 

--- a/internal/adapter/codex/render_test.go
+++ b/internal/adapter/codex/render_test.go
@@ -2,6 +2,7 @@ package codex_test
 
 import (
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,25 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// TestProjectScope_EmptyProjectErrors pins the adapter-boundary guard for Codex:
+// a project-scope Render/Ingest with no project root must fail loudly
+// (adapter.ErrProjectRootRequired) rather than silently fall through to the
+// user-scope ~/.codex/ paths.
+func TestProjectScope_EmptyProjectErrors(t *testing.T) {
+	enabled := true
+	c := source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "x",
+		Server: source.MCPServerSpec{Command: "y", Enabled: &enabled},
+	}}}
+	a := codex.New(codex.Options{TargetRoot: t.TempDir()})
+	if _, _, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Render: want ErrProjectRootRequired, got %v", err)
+	}
+	if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Ingest: want ErrProjectRootRequired, got %v", err)
+	}
+}
 
 // findOp returns the first op whose path ends with suffix.
 func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {

--- a/internal/adapter/codex/render_test.go
+++ b/internal/adapter/codex/render_test.go
@@ -30,6 +30,11 @@ func TestProjectScope_EmptyProjectErrors(t *testing.T) {
 	if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
 		t.Fatalf("Ingest: want ErrProjectRootRequired, got %v", err)
 	}
+	// IngestPlugins resolves scope-dependent paths too (reads config.toml), so it
+	// carries the same guard.
+	if _, _, err := a.IngestPlugins(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("IngestPlugins: want ErrProjectRootRequired, got %v", err)
+	}
 }
 
 // findOp returns the first op whose path ends with suffix.

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -23,6 +23,9 @@ import (
 // `mode` key (which is dropped during ingest because it is an OpenCode-specific
 // artifact, not part of canonical).
 func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return source.Canonical{}, err
+	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 	var c source.Canonical
 

--- a/internal/adapter/opencode/ingest_test.go
+++ b/internal/adapter/opencode/ingest_test.go
@@ -2,6 +2,7 @@ package opencode_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -9,6 +10,40 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// TestIngest_ProjectScopeMCP_ReadsRootNotDotOpencode is artifact-anchored: it
+// writes a real <project>/opencode.json (OpenCode's project config location)
+// AND a <project>/.opencode/opencode.json trap, then ingests at project scope
+// and asserts ONLY the root file's server is captured — OpenCode does not read
+// .opencode/opencode.json, so neither does agentsync.
+func TestIngest_ProjectScopeMCP_ReadsRootNotDotOpencode(t *testing.T) {
+	proj := t.TempDir()
+	if err := os.WriteFile(filepath.Join(proj, "opencode.json"),
+		[]byte(`{"mcp":{"projapi":{"type":"local","command":["node","s.js"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Trap: a server in .opencode/opencode.json must NOT be read.
+	dotDir := filepath.Join(proj, ".opencode")
+	if err := os.MkdirAll(dotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotDir, "opencode.json"),
+		[]byte(`{"mcp":{"shouldNotImport":{"type":"local","command":["trap"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	out, err := a.Ingest(adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("want exactly 1 MCP server (from root opencode.json), got %d: %+v", len(out.MCPServers), out.MCPServers)
+	}
+	if out.MCPServers[0].ID != "projapi" {
+		t.Fatalf("want %q from <root>/opencode.json, got %q (.opencode/opencode.json wrongly read?)", "projapi", out.MCPServers[0].ID)
+	}
+}
 
 // TestIngest_RoundTripsMCP exercises: Render → Apply → Ingest for MCP servers.
 func TestIngest_RoundTripsMCP(t *testing.T) {

--- a/internal/adapter/opencode/paths.go
+++ b/internal/adapter/opencode/paths.go
@@ -5,7 +5,7 @@ import "path/filepath"
 // Paths resolves the destination paths for a given (scope, project, target-root).
 type Paths struct {
 	ConfigDir       string // ~/.config/opencode
-	Settings        string // ~/.config/opencode/opencode.json
+	Settings        string // ~/.config/opencode/opencode.json (user) or <proj>/opencode.json (project)
 	AgentsDir       string // ~/.config/opencode/agents (user) or .opencode/agents (project)
 	CommandsDir     string // ~/.config/opencode/commands (user) or .opencode/commands (project)
 	ClaudeSkillsDir string // ~/.claude/skills (shared with Claude!)
@@ -17,8 +17,12 @@ type Paths struct {
 func ResolvePaths(targetRoot, project string, projectScope bool) Paths {
 	if projectScope && project != "" {
 		return Paths{
-			ConfigDir:       filepath.Join(project, ".opencode"),
-			Settings:        filepath.Join(project, ".opencode", "opencode.json"),
+			ConfigDir: filepath.Join(project, ".opencode"),
+			// Project JSON config is <project>/opencode.json at the repo ROOT —
+			// OpenCode does NOT read <project>/.opencode/opencode.json (the
+			// .opencode/ dir holds only the agents/commands/skills subdirs). See
+			// https://opencode.ai/docs/config/ (config-source precedence).
+			Settings:        filepath.Join(project, "opencode.json"),
 			AgentsDir:       filepath.Join(project, ".opencode", "agents"),
 			CommandsDir:     filepath.Join(project, ".opencode", "commands"),
 			ClaudeSkillsDir: filepath.Join(project, ".claude", "skills"),

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -12,6 +12,9 @@ import (
 
 // Render converts the resolved canonical into FileOps for OpenCode.
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	if err := adapter.RequireProjectRoot(scope, project); err != nil {
+		return nil, nil, err
+	}
 	c := r.Canonical() //nolint:forbidigo // sanctioned render egress: project the resolved model into FileOps (never written back to source)
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
 

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -2,6 +2,7 @@ package opencode_test
 
 import (
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,24 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
+
+// TestProjectScope_EmptyProjectErrors pins the adapter-boundary guard for
+// OpenCode: a project-scope Render/Ingest with no project root must fail loudly
+// (adapter.ErrProjectRootRequired) rather than silently fall through to the
+// user-scope ~/.config/opencode/ paths.
+func TestProjectScope_EmptyProjectErrors(t *testing.T) {
+	c := source.Canonical{MCPServers: []source.MCPServer{{
+		ID:     "x",
+		Server: source.MCPServerSpec{Command: "y"},
+	}}}
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	if _, _, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Render: want ErrProjectRootRequired, got %v", err)
+	}
+	if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+		t.Fatalf("Ingest: want ErrProjectRootRequired, got %v", err)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Task 4: MCP

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -61,6 +61,54 @@ func TestRender_MCP(t *testing.T) {
 	}
 }
 
+// TestRender_MCP_ProjectScope verifies project-scope MCP servers target
+// <project>/opencode.json — OpenCode's documented project config location at the
+// repo ROOT — NOT <project>/.opencode/opencode.json (which OpenCode does not
+// read; the .opencode/ directory holds only the agents/commands/skills subdirs).
+func TestRender_MCP_ProjectScope(t *testing.T) {
+	enabled := true
+	projRoot := t.TempDir()
+	srv := source.MCPServer{
+		ID: "company-api",
+		Server: source.MCPServerSpec{
+			Type: "stdio", Command: "npx", Args: []string{"-y", "@company/mcp"},
+			Agents: []string{"opencode"}, Enabled: &enabled,
+		},
+	}
+	// At project scope apply renders only the project overlay (c.Project).
+	projCanon := source.Canonical{MCPServers: []source.MCPServer{srv}}
+	merged := source.Canonical{MCPServers: []source.MCPServer{srv}, Project: &projCanon}
+
+	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(merged), adapter.ScopeProject, projRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantMCP := filepath.Join(projRoot, "opencode.json")
+	wrongMCP := filepath.Join(projRoot, ".opencode", "opencode.json")
+	var found bool
+	for _, op := range ops {
+		if op.Path == wrongMCP {
+			t.Fatalf("project MCP must not land in .opencode/opencode.json (OpenCode does not read it): %s", op.Path)
+		}
+		if op.Path == wantMCP {
+			found = true
+			if op.MergeStrategy != "merge-jsonc-keys" {
+				t.Fatalf("merge strategy = %q", op.MergeStrategy)
+			}
+			var ours map[string]any
+			_ = json.Unmarshal(op.Content, &ours)
+			if _, ok := ours["mcp"].(map[string]any)["company-api"]; !ok {
+				t.Fatalf("company-api missing under mcp: %v", ours)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no <project>/opencode.json op produced; ops=%+v", ops)
+	}
+}
+
 // TestRender_MCP_PreservesHeaders is the regression for OpenCode silently
 // dropping the `headers` of a remote MCP server — a server requiring an
 // Authorization header would render unauthenticated and broken, with no Skip.

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -26,11 +26,15 @@ func TestRender_MCP(t *testing.T) {
 			Agents: []string{"opencode"}, Enabled: &enabled,
 		},
 	}}}
-	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	root := t.TempDir()
+	a := opencode.New(opencode.Options{TargetRoot: root})
 	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	// Exact path, not HasSuffix: a loose suffix would match both the user-scope
+	// .config/opencode/opencode.json and a project .opencode/opencode.json.
+	wantSettings := filepath.Join(root, ".config", "opencode", "opencode.json")
 	var found bool
 	for _, op := range ops {
-		if strings.HasSuffix(op.Path, "opencode.json") {
+		if op.Path == wantSettings {
 			found = true
 			if op.MergeStrategy != "merge-jsonc-keys" {
 				t.Fatalf("merge strategy = %q", op.MergeStrategy)
@@ -120,10 +124,12 @@ func TestRender_MCP_PreservesHeaders(t *testing.T) {
 			Headers: map[string]string{"Authorization": "Bearer tok"},
 		},
 	}}}
-	a := opencode.New(opencode.Options{TargetRoot: t.TempDir()})
+	root := t.TempDir()
+	a := opencode.New(opencode.Options{TargetRoot: root})
 	ops, _, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	wantSettings := filepath.Join(root, ".config", "opencode", "opencode.json")
 	for _, op := range ops {
-		if !strings.HasSuffix(op.Path, "opencode.json") {
+		if op.Path != wantSettings {
 			continue
 		}
 		var ours map[string]any

--- a/internal/adapter/requireprojectroot_test.go
+++ b/internal/adapter/requireprojectroot_test.go
@@ -1,0 +1,40 @@
+package adapter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// TestRequireProjectRoot pins the adapter-boundary guard: only the
+// (ScopeProject, "") combination is rejected — every other pairing passes. This
+// is the single source of truth each adapter's Render/Ingest delegates to, so a
+// project-scope call with no root can never silently fall through to user paths.
+func TestRequireProjectRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   adapter.Scope
+		project string
+		wantErr bool
+	}{
+		{"user scope, empty project — ok", adapter.ScopeUser, "", false},
+		{"user scope, with project — ok", adapter.ScopeUser, "/repo", false},
+		{"project scope, with root — ok", adapter.ScopeProject, "/repo", false},
+		{"project scope, empty root — error", adapter.ScopeProject, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := adapter.RequireProjectRoot(tt.scope, tt.project)
+			if tt.wantErr {
+				if !errors.Is(err, adapter.ErrProjectRootRequired) {
+					t.Fatalf("want ErrProjectRootRequired, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/adapter/requireprojectroot_test.go
+++ b/internal/adapter/requireprojectroot_test.go
@@ -9,8 +9,9 @@ import (
 
 // TestRequireProjectRoot pins the adapter-boundary guard: only the
 // (ScopeProject, "") combination is rejected — every other pairing passes. This
-// is the single source of truth each adapter's Render/Ingest delegates to, so a
-// project-scope call with no root can never silently fall through to user paths.
+// is the single source of truth each adapter's Render/Ingest/IngestPlugins
+// delegates to, so a project-scope call with no root can never silently fall
+// through to user paths.
 func TestRequireProjectRoot(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/import_project_test.go
+++ b/internal/cli/import_project_test.go
@@ -27,7 +27,8 @@ func TestIntegration_Import_ProjectScope(t *testing.T) {
 	}
 
 	// Native project-scope config: a subagent under <proj>/.claude/agents/ and an
-	// MCP server in <proj>/.claude/settings.json (the project-scope MCP location).
+	// MCP server in <proj>/.mcp.json (the upstream project-scope MCP location —
+	// the file `claude mcp add --scope project` writes).
 	claudeDir := filepath.Join(proj, ".claude")
 	if err := os.MkdirAll(filepath.Join(claudeDir, "agents"), 0o755); err != nil {
 		t.Fatal(err)
@@ -36,7 +37,7 @@ func TestIntegration_Import_ProjectScope(t *testing.T) {
 		[]byte("---\ndescription: project reviewer\n---\nReview carefully.\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+	if err := os.WriteFile(filepath.Join(proj, ".mcp.json"),
 		[]byte(`{"mcpServers":{"projapi":{"command":"node","args":["s.js"]}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/m5_integration_test.go
+++ b/internal/cli/m5_integration_test.go
@@ -35,7 +35,7 @@ func scaffoldProjectMCP(t *testing.T, projectDir, id, command string, args ...st
 //   - a project-scope MCP server in <dir>/.agentsync/mcp/
 //   - chdir into project dir
 //   - apply --scope project (walks up to the .agentsync/ tree from cwd)
-//   - verify <project>/.claude/settings.json contains the project MCP
+//   - verify <project>/.mcp.json contains the project MCP
 func TestIntegration_Project_Overlay(t *testing.T) {
 	tmpHome := t.TempDir()
 	projectDir := t.TempDir()
@@ -67,13 +67,13 @@ func TestIntegration_Project_Overlay(t *testing.T) {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
 
-	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-	body, err := os.ReadFile(settingsPath)
+	mcpPath := filepath.Join(projectDir, ".mcp.json")
+	body, err := os.ReadFile(mcpPath)
 	if err != nil {
-		t.Fatalf("read project settings.json: %v", err)
+		t.Fatalf("read project .mcp.json: %v", err)
 	}
 	if !strings.Contains(string(body), "proj-mcp") {
-		t.Fatalf("project-scope MCP not landed in settings.json: %s", body)
+		t.Fatalf("project-scope MCP not landed in .mcp.json: %s", body)
 	}
 }
 
@@ -212,13 +212,13 @@ func TestIntegration_Project_ExplicitFlag(t *testing.T) {
 		t.Fatalf("apply --project: %v\n%s", err, out)
 	}
 
-	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-	body, err := os.ReadFile(settingsPath)
+	mcpPath := filepath.Join(projectDir, ".mcp.json")
+	body, err := os.ReadFile(mcpPath)
 	if err != nil {
-		t.Fatalf("read project settings.json: %v", err)
+		t.Fatalf("read project .mcp.json: %v", err)
 	}
 	if !strings.Contains(string(body), "api-mcp") {
-		t.Fatalf("project MCP (api-mcp) not in settings.json: %s", body)
+		t.Fatalf("project MCP (api-mcp) not in .mcp.json: %s", body)
 	}
 }
 

--- a/internal/cli/m5_integration_test.go
+++ b/internal/cli/m5_integration_test.go
@@ -293,3 +293,89 @@ func TestIntegration_Project_Memory(t *testing.T) {
 		t.Fatalf("project memory content not in CLAUDE.md: %s", body)
 	}
 }
+
+// TestIntegration_Project_OpenCode_MCP verifies project-scope apply writes
+// OpenCode MCP servers to <root>/opencode.json (the repo root), NOT to
+// <root>/.opencode/opencode.json — which OpenCode does not read. This is the
+// CLI/apply-level counterpart to the adapter-unit project-scope test.
+func TestIntegration_Project_OpenCode_MCP(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+	scaffoldProjectMCP(t, projectDir, "oc-mcp", "node", "server.js")
+
+	if out, err := runCLI(t, env, "apply", "--project", projectDir); err != nil {
+		t.Fatalf("apply --project: %v\n%s", err, out)
+	}
+
+	rootCfg := filepath.Join(projectDir, "opencode.json")
+	body, err := os.ReadFile(rootCfg)
+	if err != nil {
+		t.Fatalf("read project opencode.json at repo root: %v", err)
+	}
+	if !strings.Contains(string(body), "oc-mcp") {
+		t.Fatalf("project MCP not in <root>/opencode.json: %s", body)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".opencode", "opencode.json")); err == nil {
+		t.Fatal("project MCP wrongly written to .opencode/opencode.json (OpenCode does not read it)")
+	}
+}
+
+// TestIntegration_Project_MCPJsonDriftDetected verifies status at project scope
+// classifies a hand-edit to <root>/.mcp.json as drift — i.e. the project-MCP
+// dest is wired into the status/diff/reconcile drift path (which share the same
+// classifier) like any other dest, now that it lives at the repo root.
+func TestIntegration_Project_MCPJsonDriftDetected(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+	// Server id deliberately free of the substring "drift" so the drift
+	// assertion below can only match the drift *class*, never the id in the path.
+	scaffoldProjectMCP(t, projectDir, "apisrv", "npx", "-y", "@x/mcp")
+
+	if out, err := runCLI(t, env, "apply", "--project", projectDir); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	mcpPath := filepath.Join(projectDir, ".mcp.json")
+	body, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("read .mcp.json: %v", err)
+	}
+	// Hand-edit an agentsync-owned key to introduce drift.
+	modified := strings.ReplaceAll(string(body), `"npx"`, `"npm"`)
+	if modified == string(body) {
+		t.Fatal("fixture did not contain the expected command to drift")
+	}
+	if err := os.WriteFile(mcpPath, []byte(modified), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status", "--project", projectDir)
+	if err != nil {
+		t.Fatalf("status --project: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "drift") {
+		t.Fatalf("status did not report drift on project .mcp.json:\n%s", out)
+	}
+}

--- a/website/src/content/docs/guides/projects.mdx
+++ b/website/src/content/docs/guides/projects.mdx
@@ -115,13 +115,14 @@ cwd to the `.agentsync/` tree):
 ```bash frame="terminal"
 cd ~/code/myrepo
 agentsync apply --scope project   # walks up to the .agentsync/ tree
-ls .claude/settings.json          # project-scope config landed
+ls .mcp.json                      # project-scope MCP servers landed (repo root)
 ```
 
 ## Import a project's native config
 
-Already have native project-scope config (e.g. `<root>/.claude/`)? Capture it
-straight into the project tree:
+Already have native project-scope config (e.g. `<root>/.claude/`, or a
+`<root>/.mcp.json` from `claude mcp add --scope project`)? Capture it straight
+into the project tree:
 
 ```bash
 cd ~/code/myrepo


### PR DESCRIPTION
## What

Fixes #56 and a sibling bug of the same class found by fanning the audit out across the other adapters. Two adapters wrote project-scope config to a native file the harness does not actually read:

| Adapter | was written to | harness actually reads | fix |
|---|---|---|---|
| **Claude** | `<root>/.claude/settings.json` (`mcpServers`) | `<root>/.mcp.json` | render/ingest now use `.mcp.json` |
| **OpenCode** | `<root>/.opencode/opencode.json` | `<root>/opencode.json` (repo root) | project `Settings` now at repo root |

Both verified against the canonical upstream docs before coding (per the repo's CLAUDE.md cross-reference rule):
- Claude: [MCP scopes](https://code.claude.com/docs/en/mcp#mcp-installation-scopes) — Project → `.mcp.json in project root`, top-level `{ "mcpServers": … }`.
- OpenCode: [config](https://opencode.ai/docs/config/) — project config is `opencode.json` at the **root**; *"OpenCode does not read from `.opencode/opencode.json`"* (`.opencode/` is only for `agents/`/`commands/`/`skills/` subdirs, which were already correct).

## Commits

1. **`fix(adapter): render/ingest Claude project MCP at <root>/.mcp.json`** — new `Paths.MCPProject`; `renderMCP`/`Ingest` target it at project scope; same `{"mcpServers": …}` shape + `merge-json-keys` (foreign keys + unmodeled fields like `timeout` survive via `Extra`). User scope (`~/.claude.json`) unchanged. Clean switch, no back-compat read of `settings.json`. Docs: capability matrix, architecture, components, user guide, projects guide, CHANGELOG.
2. **`fix(adapter): render/ingest OpenCode project config at <root>/opencode.json`** — project-scope `Paths.Settings` → repo root; `agents/`/`commands/` stay under `.opencode/`. User scope unchanged. CHANGELOG updated.

## Tests (TDD — written red first for both)

- **Render** — project MCP/config lands at the correct file and explicitly **not** at the old wrong one.
- **Ingest** — reads the correct file and ignores a trap planted at the old location.
- **Claude fidelity (artifact-anchored)** — a `<root>/.mcp.json` with an unmodeled `timeout` survives ingest→render via `Extra`.
- Flipped the project overlay / explicit-flag and project-import integration fixtures to `.mcp.json`.

Full unit/integration + `-tags=e2e` + `-tags=bdd` green; `golangci-lint` clean (0 issues).

## Audit scope (the rest came back clean)

The same fan-out checked every adapter/component at both scopes:
- **Codex** — clean. MCP/hooks correctly share `~/.codex/config.toml`; project overrides at `<root>/.codex/config.toml` (verified Codex reads project-local `.codex/config.toml`); memory/skills/prompts all match. (Project-scope slash commands are correctly *skipped* — Codex prompts are home-only.)
- **Claude (other 5 components)** — memory/skills/subagents/commands/hooks all match upstream at both scopes.
- **Cursor** — noop, writes nothing.

## Related finding (separate issue, not in this PR)

The audit also surfaced **#66**: Claude **LSP** servers are written to `settings.json#/lspServers`, but Claude reads LSP only from **plugin manifests** (`.lsp.json`/`plugin.json#lspServers`) — so it's silently ignored and the "LSP ✓ native" matrix claim is overstated. That one needs a design decision (downgrade-to-Skip vs. project-as-plugin), so it's tracked in #66 rather than bundled here.

Closes #56

https://claude.ai/code/session_01HHfVjqHZbS59rXW3LZ8uef