### PR TITLE
feat(website): add Context7 AI chat widget to docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   / secrets axes and an honest read on where agentsync is differentiated.
   Mirrored to the site at `/comparison/` via
   `sync-docs.mjs` (sidebar: **Start here → How agentsync compares**).
+- **Context7 AI chat widget on the docs site.** The published site at
+  [agentsync.cc](https://agentsync.cc) now loads the Context7 chat widget on
+  every page (an async floating chat button, wired to the
+  `/spxrogers/agentsync` Context7 source) via a `script` tag in Starlight's
+  `head` config (`website/astro.config.mjs`).
 
 ## [0.1.0] — 2026-06-05
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -38,6 +38,17 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: { property: 'og:image', content: 'https://agentsync.cc/og.png' },
 				},
+				{
+					// Context7 AI chat widget — loads asynchronously and renders a
+					// floating chat button on every page. data-library points at this
+					// project's Context7 docs source.
+					tag: 'script',
+					attrs: {
+						src: 'https://context7.com/widget.js',
+						'data-library': '/spxrogers/agentsync',
+						async: true,
+					},
+				},
 			],
 			sidebar: [
 				{


### PR DESCRIPTION
## What

Adds the [Context7](https://context7.com) AI chat widget to the published docs site ([agentsync.cc](https://agentsync.cc)). It renders an async-loaded floating chat button on **every** page, wired to the `/spxrogers/agentsync` Context7 source.

## How

The site is an **Astro Starlight** project, which owns the per-page `<head>` — there's no hand-editable root HTML/layout file. The idiomatic injection point for a tag on every page is Starlight's `head` config array in `website/astro.config.mjs` (which already held the `og:image` meta tag). The widget is added there as a `script` tag:

```js
{
  tag: 'script',
  attrs: {
    src: 'https://context7.com/widget.js',
    'data-library': '/spxrogers/agentsync',
    async: true,
  },
},
```

- **`async`** keeps the third-party script non-render-blocking.
- Optional `data-color` is left off — the widget's default `#059669` already matches agentsync's emerald branding. `data-position`/`data-placeholder` fall back to widget defaults.

## Verification

- `bun install --frozen-lockfile` + `bun run build` — succeeds, **31 pages built**, no errors.
- Confirmed the script renders into **all 31/31** generated HTML pages (spot-checked the homepage and `/guides/secrets/`):
  ```html
  <script src="https://context7.com/widget.js" data-library="/spxrogers/agentsync" async>
  ```

## Docs

Per the repo's docs-sync policy, this user-visible site change is recorded under `CHANGELOG.md` → `[Unreleased]` → `Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0115fjirvh76Ti4Jy8XdwxzQ)_