### PR TITLE
feat(cli): label already-synced destinations in apply --dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Changed
 
+- **`apply --dry-run` now distinguishes already-synced destinations from pending
+  writes.** Previously every planned op was listed as `→ write`, even when the
+  destination already held exactly the bytes apply would write — so a dry-run on
+  an in-sync tree read like a wall of pending work. The preview now runs the real
+  apply pipeline through non-writing writers (so each merge is performed against
+  the on-disk destination, matching the eventual apply exactly) and labels each op
+  `✓ synced` or `→ write`; the summary line gains a `— N to write, M already
+  synced` tally. Nothing is written, exactly as before.
 - **The M5 single-file `.agentsync.toml` project marker is retired** (one project
   schema, not two). It is no longer read; `agentsync` surfaces a migration error
   pointing at `init --scope project` when it finds one. The marker's

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ New here? The **[User guide](docs/user-guide.md)** takes you 0→100.
     agentsync agent add claude
     agentsync agent add opencode
     agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
-    agentsync apply --dry-run    # preview translation report before writing
+    agentsync apply --dry-run    # preview what would change vs. is already synced
     agentsync apply
 
 ## Documentation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,7 +294,10 @@ Key stages:
 8. **Record** new hashes in `targets.json` (`internal/state`) and print the
    translation report.
 
-`--dry-run` runs steps 1–6 and prints the plan/report without writing.
+`--dry-run` runs steps 1–6, then a non-writing pass of step 7 (the writer's merge
++ convergence check, no disk write) so it can label each destination `✓ synced`
+vs `→ write` and preview foreign-collision backups, and prints the plan/report —
+all without writing a byte.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -157,7 +157,8 @@ renders nothing. `agent add` rejects these unless `AGENTSYNC_ALLOW_UNIMPLEMENTED
 Orchestrates apply: canonical + registry → per-agent `FileOp`s/`Skip`s, runs
 collision detection and backups, records state, synthesizes cleanup ops for
 orphaned owned keys, and builds the translation report.
-- **Key:** `Plan`; `Apply`; `PreviewCollisions`; `Writer`
+- **Key:** `Plan`; `Apply`; `PreviewApply` (dry-run: collision preview +
+  synced/would-change verdict); `Writer`
   (`NewWriter`/`NewPreviewWriter`); `TranslationReport` (`PrintText`/`PrintJSON`);
   `BuildReport`; `RecordOpsState`; `OrphanFiles`; `PruneStaleState`;
   `BackupFile`/`PruneBackups`; `CollisionReport`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -132,10 +132,14 @@ jq '.mcpServers.github' ~/.claude.json
 jq '.mcp.github'        ~/.config/opencode/opencode.json
 ```
 
