### PR TITLE
chore(dogfood): mark Codex as shipped in project memory

### DIFF
--- a/.agentsync/memory/AGENTS.md
+++ b/.agentsync/memory/AGENTS.md
@@ -5,7 +5,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 ## What this is
 
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
-configurations (Claude Code, OpenCode, and — planned — Codex CLI, Cursor). The
+configurations (Claude Code, OpenCode, Codex, and — planned — Cursor). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 ## What this is
 
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
-configurations (Claude Code, OpenCode, and — planned — Codex CLI, Cursor). The
+configurations (Claude Code, OpenCode, Codex, and — planned — Cursor). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 ## What this is
 
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
-configurations (Claude Code, OpenCode, and — planned — Codex CLI, Cursor). The
+configurations (Claude Code, OpenCode, Codex, and — planned — Cursor). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged


### PR DESCRIPTION
## What

The project-memory "What this is" blurb listed Codex under **planned**, but Codex has been a fully registered, shipped adapter for a while:

- `internal/adapter/codex/` — real adapter (memory, skills, subagents, commands, hooks, MCP)
- wired into the registry via `codex.New(...)` in `internal/cli/registry_internal.go:19`, next to Claude and OpenCode
- `docs/capability-matrix.md` already lists Codex as **✅ Adapter (some components projected)**

Only **Cursor** remains planned (registered as a no-op).

## How

This repo is agentsync-managed, so the fix edits the **canonical source** and re-renders — it does not hand-edit the rendered files:

1. Edited `.agentsync/memory/AGENTS.md` so Codex moves out of the "planned" list, leaving `(Claude Code, OpenCode, Codex, and — planned — Cursor)`.
2. Re-rendered the two passthrough memory targets with `agentsync apply --scope project`:
   - `CLAUDE.md` (claude memory)
   - `AGENTS.md` (codex memory)

The diff is the identical one-line correction in all three files; nothing else changed.

## Context

Companion to the GitHub repo **description** update (done out-of-band, since it's a repo setting not in the tree): now reads *"Sync AI coding-agent configs (Claude Code, OpenCode, Codex, and more)…"*. This PR brings the in-repo project memory in line with that.

Other surfaces (`README.md`, `docs/user-guide.md`, capability matrices) already described Codex as shipped — no change needed there. The two CHANGELOG "Codex planned" mentions are historical release-note entries left as-is.

## Test plan

- [x] `agentsync apply --scope project` succeeded (4 ops)
- [x] `agentsync status --scope project` → **4 clean**
- [x] `git diff` shows only the intended one-line wording change across the canonical source + 2 rendered files

🤖 Generated with [Claude Code](https://claude.com/claude-code)