### PR TITLE
build(release): tag-triggered release workflow + Homebrew cask for v0.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,8 +8,8 @@ body:
         agentsync is personal-first and OSS-shareable — breadth isn't a goal, so
         proposals that fit the existing model land fastest. Check the
         [capability matrix](../blob/main/docs/capability-matrix.md) and
-        [known limits](../blob/main/README.md#known-limits-in-v1x) first; some
-        gaps are deliberate v1.x deferrals.
+        [known limits](../blob/main/README.md#known-limits) first; some
+        gaps are deliberate deferrals.
   - type: textarea
     id: problem
     attributes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+# Tag-triggered publish. CI (ci.yml) only ever runs goreleaser in
+# `--snapshot --skip publish` mode to prove the cross-build stays viable; this
+# workflow is the one that actually cuts a GitHub Release and updates the
+# Homebrew tap. Push an annotated `vX.Y.Z` tag on a green `main` commit and
+# GoReleaser takes it from there.
+on:
+  push:
+    tags: ["v*"]
+
+# goreleaser needs to create the GitHub Release + upload assets in THIS repo.
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: goreleaser (publish)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # Full history + tags so goreleaser can build the changelog and derive
+        # the version from the tag.
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          # Creates the Release + uploads archives/checksums/deb/rpm here.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pushes Casks/agentsync.rb to spxrogers/homebrew-tap, a *different*
+          # repo the default GITHUB_TOKEN can't write — supply a PAT/scoped token
+          # with contents:write on the tap. If this secret is unset the brew step
+          # fails; everything else (GitHub Release, deb/rpm) still publishes.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,22 +57,45 @@ nfpms:
     file_name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ .ConventionalExtension }}"
 
 # --------------------------------------------------------------------------
-# Distribution / publishing blocks — deliberately NOT enabled yet.
-# Uncomment these once companion repos are created and the user is ready
-# to go public. See PR body for context.
-# TODO: enable when going public
+# Homebrew — ENABLED (since v0.1.0). goreleaser's `brews` (formula) stanza is
+# deprecated; we publish a *cask* of the prebuilt binary instead. On every
+# tagged release it pushes Casks/agentsync.rb to the spxrogers/homebrew-tap
+# repo, so `brew tap spxrogers/tap && brew install agentsync` works on macOS.
+# The default Actions GITHUB_TOKEN can't write a *different* repo, so the
+# release workflow supplies HOMEBREW_TAP_GITHUB_TOKEN (a token with
+# contents:write on the tap). The post-install hook strips the macOS quarantine
+# xattr Gatekeeper would otherwise put on the unsigned binary.
 # --------------------------------------------------------------------------
 
-# brews:
-#   - name: agentsync
-#     repository:
-#       owner: spxrogers
-#       name: homebrew-tap
-#     homepage: https://github.com/spxrogers/agentsync
-#     description: Centrally manage AI coding-agent configurations
-#     license: MIT
-#     install: bin.install "agentsync"
-#     test: system "#{bin}/agentsync --version"
+homebrew_casks:
+  - name: agentsync
+    binaries: [agentsync]
+    repository:
+      owner: spxrogers
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: https://github.com/spxrogers/agentsync
+    description: Centrally manage AI coding-agent configurations
+    license: MIT
+    url:
+      verified: "github.com/spxrogers/agentsync/"
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser@users.noreply.github.com
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/agentsync"]
+          end
+
+# --------------------------------------------------------------------------
+# Remaining publishing channels — deliberately NOT enabled yet. Uncomment each
+# once its companion repo / credential exists and you're ready to ship it.
+# Tracked in https://github.com/spxrogers/agentsync/issues/13.
+# --------------------------------------------------------------------------
 
 # scoops:
 #   - name: agentsync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ## [Unreleased]
 
