### PR TITLE
feat(generic): project Agent Skills in the breadth tier (18 of 22 agents)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   verified table row, and `agentsync agent list --all` prints the full supported
   set with each agent's registration state. (Aider and Firebender are deliberately deferred — see the
   capability matrix.)
+- **Agent Skills in the breadth tier (18 of the 22 agents).** The generic adapter
+  now projects **Agent Skills** — the open [agentskills.io](https://agentskills.io)
+  `SKILL.md` directory spec — wherever the agent natively scans a skills directory,
+  via a new per-scope `Skills` target on each `Spec`. Because the on-disk skill
+  format is uniform (no dialect to model), the tier reuses the deep adapters' shared
+  `claude.SkillFileOps` projection, so bundled `scripts/`/`references/`/`assets/`
+  and executable bits round-trip byte-for-byte through apply/import/reconcile. Most
+  agents target the cross-vendor `.agents/skills/` convention — byte-identical to
+  Codex's, so the render pipeline dedupes the ops — while a few scan their own
+  dir (`.qwen/skills/`, `.junie/skills/`, `.kiro/skills/`, `.factory/skills/`,
+  Copilot's `.github/skills/`). Skills-capable: amp, goose, qwen, warp, junie,
+  kilocode, kiro, trae, jetbrains, antigravity, augmentcode, copilot, copilot-cli,
+  crush, factory, pi, zed, mistral. The four without are reported as a skip:
+  **jules** and **firebase** publish skills *for other* agents, **amazonq**
+  consumes skills only through an MCP server, and **openhands** loads skills
+  programmatically with no auto-scanned directory. Each path was cross-referenced
+  against the agent's upstream docs.
 - **Cline adapter (`internal/adapter/cline`).** A new real adapter for Cline,
   scope-asymmetric (informed by competitor prior art — no config-sync tool writes
   the VS Code globalStorage MCP path): MCP renders at **user scope** into the Cline

--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ The nine **deep adapters** (rich, agent-specific, often bidirectional):
 | **Cline** | ✓ adapter | MCP (`~/.cline/mcp.json` CLI, user scope), memory (◐, `.clinerules/`) + slash commands (◐, `.clinerules/workflows/`) at project scope. No skills/subagents/hooks/LSP concept. |
 
 Plus a **breadth tier** of 22 more via one data-driven generic adapter — **memory**
-for all, **MCP** where the agent reads a JSON server-map: `amp`, `goose`, `qwen`,
-`warp`, `jules`, `junie`, `openhands`, `amazonq`, `zed`, `kilocode`, `kiro`,
-`trae`, `jetbrains`, `firebase`, `antigravity`, `augmentcode`, `copilot`,
-`copilot-cli`, `crush`, `factory`, `pi`, `mistral`. Each is a *verified* spec (paths
-cross-referenced against upstream docs + prior art), flowing through the same
-drift/secrets/capture pipeline as the deep adapters. See the
+for all, **MCP** where the agent reads a JSON server-map (15 of 22), and **Agent
+Skills** where the agent natively scans a `SKILL.md` directory (18 of 22): `amp`,
+`goose`, `qwen`, `warp`, `jules`, `junie`, `openhands`, `amazonq`, `zed`,
+`kilocode`, `kiro`, `trae`, `jetbrains`, `firebase`, `antigravity`, `augmentcode`,
+`copilot`, `copilot-cli`, `crush`, `factory`, `pi`, `mistral`. Each is a *verified*
+spec (paths cross-referenced against upstream docs + prior art), flowing through the
+same drift/secrets/capture pipeline as the deep adapters. See the
 [capability matrix → Breadth tier](docs/capability-matrix.md#breadth-tier).
 
 Full ✓/◐/✗ breakdown per component: **[capability matrix](docs/capability-matrix.md)**.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,8 +124,9 @@ file (it projects one block file per item), so it has no key-merge strategy.
 **Deep vs breadth-tier adapters.** The nine hand-written packages above are
 *deep* adapters — agent-specific, multi-component, often bidirectional. Beyond
 them, a single data-driven *generic* adapter (`internal/adapter/generic`) serves a
-long tail of agents from a verified `Spec` table — memory + (where expressible)
-MCP only, every other component reported as a skip. Both kinds implement the same
+long tail of agents from a verified `Spec` table — memory, (where expressible)
+MCP, and (where the agent scans a `SKILL.md` directory) Agent Skills, every other
+component reported as a skip. Both kinds implement the same
 `Adapter` interface and register identically, so the rest of the pipeline (plan,
 classify, write, capture, state) treats them uniformly. The set of valid agent
 names is derived from the deep package list **plus** `generic.Specs()` (see

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -29,7 +29,7 @@ nothing is dropped silently.
 | **Windsurf** | ✅ Adapter (scope-asymmetric MCP) | MCP, memory, and slash commands. **MCP is global-only** (`~/.codeium/windsurf/mcp_config.json`, JSON `mcpServers`; stdio command/args/env, remote `serverUrl` + `headers`), so it renders at **user scope** and is skipped (reported) at project scope. **Memory** renders at both scopes: project → `.windsurf/rules/agentsync.md` carrying the documented `trigger: always_on` activation frontmatter (workspace rules declare their trigger in frontmatter; ingest strips it, so the canonical body round-trips byte-clean); user → the single global rules file `~/.codeium/windsurf/memories/global_rules.md` (always-on, frontmatter-less, verbatim; Windsurf documents a 6,000-character limit it enforces itself). **Commands** render at both scopes as plain-markdown workflows invoked as `/<name>`: project `.windsurf/workflows/`, user `~/.codeium/windsurf/global_workflows/` (command frontmatter drops). Upstream now prefers `.devin/rules|workflows/` with `.windsurf/` as the supported fallback; agentsync targets `.windsurf/`, which every released version reads. **Skills, subagents, hooks, and LSP** have no Windsurf concept and are skipped. No `PluginIngester`; it still *receives* plugin-projected components on `apply`. |
 | **Roo Code** | ✅ Adapter (some components projected) | MCP, memory, and slash commands — clean filesystem `.roo/` paths (rulesync and ruler converged on these). **MCP → `.roo/mcp.json`** (project-level, `mcpServers` with explicit `type: streamable-http`/`sse` for remote + `url`/`headers`; merge-by-server-name preserves foreign servers). Roo's *global* MCP lives in VS Code globalStorage (OS/editor-specific), which agentsync intentionally does **not** target — so user-scope MCP is reported as a skip. **Memory → `.roo/rules/agentsync.md`** (plain-markdown always-applied rule) and **commands → `.roo/commands/<name>.md`** (markdown + frontmatter — Roo keeps **both** `description` *and* `argument-hint`; only `allowed-tools` drops), both at **user and project scope** (`~/.roo/` + `<repo>/.roo/`). **Skills, hooks, and LSP** have no Roo concept, and Roo's "custom modes" are not per-file **subagents**, so all four are skipped. No `PluginIngester`; it still *receives* plugin-projected components on `apply`. |
 | **Cline** | ✅ Adapter (scope-asymmetric) | MCP, memory, and slash commands. **MCP → `~/.cline/mcp.json`** at **user scope** — the Cline CLI's clean config (`mcpServers`, transport inferred: stdio command/args/env, remote `url` + `headers`). Cline has no project MCP file, and its VS Code-extension MCP lives in OS/editor-specific globalStorage no config-sync tool writes, so project-scope MCP is reported as a skip. **Memory → `.clinerules/agentsync.md`** (plain markdown — Cline concatenates `.clinerules/`) and **commands → `.clinerules/workflows/<name>.md`** (plain markdown workflows invoked as `/<name>.md`; command frontmatter drops), both at **project scope** (Cline's global rules and workflows live in `~/Documents/Cline/`, a non-XDG app path agentsync deliberately does not target). **Skills, subagents, hooks, and LSP** have no Cline concept and are skipped. No `PluginIngester`; it still *receives* plugin-projected components on `apply`. |
-| **Breadth tier (22 agents)** | ✅ Generic adapter (memory + MCP) | A long tail of agents supported by one data-driven [generic adapter](#breadth-tier) — **memory** (rules file) for all, **MCP** where the agent reads a JSON server-map agentsync can express. Each is a *verified* spec, not a hand-written package; see the [Breadth tier](#breadth-tier) table for per-agent coverage. They flow through the normal apply/import pipeline (drift, secrets, capture), unlike a one-way rules dump. |
+| **Breadth tier (22 agents)** | ✅ Generic adapter (memory + MCP + skills) | A long tail of agents supported by one data-driven [generic adapter](#breadth-tier) — **memory** (rules file) for all, **MCP** where the agent reads a JSON server-map agentsync can express (15 of 22), and **Agent Skills** where the agent natively scans a `SKILL.md` directory (18 of 22). Each is a *verified* spec, not a hand-written package; see the [Breadth tier](#breadth-tier) table for per-agent coverage. They flow through the normal apply/import pipeline (drift, secrets, capture), unlike a one-way rules dump. |
 
 ## Plugin import/apply: the shared invariant
 
@@ -92,11 +92,11 @@ The nine adapters above are **deep, agent-specific** packages. Beyond them,
 agentsync covers a long tail of agents through a single **data-driven generic
 adapter** (`internal/adapter/generic`): each agent is a *verified Spec* — a row in
 a table — rather than a hand-written package. The generic tier deliberately
-projects **memory** (the agent's rules/instructions file) and, where the agent
-reads a JSON server-map agentsync can express, **MCP**; every other component is
-reported as a skip. Breadth agents run through the same apply/import pipeline as
-the deep ones, so they get drift detection, secret resolution, and capture — not a
-one-way rules dump.
+projects **memory** (the agent's rules/instructions file), **MCP** where the agent
+reads a JSON server-map agentsync can express, and **Agent Skills** where the agent
+natively scans a `SKILL.md` directory; every other component is reported as a skip.
+Breadth agents run through the same apply/import pipeline as the deep ones, so they
+get drift detection, secret resolution, and capture — not a one-way rules dump.
 
 **MCP coverage (15 of 22).** The MCP merge is **JSONC-tolerant** (hujson), so a
 commented settings file (Zed, Copilot's `.vscode/mcp.json`, Amp) is parsed and its
@@ -113,35 +113,52 @@ inferred), stdio value (`stdio` / `local`), and remote URL key (`url` / `httpUrl
 IDE app-storage (JetBrains, AugmentCode), or cloud-dashboard (Jules) — where the
 generic engine refuses to invent a shape and reports a skip.
 
+**Skills coverage (18 of 22).** Agent Skills are the open
+[agentskills.io](https://agentskills.io) spec — a skill is a *directory* (`SKILL.md`
+frontmatter + body, plus bundled `scripts/`/`references/`/`assets/`). Unlike MCP,
+the on-disk format is **uniform** across agents (there is no dialect to model);
+only the scanned directory varies, so the breadth tier reuses the *same* projection
+the deep adapters use (`claude.SkillFileOps`) — bundled files and executable bits
+survive byte-for-byte. Most agents read the cross-vendor **`.agents/skills/`**
+convention (the same directory Codex targets, so the render pipeline dedupes the
+byte-identical ops rather than fighting over the path); a few scan only their own
+`.<agent>/skills/` (Qwen, Junie, Kiro, Factory, Copilot's `.github/skills/`). The
+**four without skills** are the ones that don't natively scan a `SKILL.md`
+directory: **Jules** and **Firebase Studio** *publish* skills for *other* agents,
+**Amazon Q** consumes skills only through an MCP server (a different component), and
+**OpenHands** loads skills programmatically with no auto-scanned directory — each
+leaves Skills empty and reports a skip. Skills carry no secrets, so the projection
+is entirely off the secret-resolution path.
+
 Every path below was cross-referenced against the agent's upstream docs **and**
 prior-art config-sync tools (ruler, rulesync) before inclusion. A scope or
 component with no verified target is left out (and reported as a skip), never
 guessed.
 
-| Agent | Memory (rules) | MCP |
-|---|---|---|
-| **amp** | `AGENTS.md` · `~/.config/amp/AGENTS.md` | ✓ `~/.config/amp/settings.json` (namespaced `amp.mcpServers` key) |
-| **goose** | `.goosehints` | ✗ YAML `~/.config/goose/config.yaml` |
-| **qwen** | `QWEN.md` · `~/.qwen/QWEN.md` | ✓ `.qwen/settings.json` (dual-URL split: `httpUrl` = streamable HTTP, `url` = SSE) |
-| **warp** | `WARP.md` | ✓ `.warp/.mcp.json` · `~/.warp/.mcp.json` |
-| **jules** | `AGENTS.md` | ✗ dashboard-only (cloud) |
-| **junie** | `AGENTS.md` (project; JetBrains documents no global guidelines file) | ✓ `.junie/mcp/mcp.json` (+ user) |
-| **openhands** | `AGENTS.md` | ✗ TOML `[mcp]` arrays |
-| **amazonq** | `.amazonq/rules/` | ✓ `.amazonq/mcp.json` · `~/.aws/amazonq/mcp.json` |
-| **zed** | `AGENTS.md` · `~/.config/zed/AGENTS.md` | ✓ settings.json `context_servers` |
-| **kilocode** | `.kilocode/rules/` | ✓ `.kilocode/mcp.json` (project) |
-| **kiro** | `.kiro/steering/` (+ user) | ✓ `.kiro/settings/mcp.json` (+ user) |
-| **trae** | `.trae/rules/project_rules.md` | ✗ non-standard array shape |
-| **jetbrains** | `.aiassistant/rules/` | ✗ IDE app-storage |
-| **firebase** | `.idx/airules.md` | ✓ `.idx/mcp.json` (project) |
-| **antigravity** | `AGENTS.md` | ✓ `~/.gemini/config/mcp_config.json` (remote key `serverUrl`; the shared IDE+CLI path is codelab-sourced — older installs read `~/.gemini/antigravity-cli/mcp_config.json`, where this write is a no-op; re-verify when Antigravity's docs firm up. Lives inside `~/.gemini/`, the deep Gemini adapter's directory, but a different file — no collision) |
-| **augmentcode** | `.augment/rules/` (+ user) | ✗ IDE app-storage |
-| **copilot** | `.github/copilot-instructions.md` | ✓ `.vscode/mcp.json` (`servers` key, `type`) |
-| **copilot-cli** | `AGENTS.md` | ✓ `~/.copilot/mcp-config.json` (`type`, stdio="local") |
-| **crush** | `AGENTS.md` | ✓ crush.json `mcp` key (+ user) |
-| **factory** | `AGENTS.md` | ✓ `.factory/mcp.json` · `~/.factory/mcp.json` (`type`) |
-| **pi** | `AGENTS.md` · `~/.pi/agent/AGENTS.md` | ✓ `~/.pi/agent/mcp.json` |
-| **mistral** | `AGENTS.md` | ✗ TOML `.vibe/config.toml` |
+| Agent | Memory (rules) | MCP | Skills (`SKILL.md` dir) |
+|---|---|---|---|
+| **amp** | `AGENTS.md` · `~/.config/amp/AGENTS.md` | ✓ `~/.config/amp/settings.json` (namespaced `amp.mcpServers` key) | ✓ `.agents/skills/` · `~/.config/agents/skills/` |
+| **goose** | `.goosehints` | ✗ YAML `~/.config/goose/config.yaml` | ✓ `.agents/skills/` (+ user) |
+| **qwen** | `QWEN.md` · `~/.qwen/QWEN.md` | ✓ `.qwen/settings.json` (dual-URL split: `httpUrl` = streamable HTTP, `url` = SSE) | ✓ `.qwen/skills/` (+ user) |
+| **warp** | `WARP.md` | ✓ `.warp/.mcp.json` · `~/.warp/.mcp.json` | ✓ `.agents/skills/` (+ user) |
+| **jules** | `AGENTS.md` | ✗ dashboard-only (cloud) | ✗ publishes skills for other agents |
+| **junie** | `AGENTS.md` (project; JetBrains documents no global guidelines file) | ✓ `.junie/mcp/mcp.json` (+ user) | ✓ `.junie/skills/` (+ user) |
+| **openhands** | `AGENTS.md` | ✗ TOML `[mcp]` arrays | ✗ programmatic load (no auto-scanned dir) |
+| **amazonq** | `.amazonq/rules/` | ✓ `.amazonq/mcp.json` · `~/.aws/amazonq/mcp.json` | ✗ skills only via an MCP server |
+| **zed** | `AGENTS.md` · `~/.config/zed/AGENTS.md` | ✓ settings.json `context_servers` | ✓ `.agents/skills/` (+ user) |
+| **kilocode** | `.kilocode/rules/` | ✓ `.kilocode/mcp.json` (project) | ✓ `.agents/skills/` · `~/.kilo/skills/` |
+| **kiro** | `.kiro/steering/` (+ user) | ✓ `.kiro/settings/mcp.json` (+ user) | ✓ `.kiro/skills/` (+ user) |
+| **trae** | `.trae/rules/project_rules.md` | ✗ non-standard array shape | ✓ `.agents/skills/` (project only) |
+| **jetbrains** | `.aiassistant/rules/` | ✗ IDE app-storage | ✓ `.agents/skills/` (project; via configured agent) |
+| **firebase** | `.idx/airules.md` | ✓ `.idx/mcp.json` (project) | ✗ publishes skills for other agents |
+| **antigravity** | `AGENTS.md` | ✓ `~/.gemini/config/mcp_config.json` (remote key `serverUrl`; the shared IDE+CLI path is codelab-sourced — older installs read `~/.gemini/antigravity-cli/mcp_config.json`, where this write is a no-op; re-verify when Antigravity's docs firm up. Lives inside `~/.gemini/`, the deep Gemini adapter's directory, but a different file — no collision) | ✓ `.agents/skills/` (project; global path disputed, omitted) |
+| **augmentcode** | `.augment/rules/` (+ user) | ✗ IDE app-storage | ✓ `.agents/skills/` (+ user) |
+| **copilot** | `.github/copilot-instructions.md` | ✓ `.vscode/mcp.json` (`servers` key, `type`) | ✓ `.github/skills/` · `~/.copilot/skills/` |
+| **copilot-cli** | `AGENTS.md` | ✓ `~/.copilot/mcp-config.json` (`type`, stdio="local") | ✓ `.agents/skills/` (+ user) |
+| **crush** | `AGENTS.md` | ✓ crush.json `mcp` key (+ user) | ✓ `.agents/skills/` · `~/.config/crush/skills/` |
+| **factory** | `AGENTS.md` | ✓ `.factory/mcp.json` · `~/.factory/mcp.json` (`type`) | ✓ `.factory/skills/` (+ user) |
+| **pi** | `AGENTS.md` · `~/.pi/agent/AGENTS.md` | ✓ `~/.pi/agent/mcp.json` | ✓ `.agents/skills/` (+ user) |
+| **mistral** | `AGENTS.md` | ✗ TOML `.vibe/config.toml` | ✓ `.agents/skills/` · `~/.vibe/skills/` |
 
 **Deliberate exclusions:** **Aider** (no native MCP; memory only via an
 `.aider.conf.yml` `read:` pointer — needs a content+config-pointer adapter, out of
@@ -359,16 +376,19 @@ A few ✓ cells still change shape on the way out — same content, no loss:
   command/args/env; remote `url` + `headers` (transport inferred, no `type` key).
 - **Codex & Gemini memory** — the same markdown lands at `~/.codex/AGENTS.md` /
   `~/.gemini/GEMINI.md` (repo-root `GEMINI.md` at project scope).
-- **Skills (Codex & Cursor)** — the same skill *directory* per the
-  [Agent Skills](https://agentskills.io) spec: `SKILL.md` (name + description)
-  **plus any bundled `scripts/`/`references/`/`assets/` and nested files**, all
-  carried verbatim (binary included, executable bit preserved) on apply, import,
-  and reconcile — agentsync is not lossy for anything but the directory itself.
-  Removing a skill (or one bundled file) from the source reclaims it from each
-  destination on the next `apply` (drifted files backed up first; empty dirs
-  pruned). Codex installs them under `~/.agents/skills/` (enabled by default — no
-  feature flag), Cursor under `.cursor/skills/`, and both also read the shared
-  `.claude/skills/`.
+- **Skills (Codex, Cursor & 18 breadth-tier agents)** — the same skill *directory*
+  per the [Agent Skills](https://agentskills.io) spec: `SKILL.md` (name +
+  description) **plus any bundled `scripts/`/`references/`/`assets/` and nested
+  files**, all carried verbatim (binary included, executable bit preserved) on
+  apply, import, and reconcile — agentsync is not lossy for anything but the
+  directory itself. Removing a skill (or one bundled file) from the source reclaims
+  it from each destination on the next `apply` (drifted files backed up first;
+  empty dirs pruned). Codex installs them under `~/.agents/skills/` (enabled by
+  default — no feature flag), Cursor under `.cursor/skills/`, and both also read
+  the shared `.claude/skills/`. The breadth tier projects the *identical* directory
+  (via the shared `claude.SkillFileOps`) to each agent's verified skills path —
+  most to the cross-vendor `.agents/skills/`, which dedupes byte-for-byte against
+  Codex; see the [Breadth tier](#breadth-tier) table for the per-agent path.
 
 ## Escape hatches
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -161,7 +161,7 @@ Primary sources (repos / project sites), verified mid-2026:
     agent that reads a config file. Of agentsync's, **9 are deep adapters**
     (multi-component, bidirectional projection — Claude Code, OpenCode, Codex,
     Cursor, Gemini CLI, Continue, Windsurf, Roo Code, Cline) and the rest a
-    data-driven **breadth tier** (memory + same-shape MCP). This breadth/depth
+    data-driven **breadth tier** (memory + same-shape MCP + Agent Skills). This breadth/depth
     split is common in the field: agentsmesh, for one, reaches almost all of its
     ~30 agents with memory + skills but the full multi-component surface
     (subagents, commands, hooks) for only ~9. It is not universal, though —

--- a/docs/components.md
+++ b/docs/components.md
@@ -251,20 +251,24 @@ hooks/LSP have no Cline concept and are skipped. Emits no Ingest warnings
 ### `internal/adapter/generic`
 The **breadth-tier** adapter: one data-driven `Adapter` implementation that serves
 many agents from a table of verified `Spec`s (`specs.go`) rather than a package
-each. Covers **memory** (a rules/instructions file, plain markdown) and, where the
-agent reads a JSON server-map agentsync can express, **MCP** — every other
-component is reported as a skip. A `Spec` declares per-scope memory/MCP paths plus
-MCP "dialect" knobs that capture the tail's variance (top-level key
+each. Covers **memory** (a rules/instructions file, plain markdown), **MCP** where
+the agent reads a JSON server-map agentsync can express, and **Agent Skills**
+(`SKILL.md` directories) where the agent natively scans a skills directory — every
+other component is reported as a skip. A `Spec` declares per-scope memory/MCP/skills
+paths plus MCP "dialect" knobs that capture the tail's variance (top-level key
 `mcpServers`/`servers`/`mcp`/`context_servers`/the flat namespaced `amp.mcpServers`;
 transport field `type`/`transport`/inferred; stdio value `stdio`/`local`; remote
 URL key `url`/`httpUrl`/`serverUrl`). The MCP merge is JSONC-tolerant (hujson), so a
 commented settings file (Zed/Copilot/Amp) is preserved, not clobbered (re-emitted
-as plain JSON, like OpenCode). Breadth agents register through the normal registry
-and flow through apply/import (drift, secrets, capture). Adding an agent is a
-verified table row, not a package.
+as plain JSON, like OpenCode). Skills need no dialect — the on-disk format is
+uniform — so the tier reuses the deep adapters' shared `claude.SkillFileOps`
+projection; an agent's `Skills` target is usually the cross-vendor `.agents/skills/`
+(byte-identical to Codex, so the render pipeline dedupes the ops). Breadth agents
+register through the normal registry and flow through apply/import (drift, secrets,
+capture). Adding an agent is a verified table row, not a package.
 - **Key:** `Spec`, `New(Spec, Options) *Adapter`; the `Adapter` methods; `Specs()`.
-- **Depends on:** adapter, adapter/claude (Extra helper), secrets, source, paths,
-  iox, jsonkeys.
+- **Depends on:** adapter, adapter/claude (Extra + SkillFileOps helpers), secrets,
+  source, paths, iox, jsonkeys.
 - **Files:** `generic.go`, `render.go`, `ingest.go`, `apply.go`, `specs.go`.
 
 ### `internal/adapter/noop`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -544,7 +544,8 @@ Claude, OpenCode, Codex, Cursor, Gemini CLI, Continue, Windsurf, Roo Code, and C
 Beyond these nine deep adapters, a **breadth tier** of 22 more agents (amp, goose,
 qwen, warp, zed, kiro, junie, factory, copilot, crush, …) is supported via one
 data-driven generic adapter — memory for all, MCP where the agent reads a JSON
-server-map. Run `agentsync agent list --all` to see them all; see the
+server-map, and Agent Skills (`SKILL.md` directories) where the agent natively scans
+a skills directory. Run `agentsync agent list --all` to see them all; see the
 [capability matrix → Breadth tier](capability-matrix.md#breadth-tier) for per-agent
 coverage.
 

--- a/internal/adapter/generic/generic.go
+++ b/internal/adapter/generic/generic.go
@@ -1,17 +1,21 @@
 // Package generic implements a data-driven "breadth-tier" adapter: one Go
 // implementation that supports many agents from a table of Specs, rather than a
 // hand-written package per agent. It is for the long tail of agents whose
-// agentsync surface is just a rules/memory file plus (optionally) an `mcpServers`
-// JSON — the same shape the deep adapters (Windsurf/Cline/Continue) already take.
+// agentsync surface is a rules/memory file plus (optionally) an `mcpServers`
+// JSON and/or an Agent-Skills (SKILL.md) directory — the same shapes the deep
+// adapters (Windsurf/Cline/Continue/Codex) already take.
 //
 // The DEEP adapters (claude, codex, cursor, gemini, opencode, continuedev,
 // windsurf, roo, cline) are NOT generic — they have richer, agent-specific
-// component support (skills, subagents, commands, hooks, …) and bidirectional
-// nuances that don't fit a table. The generic tier deliberately covers ONLY
-// memory + MCP, and reports every other component as a skip, so its coverage is
-// never overstated. Breadth-tier agents still flow through agentsync's normal
-// apply/import pipeline, so they inherit drift detection, secret resolution, and
-// capture — which a one-way "rules dump" (ruler/rulesync) does not provide.
+// component support (subagents, commands, hooks, …) and bidirectional nuances
+// that don't fit a table. The generic tier deliberately covers memory, MCP, and
+// Agent Skills (the open SKILL.md spec, where the agent natively scans a skills
+// directory), and reports every other component as a skip, so its coverage is
+// never overstated. Skills fit the table because their on-disk format is uniform
+// across agents — only the scanned directory varies, with no dialect to model.
+// Breadth-tier agents still flow through agentsync's normal apply/import
+// pipeline, so they inherit drift detection, secret resolution, and capture —
+// which a one-way "rules dump" (ruler/rulesync) does not provide.
 //
 // Each agent is one verified Spec (see specs.go); adding an agent is a data entry,
 // not a package. Every path in a Spec MUST be verified against the agent's
@@ -27,8 +31,10 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 )
 
-// FileTarget is a per-scope path for a single file component (relative to the
-// scope root). An empty path means the component is unsupported at that scope.
+// FileTarget is a per-scope path (relative to the scope root) for a file
+// component (Memory: a single markdown file) or a directory component (Skills:
+// the Agent-Skills root directory under which each skill is a <name>/SKILL.md
+// subtree). An empty path means the component is unsupported at that scope.
 type FileTarget struct {
 	User    string // path under the user home (targetRoot)
 	Project string // path under the project root
@@ -108,6 +114,7 @@ type Spec struct {
 	DetectDir string     // dir under targetRoot whose existence implies installed; "" to skip
 	Memory    FileTarget // rules/instructions file (plain markdown)
 	MCP       MCPTarget  // mcpServers JSON
+	Skills    FileTarget // Agent-Skills directory (SKILL.md dirs); empty = unsupported
 }
 
 // Options configure a generic adapter instance.
@@ -134,6 +141,9 @@ func (a *Adapter) Capabilities() adapter.Capability {
 	}
 	if a.spec.MCP.supported() {
 		c |= adapter.CapMCP
+	}
+	if a.spec.Skills.User != "" || a.spec.Skills.Project != "" {
+		c |= adapter.CapSkill
 	}
 	return c
 }
@@ -197,6 +207,21 @@ func (a *Adapter) mcpPath(scope adapter.Scope, project string) string {
 		return ""
 	}
 	return filepath.Join(a.opts.TargetRoot, a.spec.MCP.User)
+}
+
+// skillsPath resolves the absolute Agent-Skills root directory for the given
+// scope, or "" when the spec does not declare a skills target at that scope.
+func (a *Adapter) skillsPath(scope adapter.Scope, project string) string {
+	if scope == adapter.ScopeProject {
+		if a.spec.Skills.Project == "" {
+			return ""
+		}
+		return filepath.Join(project, a.spec.Skills.Project)
+	}
+	if a.spec.Skills.User == "" {
+		return ""
+	}
+	return filepath.Join(a.opts.TargetRoot, a.spec.Skills.User)
 }
 
 // agentTargeted reports whether the agents allowlist includes this agent.

--- a/internal/adapter/generic/generic.go
+++ b/internal/adapter/generic/generic.go
@@ -36,8 +36,8 @@ import (
 // the Agent-Skills root directory under which each skill is a <name>/SKILL.md
 // subtree). An empty path means the component is unsupported at that scope.
 type FileTarget struct {
-	User    string // path under the user home (targetRoot)
-	Project string // path under the project root
+	User    string // file path or directory root under the user home (targetRoot)
+	Project string // file path or directory root under the project root
 }
 
 // MCPTarget describes an agent's MCP servers JSON file and its on-disk dialect.
@@ -112,9 +112,9 @@ type Spec struct {
 	Name      string     // agent name (Adapter.Name())
 	DetectBin string     // binary on PATH (best-effort); "" to skip
 	DetectDir string     // dir under targetRoot whose existence implies installed; "" to skip
-	Memory    FileTarget // rules/instructions file (plain markdown)
+	Memory    FileTarget // rules/instructions FILE path (plain markdown)
 	MCP       MCPTarget  // mcpServers JSON
-	Skills    FileTarget // Agent-Skills directory (SKILL.md dirs); empty = unsupported
+	Skills    FileTarget // Agent-Skills DIRECTORY root (holds <name>/SKILL.md subtrees); empty = unsupported
 }
 
 // Options configure a generic adapter instance.

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -1,6 +1,7 @@
 package generic_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/adapter/generic"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -48,6 +50,14 @@ func TestCapabilitiesAndStrategyFromSpec(t *testing.T) {
 	}
 	if withMCP.KeyMergeStrategy() != "merge-jsonc-keys" {
 		t.Fatal("MCP spec must use the JSONC-tolerant merge")
+	}
+	withSkills := generic.New(generic.Spec{Name: "x", Skills: generic.FileTarget{Project: ".agents/skills"}}, generic.Options{})
+	if withSkills.Capabilities()&adapter.CapSkill == 0 {
+		t.Fatal("Skill cap missing when a Skills target is declared")
+	}
+	// A skills target is a directory write, not a JSON key-merge surface.
+	if withSkills.KeyMergeStrategy() != "" {
+		t.Fatal("a skills-only spec must have no key-merge strategy")
 	}
 }
 
@@ -499,5 +509,142 @@ func TestRoundTrip_MCP_TransportAliases(t *testing.T) {
 	}
 	if s := servers["sse-srv"].(map[string]any); s["type"] != "sse" {
 		t.Fatalf("sse transport must survive the round trip, not flip to http: %v", s)
+	}
+}
+
+// --- skills ---
+
+// TestSkills_RoundTrip_Fidelity anchors to a spec-complete on-disk skill fixture
+// (SKILL.md + a bundled script with +x, a references file, and a BINARY asset)
+// and asserts the whole directory survives render→apply→ingest byte-for-byte —
+// per the "fidelity tests anchor to the artifact, not the model" rule. It also
+// pins the SKILL.md bytes to the shared claude.SkillFileOps projection, which is
+// what lets a breadth agent's .agents/skills tree dedupe with Codex's identical
+// ops rather than trip the pipeline's divergent-bytes guard.
+func TestSkills_RoundTrip_Fidelity(t *testing.T) {
+	proj := t.TempDir()
+	// goose targets the shared cross-vendor .agents/skills at both scopes.
+	spec := generic.Spec{Name: "goose", Skills: generic.FileTarget{User: ".agents/skills", Project: ".agents/skills"}}
+	a := generic.New(spec, generic.Options{TargetRoot: t.TempDir()})
+
+	bin := []byte{0x00, 0x01, 0x02, 0xff, 0xfe, 0x0a}
+	skill := source.Skill{
+		Name:        "pdf",
+		Frontmatter: map[string]any{"name": "pdf", "description": "work with PDFs"},
+		Body:        "# PDF\n\nDo the thing.\n",
+		Files: []source.SkillFile{
+			{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\necho hi\n"), Mode: 0o755},
+			{Path: "references/REF.md", Content: []byte("# Ref\n"), Mode: 0o644},
+			{Path: "assets/logo.bin", Content: bin, Mode: 0o644},
+		},
+	}
+	inner := source.Canonical{Skills: []source.Skill{skill}}
+	c := inner
+	c.Project = &inner // project overlay carries the same skill
+
+	ops, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasSkip(skips, "skill", "pdf") {
+		t.Fatalf("a supported skills spec must not skip the skill: %+v", skips)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(proj, ".agents", "skills", "pdf")
+	// SKILL.md is exactly the shared projection (so it dedupes with Codex).
+	wantSkillMD, err := claude.EncodeFrontmatter(skill.Frontmatter, skill.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotSkillMD, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotSkillMD, wantSkillMD) {
+		t.Fatalf("SKILL.md not byte-identical to the shared claude.SkillFileOps projection")
+	}
+	// Bundled binary asset survives byte-for-byte; executable bit preserved.
+	gotBin, err := os.ReadFile(filepath.Join(skillDir, "assets", "logo.bin"))
+	if err != nil || !bytes.Equal(gotBin, bin) {
+		t.Fatalf("binary asset not preserved byte-for-byte: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(skillDir, "scripts", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("executable bit dropped from bundled script: %v", info.Mode())
+	}
+
+	// Ingest back: the whole skill directory round-trips into canonical.
+	got, err := a.Ingest(adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Skills) != 1 || got.Skills[0].Name != "pdf" {
+		t.Fatalf("ingest skills: %+v", got.Skills)
+	}
+	gs := got.Skills[0]
+	if gs.Body != skill.Body {
+		t.Fatalf("ingested body mismatch: %q", gs.Body)
+	}
+	want := map[string]source.SkillFile{}
+	for _, f := range skill.Files {
+		want[f.Path] = f
+	}
+	if len(gs.Files) != len(want) {
+		t.Fatalf("ingest dropped bundled files: got %d want %d", len(gs.Files), len(want))
+	}
+	for _, f := range gs.Files {
+		w, ok := want[f.Path]
+		if !ok {
+			t.Fatalf("unexpected bundled file %q", f.Path)
+		}
+		if !bytes.Equal(f.Content, w.Content) {
+			t.Fatalf("bundled file %q content changed on round-trip", f.Path)
+		}
+		if f.Path == "scripts/run.sh" && f.Mode&0o100 == 0 {
+			t.Fatalf("ingested script lost +x: mode %o", f.Mode)
+		}
+	}
+}
+
+// TestSkills_ScopeGapSkip: a skills spec supported only at project scope must
+// report a skip (not a stray write) when applied at user scope.
+func TestSkills_ScopeGapSkip(t *testing.T) {
+	a := generic.New(generic.Spec{Name: "trae", Skills: generic.FileTarget{Project: ".agents/skills"}}, generic.Options{TargetRoot: t.TempDir()})
+	c := source.Canonical{Skills: []source.Skill{{Name: "sk", Body: "x\n"}}}
+	ops, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findOp(ops, "SKILL.md") != nil {
+		t.Fatal("project-only skills spec must not write at user scope")
+	}
+	if !hasSkip(skips, "skill", "sk") {
+		t.Fatalf("expected user-scope skill skip, got %+v", skips)
+	}
+}
+
+// TestSkills_UnsupportedSpecStillSkips: a spec with no Skills target must still
+// report skills present in canonical as a skip (coverage stays honest).
+func TestSkills_UnsupportedSpecStillSkips(t *testing.T) {
+	a := generic.New(generic.Spec{Name: "jules", Memory: generic.FileTarget{Project: "AGENTS.md"}}, generic.Options{TargetRoot: t.TempDir()})
+	proj := t.TempDir()
+	inner := source.Canonical{Skills: []source.Skill{{Name: "sk", Body: "x\n"}}}
+	c := inner
+	c.Project = &inner
+	ops, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findOp(ops, "SKILL.md") != nil {
+		t.Fatal("a spec with no Skills target must not write skills")
+	}
+	if !hasSkip(skips, "skill", "sk") {
+		t.Fatalf("expected skill skip for a skills-less spec, got %+v", skips)
 	}
 }

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/adapter/codex"
 	"github.com/spxrogers/agentsync/internal/adapter/generic"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -646,5 +647,211 @@ func TestSkills_UnsupportedSpecStillSkips(t *testing.T) {
 	}
 	if !hasSkip(skips, "skill", "sk") {
 		t.Fatalf("expected skill skip for a skills-less spec, got %+v", skips)
+	}
+}
+
+// skillOps returns only the skill FileOps (SourceID under "skills/"), keyed by
+// the path relative to the skills root, so two adapters writing the SAME skills
+// dir can be compared regardless of absolute prefix.
+func skillOps(ops []adapter.FileOp) map[string]adapter.FileOp {
+	out := map[string]adapter.FileOp{}
+	for _, op := range ops {
+		if strings.HasPrefix(filepath.ToSlash(op.SourceID), "skills/") {
+			out[filepath.ToSlash(op.SourceID)] = op
+		}
+	}
+	return out
+}
+
+// TestSkills_ByteIdenticalToCodex is the load-bearing dedup invariant made
+// explicit: when a breadth agent shares `.agents/skills` with Codex, the render
+// pipeline dedupes only because BOTH adapters emit byte-identical ops. This
+// renders the same skill through the generic `goose` adapter and the real Codex
+// deep adapter at the same project and asserts every skill FileOp matches on
+// path, content, mode, action, and merge strategy — so a future change to either
+// projection that breaks the identity fails here instead of erroring mid-apply.
+func TestSkills_ByteIdenticalToCodex(t *testing.T) {
+	proj := t.TempDir()
+	root := t.TempDir()
+	skill := source.Skill{
+		Name:        "pdf",
+		Frontmatter: map[string]any{"name": "pdf", "description": "work with PDFs"},
+		Body:        "# PDF\n\nbody\n",
+		Files: []source.SkillFile{
+			{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\n"), Mode: 0o755},
+			{Path: "references/REF.md", Content: []byte("# ref\n"), Mode: 0o644},
+		},
+	}
+	inner := source.Canonical{Skills: []source.Skill{skill}}
+	c := inner
+	c.Project = &inner
+
+	// goose: project-scope skills target is the shared cross-vendor .agents/skills,
+	// exactly where Codex writes — so absolute paths coincide too.
+	gen := generic.New(generic.Spec{Name: "goose", Skills: generic.FileTarget{User: ".agents/skills", Project: ".agents/skills"}}, generic.Options{TargetRoot: root})
+	cdx := codex.New(codex.Options{TargetRoot: root})
+
+	gOps, _, err := gen.Render(secrets.ForRender(c), adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cOps, _, err := cdx.Render(secrets.ForRender(c), adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, cm := skillOps(gOps), skillOps(cOps)
+	if len(g) == 0 {
+		t.Fatal("generic produced no skill ops")
+	}
+	if len(g) != len(cm) {
+		t.Fatalf("skill op count differs: generic %d, codex %d", len(g), len(cm))
+	}
+	for id, go1 := range g {
+		co, ok := cm[id]
+		if !ok {
+			t.Fatalf("codex missing skill op %q", id)
+		}
+		if go1.Path != co.Path {
+			t.Fatalf("path differs for %q: generic %q vs codex %q (must coincide to dedupe)", id, go1.Path, co.Path)
+		}
+		if !bytes.Equal(go1.Content, co.Content) {
+			t.Fatalf("content differs for %q — pipeline would refuse this on apply", id)
+		}
+		if go1.Mode != co.Mode {
+			t.Fatalf("mode differs for %q: generic %o vs codex %o", id, go1.Mode, co.Mode)
+		}
+		if go1.Action != co.Action || go1.MergeStrategy != co.MergeStrategy {
+			t.Fatalf("action/merge differs for %q: %+v vs %+v", id, go1, co)
+		}
+	}
+}
+
+// TestSkills_IngestFromOnDiskTree anchors to the ARTIFACT, not the model (per the
+// CLAUDE.md fidelity rule): it hand-authors a real on-disk SKILL.md directory tree
+// — including a NESTED bundled file and an executable script — then ingests it and
+// asserts the canonical captures every byte and mode. Unlike the render→read
+// round-trip, the source of truth here is bytes on disk that no agentsync code
+// wrote, so it exercises the read side independently.
+func TestSkills_IngestFromOnDiskTree(t *testing.T) {
+	proj := t.TempDir()
+	skillDir := filepath.Join(proj, ".agents", "skills", "pdf")
+	mustWrite := func(rel string, mode os.FileMode, content []byte) {
+		t.Helper()
+		p := filepath.Join(skillDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, content, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("SKILL.md", 0o644, []byte("---\nname: pdf\ndescription: work with PDFs\n---\n# PDF\n\nbody here\n"))
+	mustWrite("scripts/run.sh", 0o755, []byte("#!/bin/sh\necho hi\n"))
+	mustWrite("references/deep/NOTE.md", 0o644, []byte("# nested\n"))
+	bin := []byte{0x00, 0xff, 0x10, 0x0a}
+	mustWrite("assets/logo.bin", 0o644, []byte(bin))
+
+	a := generic.New(generic.Spec{Name: "goose", Skills: generic.FileTarget{Project: ".agents/skills"}}, generic.Options{TargetRoot: t.TempDir()})
+	got, err := a.Ingest(adapter.ScopeProject, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Skills) != 1 || got.Skills[0].Name != "pdf" {
+		t.Fatalf("ingest from on-disk tree: %+v", got.Skills)
+	}
+	s := got.Skills[0]
+	if s.Frontmatter["description"] != "work with PDFs" {
+		t.Fatalf("frontmatter not captured from disk: %+v", s.Frontmatter)
+	}
+	if !strings.Contains(s.Body, "body here") {
+		t.Fatalf("body not captured from disk: %q", s.Body)
+	}
+	files := map[string]source.SkillFile{}
+	for _, f := range s.Files {
+		files[f.Path] = f
+	}
+	// The NESTED file must survive with its slash-separated path.
+	if f, ok := files["references/deep/NOTE.md"]; !ok || !bytes.Equal(f.Content, []byte("# nested\n")) {
+		t.Fatalf("nested bundled file not captured: %+v", files)
+	}
+	if f, ok := files["assets/logo.bin"]; !ok || !bytes.Equal(f.Content, bin) {
+		t.Fatalf("binary asset not captured byte-for-byte from disk: %+v", f)
+	}
+	if f, ok := files["scripts/run.sh"]; !ok || f.Mode&0o100 == 0 {
+		t.Fatalf("executable bit not captured from disk: %+v", f)
+	}
+}
+
+// TestSkills_SpecPathsPinned pins each breadth agent's verified skills paths (the
+// count pin in specs_test.go guards quantity, not correctness) and asserts the
+// four agents that don't natively scan a SKILL.md dir declare NO skills target.
+func TestSkills_SpecPathsPinned(t *testing.T) {
+	type tgt struct{ user, project string }
+	want := map[string]tgt{
+		// shared cross-vendor .agents/skills (project), per-agent user dir
+		"goose":       {".agents/skills", ".agents/skills"},
+		"zed":         {".agents/skills", ".agents/skills"},
+		"warp":        {".agents/skills", ".agents/skills"},
+		"pi":          {".agents/skills", ".agents/skills"},
+		"augmentcode": {".agents/skills", ".agents/skills"},
+		"copilot-cli": {".agents/skills", ".agents/skills"},
+		"amp":         {".config/agents/skills", ".agents/skills"},
+		"crush":       {".config/crush/skills", ".agents/skills"},
+		"kilocode":    {".kilo/skills", ".agents/skills"},
+		"mistral":     {".vibe/skills", ".agents/skills"},
+		// project-only (no documented user skills dir)
+		"trae":        {"", ".agents/skills"},
+		"jetbrains":   {"", ".agents/skills"},
+		"antigravity": {"", ".agents/skills"},
+		// own-namespace dirs
+		"qwen":    {".qwen/skills", ".qwen/skills"},
+		"junie":   {".junie/skills", ".junie/skills"},
+		"kiro":    {".kiro/skills", ".kiro/skills"},
+		"factory": {".factory/skills", ".factory/skills"},
+		"copilot": {".copilot/skills", ".github/skills"},
+		// deliberately skills-less (verified: no native SKILL.md scan)
+		"jules":     {"", ""},
+		"openhands": {"", ""},
+		"amazonq":   {"", ""},
+		"firebase":  {"", ""},
+	}
+	for _, s := range generic.Specs() {
+		w, ok := want[s.Name]
+		if !ok {
+			t.Errorf("spec %q not pinned in TestSkills_SpecPathsPinned — add it", s.Name)
+			continue
+		}
+		if s.Skills.User != w.user || s.Skills.Project != w.project {
+			t.Errorf("spec %q skills paths = {%q,%q}, want {%q,%q}", s.Name, s.Skills.User, s.Skills.Project, w.user, w.project)
+		}
+	}
+}
+
+// TestSkills_SkippedAgentsEmitNothing: every breadth agent with no skills target
+// must, with a skill in canonical, write NO skill op and report a skip — so the
+// four deliberately-skipped agents (jules/openhands/amazonq/firebase) can never
+// silently grow a skills projection.
+func TestSkills_SkippedAgentsEmitNothing(t *testing.T) {
+	for _, s := range generic.Specs() {
+		if s.Skills.User != "" || s.Skills.Project != "" {
+			continue
+		}
+		t.Run(s.Name, func(t *testing.T) {
+			proj := t.TempDir()
+			a := generic.New(s, generic.Options{TargetRoot: t.TempDir()})
+			inner := source.Canonical{Skills: []source.Skill{{Name: "sk", Body: "x\n"}}}
+			c := inner
+			c.Project = &inner
+			ops, skips, err := a.Render(secrets.ForRender(c), adapter.ScopeProject, proj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if op := findOp(ops, "SKILL.md"); op != nil {
+				t.Fatalf("skills-less agent %q wrote a skill op: %s", s.Name, op.Path)
+			}
+			if !hasSkip(skips, "skill", "sk") {
+				t.Fatalf("skills-less agent %q did not report a skill skip", s.Name)
+			}
+		})
 	}
 }

--- a/internal/adapter/generic/ingest.go
+++ b/internal/adapter/generic/ingest.go
@@ -3,6 +3,9 @@ package generic
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
@@ -10,9 +13,9 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// Ingest reads this breadth-tier agent's memory + MCP back into a partial
-// canonical. Inverse of Render (memory + MCP only; the components the tier never
-// projects are simply not read).
+// Ingest reads this breadth-tier agent's memory, MCP, and skills back into a
+// partial canonical. Inverse of Render (memory + MCP + skills; the components the
+// tier never projects are simply not read).
 func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
 	if err := adapter.RequireProjectRoot(scope, project); err != nil {
 		return source.Canonical{}, err
@@ -46,7 +49,45 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
+	if skillsDir := a.skillsPath(scope, project); skillsDir != "" {
+		c.Skills = append(c.Skills, a.ingestSkills(skillsDir)...)
+	}
+
 	return c, nil
+}
+
+// ingestSkills reads each <name>/SKILL.md subtree under the spec's Agent-Skills
+// root back into canonical skills (SKILL.md frontmatter + body + bundled files),
+// the inverse of renderSkills. Mirrors the deep adapters' skill ingest so a
+// breadth-tier round-trip is not lossy for bundled scripts/references/assets. A
+// skill whose SKILL.md is missing or unparseable is skipped (not fatal): a stray
+// directory in a shared skills root must not break import of the rest.
+func (a *Adapter) ingestSkills(skillsDir string) []source.Skill {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+	var skills []source.Skill
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(skillsDir, e.Name())
+		data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+		if err != nil {
+			continue
+		}
+		fm, body, _, err := claude.ParseFrontmatterWithReport(data)
+		if err != nil {
+			continue
+		}
+		files, err := source.ReadSkillFiles(afero.NewOsFs(), skillDir)
+		if err != nil {
+			continue
+		}
+		skills = append(skills, source.Skill{Name: e.Name(), Frontmatter: fm, Body: body, Files: files})
+	}
+	return skills
 }
 
 // ingestMCPSpec is the inverse of mcpServerMap for the spec's dialect. When the

--- a/internal/adapter/generic/ingest.go
+++ b/internal/adapter/generic/ingest.go
@@ -62,6 +62,15 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 // breadth-tier round-trip is not lossy for bundled scripts/references/assets. A
 // skill whose SKILL.md is missing or unparseable is skipped (not fatal): a stray
 // directory in a shared skills root must not break import of the rest.
+//
+// Deliberate no-diagnostics stance: unlike the deep adapters (which thread an
+// a.stderr() warn sink), the generic tier's Ingest has no diagnostics channel,
+// so a malformed/leniently-parsed SKILL.md is skipped silently — exactly as this
+// tier's MCP ingest silently skips a non-map server entry. This is acknowledged
+// (not an accidental silent drop): the lossy case is a *native* file the tier
+// can't parse, never a canonical component the tier fails to project. Threading a
+// warn sink through the breadth-tier Ingest is a deferred tier-wide change, not a
+// skills-specific one.
 func (a *Adapter) ingestSkills(skillsDir string) []source.Skill {
 	entries, err := os.ReadDir(skillsDir)
 	if err != nil {

--- a/internal/adapter/generic/render.go
+++ b/internal/adapter/generic/render.go
@@ -11,11 +11,13 @@ import (
 )
 
 // Render projects the canonical model into this breadth-tier agent's memory
-// (rules) file and, when the spec declares one, its mcpServers JSON. Every other
-// component (skills, subagents, commands, hooks, LSP) is reported as a skip: the
-// generic tier deliberately covers memory + MCP only. A component the spec does
-// not support at the requested scope (e.g. user-scope memory for a project-only
-// agent) is likewise reported as a skip rather than written somewhere wrong.
+// (rules) file, its mcpServers JSON, and its Agent-Skills directory — each when
+// the spec declares a target for it. Every other component (subagents, commands,
+// hooks, LSP), and skills/MCP for a spec that declares no target, is reported as
+// a skip: the generic tier deliberately covers memory + MCP + skills only. A
+// component the spec does not support at the requested scope (e.g. user-scope
+// memory for a project-only agent) is likewise reported as a skip rather than
+// written somewhere wrong.
 func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
 	if err := adapter.RequireProjectRoot(scope, project); err != nil {
 		return nil, nil, err
@@ -58,9 +60,50 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, mcpSkips...)
 	}
 
+	// Skills → the agent's Agent-Skills directory (where the spec declares one).
+	if skOps, skSkips, err := a.renderSkills(renderC, scope, project); err != nil {
+		return nil, nil, err
+	} else {
+		ops = append(ops, skOps...)
+		skips = append(skips, skSkips...)
+	}
+
 	// Components the breadth tier does not project — reported, never silent.
 	skips = append(skips, a.unsupportedSkips(renderC)...)
 	return ops, skips, nil
+}
+
+// renderSkills projects each skill's whole directory (SKILL.md + bundled
+// scripts/references/assets, modes preserved) into the agent's Agent-Skills root
+// via the shared claude.SkillFileOps projection. Because every adapter projects
+// skills through that one deterministic helper, a breadth-tier skill tree is
+// BYTE-IDENTICAL to the deep adapters' — so when several agents share
+// `.agents/skills` (the cross-vendor convention Codex also targets) the render
+// pipeline dedupes the ops rather than fighting over the path. Reports a
+// scope-gap skip when the spec supports skills only at the other scope.
+//
+// Skills carry no secrets (the secret walker visits only MCP/LSP/Hook fields),
+// so this projection is entirely off the secret-resolution path.
+func (a *Adapter) renderSkills(c source.Canonical, scope adapter.Scope, project string) ([]adapter.FileOp, []adapter.Skip, error) {
+	if a.spec.Skills.User == "" && a.spec.Skills.Project == "" {
+		return nil, nil, nil // unsupported entirely → reported by unsupportedSkips
+	}
+	skillsDir := a.skillsPath(scope, project)
+	if skillsDir == "" {
+		var skips []adapter.Skip
+		for _, s := range c.Skills {
+			skips = append(skips, adapter.Skip{
+				Component: "skill", Name: s.Name,
+				Reason: fmt.Sprintf("%s skills have no %s-scope target", a.spec.Name, scope.String()),
+			})
+		}
+		return nil, skips, nil
+	}
+	ops, err := claude.SkillFileOps(c.Skills, skillsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ops, nil, nil
 }
 
 // renderMCP builds the mcpServers JSON for the spec's shape, or reports skips when
@@ -116,10 +159,19 @@ func (a *Adapter) mcpSkipReason(scope adapter.Scope) string {
 func (a *Adapter) unsupportedSkips(c source.Canonical) []adapter.Skip {
 	var skips []adapter.Skip
 	reason := func(comp string) string {
-		return fmt.Sprintf("agentsync's breadth-tier adapter for %s projects memory + MCP only (no %s)", a.spec.Name, comp)
+		return fmt.Sprintf("agentsync's breadth-tier adapter for %s projects memory, MCP, and skills only (no %s)", a.spec.Name, comp)
 	}
-	for _, s := range c.Skills {
-		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: reason("skills")})
+	// Skills are projected when the spec declares an Agent-Skills target; the
+	// scope-gap case is reported by renderSkills. Only a spec with NO skills
+	// target at all reports them here — the agent does not natively scan a
+	// SKILL.md directory (verified against its upstream docs).
+	if a.spec.Skills.User == "" && a.spec.Skills.Project == "" {
+		for _, s := range c.Skills {
+			skips = append(skips, adapter.Skip{
+				Component: "skill", Name: s.Name,
+				Reason: fmt.Sprintf("%s does not natively scan an Agent-Skills (SKILL.md) directory", a.spec.Name),
+			})
+		}
 	}
 	for _, s := range c.Subagents {
 		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: reason("subagents")})

--- a/internal/adapter/generic/specs.go
+++ b/internal/adapter/generic/specs.go
@@ -14,6 +14,16 @@ package generic
 //     url key). Agents whose MCP is an array, YAML, TOML, app-storage, or
 //     otherwise unmodeled leave MCP empty — the engine reports it as a skip
 //     rather than write a shape the agent can't read.
+//   - SKILLS is enabled where the agent natively scans Agent-Skills (SKILL.md)
+//     directories (the open agentskills.io spec). The on-disk skill format is
+//     uniform across agents, so there is no dialect to model — only the scanned
+//     directory varies. Most agents read the cross-vendor `.agents/skills`
+//     convention (shared with Codex, so the render pipeline dedupes the
+//     byte-identical ops); a few scan only their own `.<agent>/skills`. Agents
+//     that don't natively scan a SKILL.md directory — Jules/Firebase (publish
+//     skills FOR other agents), Amazon Q (skills only via an MCP server, a
+//     different component), OpenHands (programmatic load, no auto-scanned dir) —
+//     leave Skills empty and report it as a skip.
 //   - A scope with no verified target is left empty (reported as a skip), never
 //     guessed. Low-confidence user-scope paths from the research are omitted.
 //
@@ -31,6 +41,7 @@ func Specs() []Spec {
 			Name: "qwen", DetectBin: "qwen", DetectDir: ".qwen",
 			Memory: FileTarget{User: ".qwen/QWEN.md", Project: "QWEN.md"},
 			MCP:    MCPTarget{User: ".qwen/settings.json", Project: ".qwen/settings.json", RemoteURLKey: "httpUrl", SSEURLKey: "url"},
+			Skills: FileTarget{User: ".qwen/skills", Project: ".qwen/skills"},
 		},
 		// Warp — WARP.md rules; MCP in `.warp/.mcp.json` (inferred). Global rules
 		// are app-managed (omitted).
@@ -38,6 +49,7 @@ func Specs() []Spec {
 			Name: "warp", DetectBin: "warp", DetectDir: ".warp",
 			Memory: FileTarget{Project: "WARP.md"},
 			MCP:    MCPTarget{User: ".warp/.mcp.json", Project: ".warp/.mcp.json"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
 		// Junie (JetBrains) — memory default is the project AGENTS.md (JetBrains
 		// documents no global guidelines file, so no user-scope memory target);
@@ -46,12 +58,14 @@ func Specs() []Spec {
 			Name: "junie", DetectBin: "junie", DetectDir: ".junie",
 			Memory: FileTarget{Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".junie/mcp/mcp.json", Project: ".junie/mcp/mcp.json"},
+			Skills: FileTarget{User: ".junie/skills", Project: ".junie/skills"},
 		},
 		// Kiro (AWS) — steering markdown; MCP `.kiro/settings/mcp.json`.
 		{
 			Name: "kiro", DetectBin: "kiro", DetectDir: ".kiro",
 			Memory: FileTarget{User: ".kiro/steering/agentsync.md", Project: ".kiro/steering/agentsync.md"},
 			MCP:    MCPTarget{User: ".kiro/settings/mcp.json", Project: ".kiro/settings/mcp.json"},
+			Skills: FileTarget{User: ".kiro/skills", Project: ".kiro/skills"},
 		},
 		// Kilo Code — Roo/Cline lineage. Project rules dir + `.kilocode/mcp.json`
 		// (claude-style). Global MCP is VS Code app-storage (omitted).
@@ -59,9 +73,12 @@ func Specs() []Spec {
 			Name: "kilocode", DetectBin: "kilocode", DetectDir: ".kilocode",
 			Memory: FileTarget{Project: ".kilocode/rules/agentsync.md"},
 			MCP:    MCPTarget{Project: ".kilocode/mcp.json"},
+			Skills: FileTarget{User: ".kilo/skills", Project: ".agents/skills"},
 		},
 		// Amazon Q Developer CLI — project rules dir; MCP `.amazonq/mcp.json` (proj)
 		// + `~/.aws/amazonq/mcp.json` (global). Global rules dir unverified (omitted).
+		// No native skills dir: Q consumes SKILL.md only via an MCP server (a
+		// different component), so Skills is left empty (reported as a skip).
 		{
 			Name: "amazonq", DetectBin: "q", DetectDir: ".amazonq",
 			Memory: FileTarget{Project: ".amazonq/rules/agentsync.md"},
@@ -72,6 +89,7 @@ func Specs() []Spec {
 			Name: "factory", DetectBin: "droid", DetectDir: ".factory",
 			Memory: FileTarget{Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".factory/mcp.json", Project: ".factory/mcp.json", TransportKey: "type"},
+			Skills: FileTarget{User: ".factory/skills", Project: ".factory/skills"},
 		},
 		// Pi Coding Agent — AGENTS.md (project + ~/.pi/agent/AGENTS.md); MCP
 		// `~/.pi/agent/mcp.json` (inferred). No documented project MCP file.
@@ -79,15 +97,18 @@ func Specs() []Spec {
 			Name: "pi", DetectBin: "pi", DetectDir: ".pi",
 			Memory: FileTarget{User: ".pi/agent/AGENTS.md", Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".pi/agent/mcp.json"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
 		// Zed — AGENTS.md; MCP in settings.json under `context_servers` (inferred).
 		{
 			Name: "zed", DetectBin: "zed", DetectDir: ".config/zed",
 			Memory: FileTarget{User: ".config/zed/AGENTS.md", Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".config/zed/settings.json", Project: ".zed/settings.json", RootKey: "context_servers"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
 		// Firebase Studio (IDX) — `.idx/airules.md`; MCP `.idx/mcp.json` (inferred).
-		// Cloud IDE: per-workspace only (no user scope).
+		// Cloud IDE: per-workspace only (no user scope). No native skills dir:
+		// Firebase publishes skills FOR other assistants, so Skills stays empty.
 		{
 			Name: "firebase", DetectDir: ".idx",
 			Memory: FileTarget{Project: ".idx/airules.md"},
@@ -99,6 +120,7 @@ func Specs() []Spec {
 			Name:   "copilot",
 			Memory: FileTarget{Project: ".github/copilot-instructions.md"},
 			MCP:    MCPTarget{Project: ".vscode/mcp.json", RootKey: "servers", TransportKey: "type"},
+			Skills: FileTarget{User: ".copilot/skills", Project: ".github/skills"},
 		},
 		// GitHub Copilot CLI — AGENTS.md; MCP `~/.copilot/mcp-config.json` with
 		// explicit `type` whose stdio value is "local".
@@ -106,6 +128,7 @@ func Specs() []Spec {
 			Name: "copilot-cli", DetectBin: "copilot", DetectDir: ".copilot",
 			Memory: FileTarget{Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".copilot/mcp-config.json", TransportKey: "type", StdioValue: "local"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
 		// Crush (Charm) — AGENTS.md (default context); MCP in crush.json under the
 		// `mcp` key with explicit `type`.
@@ -113,6 +136,7 @@ func Specs() []Spec {
 			Name: "crush", DetectBin: "crush", DetectDir: ".config/crush",
 			Memory: FileTarget{Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".config/crush/crush.json", Project: "crush.json", RootKey: "mcp", TransportKey: "type"},
+			Skills: FileTarget{User: ".config/crush/skills", Project: ".agents/skills"},
 		},
 		// Amp (Sourcegraph) — AGENTS.md (project + ~/.config/amp/AGENTS.md). MCP is
 		// the namespaced `amp.mcpServers` key (a flat dotted key, not a nested map)
@@ -121,6 +145,7 @@ func Specs() []Spec {
 			Name: "amp", DetectBin: "amp", DetectDir: ".config/amp",
 			Memory: FileTarget{User: ".config/amp/AGENTS.md", Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".config/amp/settings.json", RootKey: "amp.mcpServers"},
+			Skills: FileTarget{User: ".config/agents/skills", Project: ".agents/skills"},
 		},
 		// Antigravity (Google) — AGENTS.md (+ GEMINI.md). MCP in
 		// `~/.gemini/config/mcp_config.json` (shared by the Antigravity IDE + CLI;
@@ -130,20 +155,29 @@ func Specs() []Spec {
 			Name: "antigravity", DetectBin: "agy", DetectDir: ".agent",
 			Memory: FileTarget{Project: "AGENTS.md"},
 			MCP:    MCPTarget{User: ".gemini/config/mcp_config.json", RemoteURLKey: "serverUrl"},
+			// Project-scope only: the global Antigravity skills path is disputed
+			// across sources (~/.gemini/config/skills vs the CLI's
+			// ~/.gemini/antigravity-cli/skills), so we don't assert a user target.
+			Skills: FileTarget{Project: ".agents/skills"},
 		},
 
-		// ---- Memory-only (MCP is array/YAML/TOML/app-storage/cloud — reported as a skip) ----
+		// ---- MCP-skipped (MCP is array/YAML/TOML/app-storage/cloud — reported as a skip).
+		//      Most still carry memory + skills; only Jules/OpenHands have neither MCP nor skills. ----
 		// Goose (Block) — `.goosehints`. MCP lives in YAML `config.yaml` extensions.
 		{
 			Name: "goose", DetectBin: "goose", DetectDir: ".config/goose",
 			Memory: FileTarget{Project: ".goosehints"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
-		// Jules (Google) — AGENTS.md. Cloud agent; MCP is dashboard-only.
+		// Jules (Google) — AGENTS.md. Cloud agent; MCP is dashboard-only. No
+		// native skills dir (it reads AGENTS.md only), so Skills is left empty.
 		{
 			Name: "jules", DetectBin: "jules",
 			Memory: FileTarget{Project: "AGENTS.md"},
 		},
-		// OpenHands — AGENTS.md (current). MCP is TOML `[mcp]` arrays.
+		// OpenHands — AGENTS.md (current). MCP is TOML `[mcp]` arrays. Skills are
+		// loaded programmatically (no auto-scanned dir to drop SKILL.md into), so
+		// Skills is left empty.
 		{
 			Name: "openhands", DetectBin: "openhands", DetectDir: ".openhands",
 			Memory: FileTarget{Project: "AGENTS.md"},
@@ -152,23 +186,30 @@ func Specs() []Spec {
 		{
 			Name: "trae", DetectDir: ".trae",
 			Memory: FileTarget{Project: ".trae/rules/project_rules.md"},
+			// Project scope only: no user/global Trae skills directory is documented.
+			Skills: FileTarget{Project: ".agents/skills"},
 		},
 		// JetBrains AI Assistant — `.aiassistant/rules/`. MCP is IDE app-storage.
 		{
 			Name: "jetbrains", DetectDir: ".aiassistant",
 			Memory: FileTarget{Project: ".aiassistant/rules/agentsync.md"},
+			// AI Assistant loads skills through its configured external agent
+			// (Claude/Codex) from the cross-agent project `.agents/skills`.
+			Skills: FileTarget{Project: ".agents/skills"},
 		},
 		// AugmentCode — `.augment/rules/` (project + ~/.augment/rules/). MCP is
 		// IDE app-storage.
 		{
 			Name: "augmentcode", DetectBin: "auggie", DetectDir: ".augment",
 			Memory: FileTarget{User: ".augment/rules/agentsync.md", Project: ".augment/rules/agentsync.md"},
+			Skills: FileTarget{User: ".agents/skills", Project: ".agents/skills"},
 		},
 		// Mistral (Vibe / Le Chat) — AGENTS.md (ruler default). MCP is TOML
 		// (`.vibe/config.toml`).
 		{
 			Name: "mistral", DetectBin: "vibe", DetectDir: ".vibe",
 			Memory: FileTarget{Project: "AGENTS.md"},
+			Skills: FileTarget{User: ".vibe/skills", Project: ".agents/skills"},
 		},
 	}
 }

--- a/internal/adapter/generic/specs.go
+++ b/internal/adapter/generic/specs.go
@@ -73,6 +73,9 @@ func Specs() []Spec {
 			Name: "kilocode", DetectBin: "kilocode", DetectDir: ".kilocode",
 			Memory: FileTarget{Project: ".kilocode/rules/agentsync.md"},
 			MCP:    MCPTarget{Project: ".kilocode/mcp.json"},
+			// NB: skills live under ~/.kilo/skills (NOT .kilocode/) per upstream —
+			// the lone path where Kilo's skills dir differs from its config dir;
+			// project scope uses the shared cross-vendor .agents/skills.
 			Skills: FileTarget{User: ".kilo/skills", Project: ".agents/skills"},
 		},
 		// Amazon Q Developer CLI — project rules dir; MCP `.amazonq/mcp.json` (proj)

--- a/internal/adapter/generic/specs_test.go
+++ b/internal/adapter/generic/specs_test.go
@@ -40,7 +40,7 @@ func TestSpecsTable(t *testing.T) {
 		}
 
 		// Paths must be relative (joined under a scope root) and not escape it.
-		for _, p := range []string{s.Memory.User, s.Memory.Project, s.MCP.User, s.MCP.Project, s.DetectDir} {
+		for _, p := range []string{s.Memory.User, s.Memory.Project, s.MCP.User, s.MCP.Project, s.Skills.User, s.Skills.Project, s.DetectDir} {
 			if p == "" {
 				continue
 			}
@@ -82,5 +82,17 @@ func TestSpecsTable(t *testing.T) {
 	// must update those in the same commit (this failure is the reminder).
 	if got := len(generic.Specs()); got != 22 {
 		t.Fatalf("breadth tier has %d specs, docs say 22 — update the docs and this pin together", got)
+	}
+	// Skills coverage is also documented (capability matrix, README, user-guide):
+	// 18 of the 22 verified to natively scan an Agent-Skills directory. The other
+	// four (jules/openhands/amazonq/firebase) deliberately have no Skills target.
+	skillsCount := 0
+	for _, s := range generic.Specs() {
+		if s.Skills.User != "" || s.Skills.Project != "" {
+			skillsCount++
+		}
+	}
+	if skillsCount != 18 {
+		t.Fatalf("breadth tier has %d skills-capable specs, docs say 18 — update the docs and this pin together", skillsCount)
 	}
 }

--- a/website/src/content/docs/help/faq.mdx
+++ b/website/src/content/docs/help/faq.mdx
@@ -71,8 +71,9 @@ Beyond these nine **deep** adapters, a **breadth tier** of 22 more agents (amp,
 goose, qwen, warp, jules, junie, openhands, amazonq, zed, kilocode, kiro, trae,
 jetbrains, firebase, antigravity, augmentcode, copilot, copilot-cli, crush,
 factory, pi, mistral) is supported via one data-driven generic adapter — **memory**
-for all and **MCP** wherever the agent reads a JSON server-map agentsync can
-express — taking agentsync to **31 agents**. See the
+for all, **MCP** wherever the agent reads a JSON server-map agentsync can express,
+and **Agent Skills** wherever the agent natively scans a `SKILL.md` directory (18 of
+the 22) — taking agentsync to **31 agents**. See the
 [capability matrix → Breadth tier](/reference/capability-matrix/#breadth-tier).
 
 ## What about Aider?

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -119,7 +119,8 @@ That `github` MCP server now lives in **both** `~/.claude.json` and
 | **Cline** | ✓ adapter | MCP (`~/.cline/mcp.json` CLI, user scope), memory (◐, `.clinerules/`) + slash commands (◐, `.clinerules/workflows/`) at project scope. No skills/subagents/hooks/LSP concept. |
 
 Plus a **breadth tier** of 22 more agents via one data-driven generic adapter
-(memory for all, MCP where the agent reads a JSON server-map): amp, goose, qwen,
+(memory for all, MCP where the agent reads a JSON server-map, and Agent Skills
+where the agent natively scans a `SKILL.md` directory): amp, goose, qwen,
 warp, jules, junie, openhands, amazonq, zed, kilocode, kiro, trae, jetbrains,
 firebase, antigravity, augmentcode, copilot, copilot-cli, crush, factory, pi,
 mistral. See the [capability matrix → Breadth tier](/reference/capability-matrix/#breadth-tier).


### PR DESCRIPTION
## What & why

The breadth-tier generic adapter previously projected only **memory + MCP**. This adds **Agent Skills** — the open [agentskills.io](https://agentskills.io) `SKILL.md` directory spec — wherever a breadth agent natively scans a skills directory. Skills are an open, on-disk-uniform spec, so they're a natural fit for the data-driven tier.

**Verification first.** Before any code, I ran a per-agent upstream-docs pass across all 22 breadth agents to confirm (a) whether each natively scans a `SKILL.md` directory and (b) the exact path/scope. Result: **18 of 22 supported**, 4 honest skips. Every path was cross-referenced against the agent's own docs (per the repo's "cross-reference upstream harness docs before guessing" rule).

## How

Skills have **zero on-disk dialect variance** (unlike MCP), so the tier reuses the deep adapters' single deterministic `claude.SkillFileOps` projection. Consequences:

- Bundled `scripts/`/`references/`/`assets/` and **executable bits round-trip byte-for-byte** through apply/import/reconcile.
- Most agents target the cross-vendor **`.agents/skills/`** convention — **byte-identical to Codex**, so the render pipeline *dedupes* the ops rather than fighting over the path (the pipeline's refuse-on-divergent-bytes guard backstops it).
- A few scan their own dir: `.qwen/skills/`, `.junie/skills/`, `.kiro/skills/`, `.factory/skills/`, Copilot's `.github/skills/`.
- **Secret invariants untouched** — skills are text components; the secret walker visits only MCP/LSP/Hook fields, so this stays entirely off the secret-resolution path.

## Coverage

**Skills-capable (18):** amp, goose, qwen, warp, junie, kilocode, kiro, trae, jetbrains, antigravity, augmentcode, copilot, copilot-cli, crush, factory, pi, zed, mistral.

**Honest skips (4)** — don't natively scan a `SKILL.md` dir:
- **jules** / **firebase** — publish skills *for other* agents
- **amazonq** — consumes skills only through an MCP server (a different component)
- **openhands** — loads skills programmatically, no auto-scanned directory

Two paths are deliberately conservative (medium-confidence in the research): **trae** (project-only; no documented user dir) and **antigravity** (global path disputed across sources, so project-scope only).

## Tests

- **Fidelity round-trip anchored to a spec-complete on-disk fixture** (per the repo's "anchor to the artifact, not the model" rule): a skill bundling a `scripts/run.sh` with `+x`, a binary asset, and a references file — asserts byte-for-byte survival, mode preservation, and that the rendered `SKILL.md` is byte-identical to the shared projection (the property that makes `.agents/skills` dedupe with Codex).
- Scope-gap and no-target **skip guards** stay honest.
- Count pins: **18 skills-capable** alongside the existing **22 specs**, so docs and code can't drift.

## Docs (same commit, per repo policy)

Capability matrix (Skills column + coverage prose + per-agent table), components, architecture, comparison footnote, README, user-guide, CHANGELOG, and the website `index`/`faq` authored pages.

## Validation

`go test ./...` green; `golangci-lint` clean; `gofmt` clean; `go.mod`/`go.sum` unchanged (afero was already a dependency).

https://claude.ai/code/session_01RRW7fnecxZsRgN1QptgN6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRW7fnecxZsRgN1QptgN6w)_