### PR TITLE
feat(cli): verify supports --scope project / --project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
   flag — and a non-TTY stdin — makes it fail closed instead. `--scope
   project`/`--project` with no `.agentsync/` tree is a hard error pointing at
   `init --scope project`, never a silent downgrade to user scope.
+- **`verify --scope project` / `--project <path>`.** `verify` now takes the same
+  scope flags as `status`/`diff`/`apply`, so a project `.agentsync/` tree can be
+  schema-linted and have its `${secret:…}`/`${env:…}` references validated.
+  Project references resolve against the inherited user secrets backend exactly
+  as `apply` does (so the two never disagree), and the existing missing-home /
+  half-initialized guards now report the scope-appropriate `init` command.
+  Default stays user scope.
 
 ### Fixed
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -558,7 +558,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 |---|---|---|
 | `init [<git-url>]` | Create `~/.agentsync/` (user scope); optionally clone a bootstrap repo. `--scope project` scaffolds a project tree at `<cwd>/.agentsync/` instead; `--project <path>` targets `<path>/.agentsync/` (implies project scope). A git-URL clone is user-scope only. | `--scope --project` |
 | `doctor` | Diagnose setup: PATH, home/state writability, config schema, secrets backend; flags natively-installed plugins missing from source. | |
-| `verify` | Validate config and surface every unresolved `${secret:}`/`${env:}` ref. | |
+| `verify` | Validate config and surface every unresolved `${secret:}`/`${env:}` ref. `--scope project`/`--project <path>` schema-lints the project tree and validates its references against the inherited user secrets backend. | `--scope --project` |
 | `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -7,41 +7,68 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
 func newVerifyCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		scopeFlag   string
+		projectFlag string
+	)
+	cmd := &cobra.Command{
 		Use:   "verify",
-		Short: "schema-lint ~/.agentsync/ and validate secrets resolvability on demand",
+		Short: "schema-lint the canonical source and validate secrets resolvability on demand",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			fs := afero.NewOsFs()
+			// home is the USER agentsync home. It is both the user-scope source
+			// root AND the anchor for relative secrets paths (identity_file /
+			// file) at EVERY scope: project trees inherit the user's [secrets]
+			// config and resolve against the same vault, exactly as apply does, so
+			// verify and apply never disagree on which key/file to read.
 			home := paths.AgentsyncHome(paths.OSEnv{})
-			// source.Load tolerates a missing home and returns an empty model,
-			// so without this guard `verify` on an uninitialized machine
-			// printed a false "ok" and exited 0. Fail with a pointer to init.
-			if _, err := os.Stat(home); err != nil {
-				if os.IsNotExist(err) {
-					return fmt.Errorf("agentsync home %s does not exist; run `agentsync init` first", home)
-				}
-				return fmt.Errorf("verify: stat %s: %w", home, err)
+			userHome := paths.HomeDir(paths.OSEnv{})
+
+			// Resolve scope ONCE — resolveScope may prompt interactively when cwd
+			// sits inside a project tree and no scope was given, so calling it
+			// twice (here and again inside a shared loader) would prompt twice.
+			sc, projectRoot, err := resolveScope(cmd, scopeFlag, projectFlag, noInputFlag(cmd))
+			if err != nil {
+				return err
 			}
-			// A home dir can exist without agentsync.toml — an authoring command
-			// (e.g. `mcp add`) run before `init` scaffolds component dirs + .state
-			// but not the config. source.Load tolerates the missing file (empty
-			// Config), so without this guard verify reported a false "ok" on a
-			// half-initialized home. Require the config marker.
-			if _, err := os.Stat(filepath.Join(home, "agentsync.toml")); err != nil {
-				if os.IsNotExist(err) {
-					return fmt.Errorf("agentsync home %s is missing agentsync.toml (half-initialized); run `agentsync init`", home)
-				}
-				return fmt.Errorf("verify: stat agentsync.toml: %w", err)
+
+			// The source root the init/half-init guards below check: the project
+			// tree at project scope, the user home otherwise. resolveScope already
+			// guarantees a project tree's .agentsync/ DIRECTORY exists; the guards
+			// add the agentsync.toml check so verify never reports a false "ok" on
+			// a half-initialized tree (source.Load tolerates a missing config).
+			sourceRoot := home
+			if sc == adapter.ScopeProject {
+				sourceRoot = project.Home(projectRoot)
 			}
-			c, err := source.Load(afero.NewOsFs(), home)
+			if err := requireInitializedSource(sourceRoot, sc); err != nil {
+				return err
+			}
+
+			// Load the source for this scope: the user base, plus the project
+			// overlay at project scope so the project's ${secret:…}/${env:…}
+			// references resolve against the inherited user [secrets] config —
+			// mirroring apply's merged render. verify deliberately does NOT project
+			// marketplace plugins; it validates the source the user authors.
+			c, err := source.Load(fs, home)
 			if err != nil {
 				return fmt.Errorf("verify: %w", err)
+			}
+			if sc == adapter.ScopeProject {
+				pc, perr := source.Load(fs, sourceRoot)
+				if perr != nil {
+					return fmt.Errorf("verify: load project source %s: %w", sourceRoot, perr)
+				}
+				c = project.Merge(c, pc)
 			}
 			for name := range c.Config.Agents {
 				if err := validateAgent(name); err != nil {
@@ -59,7 +86,7 @@ func newVerifyCmd() *cobra.Command {
 			// reference shape, so the schema decode + this pass cover
 			// the offline-validatable space.
 			if os.Getenv("AGENTSYNC_ALLOW_OFFLINE_VERIFY") != "1" {
-				secBackend := secrets.SelectBackend(c.Config.Secrets, home, paths.HomeDir(paths.OSEnv{}))
+				secBackend := secrets.SelectBackend(c.Config.Secrets, home, userHome)
 				envBackend := secrets.EnvBackend{}
 				if _, err := secrets.SubstituteCanonical(c, secBackend, envBackend); err != nil {
 					return fmt.Errorf("verify ${secret:}/${env:} resolution: %w", err)
@@ -69,6 +96,36 @@ func newVerifyCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
+	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	return cmd
+}
+
+// requireInitializedSource fails verify with an actionable error when the source
+// root for the chosen scope is absent or half-initialized (present but missing
+// agentsync.toml). source.Load tolerates both and returns an empty model, so
+// without this guard verify would print a false "ok: schema valid" on a tree
+// that was never set up. The message points at the scope-appropriate `init`.
+func requireInitializedSource(root string, sc adapter.Scope) error {
+	label := "agentsync home"
+	initCmd := "`agentsync init`"
+	if sc == adapter.ScopeProject {
+		label = "project source tree"
+		initCmd = "`agentsync init --scope project`"
+	}
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s %s does not exist; run %s first", label, root, initCmd)
+		}
+		return fmt.Errorf("verify: stat %s: %w", root, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "agentsync.toml")); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s %s is missing agentsync.toml (half-initialized); run %s", label, root, initCmd)
+		}
+		return fmt.Errorf("verify: stat agentsync.toml: %w", err)
+	}
+	return nil
 }
 
 // verifySecrets validates the [secrets] block beyond the schema decode:

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -140,3 +140,116 @@ func TestVerify_UnknownAgent(t *testing.T) {
 		t.Fatal("verify should reject unknown agent name")
 	}
 }
+
+// TestVerify_HelpListsScopeFlags is the acceptance check that `verify --help`
+// now documents --scope and --project, matching status/diff.
+func TestVerify_HelpListsScopeFlags(t *testing.T) {
+	out, _ := runCLI(t, nil, "verify", "--help")
+	for _, flag := range []string{"--scope", "--project"} {
+		if !strings.Contains(out, flag) {
+			t.Fatalf("verify --help missing %q. Got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestVerify_ProjectScope_OK schema-lints a project .agentsync/ tree and
+// resolves its references via --project (which implies project scope). The
+// project MCP server carries an ${env:} reference so the secret-resolution pass
+// is exercised, not just the schema decode.
+func TestVerify_ProjectScope_OK(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome, "PROJ_TOKEN": "s3cr3t"}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	// A valid project-scope MCP server referencing an env var that is set, so
+	// the ${env:} resolution pass succeeds.
+	mcp := filepath.Join(proj, ".agentsync", "mcp", "projapi.toml")
+	body := "[server]\ntype = \"stdio\"\ncommand = \"node\"\nargs = [\"s.js\"]\nenv = { TOKEN = \"${env:PROJ_TOKEN}\" }\n"
+	if err := os.WriteFile(mcp, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "verify", "--project", proj)
+	if err != nil {
+		t.Fatalf("verify --project: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Fatalf("verify --project output missing 'ok': %s", out)
+	}
+}
+
+// TestVerify_ProjectScope_BadTOML asserts schema-linting reaches the project
+// tree: a malformed file under <proj>/.agentsync/ fails verify at project scope.
+func TestVerify_ProjectScope_BadTOML(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(proj, ".agentsync", "mcp", "broken.toml")
+	if err := os.WriteFile(bad, []byte("[server\nmissing-bracket"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCLI(t, env, "verify", "--scope", "project", "--project", proj); err == nil {
+		t.Fatal("verify --scope project should fail on malformed project TOML")
+	}
+}
+
+// TestVerify_ProjectScope_HalfInit asserts the half-init guard adapts to the
+// project case: a <proj>/.agentsync/ directory with no agentsync.toml (so
+// source.Load tolerates it and would otherwise report a false "ok") is rejected
+// with a message naming agentsync.toml and the project init command.
+func TestVerify_ProjectScope_HalfInit(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	// A .agentsync/ tree exists (so scope resolution accepts the project root)
+	// but it has no agentsync.toml.
+	if err := os.MkdirAll(filepath.Join(proj, ".agentsync", "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runCLI(t, env, "verify", "--project", proj)
+	if err == nil {
+		t.Fatal("verify on a half-initialized project tree must error")
+	}
+	if !strings.Contains(err.Error(), "agentsync.toml") || !strings.Contains(err.Error(), "init") {
+		t.Fatalf("error should name agentsync.toml + point at init; got: %v", err)
+	}
+}
+
+// TestVerify_ProjectScope_NoTree asserts verify surfaces the shared
+// scope-resolution error when --project points at a path with no .agentsync/
+// tree, rather than silently degrading to user scope.
+func TestVerify_ProjectScope_NoTree(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "verify", "--project", proj)
+	if err == nil {
+		t.Fatal("verify --project with no .agentsync/ tree should error")
+	}
+	if !strings.Contains(err.Error(), ".agentsync") {
+		t.Fatalf("error should mention the missing .agentsync/ tree; got: %v", err)
+	}
+}

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -20,7 +20,7 @@ import { Aside } from '@astrojs/starlight/components';
 |---|---|---|
 | `init [<git-url>]` | Create `~/.agentsync/`; optionally clone a bootstrap repo. `--scope project` / `--project <path>` scaffolds a project tree instead. | `--scope --project` |
 | `doctor` | Diagnose setup: PATH, home/state writability, schema, secrets backend. | |
-| `verify` | Validate config; surface unresolved `${secret:}` / `${env:}` refs. | |
+| `verify` | Validate config; surface unresolved `${secret:}` / `${env:}` refs. `--scope project` / `--project <path>` lints the project tree instead. | `--scope --project` |
 | `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
