### PR TITLE
docs(dogfood): note repo is agentsync-managed in project memory

### DIFF
--- a/.agentsync/memory/AGENTS.md
+++ b/.agentsync/memory/AGENTS.md
@@ -23,6 +23,28 @@ resolved at apply time from an age-encrypted vault.
   aspirational and not wired in v1.0 (`apply --strict/--force/--agent` flags, an
   `agentsync skill` command) — trust the code over the spec on the CLI surface.
 
+## This repo is agentsync-managed — change `.agentsync/`, not the rendered files
+
+agentsync dogfoods itself: this repository's own agent configuration is managed
+by agentsync ([agentsync.cc](https://agentsync.cc)). The canonical source of
+truth is the project-scope **`.agentsync/`** tree at the repo root — memory
+(`.agentsync/memory/AGENTS.md`), skills (`.agentsync/skills/<name>/SKILL.md`),
+MCP servers, subagents, commands, hooks, and `agentsync.toml`.
+
+The native agent files are **rendered** from that tree by `agentsync apply
+--scope project`; they are build output, not sources — do not hand-edit them:
+
+- this file — `CLAUDE.md` (claude memory) and `AGENTS.md` (codex memory) — is a
+  passthrough render of `.agentsync/memory/AGENTS.md`;
+- `.claude/skills/…` and `.agents/skills/…` render from `.agentsync/skills/…`.
+
+**To change memory, skills, MCP config, or any agent setting in this repo, edit
+the canonical file under `.agentsync/` and re-render with `agentsync apply
+--scope project`.** A direct edit to a rendered file is overwritten on the next
+apply and surfaces as drift in `agentsync status --scope project`; to fold an
+edit already made in a native file back into the canonical source, capture it
+with `agentsync import`/`reconcile --scope project` instead.
+
 ## Keep the docs in sync — non-negotiable
 
 Docs are part of the contract, not an afterthought. **No commit may change an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,28 @@ resolved at apply time from an age-encrypted vault.
   aspirational and not wired in v1.0 (`apply --strict/--force/--agent` flags, an
   `agentsync skill` command) — trust the code over the spec on the CLI surface.
 
+## This repo is agentsync-managed — change `.agentsync/`, not the rendered files
+
+agentsync dogfoods itself: this repository's own agent configuration is managed
+by agentsync ([agentsync.cc](https://agentsync.cc)). The canonical source of
+truth is the project-scope **`.agentsync/`** tree at the repo root — memory
+(`.agentsync/memory/AGENTS.md`), skills (`.agentsync/skills/<name>/SKILL.md`),
+MCP servers, subagents, commands, hooks, and `agentsync.toml`.
+
+The native agent files are **rendered** from that tree by `agentsync apply
+--scope project`; they are build output, not sources — do not hand-edit them:
+
+- this file — `CLAUDE.md` (claude memory) and `AGENTS.md` (codex memory) — is a
+  passthrough render of `.agentsync/memory/AGENTS.md`;
+- `.claude/skills/…` and `.agents/skills/…` render from `.agentsync/skills/…`.
+
+**To change memory, skills, MCP config, or any agent setting in this repo, edit
+the canonical file under `.agentsync/` and re-render with `agentsync apply
+--scope project`.** A direct edit to a rendered file is overwritten on the next
+apply and surfaces as drift in `agentsync status --scope project`; to fold an
+edit already made in a native file back into the canonical source, capture it
+with `agentsync import`/`reconcile --scope project` instead.
+
 ## Keep the docs in sync — non-negotiable
 
 Docs are part of the contract, not an afterthought. **No commit may change an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,28 @@ resolved at apply time from an age-encrypted vault.
   aspirational and not wired in v1.0 (`apply --strict/--force/--agent` flags, an
   `agentsync skill` command) — trust the code over the spec on the CLI surface.
 
+## This repo is agentsync-managed — change `.agentsync/`, not the rendered files
+
+agentsync dogfoods itself: this repository's own agent configuration is managed
+by agentsync ([agentsync.cc](https://agentsync.cc)). The canonical source of
+truth is the project-scope **`.agentsync/`** tree at the repo root — memory
+(`.agentsync/memory/AGENTS.md`), skills (`.agentsync/skills/<name>/SKILL.md`),
+MCP servers, subagents, commands, hooks, and `agentsync.toml`.
+
+The native agent files are **rendered** from that tree by `agentsync apply
+--scope project`; they are build output, not sources — do not hand-edit them:
+
+- this file — `CLAUDE.md` (claude memory) and `AGENTS.md` (codex memory) — is a
+  passthrough render of `.agentsync/memory/AGENTS.md`;
+- `.claude/skills/…` and `.agents/skills/…` render from `.agentsync/skills/…`.
+
+**To change memory, skills, MCP config, or any agent setting in this repo, edit
+the canonical file under `.agentsync/` and re-render with `agentsync apply
+--scope project`.** A direct edit to a rendered file is overwritten on the next
+apply and surfaces as drift in `agentsync status --scope project`; to fold an
+edit already made in a native file back into the canonical source, capture it
+with `agentsync import`/`reconcile --scope project` instead.
+
 ## Keep the docs in sync — non-negotiable
 
 Docs are part of the contract, not an afterthought. **No commit may change an


### PR DESCRIPTION
## What

Follow-up to #61 (which made this repo dogfood agentsync). Adds a **"This repo is agentsync-managed"** section to the canonical project memory so future agent sessions know the native config files are *rendered output*, not sources.

The section explains:
- this repo dogfoods agentsync ([agentsync.cc](https://agentsync.cc)); the project-scope **`.agentsync/`** tree is the source of truth for memory, skills, MCP servers, subagents, commands, hooks, and `agentsync.toml`;
- the native files are **rendered** by `agentsync apply --scope project` — don't hand-edit them:
  - `CLAUDE.md` (claude memory) + `AGENTS.md` (codex memory) are passthrough renders of `.agentsync/memory/AGENTS.md`;
  - `.claude/skills/…` and `.agents/skills/…` render from `.agentsync/skills/…`;
- to change anything, edit the canonical file under `.agentsync/` and re-render, or fold an already-made native edit back with `agentsync import`/`reconcile --scope project`.

## How

Edited the **canonical source** (`.agentsync/memory/AGENTS.md`) — not the rendered files — then re-rendered with `agentsync apply --scope project`. `CLAUDE.md` and `AGENTS.md` are byte-identical passthrough renders of the source. No Go changed; no doc/changelog updates triggered (internal project memory, not an interface/contract/CLI/schema/capability change).

## Files

- `.agentsync/memory/AGENTS.md` — canonical source (the real edit)
- `CLAUDE.md` — claude memory render
- `AGENTS.md` — codex memory render

(All three byte-identical, as the memory render is a passthrough.)

## Verification

| Check | Result |
| --- | --- |
| `agentsync status --scope project` | **4 clean**, exit 0 |
| `agentsync diff --scope project` | **no diff** |
| `.agentsync/memory/AGENTS.md` == `CLAUDE.md` == `AGENTS.md` | byte-identical |

Every CLI claim in the new text (`apply`/`status`/`diff`/`import`/`reconcile` accepting `--scope project`) and the render mapping were verified against the code and PR #61 before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)