-> **`apply --dry-run` is your friend.** It prints the full
-> [translation report](#multi-agent-fan-out) — what lands natively (✓), what's
-> projected with loss (◐), and what's skipped (✗) — without writing a byte. Run
-> it before every real apply until you trust the output.
+> **`apply --dry-run` is your friend.** It lists every destination the apply
+> would touch, labeling each `✓ synced` (already holds our exact bytes) or
+> `→ write` (would be created or changed) — with a `— N to write, M already
+> synced` tally — so a clean re-apply reads as a no-op instead of a wall of
+> "write"s. It also prints the full [translation report](#multi-agent-fan-out) —
+> what lands natively (✓), what's projected with loss (◐), and what's skipped
+> (✗) — and previews any foreign-collision backups, all without writing a byte.
+> Run it before every real apply until you trust the output.
 
 ---
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,24 +121,30 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		if err != nil {
 			return err
 		}
+		// Run the pipeline through non-writing preview writers so we know, per
+		// destination, whether the real apply would actually change it (and back
+		// up any foreign content first) or find it already in sync. Without this
+		// the dry-run labels every op "write" even when nothing would change.
+		previews, _, wouldChange, perr := render.PreviewApply(plan, reg, s, home, userHome, sc, projectRoot)
+		if perr != nil {
+			return perr
+		}
 		w := p.Out
-		fmt.Fprintf(w, "%s %d ops total across %d agent(s)\n", p.Bold("Plan:"), plan.Total(), len(plan.PerAgent))
+		toWrite, synced := planSyncCounts(plan, wouldChange)
+		fmt.Fprintf(w, "%s %d ops total across %d agent(s) — %d to write, %d already synced\n",
+			p.Bold("Plan:"), plan.Total(), len(plan.PerAgent), toWrite, synced)
 		for _, name := range reg.Names() {
 			res, ok := plan.PerAgent[name]
 			if !ok {
 				continue
 			}
 			fmt.Fprintf(w, "  %s %d ops, %d skips\n", p.Bold(ui.Pad(name, 10)), len(res.Ops), len(res.Skips))
-			// List every destination path so the user can see exactly
-			// what apply will touch. Without this the dry-run hides the
-			// most useful piece of information (which files will be
-			// written) behind an op count.
+			// List every destination path so the user can see exactly what
+			// apply will touch — and, for each, whether it would be written or
+			// is already in sync, so a clean re-apply reads as a no-op instead
+			// of a wall of "write"s.
 			for _, op := range res.Ops {
-				action := op.Action
-				if action == "" {
-					action = "write"
-				}
-				fmt.Fprintf(w, "    %s %s %s\n", p.Cyan(ui.GlyphArrow), p.Cyan(ui.Pad(action, 5)), op.Path)
+				printPlannedOp(w, p, op, wouldChange)
 			}
 		}
 		// Foreign-collision preview: which destinations contain content
@@ -145,10 +152,6 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		// before overwrite. The dry-run previously hid this; users only
 		// found out which files were about to be backed up after the
 		// real apply ran.
-		previews, perr := render.PreviewCollisions(plan, reg, s, home, userHome, sc, projectRoot)
-		if perr != nil {
-			return perr
-		}
 		if len(previews) > 0 {
 			fmt.Fprintln(w)
 			fmt.Fprintf(w, "%s %d (the real apply will back these up before overwriting)\n",
@@ -233,6 +236,49 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 		report.PrintTextStyled(w, p)
 	}
 	return nil
+}
+
+// printPlannedOp renders one planned destination op in the `apply --dry-run`
+// listing. A write op whose destination already holds our exact bytes (it is
+// NOT in wouldChange, computed by render.PreviewApply) is labeled "synced" with
+// a green check, so a clean re-apply reads as a no-op instead of a wall of
+// pending "write"s; anything that would actually change keeps the cyan arrow.
+func printPlannedOp(w io.Writer, p *ui.Printer, op adapter.FileOp, wouldChange map[string]bool) {
+	if isSyncedOp(op, wouldChange) {
+		fmt.Fprintf(w, "    %s %s %s\n", p.Green(ui.GlyphOK), p.Green(ui.Pad("synced", 6)), op.Path)
+		return
+	}
+	action := op.Action
+	if action == "" {
+		action = "write"
+	}
+	fmt.Fprintf(w, "    %s %s %s\n", p.Cyan(ui.GlyphArrow), p.Cyan(ui.Pad(action, 6)), op.Path)
+}
+
+// isSyncedOp reports whether a planned op is a write the destination already
+// satisfies — i.e. a real apply would skip it. Delete ops, and any write whose
+// destination would be created or modified, are never "synced".
+func isSyncedOp(op adapter.FileOp, wouldChange map[string]bool) bool {
+	if op.Action != "" && op.Action != "write" {
+		return false
+	}
+	return !wouldChange[op.Path]
+}
+
+// planSyncCounts splits the plan's ops into how many a real apply would write
+// (or delete) versus how many are already in sync, so the dry-run summary line
+// can quantify what the per-op labels show.
+func planSyncCounts(plan render.RenderPlan, wouldChange map[string]bool) (toWrite, synced int) {
+	for _, res := range plan.PerAgent {
+		for _, op := range res.Ops {
+			if isSyncedOp(op, wouldChange) {
+				synced++
+			} else {
+				toWrite++
+			}
+		}
+	}
+	return toWrite, synced
 }
 
 // saveBestEffortState records hashes for the ops agentsync actually wrote

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // TestApply_PartialFailureRescuesState exercises saveBestEffortState (the
@@ -298,6 +300,68 @@ func TestApply_DryRunListsDestinations(t *testing.T) {
 	}
 	if !strings.Contains(out, ".claude.json") {
 		t.Fatalf("dry-run did not list destination paths; got:\n%s", out)
+	}
+}
+
+// TestApply_DryRunLabelsSyncedVsWrite is the regression for the finding that
+// `apply --dry-run` labeled every op "write" even when the destination already
+// held our exact bytes — so a dry-run on an in-sync tree looked like pending
+// work. After a real apply everything is in sync, so the dry-run must label the
+// destinations "synced" (0 to write); editing one source then surfaces it as a
+// "write" while the untouched one stays "synced".
+func TestApply_DryRunLabelsSyncedVsWrite(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	mkSkill := func(name, desc string) {
+		t.Helper()
+		p := filepath.Join(tmp, ".agentsync", "skills", name, "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + name + "\ndescription: " + desc + "\n---\nbody\n"
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkSkill("alpha", "first")
+	mkSkill("bravo", "second")
+
+	// Sync both skills to disk.
+	mustRun(t, env, "apply")
+
+	// A dry-run now finds both rendered skills already in sync.
+	out, err := runCLI(t, env, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("apply --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, ui.GlyphOK+" synced") {
+		t.Fatalf("dry-run did not label already-synced destinations; got:\n%s", out)
+	}
+	if !strings.Contains(out, "0 to write") {
+		t.Fatalf("dry-run summary did not report a clean no-op; got:\n%s", out)
+	}
+	if strings.Contains(out, ui.GlyphArrow+" write") {
+		t.Fatalf("dry-run labeled an in-sync destination as a write; got:\n%s", out)
+	}
+
+	// Edit one source: that skill must now show a pending write while the
+	// untouched one stays synced.
+	mkSkill("alpha", "edited")
+	out, err = runCLI(t, env, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("apply --dry-run (after edit): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, ui.GlyphArrow+" write") {
+		t.Fatalf("dry-run did not surface the pending write; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 to write") {
+		t.Fatalf("dry-run summary miscounted pending writes; got:\n%s", out)
+	}
+	if !strings.Contains(out, ui.GlyphOK+" synced") {
+		t.Fatalf("dry-run lost the still-synced destination; got:\n%s", out)
 	}
 }
 

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -119,15 +119,18 @@ func Plan(r secrets.Resolved, reg *adapter.Registry, agents []string, scope adap
 	return out, nil
 }
 
-// PreviewCollisions runs the same per-file / per-pointer foreign-collision
-// check that Apply runs at write time, but writes nothing. It returns the
-// reports a real apply would have produced. Used by `apply --dry-run` so
-// the user can see — before committing — exactly which destination files
-// are about to be backed up and overwritten.
+// PreviewApply runs the apply pipeline through non-writing preview writers and
+// reports what a real apply would do, without touching disk. It returns the
+// foreign-collision reports a real apply would produce, plus the per-destination
+// convergence verdict: `unchanged` paths already hold exactly the bytes apply
+// would write (the dry-run shows them as "synced"), and `wouldChange` paths
+// would be created or modified (shown as "write"). Used by `apply --dry-run`.
 //
-// We have to re-run the deduplication that Apply does (path-level
-// first-writer-wins) so the dry-run preview matches what really happens.
-func PreviewCollisions(
+// It supersedes the older op.Content-only collision preview: because it runs the
+// real adapter Apply, each merge is performed for real (against the on-disk
+// destination), so the preview's synced/write verdict and collision set match
+// the eventual apply exactly rather than approximating it.
+func PreviewApply(
 	p RenderPlan,
 	reg *adapter.Registry,
 	st *state.Targets,
@@ -135,50 +138,9 @@ func PreviewCollisions(
 	userHome string,
 	scope adapter.Scope,
 	project string,
-) ([]CollisionReport, error) {
-	if st == nil {
-		return nil, nil
-	}
-	var all []CollisionReport
-	seen := map[string][]byte{}
-	for _, name := range reg.Names() {
-		res, ok := p.PerAgent[name]
-		if !ok {
-			continue
-		}
-		w := NewPreviewWriter(st, home, userHome, scope, project, name)
-		for _, op := range res.Ops {
-			if op.Action != "" && op.Action != "write" {
-				continue
-			}
-			// Mirror Apply's dedup AND its divergence guard: only whole-file
-			// replace writes are collapsed by path; identical content dedups,
-			// but divergent content for the same path fails loud — otherwise
-			// --dry-run would show a clean preview that the real apply rejects.
-			if !IsKeyMerge(op.MergeStrategy) {
-				if prev, ok := seen[op.Path]; ok {
-					if !bytes.Equal(prev, op.Content) {
-						return all, fmt.Errorf(
-							"agent %q renders different content than an earlier agent for the same path %s; "+
-								"refusing to silently drop one (shared paths must render identical bytes)",
-							name, op.Path,
-						)
-					}
-					continue
-				}
-				seen[op.Path] = op.Content
-			}
-			// We don't have the post-merge finalBytes here without
-			// re-running the adapter. For preview purposes a conservative
-			// "is something there that doesn't look exactly like our op"
-			// is sufficient — Apply's real maybeBackup will recompute and
-			// suppress the report if the on-disk content happens to match
-			// the post-merge bytes exactly.
-			_ = w.maybeBackup(op, op.Content)
-		}
-		all = append(all, w.Reports()...)
-	}
-	return all, nil
+) (reports []CollisionReport, unchanged, wouldChange map[string]bool, err error) {
+	reports, _, unchanged, wouldChange, err = applyPlan(p, reg, st, home, userHome, scope, project, true)
+	return reports, unchanged, wouldChange, err
 }
 
 // ownedKeysFor returns the JSON-pointer strings owned by agentsync for a given
@@ -367,17 +329,44 @@ func Apply(
 	scope adapter.Scope,
 	project string,
 ) ([]CollisionReport, map[string]bool, map[string]bool, error) {
-	written := map[string]bool{}
-	unchanged := map[string]bool{}
+	reports, written, unchanged, _, err := applyPlan(p, reg, st, home, userHome, scope, project, false)
+	return reports, written, unchanged, err
+}
+
+// applyPlan is the shared body of Apply and PreviewApply. With dryRun=false it
+// commits the plan through real Writers (the public Apply); with dryRun=true it
+// runs the identical pipeline — same dedup, same skill-orphan reclamation, same
+// per-op merge — through non-writing preview Writers, so the collision reports
+// and the synced/would-change verdicts a dry-run shows are computed by the very
+// code a real apply runs and can never disagree with it.
+//
+// It returns the union of CollisionReports plus three path sets: `written`
+// (committed this run; empty under dryRun), `unchanged` (the destination already
+// held our exact bytes), and `wouldChange` (a dry-run write that would create or
+// modify the destination; empty on a real apply, since the write is performed).
+// On adapter error the work done before the failure is reflected and not rolled
+// back (per-file writes are atomic, the plan as a whole is not transactional).
+func applyPlan(
+	p RenderPlan,
+	reg *adapter.Registry,
+	st *state.Targets,
+	home string,
+	userHome string,
+	scope adapter.Scope,
+	project string,
+	dryRun bool,
+) (reports []CollisionReport, written, unchanged, wouldChange map[string]bool, err error) {
+	written = map[string]bool{}
+	unchanged = map[string]bool{}
+	wouldChange = map[string]bool{}
 	if st == nil {
 		// Defensive: a nil state would make every write look like a
 		// foreign collision and produce duplicate backups. Callers that
 		// don't yet have a state object should construct an empty one
 		// (state.New) rather than passing nil.
-		return nil, written, unchanged, fmt.Errorf("render.Apply: nil state")
+		return nil, written, unchanged, wouldChange, fmt.Errorf("render.Apply: nil state")
 	}
 
-	var allReports []CollisionReport
 	seen := map[string][]byte{}
 	deletedSkillOrphans := map[string]struct{}{}
 	for _, name := range reg.Names() {
@@ -387,7 +376,7 @@ func Apply(
 		}
 		a := reg.Lookup(name)
 		if a == nil {
-			return allReports, written, unchanged, fmt.Errorf("adapter %q not registered at apply", name)
+			return reports, written, unchanged, wouldChange, fmt.Errorf("adapter %q not registered at apply", name)
 		}
 		var deduped []adapter.FileOp
 		for _, op := range res.Ops {
@@ -406,7 +395,7 @@ func Apply(
 					// dropping one agent's bytes would be data loss — so fail
 					// loud rather than pick a winner.
 					if !bytes.Equal(prev, op.Content) {
-						return allReports, written, unchanged, fmt.Errorf(
+						return reports, written, unchanged, wouldChange, fmt.Errorf(
 							"agent %q renders different content than an earlier agent for the same path %s; "+
 								"refusing to silently drop one (shared paths must render identical bytes)",
 							name, op.Path,
@@ -429,18 +418,26 @@ func Apply(
 			deletedSkillOrphans[del.Path] = struct{}{}
 			deduped = append(deduped, del)
 		}
-		w := NewWriter(st, home, userHome, scope, project, name)
-		err := a.Apply(deduped, w)
-		allReports = append(allReports, w.Reports()...)
+		var w *Writer
+		if dryRun {
+			w = NewPreviewWriter(st, home, userHome, scope, project, name)
+		} else {
+			w = NewWriter(st, home, userHome, scope, project, name)
+		}
+		aerr := a.Apply(deduped, w)
+		reports = append(reports, w.Reports()...)
 		for path := range w.Wrote() {
 			written[path] = true
 		}
 		for path := range w.Unchanged() {
 			unchanged[path] = true
 		}
-		if err != nil {
-			return allReports, written, unchanged, fmt.Errorf("apply %s: %w", name, err)
+		for path := range w.WouldChange() {
+			wouldChange[path] = true
+		}
+		if aerr != nil {
+			return reports, written, unchanged, wouldChange, fmt.Errorf("apply %s: %w", name, aerr)
 		}
 	}
-	return allReports, written, unchanged, nil
+	return reports, written, unchanged, wouldChange, nil
 }

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -90,7 +90,12 @@ type Writer struct {
 	backedUp   map[string]bool // path → already-backed-up this run
 	wrote      map[string]bool // path → destination owned/written this run
 	unchanged  map[string]bool // path → already held our exact bytes (write skipped)
-	reports    []CollisionReport
+	// wouldChange is populated only under dryRun: path → the write would have
+	// created or modified the destination (it did not already hold our bytes).
+	// It is the complement of unchanged for the preview, letting `apply
+	// --dry-run` label each destination "write" vs "synced".
+	wouldChange map[string]bool
+	reports     []CollisionReport
 	// dryRun, when true, skips both the destination write AND the backup
 	// write. The reports slice is still populated so callers can preview
 	// the foreign-collisions a real apply would produce.
@@ -127,16 +132,17 @@ func NewWriter(st *state.Targets, home, userHome string, scope adapter.Scope, pr
 	now := time.Now().UTC()
 	ts := fmt.Sprintf("%s-%09d", now.Format("20060102T150405Z"), now.Nanosecond())
 	return &Writer{
-		state:      st,
-		home:       home,
-		userHome:   userHome,
-		scope:      scope,
-		project:    project,
-		agent:      agent,
-		backupRoot: filepath.Join(home, ".state", "backups", ts),
-		backedUp:   map[string]bool{},
-		wrote:      map[string]bool{},
-		unchanged:  map[string]bool{},
+		state:       st,
+		home:        home,
+		userHome:    userHome,
+		scope:       scope,
+		project:     project,
+		agent:       agent,
+		backupRoot:  filepath.Join(home, ".state", "backups", ts),
+		backedUp:    map[string]bool{},
+		wrote:       map[string]bool{},
+		unchanged:   map[string]bool{},
+		wouldChange: map[string]bool{},
 	}
 }
 
@@ -164,6 +170,13 @@ func (w *Writer) Wrote() map[string]bool { return w.wrote }
 // skipped. apply uses it to report "up to date" instead of "applied: N ops".
 func (w *Writer) Unchanged() map[string]bool { return w.unchanged }
 
+// WouldChange returns the set of destination paths a dry-run write would have
+// created or modified (the complement of Unchanged for the preview). It is only
+// populated when the writer is in dry-run mode; on a real apply it is empty
+// because the write is actually performed. `apply --dry-run` uses it to label
+// each planned destination "write" vs "synced".
+func (w *Writer) WouldChange() map[string]bool { return w.wouldChange }
+
 // Write satisfies adapter.DestWriter. finalBytes is the post-merge content
 // for merge ops, or op.Content for replace ops.
 func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
@@ -172,16 +185,24 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 	// mtime (which misleads mtime-watching tooling and makes a clean re-apply
 	// look like real work). The post-condition (dest == finalBytes) already
 	// holds, so still mark it owned for state recording; nothing is overwritten,
-	// so there is nothing to back up. Skipped under dry-run (no read needed).
-	if !w.dryRun {
-		if cur, err := os.ReadFile(op.Path); err == nil && bytes.Equal(cur, finalBytes) {
-			w.wrote[op.Path] = true
-			w.unchanged[op.Path] = true
-			return nil
-		}
+	// so there is nothing to back up. The same read drives the dry-run preview:
+	// it is what lets `apply --dry-run` label a converged destination "synced"
+	// rather than "write".
+	if cur, err := os.ReadFile(op.Path); err == nil && bytes.Equal(cur, finalBytes) {
+		w.wrote[op.Path] = true
+		w.unchanged[op.Path] = true
+		return nil
 	}
+	// The write would create or change op.Path. Back up any foreign content
+	// first (a dry-run records the collision report but writes no backup).
 	if err := w.maybeBackup(op, finalBytes); err != nil {
 		return err
+	}
+	if w.dryRun {
+		// Preview only: record that this destination WOULD change so the
+		// dry-run can label it, and touch nothing on disk.
+		w.wouldChange[op.Path] = true
+		return nil
 	}
 	mode := os.FileMode(op.Mode)
 	if mode == 0 {

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -469,10 +469,10 @@ func TestRenderApply_SharedWriteDivergence(t *testing.T) {
 	})
 }
 
-// TestPreviewCollisions_SharedWriteDivergence ensures `apply --dry-run`'s
-// preview fails loud on divergent shared-path content, matching Apply — so the
-// dry-run can't show a clean preview that the real apply then aborts on.
-func TestPreviewCollisions_SharedWriteDivergence(t *testing.T) {
+// TestPreviewApply_SharedWriteDivergence ensures `apply --dry-run`'s preview
+// fails loud on divergent shared-path content, matching Apply — so the dry-run
+// can't show a clean preview that the real apply then aborts on.
+func TestPreviewApply_SharedWriteDivergence(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, ".agentsync")
 	_ = os.MkdirAll(home, 0o755)
@@ -485,8 +485,62 @@ func TestPreviewCollisions_SharedWriteDivergence(t *testing.T) {
 		"claude":   {Ops: []adapter.FileOp{{Action: "write", Path: dest, Content: []byte("A"), Mode: 0o644, SourceID: "skills/x/SKILL.md"}}},
 		"opencode": {Ops: []adapter.FileOp{{Action: "write", Path: dest, Content: []byte("B"), Mode: 0o644, SourceID: "skills/x/SKILL.md"}}},
 	}}
-	if _, err := render.PreviewCollisions(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err == nil {
+	if _, _, _, err := render.PreviewApply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, ""); err == nil {
 		t.Fatal("expected dry-run preview to fail loud on divergent shared-path content")
+	}
+}
+
+// TestPreviewApply_SyncedVsWouldChange pins the synced/would-change verdict the
+// dry-run listing is built on: a destination already holding our exact bytes is
+// reported `unchanged` (labeled "synced"), a destination with different content
+// is reported in `wouldChange` (labeled "write"), and a missing destination —
+// which a real apply would create — is also `wouldChange`.
+func TestPreviewApply_SyncedVsWouldChange(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+
+	synced := filepath.Join(tmp, ".claude", "skills", "a", "SKILL.md")
+	changed := filepath.Join(tmp, ".claude", "skills", "b", "SKILL.md")
+	missing := filepath.Join(tmp, ".claude", "skills", "c", "SKILL.md")
+	for _, d := range []string{synced, changed} {
+		_ = os.MkdirAll(filepath.Dir(d), 0o755)
+	}
+	_ = os.WriteFile(synced, []byte("same\n"), 0o644)
+	_ = os.WriteFile(changed, []byte("old\n"), 0o644)
+
+	reg := adapter.NewRegistry()
+	_ = reg.Register(&fakeJSONApply{name: "claude"})
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{
+			{Action: "write", Path: synced, Content: []byte("same\n"), Mode: 0o644, SourceID: "skills/a/SKILL.md"},
+			{Action: "write", Path: changed, Content: []byte("new\n"), Mode: 0o644, SourceID: "skills/b/SKILL.md"},
+			{Action: "write", Path: missing, Content: []byte("new\n"), Mode: 0o644, SourceID: "skills/c/SKILL.md"},
+		}},
+	}}
+
+	_, unchanged, wouldChange, err := render.PreviewApply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("PreviewApply: %v", err)
+	}
+	if !unchanged[synced] {
+		t.Errorf("a destination already holding our bytes must be Unchanged; got unchanged=%v", unchanged)
+	}
+	if wouldChange[synced] {
+		t.Errorf("a synced destination must NOT be in wouldChange; got %v", wouldChange)
+	}
+	if !wouldChange[changed] {
+		t.Errorf("a divergent destination must be in wouldChange; got %v", wouldChange)
+	}
+	if !wouldChange[missing] {
+		t.Errorf("a missing destination (apply would create it) must be in wouldChange; got %v", wouldChange)
+	}
+	// A dry-run must not have written or created anything.
+	if data, _ := os.ReadFile(changed); string(data) != "old\n" {
+		t.Errorf("dry-run mutated a live destination; got %q", data)
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Errorf("dry-run created a destination it should only have previewed")
 	}
 }
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -131,7 +131,10 @@ agentsync secrets edit
 ### `apply`
 Renders the source and writes each agent's native config. **Offline** — it never
 touches the network. `--dry-run` runs the full pipeline and prints the plan and
-translation report without writing a byte.
+translation report without writing a byte; each planned destination is labeled
+`✓ synced` (already holds our exact bytes) or `→ write` (would be created or
+changed), with a `— N to write, M already synced` tally, so an in-sync tree reads
+as a no-op rather than a list of pending writes.
 
 ```bash
 agentsync apply --dry-run


### PR DESCRIPTION
## What was wrong

`apply --dry-run` printed `→ write` for **every** planned op, even when the destination already held exactly the bytes apply would write — so a dry-run on an in-sync tree read like a wall of pending work and gave no signal that nothing would change:

```
Plan: 4 ops total across 2 agent(s)
  claude     2 ops, 0 skips
    → write /…/CLAUDE.md
    → write /…/.claude/skills/review-loop/SKILL.md
  codex      2 ops, 0 skips
    → write /…/AGENTS.md
    → write /…/.agents/skills/review-loop/SKILL.md
```

The real `apply` already knew the difference (the `Writer.Write` convergence check populates an `unchanged` set, used to print "up to date: N ops, no changes"), but the dry-run path never ran it — it only listed the plan's ops with a static "write" label.

## The fix

The dry-run now runs the **real apply pipeline through non-writing preview writers** (`render.PreviewApply`), so the synced/would-change verdict is computed by the exact code a real apply runs (each merge performed against the on-disk file) — it can't disagree with what apply will actually do.

After a real apply (in-sync tree):

```
Plan: 2 ops total across 1 agent(s) — 0 to write, 2 already synced
  claude     2 ops, 0 skips
    ✓ synced /…/.claude/skills/alpha/SKILL.md
    ✓ synced /…/.claude/skills/bravo/SKILL.md
```

Editing one source reads correctly as a mixed state — `— 1 to write, 1 already synced`, with `→ write` on the changed file and `✓ synced` on the rest.

### Implementation

- `Writer.Write` runs its convergence read in dry-run too, recording a new `WouldChange` set (the complement of `Unchanged`) instead of touching disk.
- `Apply` and the new `PreviewApply` share one `applyPlan` body — same dedup, skill-orphan reclamation, and per-op merge — so the preview's collision set *and* verdicts match a real apply. `PreviewApply` supersedes the old `op.Content`-only `PreviewCollisions` (which approximated the merge).
- The CLI labels each op `✓ synced` / `→ write` and the summary line gains a `— N to write, M already synced` tally. Nothing is written, exactly as before.

## Verification

- New tests: `TestApply_DryRunLabelsSyncedVsWrite` (CLI, end-to-end) and `TestPreviewApply_SyncedVsWouldChange` (covers synced / changed / missing-destination, and asserts the dry-run writes/creates nothing).
- Full suite green (`go test ./...`, plus `-tags bdd` and `-tags e2e`); `golangci-lint` reports `0 issues`; `gofmt -s` / `gofumpt` / `go mod tidy` clean.
- Docs updated in the same change per the project's keep-docs-in-sync contract: `docs/user-guide.md`, `docs/architecture.md`, `docs/components.md`, `website/…/reference/cli.mdx`, `README.md`, and `CHANGELOG.md`.

## Scope note

Dry-run still doesn't preview *orphan-delete* backups (those go through `Writer.Delete`, which remains a no-op under dry-run) — that matches prior behavior and wasn't part of this report.

https://claude.ai/code/session_01UR19eta5aLAwm4RXFN8VPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UR19eta5aLAwm4RXFN8VPr)_