### PR TITLE
docs(cli): list `verify` in the cross-command scope-flag table

### DIFF
--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -212,8 +212,8 @@ agentsync explain --list
 
 | Flag | Applies to | Effect |
 |---|---|---|
-| `--scope user\|project` | init, import, apply, status, diff, reconcile, update | Force the config scope. |
-| `--project <path>` | init, import, apply, status, diff, reconcile, update | Target / apply a specific project's tree. |
+| `--scope user\|project` | init, verify, import, apply, status, diff, reconcile, update | Force the config scope. |
+| `--project <path>` | init, verify, import, apply, status, diff, reconcile, update | Target / apply a specific project's tree. |
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
 | `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). `explain --list --json` emits a `plugins` array; `explain` with ids/`--all` emits the translation `rows`. |


### PR DESCRIPTION
## Summary

Tiny docs-only follow-up to **#64** (`feat(cli): verify supports --scope project / --project`).

#64 wired `--scope` / `--project` into `agentsync verify` and updated the docs in the same commit — the per-command `### verify` section, the at-a-glance command table, the `docs/user-guide.md` row, and the `CHANGELOG`. But it missed one place: the **"Flags that work across commands"** table at the bottom of `website/src/content/docs/reference/cli.mdx`. Those two rows still enumerated every scope-aware command *except* `verify`:

```
| `--scope user|project` | init, import, apply, status, diff, reconcile, update | … |
| `--project <path>`     | init, import, apply, status, diff, reconcile, update | … |
```

This PR adds `verify` to both rows so the cross-command flag table matches the command's actual surface (and the rest of the page, which already documents it).

## How this was found

While comparing #64 against **#65** (`fix: support project scope in verify`) — an independent contribution proposing the same `verify` scope feature. #64 is the implementation landing in `main`; #65's secret-resolution path diverged from `apply`'s (it anchored the secrets backend at the project root and skipped the user-base `project.Merge`, so `verify` and `apply` could disagree on which vault/key to read). The **one thing #65 got that #64 missed** was this cross-command flag table — so this PR cherry-picks just that doc correction. Credit to @pranjalbhatia710 for catching it.

## Scope

- Docs only. No code, no behavior change — the capability already shipped in #64.
- This is the only doc surface that was out of date; `docs/user-guide.md` and `README.md` have no equivalent cross-command flag table (verified), so nothing else needs touching.

## Test plan

- [x] `git diff` shows exactly the two table rows changed.
- [x] No code paths touched; CLI surface unchanged since #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)