@@ -63,6 +63,14 @@ Validates the canonical config and surfaces **every** unresolved `${secret:…}`
 `${env:…}` reference. Ideal for CI — see
 [Verify config in CI](/recipes/ci-verification/). Pair with
 `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` on runners without an age key.
+
+Defaults to **user** scope. `--scope project` (walks up from cwd to the
+`.agentsync/` tree) or `--project <path>` schema-lints the **project** source
+tree and validates its references — resolving `${secret:…}` against the
+inherited user secrets backend, exactly as `apply` does, so the two never
+disagree. With no scope flag inside a project tree the choice is ambiguous:
+verify prompts project-vs-user, or fails closed under `--no-input` / a non-TTY
+stdin.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #62. `agentsync verify` was hard-wired to **user** scope and had no `--scope`/`--project` flags, so a project-scope `.agentsync/` source tree could not be schema-linted or have its `${secret:…}`/`${env:…}` references validated — the only source-consuming command without scope parity (`status`, `diff`, `apply`, `import`, `reconcile` all have it).

```console
$ agentsync verify --scope project     # before: "unknown flag: --scope"
$ agentsync verify --project .         # now: lints the project tree
```

## What changed

- **Flags + scope resolution mirror `status`/`diff`.** `verify` now wires `--scope` and `--project` with identical help wording and delegates to the shared `resolveScope`, so it inherits the same behavior: `--scope project` walks up from cwd to the tree, `--project <path>` implies project scope, an ambiguous tree (no flag, inside a project) prompts project-vs-user, and `--no-input` / a non-TTY stdin fails closed. A missing tree is a hard error pointing at `init --scope project`, never a silent downgrade.
- **Project references resolve exactly as `apply` does.** At project scope, verify loads the user base and overlays the project tree (`project.Merge`), then resolves `${secret:…}` against the **inherited user secrets backend** anchored at the user home. This keeps verify and apply from ever disagreeing on which key/file to read. Verify deliberately does **not** project marketplace plugins — it validates the source the user authors (unchanged from before).
- **Guards adapt to the scope.** The existing missing-home / half-initialized (`agentsync.toml` absent) guards — which exist because `source.Load` tolerates both and would otherwise print a false `ok` — now check the scope-appropriate source root and emit the matching `init` command.

