### PR TITLE
docs(memory): note Agent Skills in the breadth-tier summary

### DIFF
--- a/.agentsync/memory/AGENTS.md
+++ b/.agentsync/memory/AGENTS.md
@@ -7,7 +7,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
 configurations (31 agents: nine deep adapters — Claude Code, OpenCode, Codex,
 Cursor, Gemini CLI, Continue, Windsurf, Roo Code, Cline — plus a 22-agent generic
-"breadth tier" for memory + MCP). The
+"breadth tier" for memory + MCP + skills). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged
@@ -316,8 +316,8 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 - **New agent** → two options. For a rich, agent-specific agent, add a *deep*
   package `internal/adapter/<name>/` implementing the `Adapter` interface and
   register it (`Render` must take `secrets.Resolved`; all writes go through
-  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP,
-  add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
+  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP
+  + skills, add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
   new package; agent-name validation/`doctor`/`init` derive from the deep list +
   `generic.Specs()`. The canonical schema does not change. Either way, verify the
   agent's config paths against its upstream docs before asserting them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
 configurations (31 agents: nine deep adapters — Claude Code, OpenCode, Codex,
 Cursor, Gemini CLI, Continue, Windsurf, Roo Code, Cline — plus a 22-agent generic
-"breadth tier" for memory + MCP). The
+"breadth tier" for memory + MCP + skills). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged
@@ -316,8 +316,8 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 - **New agent** → two options. For a rich, agent-specific agent, add a *deep*
   package `internal/adapter/<name>/` implementing the `Adapter` interface and
   register it (`Render` must take `secrets.Resolved`; all writes go through
-  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP,
-  add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
+  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP
+  + skills, add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
   new package; agent-name validation/`doctor`/`init` derive from the deep list +
   `generic.Specs()`. The canonical schema does not change. Either way, verify the
   agent's config paths against its upstream docs before asserting them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Project memory for Claude Code / agent sessions working on agentsync.
 agentsync is a single-machine Go CLI that centrally manages AI coding-agent
 configurations (31 agents: nine deep adapters — Claude Code, OpenCode, Codex,
 Cursor, Gemini CLI, Continue, Windsurf, Roo Code, Cline — plus a 22-agent generic
-"breadth tier" for memory + MCP). The
+"breadth tier" for memory + MCP + skills). The
 user keeps a canonical config in `~/.agentsync/` (small TOML + markdown,
 committable to a dotfiles repo); `agentsync apply` renders it into each agent's
 native config. It's bidirectional: native edits are detected as drift and merged
@@ -316,8 +316,8 @@ doc, `.golangci.yml` (forbidigo rules), and `SECURITY.md`.
 - **New agent** → two options. For a rich, agent-specific agent, add a *deep*
   package `internal/adapter/<name>/` implementing the `Adapter` interface and
   register it (`Render` must take `secrets.Resolved`; all writes go through
-  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP,
-  add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
+  `DestWriter`). For a long-tail agent that only needs memory + (same-shape) MCP
+  + skills, add a *verified* `generic.Spec` row to `internal/adapter/generic/specs.go` — no
   new package; agent-name validation/`doctor`/`init` derive from the deep list +
   `generic.Specs()`. The canonical schema does not change. Either way, verify the
   agent's config paths against its upstream docs before asserting them.


### PR DESCRIPTION
## What

Corrects a stale capability claim in the dogfooded project memory and re-renders it.

The canonical project memory (`.agentsync/memory/AGENTS.md`) still described the generic breadth tier as **"memory + MCP"**, but #87 (`feat(generic): project Agent Skills in the breadth tier`) extended the breadth tier to also project **Agent Skills** for **18 of the 22** breadth agents. Two sentences were left out of date:

1. The one-line "what this is" summary — `"breadth tier" for memory + MCP` → `… for memory + MCP + skills`.
2. The "New agent" guidance — the breadth-tier criterion `only needs memory + (same-shape) MCP` → `… memory + (same-shape) MCP + skills`.

## How

Edited the **canonical** source only (`.agentsync/memory/AGENTS.md`), then re-rendered the native memory files via `agentsync apply --scope project` (agentsync v0.3.0). `CLAUDE.md` and `AGENTS.md` are passthrough renders of the canonical memory, so all three move together and stay byte-identical — verified with `diff` post-render.

## Why this surfaced

The dogfooding pipeline (canonical → render) was already perfectly in sync — `agentsync apply --scope project` reported `✓ up to date: 4 ops, no changes` before this change. This is a separate *source-vs-code* freshness gap: the canonical prose lagged behind a capability (#87) that already shipped. No code changes; the product docs (capability matrix, CHANGELOG) already covered #87.

## Verification

- `diff .agentsync/memory/AGENTS.md CLAUDE.md` → identical
- `diff .agentsync/memory/AGENTS.md AGENTS.md` → identical
- Only three files changed (canonical + two renders); the `review-loop` skill and `agentsync.toml` are untouched.

https://claude.ai/code/session_01JzMZEvpQMLnpYCBUR2wMJi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzMZEvpQMLnpYCBUR2wMJi)_