### PR TITLE
feat(website): add Google Analytics (gtag.js) on every page

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -39,6 +39,25 @@ export default defineConfig({
 					attrs: { property: 'og:image', content: 'https://agentsync.cc/og.png' },
 				},
 				{
+					// Google Analytics (gtag.js) — loads asynchronously and runs on
+					// every page (Starlight injects `head` entries site-wide).
+					tag: 'script',
+					attrs: {
+						src: 'https://www.googletagmanager.com/gtag/js?id=G-3LE4ZX1TWF',
+						async: true,
+					},
+				},
+				{
+					// Initialize gtag and send the page_view config for every page.
+					tag: 'script',
+					content: [
+						'window.dataLayer = window.dataLayer || [];',
+						'function gtag(){dataLayer.push(arguments);}',
+						"gtag('js', new Date());",
+						"gtag('config', 'G-3LE4ZX1TWF');",
+					].join('\n'),
+				},
+				{
 					// Context7 AI chat widget — loads asynchronously and renders a
 					// floating chat button on every page. data-library points at this
 					// project's Context7 docs source.


### PR DESCRIPTION
Inject the GA4 gtag.js loader and config snippet via Starlight's `head`
array in astro.config.mjs, so it renders site-wide on every page
(verified across all 31 built pages). Tag ID: G-3LE4ZX1TWF.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SukCAuvfuBWLs2iRx3K527