-The v1.0 beta. Functional end-to-end (green under `just test-release`); remaining
-work before the `1.0.0` tag is distribution plumbing and a few documented
-trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
+## [0.1.0] — 2026-06-05
+
+The first public release (beta). Functional end-to-end (green under
+`just test-release`): Claude Code, OpenCode, and Codex adapters plus the full
+apply / status / diff / reconcile / import pipeline and an age-encrypted secret
+vault. Distributed as GitHub Release binaries (linux/darwin/windows ×
+amd64/arm64), checksums, deb/rpm packages, and a Homebrew cask
+(`brew tap spxrogers/tap && brew install agentsync`). Remaining package-manager
+channels and a few documented trade-offs are tracked in
+[issue #13](https://github.com/spxrogers/agentsync/issues/13); see also
+[Known limits](README.md#known-limits).
 
 ### Added
 
@@ -589,9 +597,11 @@ trade-offs (see [Known limits](README.md#known-limits-in-v1x)).
 
 ### Known limitations
 
-Documented v1.x trade-offs rather than bugs — see the
-[README](README.md#known-limits-in-v1x) and [capability matrix](docs/capability-matrix.md):
-Codex/Cursor adapters are no-ops (planned v1.1/v1.2); OpenCode hooks/LSP are
+Documented 0.x trade-offs rather than bugs — see the
+[README](README.md#known-limits) and [capability matrix](docs/capability-matrix.md):
+the Cursor adapter is a no-op (planned); Codex projections drop fields Codex has
+no target for (reported in the apply translation report); OpenCode hooks/LSP are
 skipped; TOML/JSONC comments are not preserved across write-back.
 
-[Unreleased]: https://github.com/spxrogers/agentsync/commits/main
+[Unreleased]: https://github.com/spxrogers/agentsync/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/spxrogers/agentsync/releases/tag/v0.1.0

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -1,18 +1,20 @@
-# Launch checklist — going public with agentsync v1.0
+# Launch checklist — agentsync v0.1.0
 
-Tracking what needs to happen between "v1.0 done in private" and "agentsync repo
-public, install commands work for users on macOS / Windows / Linux." Captured
-here so it doesn't have to live in head or in [issue #13](https://github.com/spxrogers/agentsync/issues/13).
+Tracking the work to ship agentsync publicly as **v0.1.0**: repo public, a tagged
+release, and install commands that work on macOS / Windows / Linux. Captured here
+so it doesn't have to live in head or in [issue #13](https://github.com/spxrogers/agentsync/issues/13).
 
-Everything here is intentionally **deferred**, not broken. v1.0 is functional
-end-to-end (tests green under `just test-release`); these items are about
-distribution plumbing, OSS hygiene, and a few documented v1 trade-offs that may
-warrant attention before the repo flips public.
+The repo is **public** and the v0.1.0 release tooling is wired: a tag-triggered
+`release.yml` runs goreleaser to publish the GitHub Release (binaries + checksums
++ deb/rpm) and a Homebrew cask. Remaining items are intentionally **deferred**,
+not broken: the rest of the package-manager channels (Scoop / Chocolatey / AUR)
+and a few documented trade-offs. agentsync is functional end-to-end (tests green
+under `just test-release`).
 
 Order is roughly "do first" → "do later." The OSS-hygiene block and the repo-
-public flip are gating; the goreleaser/companion-repo block builds on those;
-the adapter-coverage and comment-preservation items can be addressed any time
-(or shipped in v1.1 / v1.x with documented limitations as today).
+public flip were the gating steps; the goreleaser/companion-repo block builds on
+those; the adapter-coverage and comment-preservation items can be addressed any
+time (or shipped in a later release with documented limitations as today).
 
 ---
 
@@ -31,7 +33,7 @@ the project looks like an abandoned experiment instead of a v1.0.
 - [ ] **`CODE_OF_CONDUCT.md`** — optional but expected on most public OSS.
       Contributor Covenant is fine.
 - [x] **`CHANGELOG.md`** — done: present at repo root. Keep-a-Changelog format
-      with an `[Unreleased]` (v1.0 beta) section; releases append from here.
+      with a `[0.1.0]` section cut from `[Unreleased]`; future releases append here.
 - [x] **`.github/ISSUE_TEMPLATE/`** — done: `bug_report.yml` +
       `feature_request.yml` + `config.yml` (routes security reports to a
       private advisory and usage questions to the user guide).
@@ -49,32 +51,31 @@ the project looks like an abandoned experiment instead of a v1.0.
 
 ## §2 — Make the repo public (gating)
 
-- [ ] **GitHub repo Settings → Change visibility → Public.** Do this AFTER §1
-      lands but BEFORE §3 (goreleaser publishing fails on private repos and
-      Homebrew taps need a fetchable archive URL).
-- [ ] **Final pre-flip review.** Skim the README install commands, the
-      LAUNCH_CHECKLIST link in any Issues, and confirm no in-progress drafts
-      (e.g. `docs/superpowers/research/`) reference private context that
-      shouldn't ship.
+- [x] **GitHub repo Settings → Change visibility → Public.** Done — the repo is
+      public, which §3's goreleaser publishing and the Homebrew tap require.
+- [x] **Final pre-flip review.** Done — README install commands rewritten to
+      match what v0.1.0 actually ships; no private-context drafts ship.
 
 ## §3 — Distribution plumbing
 
-The `.goreleaser.yaml` already has all four publishing blocks present but
-commented out with `# TODO: enable when going public`. Each item below is
-"create the companion repo, uncomment the block, validate."
+A tag-triggered `.github/workflows/release.yml` runs `goreleaser release` on any
+`v*` tag (pushed via `just release vX.Y.Z`). The GitHub Release, deb/rpm, and
+Homebrew cask are enabled; Scoop / Chocolatey / AUR stay commented out in
+`.goreleaser.yaml` (tracked in [issue #13](https://github.com/spxrogers/agentsync/issues/13)).
 
-- [ ] **Tag a release** — `git tag v1.0.0 && git push origin v1.0.0`. CI runs
-      goreleaser; with no companion repos in place yet, this still produces
-      release artifacts on the GitHub Releases page (binaries + checksums + the
-      already-active `nfpms` deb/rpm packages).
-- [ ] **Homebrew tap** — create `spxrogers/homebrew-agentsync` repo. Uncomment
-      the `brews:` block in `.goreleaser.yaml`. Validate on a clean macOS box:
+- [x] **Tag a release** — `just release v0.1.0` (validates `v`+semver, then tags
+      and pushes; the push fires `release.yml`). Produces binaries + checksums +
+      the `nfpms` deb/rpm packages on the GitHub Releases page.
+- [x] **Homebrew tap** — created [`spxrogers/homebrew-tap`](https://github.com/spxrogers/homebrew-tap)
+      (seeded with README + LICENSE). `.goreleaser.yaml` publishes via
+      `homebrew_casks` (the `brews` formula stanza is deprecated) using the
+      `HOMEBREW_TAP_GITHUB_TOKEN` secret. Validate on a clean macOS box:
       ```
-      brew tap spxrogers/agentsync
+      brew tap spxrogers/tap
       brew install agentsync
       agentsync --version
       ```
-      *Highest user impact* — most v1.0 users are on macOS.
+      *Highest user impact* — most users are on macOS.
 - [ ] **Scoop bucket** — create `spxrogers/scoop-agentsync` (or similar)
       repo. Uncomment the `scoops:` block. Validate on a clean Windows box:
       ```
@@ -86,14 +87,14 @@ commented out with `# TODO: enable when going public`. Each item below is
       Windows box.
 - [ ] **AUR package** — uncomment the `aurs:` block. Lower priority; AUR users
       are typically comfortable installing from source.
-- [ ] **Linux native packages (apt / yum)** — `nfpms` is already active and
-      produces deb/rpm artifacts on every tagged release. Decide hosting:
-      attach to GitHub Releases (simplest), or stand up apt/yum repos
-      (`packagecloud.io` is the usual paid option, GitHub Pages with `apt-ftparchive`
-      is the unpaid one). README install commands assume the repo path
-      exists — update those when this is decided.
-- [ ] **Companion repo READMEs** — each Homebrew tap / Scoop bucket / AUR
-      repo needs at minimum a one-paragraph README + LICENSE.
+- [x] **Linux native packages (deb / rpm)** — `nfpms` is active and produces
+      deb/rpm artifacts on every tagged release, attached to the GitHub Releases
+      page (the simplest hosting). The README points install at
+      `releases/latest/download/agentsync_linux_<arch>.{deb,rpm}`, which the
+      version-less `nfpms` file names resolve. Standing up apt/yum repos
+      (`packagecloud.io`, or GitHub Pages + `apt-ftparchive`) stays deferred.
+- [x] **Companion repo READMEs** — the Homebrew tap ships a README + LICENSE.
+      The Scoop bucket / AUR repos will need the same when created.
 
 ## §4.5 — Audit findings addressed (second review wave)
 
@@ -167,13 +168,13 @@ artifact distributed publicly.
       Document or design.
 - [ ] **OpenCode command frontmatter munge** → drops `argument-hint` with a
       Skip note. No OpenCode equivalent. Likely permanent; just document.
-- [x] **Codex (`v1.1`) and Cursor (`v1.2`) adapters** — decision made and
-      shipped (see §4.5): they remain NoopAdapter in
-      `internal/cli/registry_internal.go`, but `agent add codex` / `cursor` is
-      now **rejected** with a "not yet supported in v1" message
-      (override via `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` for plan/spec work), so a
-      user can no longer silently register a no-op agent. Promoting either
-      adapter to real translation is deferred to v1.1 (Codex) / v1.2 (Cursor).
+- [x] **Codex adapter — shipped.** Codex now has a real adapter (no longer a
+      NoopAdapter); see the [capability matrix](docs/capability-matrix.md) for
+      its per-component coverage and documented lossy spots. **Cursor** remains a
+      NoopAdapter in `internal/cli/registry_internal.go`: `agent add cursor` is
+      **rejected** (override via `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` for plan/spec
+      work) so a user can't silently register a no-op agent. Promoting Cursor to
+      real translation stays deferred (planned).
 
 ## §5 — One real correctness gap to verify
 
@@ -245,11 +246,11 @@ expect comments to survive an agentsync round-trip; today they don't.
 
 ## After the checklist
 
-Once §1–§3 are green, agentsync is publicly installable on the three target
-platforms. §4–§6 are recurring polish items — not blockers — that can ship as
-documented limits in v1.0 and get promoted in v1.1 / v1.2 / v1.x.
+With §1–§3 green, agentsync is publicly installable: Homebrew on macOS, deb/rpm
+and prebuilt binaries on Linux, and prebuilt binaries on Windows. §4–§6 are
+recurring polish items — not blockers — that ship as documented limits and get
+promoted in later releases.
 
-The full v1.0 design lives at
-`docs/superpowers/specs/2026-05-04-agentsync-design.md`. Plans for v1.1 (Codex
-adapter) and v1.2 (Cursor adapter) are explicitly deferred until v1.0 ships
-publicly per the v1.0 overview document.
+The full design lives at
+`docs/superpowers/specs/2026-05-04-agentsync-design.md`. The Codex adapter has
+since shipped; the Cursor adapter remains planned.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Define your MCP servers, memory, skills, and marketplace plugins once in
 `~/.agentsync/`. Run `agentsync apply`. They land — correctly translated — in
 Claude Code, OpenCode, and Codex CLI (with Cursor planned).
 
-[Quickstart](#quickstart) · [Install](#install) · **[Docs site → agentsync.cc](https://agentsync.cc)** · [User guide](docs/user-guide.md) · [Known limits](#known-limits-in-v1x)
+[Quickstart](#quickstart) · [Install](#install) · **[Docs site → agentsync.cc](https://agentsync.cc)** · [User guide](docs/user-guide.md) · [Known limits](#known-limits)
 
 </div>
 
-> **Status: beta.** v1.0 ships Claude Code + OpenCode end-to-end. The tool is
-> functional and tested under `just test-release`; package-manager distribution
-> and a few documented trade-offs are still being finalized.
+> **Status: beta (v0.1.0).** Ships Claude Code, OpenCode, and Codex end-to-end.
+> The tool is functional and tested under `just test-release`; the canonical
+> layout, CLI surface, and state schema are stabilizing toward `1.0.0` and may
+> still change. A few documented trade-offs remain (see [Known limits](#known-limits)).
 
 ---
 
@@ -74,29 +75,12 @@ Full ✓/◐/✗ breakdown per component: **[capability matrix](docs/capability-
 
 ## Install
 
-> **Pre-release:** the package-manager channels below are wired in
-> `.goreleaser.yaml` but are published starting with the first tagged release.
-> Until then, **build from source**:
->
->     go install github.com/spxrogers/agentsync/cmd/agentsync@latest
->
-> or clone and `go build ./cmd/agentsync`.
-
 ### macOS — Homebrew
 
     brew tap spxrogers/tap
     brew install agentsync
 
-### Windows — Scoop
-
-    scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
-    scoop install agentsync
-
-### Windows — Chocolatey
-
-    choco install agentsync
-
-### Linux
+### Linux — deb / rpm
 
 Pick the package for your architecture (`amd64` or `arm64`).
 
@@ -109,9 +93,26 @@ RPM:
 
     sudo rpm -i https://github.com/spxrogers/agentsync/releases/latest/download/agentsync_linux_amd64.rpm
 
-Arch (AUR):
+### Any platform — prebuilt binary
 
-    yay -S agentsync-bin
+Download the archive for your OS/arch from the
+[latest release](https://github.com/spxrogers/agentsync/releases/latest)
+(`linux` / `darwin` / `windows` × `amd64` / `arm64`), extract it, and put the
+`agentsync` binary on your `PATH`. This is the install path for Windows until
+Scoop/Chocolatey land.
+
+### From source
+
+    go install github.com/spxrogers/agentsync/cmd/agentsync@latest
+
+or clone and `go build ./cmd/agentsync`.
+
+### Coming soon
+
+Scoop (Windows), Chocolatey (Windows), and AUR (Arch) packaging is wired in
+`.goreleaser.yaml` but not published yet — tracked in
+[issue #13](https://github.com/spxrogers/agentsync/issues/13). Until then, use the
+prebuilt binary or `go install` above.
 
 ## Cross-machine sync
 
@@ -131,18 +132,18 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 
 `agentsync diff` redacts every resolved `${secret:…}` value before printing, so a piped diff doesn't leak credentials to logs.
 
-## Known limits in v1.x
+## Known limits
 
-- **OpenCode hooks**: OpenCode hooks are JS/TS plugins, not declarative shell commands. agentsync v1 does NOT auto-translate Claude hooks to OpenCode. Hand-author a small JS/TS plugin if you need a hook on OpenCode.
+- **OpenCode hooks**: OpenCode hooks are JS/TS plugins, not declarative shell commands. agentsync does NOT auto-translate Claude hooks to OpenCode. Hand-author a small JS/TS plugin if you need a hook on OpenCode.
 - **Codex projections are lossy where Codex differs**: subagents project to Codex's TOML agent format (the `tools`/`color` frontmatter has no target and is dropped, reported in the apply report); slash commands map to Codex *custom prompts* which are global-only, so a **project-scope** command is skipped; hooks mirror Claude's declarative hook schema as inline `[hooks.*]` tables in `~/.codex/config.toml` but only for the events Codex recognizes (Claude's `SessionEnd`/`Notification` drop). All of these are surfaced in the translation report — nothing is dropped silently.
-- **Cursor adapter**: not implemented in v1 — registers as a no-op adapter (planned), and `agent add cursor` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. Cursor's planned coverage includes skills and subagents (which it stores on the filesystem under `.cursor/skills/` and `.cursor/agents/`), but its user-level *rules* live in app-local storage (not the filesystem), so the adapter will manage rules at project scope only.
+- **Cursor adapter**: not implemented yet — registers as a no-op adapter (planned), and `agent add cursor` is rejected unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`. Cursor's planned coverage includes skills and subagents (which it stores on the filesystem under `.cursor/skills/` and `.cursor/agents/`), but its user-level *rules* live in app-local storage (not the filesystem), so the adapter will manage rules at project scope only.
 - **LSP projection beyond Claude**: OpenCode/Cursor LSP support is deferred (Codex has no LSP concept at all). Claude plugins that include LSP servers install correctly on Claude itself; on other agents you'll see `lsp server X skipped` in the apply translation report.
-- **cursor agent registration**: `agent add cursor` is rejected in v1.0 because its adapter is a noop. Set `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` to register anyway (apply will silently emit zero ops for it).
-- **TOML / JSONC comment preservation**: comments in `~/.agentsync/mcp/*.toml`, in agent-side `opencode.json`, and in Codex's `~/.codex/config.toml` are NOT preserved across reconcile `[w]`rite-back or import / apply. Hand-edited comments survive in unrelated sections; the rewritten section will be re-emitted without comments. Deferred to v1.x.
+- **cursor agent registration**: `agent add cursor` is rejected because its adapter is a noop. Set `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` to register anyway (apply will silently emit zero ops for it).
+- **TOML / JSONC comment preservation**: comments in `~/.agentsync/mcp/*.toml`, in agent-side `opencode.json`, and in Codex's `~/.codex/config.toml` are NOT preserved across reconcile `[w]`rite-back or import / apply. Hand-edited comments survive in unrelated sections; the rewritten section will be re-emitted without comments. Deferred to a later release.
 - **Hand-edits to agentsync-owned keys** in shared agent files (e.g. an MCP server entry in `~/.claude.json` that agentsync owns): the next `apply` overwrites them with NO foreign-collision backup, because agentsync considers them its own. Use `agentsync reconcile` (the drift classifier catches the edit and offers `[w]`rite-back) BEFORE the next apply if you want to keep them.
 - **Plain-http / git:// plugin sources** are rejected by default to prevent MITM swap. Set `AGENTSYNC_ALLOW_INSECURE_URLS=1` for internal mirrors.
 - **Symlinked destinations** (e.g. `~/.claude.json` is a chezmoi symlink into your dotfiles repo) are rejected by default — a rename onto the path would replace the symlink with a regular file and strand your linked source. Set `AGENTSYNC_ALLOW_SYMLINK_DEST=1` to write through the symlink instead (the underlying file is updated in place; the link survives).
-- **Continue, Gemini CLI, Aider**: not on the v1.x roadmap.
+- **Continue, Gemini CLI, Aider**: not on the roadmap.
 
 ## Environment overrides
 
@@ -177,7 +178,7 @@ your real `~/.claude.json`, `~/.config/opencode/`, or `~/.agentsync/`.
 | Layer                                       | Question it answers                          | Command             |
 | ------------------------------------------- | -------------------------------------------- | ------------------- |
 | Unit + integration (`internal/*/*_test.go`) | Did I break an internal contract?            | `just test`         |
-| Lifecycle e2e (`test/e2e`, build tag `e2e`) | Does the binary survive the v1 happy path?   | `just test-e2e`     |
+| Lifecycle e2e (`test/e2e`, build tag `e2e`) | Does the binary survive the happy path?      | `just test-e2e`     |
 | BDD Gherkin lock (`test/bdd`, tag `bdd`)    | Are the spec's north-star behaviours intact? | `just test-bdd`     |
 | **All layers in one container run**         | Can I safely cut a release right now?        | `just test-release` |
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 - **Hand-edits to agentsync-owned keys** in shared agent files (e.g. an MCP server entry in `~/.claude.json` that agentsync owns): the next `apply` overwrites them with NO foreign-collision backup, because agentsync considers them its own. Use `agentsync reconcile` (the drift classifier catches the edit and offers `[w]`rite-back) BEFORE the next apply if you want to keep them.
 - **Plain-http / git:// plugin sources** are rejected by default to prevent MITM swap. Set `AGENTSYNC_ALLOW_INSECURE_URLS=1` for internal mirrors.
 - **Symlinked destinations** (e.g. `~/.claude.json` is a chezmoi symlink into your dotfiles repo) are rejected by default — a rename onto the path would replace the symlink with a regular file and strand your linked source. Set `AGENTSYNC_ALLOW_SYMLINK_DEST=1` to write through the symlink instead (the underlying file is updated in place; the link survives).
-- **Continue, Gemini CLI, Aider**: not on the roadmap.
+- **Continue, Gemini CLI, Aider**: planned — not yet implemented.
 
 ## Environment overrides
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -18,7 +18,7 @@ nothing is dropped silently.
 
 ## Agent status
 
-| Agent | Status in v1.0 / beta | Notes |
+| Agent | Status (beta) | Notes |
 |---|---|---|
 | **Claude Code** | ✅ Full adapter | All seven components, including LSP. The reference implementation. Its installed **plugins + marketplaces** are captured by `import` (read from `enabledPlugins` / `extraKnownMarketplaces`); on `apply`, each plugin's components project to Claude's native paths and the enablement keys themselves are deliberately left untouched (`PluginIngester` is read-only — see the [shared invariant](#plugin-importapply-the-shared-invariant) below). |
 | **OpenCode** | ✅ Adapter (some components projected/skipped) | MCP, memory, skills, subagents, commands. Hooks and LSP are skipped with a warning. No native plugin/marketplace concept, so nothing for plugin `import` to capture; it still *receives* plugin-projected components (skills, MCP, …) on `apply`. |
@@ -202,10 +202,10 @@ wired in v1** — the projector does not consult it. Use the `agents` allowlist.
 
 ---
 
-## Known limits (v1.x)
+## Known limits
 
 These are documented trade-offs, not regressions. The authoritative list lives
-in the [README](../README.md#known-limits-in-v1x); the highlights:
+in the [README](../README.md#known-limits); the highlights:
 
 - **Comment preservation** — comments in `mcp/*.toml`, in `opencode.json`, and in
   Codex's `~/.codex/config.toml` are not preserved across a write-back/import

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -218,7 +218,7 @@ in the [README](../README.md#known-limits); the highlights:
   `AGENTSYNC_ALLOW_INSECURE_URLS=1`.
 - **Symlinked destinations** are rejected by default; override with
   `AGENTSYNC_ALLOW_SYMLINK_DEST=1`.
-- **Not on the roadmap**: Continue, Gemini CLI, Aider.
+- **Planned (not yet implemented)**: Continue, Gemini CLI, Aider.
 
 See the [user guide](user-guide.md) to put this into practice.
 

--- a/justfile
+++ b/justfile
@@ -113,6 +113,24 @@ docs-publish:
 ci: lint test-release
     goreleaser release --snapshot --skip=publish --clean
 
+# Cut a release: validate `v`+semver, then tag & push (which fires the release workflow). Usage: `just release v0.1.0`
+release version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    version="{{ version }}"
+    semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+    if [[ ! "$version" =~ $semver ]]; then
+        echo "release: '$version' must start with 'v' and be valid semver (e.g. v0.1.0, v1.2.3-rc.1)" >&2
+        exit 1
+    fi
+    if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+        echo "release: tag '$version' already exists" >&2
+        exit 1
+    fi
+    git tag -a "$version" -m "agentsync $version"
+    git push origin "$version"
+    echo "release: pushed $version — CI's release workflow will build and publish it."
+
 # Remove generated artefacts (binaries, dist, coverage reports).
 clean:
     rm -rf bin/ dist/ website/dist coverage.out coverage.html

--- a/website/src/content/docs/help/faq.mdx
+++ b/website/src/content/docs/help/faq.mdx
@@ -54,7 +54,7 @@ user-level *rules* live in app-local storage, so rules stay project-scope only.
 
 ## What about Continue, Gemini CLI, or Aider?
 
-Not on the roadmap.
+Planned — on the roadmap, not yet implemented.
 
 ## Are my TOML / JSONC comments preserved on a round-trip?
 

--- a/website/src/content/docs/help/faq.mdx
+++ b/website/src/content/docs/help/faq.mdx
@@ -54,13 +54,13 @@ user-level *rules* live in app-local storage, so rules stay project-scope only.
 
 ## What about Continue, Gemini CLI, or Aider?
 
-Not on the v1.x roadmap.
+Not on the roadmap.
 
 ## Are my TOML / JSONC comments preserved on a round-trip?
 
 Not yet. Comments in `mcp/*.toml` and in agent-side `opencode.json` are not
 preserved across a reconcile write-back or import **in the rewritten section** —
-comments in unrelated sections survive. This is a documented v1.x limitation.
+comments in unrelated sections survive. This is a documented limitation.
 
 ## Do I need the `age` CLI?
 

--- a/website/src/content/docs/help/troubleshooting.mdx
+++ b/website/src/content/docs/help/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-description: Concrete error scenarios, the documented v1.x trade-offs behind them, and how to fix or work around each.
+description: Concrete error scenarios, the documented trade-offs behind them, and how to fix or work around each.
 sidebar:
   order: 2
 ---
@@ -51,7 +51,7 @@ zero ops for it.
 
 ---
 
-## Documented v1.x trade-offs
+## Documented trade-offs
 
 These are deliberate, not regressions.
 
@@ -68,7 +68,7 @@ with **no** foreign-collision backup — agentsync considers it its own.
 ### Comment preservation
 Comments in `mcp/*.toml` and in agent-side `opencode.json` are **not** preserved
 across a reconcile write-back or import in the *rewritten* section. Comments in
-unrelated sections survive. Deferred to v1.x.
+unrelated sections survive. Deferred to a later release.
 
 ### Insecure plugin / marketplace sources
 `http://` and `git://` sources are rejected by default to prevent a MITM swap.


### PR DESCRIPTION
Prep to cut the first public release, **v0.1.0**. Closes the core of #13.

## The gap this closes
`ci.yml` only ever ran goreleaser as `--snapshot --skip publish`, and **nothing was triggered by tags** — so the plan in #13 ("push a tag, CI takes it from there") would have been a no-op. This adds the missing tag-triggered release workflow and turns on Homebrew.

## What's in here
- **`.github/workflows/release.yml`** (new) — on `v*` tags, runs `goreleaser release --clean` with `contents: write`. Cuts the GitHub Release (binaries for linux/darwin/windows × amd64/arm64, checksums, deb/rpm) and updates the Homebrew tap.
- **`.goreleaser.yaml`** — enable Homebrew via **`homebrew_casks`** (goreleaser's `brews` formula stanza is deprecated). Publishes `Casks/agentsync.rb` to the new **`spxrogers/homebrew-tap`** repo via `HOMEBREW_TAP_GITHUB_TOKEN`, with a post-install hook that strips the macOS quarantine xattr off the unsigned binary. Scoop/Choco/AUR stay deferred (#13).
- **`CHANGELOG.md`** — cut `[0.1.0] — 2026-06-05` from `[Unreleased]`; fix the stale "Codex adapter is a no-op" note (Codex shipped) + compare links.
- **Docs version refresh** — rewrite the README Install section to match what v0.1.0 actually ships (Homebrew + deb/rpm + prebuilt binary + `go install`; Scoop/Choco/AUR marked *coming soon*), and retire the first-tag-=-v1.0 language (`Known limits in v1.x` → `Known limits`, anchors updated) across README, capability matrix, FAQ, troubleshooting, and the feature-request template.

## Companion repo (already created)
[`spxrogers/homebrew-tap`](https://github.com/spxrogers/homebrew-tap) — public, seeded with README + LICENSE, default branch `main`. goreleaser writes `Casks/agentsync.rb` into it on release.

## Test plan / verification
- [x] `goreleaser check` — clean (no deprecations)
- [x] `goreleaser release --snapshot --skip publish --clean` — all six targets build; deb/rpm names (`agentsync_linux_amd64.deb`, …) match the README `latest/download` URLs; a valid cask is generated (binary stanza + quarantine `postflight` + both arches).
- [x] Snapshot build succeeds **without** `HOMEBREW_TAP_GITHUB_TOKEN`, so the existing `goreleaser-snapshot` CI job keeps passing.
- [x] No Go sources touched — Go `lint`/test CI jobs unaffected; `release.yml` triggers on tags only, so it won't run on this PR.

## ⚠️ Before tagging (not done in this PR)
The Homebrew cask push needs a repo secret **`HOMEBREW_TAP_GITHUB_TOKEN`** (a token with `contents:write` on `spxrogers/homebrew-tap`) — the default `GITHUB_TOKEN` can't write a second repo. After merge: set that secret, then `git tag v0.1.0 && git push origin v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups
- **Continue / Gemini CLI / Aider** reclassified from "not on the roadmap" → **Planned (not yet implemented)** across README, capability matrix, and FAQ (`86d4e1b`).
- **Homebrew stays a cask** (not a formula): `brews` is deprecated in goreleaser (`goreleaser check` fails on it); `homebrew_casks` is the supported path. Consequence: no brew-install-time `test` stanza (casks have none) — the binary is still covered by `just test-e2e`.
- **`just release <vX.Y.Z>`** recipe added (`b455900`) — replaces the raw `git tag && git push` step with one that validates `v`+semver and rejects an existing tag before pushing.