## Tests

Added to `internal/cli/verify_test.go`:
- `TestVerify_ProjectScope_OK` — lints a project tree and resolves an `${env:}` reference, exit 0.
- `TestVerify_ProjectScope_BadTOML` — malformed file under the project tree fails verify.
- `TestVerify_ProjectScope_HalfInit` — a `.agentsync/` dir with no `agentsync.toml` is rejected with a project-appropriate message.
- `TestVerify_ProjectScope_NoTree` — `--project` with no tree surfaces the shared resolution error.
- `TestVerify_HelpListsScopeFlags` — `verify --help` documents both flags.

Existing user-scope guard/secret tests still pass unchanged. Full `./...` suite green; `golangci-lint` clean.

## Docs (kept in sync, same commit)

- `docs/user-guide.md` command reference — `verify` row gains `--scope --project`.
- `website/src/content/docs/reference/cli.mdx` — at-a-glance row + `### verify` section.
- `CHANGELOG.md` — `[Unreleased]` → Added.

## Acceptance criteria

- [x] `verify --scope project` / `--project <path>` schema-lints the project source and validates its references; exit 0 on success.
- [x] `verify --help` documents `--scope` and `--project`, matching `status`/`diff` wording.
- [x] Default user-scope behavior and the missing-home / half-initialized guards preserved (project case gets an analogous message).
- [x] Test coverage for the project-scope path.
- [x] Docs/CLI reference updated.

https://claude.ai/code/session_0138Ce8bRX9G7Yc8rL3HKQSc

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Ce8bRX9G7Yc8rL3HKQSc)_