### PR TITLE
feat(memory): prepend an agentsync-managed banner to rendered memory files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **Managed-file banner on rendered memory.** Every rendered memory file
+  (`CLAUDE.md`, `AGENTS.md`, …) is now prepended with a short agentsync notice
+  naming the file and pointing edits back at `.agentsync/memory/AGENTS.md` +
+  `agentsync apply`, so an agent (or human) editing the native file is told it is
+  agentsync-managed. The banner lives only in the rendered file — it is wrapped in
+  reversible `<!-- agentsync:managed -->` markers, stripped on ingest and at the
+  `import`/`reconcile` write-back funnels, and re-rendered each apply, so it never
+  enters the canonical source, never compounds, and (being static) never shows as
+  drift. Rendered through one shared helper (`source.RenderManagedMemory`) so it is
+  byte-identical across all 31 agents. On by default; opt out with `[memory] banner
+  = false` in `agentsync.toml` (the project overlay inherits the user setting).
+  **Behavior change:** the first `apply` after upgrading rewrites managed memory
+  files to add the banner (a one-time `pending` in `status`).
 - **Breadth tier — 22 more agents via a data-driven generic adapter
   (`internal/adapter/generic`).** One `Adapter` implementation serves a long tail
   of agents from a verified `Spec` table: **memory** (a rules file) for all, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   drift. Rendered through one shared helper (`source.RenderManagedMemory`) so it is
   byte-identical across all 31 agents. On by default; opt out with `[memory] banner
   = false` in `agentsync.toml` (the project overlay inherits the user setting).
+  The marker `agentsync:managed` is **reserved**: agentsync rejects (with a clear
+  error, at load and at capture) any canonical memory whose body or a fragment
+  contains it, and the capture strip is anchored on the banner's own signature line
+  so a user-authored marker block is preserved verbatim — never silently deleted.
   **Behavior change:** the first `apply` after upgrading rewrites managed memory
   files to add the banner (a one-time `pending` in `status`).
 - **Breadth tier — 22 more agents via a data-driven generic adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   drift. Rendered through one shared helper (`source.RenderManagedMemory`) so it is
   byte-identical across all 31 agents. On by default; opt out with `[memory] banner
   = false` in `agentsync.toml` (the project overlay inherits the user setting).
-  The marker `agentsync:managed` is **reserved**: agentsync rejects (with a clear
-  error, at load and at capture) any canonical memory whose body or a fragment
-  contains it, and the capture strip is anchored on the banner's own signature line
-  so a user-authored marker block is preserved verbatim — never silently deleted.
+  The marker namespace `agentsync:managed` is **reserved**: agentsync rejects (with
+  a clear error, at load and at capture) any canonical memory whose body or a
+  fragment contains it, and the capture strip matches agentsync's full rendered
+  banner (not the bare markers) so a user-authored marker block is preserved
+  verbatim — never silently deleted.
   **Behavior change:** the first `apply` after upgrading rewrites managed memory
   files to add the banner (a one-time `pending` in `status`).
 - **Breadth tier — 22 more agents via a data-driven generic adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   naming the file and pointing edits back at `.agentsync/memory/AGENTS.md` +
   `agentsync apply`, so an agent (or human) editing the native file is told it is
   agentsync-managed. The banner lives only in the rendered file — it is wrapped in
-  reversible `<!-- agentsync:managed -->` markers, stripped on ingest and at the
+  reversible `<!-- agentsync:managed memory-banner -->` markers (the
+  `agentsync:managed` namespace carries a per-marker identifier so future managed
+  markers stay unambiguous), stripped on ingest and at the
   `import`/`reconcile` write-back funnels, and re-rendered each apply, so it never
   enters the canonical source, never compounds, and (being static) never shows as
   drift. Rendered through one shared helper (`source.RenderManagedMemory`) so it is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,9 @@ back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. Every adapter renders
 memory through the one helper `source.RenderManagedMemory` (which wraps
 `ExpandMemoryImports`), so the banner is byte-identical across agents. It is a
 property of the *rendered destination file only* — it is wrapped in reversible
-`<!-- agentsync:managed -->` markers and stripped by `source.StripManagedBanner`
+`<!-- agentsync:managed memory-banner -->` markers (the `agentsync:managed`
+namespace carries a per-marker identifier so future managed markers stay
+unambiguous) and stripped by `source.StripManagedBanner`
 on the way back in (each adapter's ingest, plus a backstop at the `import` /
 `reconcile` write-back funnels), so it never enters the canonical source and never
 compounds. Because the banner text is static (only the filename varies) it hashes
@@ -81,8 +83,9 @@ in `agentsync.toml` opts out (the project overlay inherits the user setting unle
 it sets its own). The `agentsync:managed` marker is **reserved**: `checkReservedMarkers`
 (in `loadMemory` and `WriteMemory`) rejects a canonical whose body or a fragment
 carries it rather than letting it collide with the banner's markers, and
-`StripManagedBanner` anchors on the banner's signature line so it removes only
-agentsync's own banner — a user-authored marker block is preserved, never deleted.
+`StripManagedBanner` matches agentsync's full rendered banner (not the bare
+markers) so it removes only agentsync's own banner — a user-authored marker block
+is preserved, never deleted.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,12 +48,12 @@ consumes them — the schema is the contract between the two.
 
 ```
 source.Canonical
-├── Config          (agentsync.toml: agents, update defaults, secrets backend)
+├── Config          (agentsync.toml: agents, update defaults, secrets backend, [memory] banner)
 ├── MCPServers      (mcp/*.toml)
 ├── Skills          (skills/<name>/ — SKILL.md + bundled scripts/references/assets)
 ├── Subagents, Commands, Hooks, LSPServers
 ├── Plugins, Marketplaces   (plugins/*.toml, marketplaces/*.toml)
-├── Memory          (memory/AGENTS.md + fragments/)
+├── Memory          (memory/AGENTS.md + fragments/; rendered files get the managed banner — see below)
 └── Project         (overlay loaded from a <root>/.agentsync/ tree, project scope)
 ```
 
@@ -64,6 +64,21 @@ is appended, an empty project `[agents]` inherits the user's enabled agents, and
 a project `plugins/<id>.toml` with `disabled = true` is excluded from projection
 in that repo. The retired M5 single-file `.agentsync.toml` marker is no longer
 read — `project.Discover` surfaces a migration error if it finds one.
+
+**Managed memory banner.** Every rendered memory file (`CLAUDE.md`, `AGENTS.md`,
+…) is prepended with a short agentsync notice naming the file and pointing edits
+back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. Every adapter renders
+memory through the one helper `source.RenderManagedMemory` (which wraps
+`ExpandMemoryImports`), so the banner is byte-identical across agents. It is a
+property of the *rendered destination file only* — it is wrapped in reversible
+`<!-- agentsync:managed -->` markers and stripped by `source.StripManagedBanner`
+on the way back in (each adapter's ingest, plus a backstop at the `import` /
+`reconcile` write-back funnels), so it never enters the canonical source and never
+compounds. Because the banner text is static (only the filename varies) it hashes
+identically on every render, so an untouched file still classifies `InSync` — the
+banner never manufactures drift. It is on by default; `[memory] banner = false`
+in `agentsync.toml` opts out (the project overlay inherits the user setting unless
+it sets its own).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,11 @@ compounds. Because the banner text is static (only the filename varies) it hashe
 identically on every render, so an untouched file still classifies `InSync` — the
 banner never manufactures drift. It is on by default; `[memory] banner = false`
 in `agentsync.toml` opts out (the project overlay inherits the user setting unless
-it sets its own).
+it sets its own). The `agentsync:managed` marker is **reserved**: `checkReservedMarkers`
+(in `loadMemory` and `WriteMemory`) rejects a canonical whose body or a fragment
+carries it rather than letting it collide with the banner's markers, and
+`StripManagedBanner` anchors on the banner's signature line so it removes only
+agentsync's own banner — a user-authored marker block is preserved, never deleted.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -61,7 +61,9 @@ memory-fragment expansion.
   `Memory`, `Project`); `Load(fs, home)`; `ParseFrontmatter`; the `Write*`
   family (`WriteMCP`, `WriteLSP`, `WritePlugin`, `WriteMarketplace`, `WriteSkill`,
   `WriteSubagent`, `WriteCommand`, `WriteHooks`, `WriteMemory`); `ReadMCP`/`ReadLSP`
-  (carry source-only fields); `ExpandMemoryImports`.
+  (carry source-only fields); `ExpandMemoryImports`; `RenderManagedMemory` /
+  `StripManagedBanner` (inject / strip the managed-file banner — see
+  `docs/architecture.md`).
 - **Depends on:** iox, jsonkeys.
 - **Files:** `schema.go`, `loader.go`, `writer.go`, `memory.go`.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -66,7 +66,11 @@ means adding an adapter — the canonical schema never changes.
 `agentsync apply` runs the **render** pipeline: load the source → resolve
 secrets → ask each enabled adapter to project the model into a set of file
 operations → write them atomically → record hashes in state. Apply is
-**local-only and offline** — it never hits the network.
+**local-only and offline** — it never hits the network. Rendered memory files
+also get a short **managed banner** prepended (naming the file, pointing edits
+back at `.agentsync/memory/AGENTS.md` + `agentsync apply`); it lives only in the
+rendered file — stripped on ingest/capture, never written to the canonical
+source — and is on by default (`[memory] banner = false` opts out).
 
 ### Capture / Ingest / write-back
 The reverse direction. **Ingest** reads an agent's native config back into the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -353,6 +353,11 @@ drift. It is on by default; opt out with a `[memory]` table in `agentsync.toml`:
 banner = false
 ```
 
+The `agentsync:managed` marker is **reserved** — if your `memory/AGENTS.md` or a
+fragment contains it, agentsync errors and asks you to remove it (so it can't
+collide with the banner). The reverse is safe too: capture only strips agentsync's
+own banner, so any other content you keep is never deleted.
+
 ### Marketplaces & plugins — the fan-out payoff
 
 This is where agentsync earns its keep. Add a marketplace, install a plugin once,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -344,9 +344,10 @@ rather than guess; the drift still shows in `status`/`diff` and you fold it into
 agentsync notice — a blockquote naming the file (e.g. `CLAUDE.md`) and pointing
 edits back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. It is written by
 agentsync, **not** stored in your canonical `memory/AGENTS.md`: it is wrapped in
-`<!-- agentsync:managed -->` markers, stripped on `import`/`reconcile`, and
-re-rendered each apply — so it never compounds and (being static) never shows as
-drift. It is on by default; opt out with a `[memory]` table in `agentsync.toml`:
+`<!-- agentsync:managed memory-banner -->` markers, stripped on
+`import`/`reconcile`, and re-rendered each apply — so it never compounds and
+(being static) never shows as drift. It is on by default; opt out with a
+`[memory]` table in `agentsync.toml`:
 
 ```toml
 [memory]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,7 +247,7 @@ first-class. Layout:
 
 ```
 ~/.agentsync/
-├── agentsync.toml            # agents, update defaults, secrets backend
+├── agentsync.toml            # agents, update defaults, secrets backend, [memory] banner
 ├── mcp/<server>.toml         # one MCP server per file
 ├── lsp/<server>.toml         # one LSP server per file
 ├── agents/<name>.md          # one subagent per file
@@ -339,6 +339,19 @@ fragment whose own text contains the marker token disables them) or were
 hand-mangled into an unbalanced/ambiguous state, agentsync refuses the write-back
 rather than guess; the drift still shows in `status`/`diff` and you fold it into
 `memory/` by hand.
+
+**The managed banner.** Every rendered memory file is prepended with a short
+agentsync notice — a blockquote naming the file (e.g. `CLAUDE.md`) and pointing
+edits back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. It is written by
+agentsync, **not** stored in your canonical `memory/AGENTS.md`: it is wrapped in
+`<!-- agentsync:managed -->` markers, stripped on `import`/`reconcile`, and
+re-rendered each apply — so it never compounds and (being static) never shows as
+drift. It is on by default; opt out with a `[memory]` table in `agentsync.toml`:
+
+```toml
+[memory]
+banner = false
+```
 
 ### Marketplaces & plugins — the fan-out payoff
 

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -190,11 +190,14 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from CLAUDE.md (verbatim, including fragment markers). The reverse-
-	// collapse into AGENTS.md + fragment files happens in the write-back layer
-	// (source.CollapseMemoryMarkers, used by import/reconcile), not here.
+	// Memory from CLAUDE.md. The agentsync managed-file banner is a render-time
+	// decoration with no canonical home, so it is stripped here (like Windsurf's
+	// activation frontmatter) — ingest yields the canonical model, which never
+	// carries the banner. Fragment markers, by contrast, are STRUCTURAL signal
+	// kept verbatim; their reverse-collapse into AGENTS.md + fragment files
+	// happens in the write-back layer (source.CollapseMemoryMarkers).
 	if data, err := os.ReadFile(p.Memory); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data))
 	}
 
 	return c, nil

--- a/internal/adapter/claude/memory.go
+++ b/internal/adapter/claude/memory.go
@@ -1,6 +1,8 @@
 package claude
 
 import (
+	"path/filepath"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -9,7 +11,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/claude/render_test.go
+++ b/internal/adapter/claude/render_test.go
@@ -200,6 +200,36 @@ func TestRender_Memory(t *testing.T) {
 	}
 }
 
+// TestRender_Memory_BannerDisabled: with [memory] banner = false the rendered
+// memory carries no managed banner — the body is written verbatim.
+func TestRender_Memory_BannerDisabled(t *testing.T) {
+	off := false
+	c := source.Canonical{
+		Config: source.Config{Memory: source.MemoryConfig{Banner: &off}},
+		Memory: source.Memory{Body: "# Personal style\n\nBe concise.\n"},
+	}
+	a := claude.New(claude.Options{TargetRoot: t.TempDir()})
+	ops, _, err := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var memOp *adapter.FileOp
+	for i, op := range ops {
+		if strings.HasSuffix(op.Path, "/CLAUDE.md") {
+			memOp = &ops[i]
+		}
+	}
+	if memOp == nil {
+		t.Fatal("no CLAUDE.md op")
+	}
+	if strings.Contains(string(memOp.Content), "agentsync:managed") {
+		t.Fatalf("banner must be suppressed when [memory] banner=false: %s", memOp.Content)
+	}
+	if string(memOp.Content) != "# Personal style\n\nBe concise.\n" {
+		t.Fatalf("memory should be the verbatim body with no banner: %q", memOp.Content)
+	}
+}
+
 func TestRender_Skills(t *testing.T) {
 	c := source.Canonical{
 		Skills: []source.Skill{{

--- a/internal/adapter/cline/ingest.go
+++ b/internal/adapter/cline/ingest.go
@@ -59,7 +59,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	// Memory from .clinerules/agentsync.md (project scope; plain markdown).
 	if p.RulesDir != "" {
 		if data, err := os.ReadFile(filepath.Join(p.RulesDir, memoryRuleFile)); err == nil {
-			c.Memory.Body = string(data)
+			c.Memory.Body = source.StripManagedBanner(string(data)) // banner stripped — see claude/ingest.go
 		}
 	}
 

--- a/internal/adapter/cline/memory.go
+++ b/internal/adapter/cline/memory.go
@@ -24,7 +24,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, [
 			Reason:    "Cline global rules live in ~/Documents/Cline/ (a non-XDG app path agentsync does not target); memory projects at project scope only (.clinerules/)",
 		}}, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, memoryRuleFile, c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          filepath.Join(p.RulesDir, memoryRuleFile),

--- a/internal/adapter/cline/render_test.go
+++ b/internal/adapter/cline/render_test.go
@@ -115,7 +115,7 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	if memOp == nil {
 		t.Fatal("memory rule op missing")
 	}
-	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner prefix: %q", memOp.Content)
 	}
 	if source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {

--- a/internal/adapter/cline/render_test.go
+++ b/internal/adapter/cline/render_test.go
@@ -112,7 +112,13 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	memOp := findOp(ops, ".clinerules/agentsync.md")
-	if memOp == nil || source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
+	if memOp == nil {
+		t.Fatal("memory rule op missing")
+	}
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner prefix: %q", memOp.Content)
+	}
+	if source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
 		t.Fatalf("memory rule wrong (under managed banner): %+v", memOp)
 	}
 	cmdOp := findOp(ops, ".clinerules/workflows/deploy.md")

--- a/internal/adapter/cline/render_test.go
+++ b/internal/adapter/cline/render_test.go
@@ -112,8 +112,8 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	memOp := findOp(ops, ".clinerules/agentsync.md")
-	if memOp == nil || string(memOp.Content) != "# Rules\n\nBe concise.\n" {
-		t.Fatalf("memory rule wrong: %+v", memOp)
+	if memOp == nil || source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
+		t.Fatalf("memory rule wrong (under managed banner): %+v", memOp)
 	}
 	cmdOp := findOp(ops, ".clinerules/workflows/deploy.md")
 	if cmdOp == nil || string(cmdOp.Content) != "Run deploy.\n" {

--- a/internal/adapter/codex/ingest.go
+++ b/internal/adapter/codex/ingest.go
@@ -130,9 +130,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from AGENTS.md (verbatim)
+	// Memory from AGENTS.md (managed-file banner stripped — see claude/ingest.go)
 	if data, err := os.ReadFile(p.Memory); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data))
 	}
 
 	return c, nil

--- a/internal/adapter/codex/memory.go
+++ b/internal/adapter/codex/memory.go
@@ -1,6 +1,8 @@
 package codex
 
 import (
+	"path/filepath"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -10,7 +12,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/continuedev/ingest.go
+++ b/internal/adapter/continuedev/ingest.go
@@ -115,7 +115,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	// Memory from .continue/rules/agentsync.md (the agentsync-owned always-apply
 	// rule), captured verbatim.
 	if data, err := os.ReadFile(filepath.Join(p.RulesDir, memoryRuleFile)); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data)) // banner stripped — see claude/ingest.go
 	}
 
 	return c, nil

--- a/internal/adapter/continuedev/memory.go
+++ b/internal/adapter/continuedev/memory.go
@@ -17,7 +17,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, memoryRuleFile, c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          filepath.Join(p.RulesDir, memoryRuleFile),

--- a/internal/adapter/continuedev/render_test.go
+++ b/internal/adapter/continuedev/render_test.go
@@ -128,8 +128,8 @@ func TestRender_Memory_PlainRule(t *testing.T) {
 	if op == nil {
 		t.Fatal("agentsync.md rule op missing")
 	}
-	if string(op.Content) != "# Rules\n\nBe concise.\n" {
-		t.Fatalf("memory should be written verbatim (no frontmatter): %q", op.Content)
+	if source.StripManagedBanner(string(op.Content)) != "# Rules\n\nBe concise.\n" {
+		t.Fatalf("memory body should be verbatim under the managed banner (no frontmatter): %q", op.Content)
 	}
 }
 

--- a/internal/adapter/continuedev/render_test.go
+++ b/internal/adapter/continuedev/render_test.go
@@ -128,7 +128,7 @@ func TestRender_Memory_PlainRule(t *testing.T) {
 	if op == nil {
 		t.Fatal("agentsync.md rule op missing")
 	}
-	if !strings.HasPrefix(string(op.Content), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(op.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner prefix: %q", op.Content)
 	}
 	if source.StripManagedBanner(string(op.Content)) != "# Rules\n\nBe concise.\n" {

--- a/internal/adapter/continuedev/render_test.go
+++ b/internal/adapter/continuedev/render_test.go
@@ -128,6 +128,9 @@ func TestRender_Memory_PlainRule(t *testing.T) {
 	if op == nil {
 		t.Fatal("agentsync.md rule op missing")
 	}
+	if !strings.HasPrefix(string(op.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner prefix: %q", op.Content)
+	}
 	if source.StripManagedBanner(string(op.Content)) != "# Rules\n\nBe concise.\n" {
 		t.Fatalf("memory body should be verbatim under the managed banner (no frontmatter): %q", op.Content)
 	}

--- a/internal/adapter/cursor/ingest.go
+++ b/internal/adapter/cursor/ingest.go
@@ -134,7 +134,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	// Cursor's app-local storage, so p.Memory is empty at user scope).
 	if p.Memory != "" {
 		if data, err := os.ReadFile(p.Memory); err == nil {
-			c.Memory.Body = string(data)
+			c.Memory.Body = source.StripManagedBanner(string(data)) // banner stripped — see claude/ingest.go
 		}
 	}
 

--- a/internal/adapter/cursor/memory.go
+++ b/internal/adapter/cursor/memory.go
@@ -1,6 +1,8 @@
 package cursor
 
 import (
+	"path/filepath"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -20,7 +22,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths, scope adapter.Scope)
 			Reason:    "Cursor stores user-level rules in app-local storage; no filesystem projection target (use project scope for AGENTS.md)",
 		}}, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/gemini/ingest.go
+++ b/internal/adapter/gemini/ingest.go
@@ -95,9 +95,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from GEMINI.md (verbatim).
+	// Memory from GEMINI.md (managed-file banner stripped — see claude/ingest.go).
 	if data, err := os.ReadFile(p.Memory); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data))
 	}
 
 	return c, nil

--- a/internal/adapter/gemini/memory.go
+++ b/internal/adapter/gemini/memory.go
@@ -1,6 +1,8 @@
 package gemini
 
 import (
+	"path/filepath"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -13,7 +15,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -100,8 +100,8 @@ func TestRender_Memory_ScopeAware(t *testing.T) {
 	a := generic.New(spec, generic.Options{TargetRoot: tmp})
 
 	uops, _, _ := a.Render(secrets.ForRender(source.Canonical{Memory: source.Memory{Body: "be terse\n"}}), adapter.ScopeUser, "")
-	if op := findOp(uops, ".config/amp/AGENTS.md"); op == nil || string(op.Content) != "be terse\n" {
-		t.Fatalf("user memory wrong: %+v", uops)
+	if op := findOp(uops, ".config/amp/AGENTS.md"); op == nil || source.StripManagedBanner(string(op.Content)) != "be terse\n" {
+		t.Fatalf("user memory wrong (under managed banner): %+v", uops)
 	}
 
 	proj := t.TempDir()

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -100,7 +100,14 @@ func TestRender_Memory_ScopeAware(t *testing.T) {
 	a := generic.New(spec, generic.Options{TargetRoot: tmp})
 
 	uops, _, _ := a.Render(secrets.ForRender(source.Canonical{Memory: source.Memory{Body: "be terse\n"}}), adapter.ScopeUser, "")
-	if op := findOp(uops, ".config/amp/AGENTS.md"); op == nil || source.StripManagedBanner(string(op.Content)) != "be terse\n" {
+	uop := findOp(uops, ".config/amp/AGENTS.md")
+	if uop == nil {
+		t.Fatalf("user memory op missing: %+v", uops)
+	}
+	if !strings.HasPrefix(string(uop.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner prefix: %q", uop.Content)
+	}
+	if source.StripManagedBanner(string(uop.Content)) != "be terse\n" {
 		t.Fatalf("user memory wrong (under managed banner): %+v", uops)
 	}
 

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -104,7 +104,7 @@ func TestRender_Memory_ScopeAware(t *testing.T) {
 	if uop == nil {
 		t.Fatalf("user memory op missing: %+v", uops)
 	}
-	if !strings.HasPrefix(string(uop.Content), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(uop.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner prefix: %q", uop.Content)
 	}
 	if source.StripManagedBanner(string(uop.Content)) != "be terse\n" {

--- a/internal/adapter/generic/ingest.go
+++ b/internal/adapter/generic/ingest.go
@@ -45,7 +45,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 
 	if memPath := a.memoryPath(scope, project); memPath != "" {
 		if data, err := os.ReadFile(memPath); err == nil {
-			c.Memory.Body = string(data)
+			c.Memory.Body = source.StripManagedBanner(string(data)) // banner stripped — see claude/ingest.go
 		}
 	}
 

--- a/internal/adapter/generic/render.go
+++ b/internal/adapter/generic/render.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
@@ -34,7 +35,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 	// Memory → the agent's rules file (plain markdown body).
 	if renderC.Memory.Body != "" {
 		if memPath := a.memoryPath(scope, project); memPath != "" {
-			body := source.ExpandMemoryImports(renderC.Memory.Body, renderC.Memory.Fragments)
+			body := source.RenderManagedMemory(renderC.Memory.Body, renderC.Memory.Fragments, filepath.Base(memPath), renderC.Config.MemoryBannerEnabled())
 			ops = append(ops, adapter.FileOp{
 				Action:        "write",
 				Path:          memPath,

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -129,9 +129,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from AGENTS.md (verbatim)
+	// Memory from AGENTS.md (managed-file banner stripped — see claude/ingest.go)
 	if data, err := os.ReadFile(p.Memory); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data))
 	}
 
 	return c, nil

--- a/internal/adapter/opencode/memory.go
+++ b/internal/adapter/opencode/memory.go
@@ -1,6 +1,8 @@
 package opencode
 
 import (
+	"path/filepath"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 )
@@ -9,7 +11,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.Memory,

--- a/internal/adapter/roo/ingest.go
+++ b/internal/adapter/roo/ingest.go
@@ -84,9 +84,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		}
 	}
 
-	// Memory from .roo/rules/agentsync.md (plain markdown).
+	// Memory from .roo/rules/agentsync.md (banner stripped — see claude/ingest.go).
 	if data, err := os.ReadFile(filepath.Join(p.RulesDir, memoryRuleFile)); err == nil {
-		c.Memory.Body = string(data)
+		c.Memory.Body = source.StripManagedBanner(string(data))
 	}
 
 	return c, nil

--- a/internal/adapter/roo/memory.go
+++ b/internal/adapter/roo/memory.go
@@ -15,7 +15,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, e
 	if c.Memory.Body == "" {
 		return nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, memoryRuleFile, c.Config.MemoryBannerEnabled())
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          filepath.Join(p.RulesDir, memoryRuleFile),

--- a/internal/adapter/roo/render_test.go
+++ b/internal/adapter/roo/render_test.go
@@ -73,8 +73,8 @@ func TestRender_ProjectScope_All(t *testing.T) {
 	}
 	// Memory → .roo/rules/agentsync.md (plain body)
 	memOp := findOp(ops, ".roo/rules/agentsync.md")
-	if memOp == nil || string(memOp.Content) != "# Rules\n\nBe concise.\n" {
-		t.Fatalf("memory rule wrong: %+v", memOp)
+	if memOp == nil || source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
+		t.Fatalf("memory rule wrong (under managed banner): %+v", memOp)
 	}
 	// Command → .roo/commands/review.md; description + argument-hint KEPT; allowed-tools dropped
 	cmdOp := findOp(ops, ".roo/commands/review.md")

--- a/internal/adapter/roo/render_test.go
+++ b/internal/adapter/roo/render_test.go
@@ -73,7 +73,13 @@ func TestRender_ProjectScope_All(t *testing.T) {
 	}
 	// Memory → .roo/rules/agentsync.md (plain body)
 	memOp := findOp(ops, ".roo/rules/agentsync.md")
-	if memOp == nil || source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
+	if memOp == nil {
+		t.Fatal("memory rule op missing")
+	}
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner prefix: %q", memOp.Content)
+	}
+	if source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {
 		t.Fatalf("memory rule wrong (under managed banner): %+v", memOp)
 	}
 	// Command → .roo/commands/review.md; description + argument-hint KEPT; allowed-tools dropped

--- a/internal/adapter/roo/render_test.go
+++ b/internal/adapter/roo/render_test.go
@@ -76,7 +76,7 @@ func TestRender_ProjectScope_All(t *testing.T) {
 	if memOp == nil {
 		t.Fatal("memory rule op missing")
 	}
-	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner prefix: %q", memOp.Content)
 	}
 	if source.StripManagedBanner(string(memOp.Content)) != "# Rules\n\nBe concise.\n" {

--- a/internal/adapter/windsurf/ingest.go
+++ b/internal/adapter/windsurf/ingest.go
@@ -62,20 +62,21 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	}
 
 	// Memory: the workspace rule at project scope (activation frontmatter
-	// stripped), the global rules file at user scope (frontmatter-less,
-	// captured verbatim).
+	// stripped), the global rules file at user scope (frontmatter-less). Both
+	// then drop the agentsync managed-file banner — a render-time decoration with
+	// no canonical home (see claude/ingest.go).
 	if p.RulesDir != "" {
 		if data, err := os.ReadFile(filepath.Join(p.RulesDir, memoryRuleFile)); err == nil {
 			body, exact := stripMemoryRuleFrontmatter(data)
 			if !exact {
 				fmt.Fprintf(warn, "warning: %s does not start with the agentsync-rendered `trigger: always_on` frontmatter; Windsurf activation metadata has no canonical home and is not captured\n", filepath.Join(p.RulesDir, memoryRuleFile))
 			}
-			c.Memory.Body = body
+			c.Memory.Body = source.StripManagedBanner(body)
 		}
 	}
 	if p.GlobalRules != "" {
 		if data, err := os.ReadFile(p.GlobalRules); err == nil {
-			c.Memory.Body = string(data)
+			c.Memory.Body = source.StripManagedBanner(string(data))
 		}
 	}
 

--- a/internal/adapter/windsurf/ingest_test.go
+++ b/internal/adapter/windsurf/ingest_test.go
@@ -140,12 +140,21 @@ func TestRoundTrip_ProjectRule_FrontmatterStripped(t *testing.T) {
 	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
 		t.Fatal(err)
 	}
+	// The rendered rule carries BOTH the activation frontmatter (at byte 0) and
+	// the managed banner (after it); ingest must strip both back to the clean body.
+	onDisk, err := os.ReadFile(filepath.Join(proj, ".windsurf", "rules", "agentsync.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(onDisk), "---\ntrigger: always_on\n---\n") || !strings.Contains(string(onDisk), "<!-- agentsync:managed -->") {
+		t.Fatalf("rendered rule should carry frontmatter + banner: %q", onDisk)
+	}
 	got, err := a.Ingest(adapter.ScopeProject, proj)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Memory.Body != body {
-		t.Fatalf("frontmatter must be stripped on ingest: %q", got.Memory.Body)
+		t.Fatalf("frontmatter and banner must both be stripped on ingest: %q", got.Memory.Body)
 	}
 
 	// Hand-changed trigger → body still captured, with a warning.

--- a/internal/adapter/windsurf/ingest_test.go
+++ b/internal/adapter/windsurf/ingest_test.go
@@ -106,8 +106,8 @@ func TestRoundTrip_GlobalRulesAndWorkflows_UserScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("global_rules.md not written: %v", err)
 	}
-	if string(onDisk) != in.Memory.Body {
-		t.Fatalf("global rules must be frontmatter-less verbatim body: %q", onDisk)
+	if source.StripManagedBanner(string(onDisk)) != in.Memory.Body {
+		t.Fatalf("global rules must be frontmatter-less verbatim body under the managed banner: %q", onDisk)
 	}
 	got, err := a.Ingest(adapter.ScopeUser, "")
 	if err != nil {

--- a/internal/adapter/windsurf/ingest_test.go
+++ b/internal/adapter/windsurf/ingest_test.go
@@ -146,7 +146,7 @@ func TestRoundTrip_ProjectRule_FrontmatterStripped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(string(onDisk), "---\ntrigger: always_on\n---\n") || !strings.Contains(string(onDisk), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(onDisk), "---\ntrigger: always_on\n---\n") || !strings.Contains(string(onDisk), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("rendered rule should carry frontmatter + banner: %q", onDisk)
 	}
 	got, err := a.Ingest(adapter.ScopeProject, proj)

--- a/internal/adapter/windsurf/memory.go
+++ b/internal/adapter/windsurf/memory.go
@@ -32,8 +32,13 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, [
 	if c.Memory.Body == "" {
 		return nil, nil, nil
 	}
-	body := source.ExpandMemoryImports(c.Memory.Body, c.Memory.Fragments)
+	banner := c.Config.MemoryBannerEnabled()
 	if p.RulesDir != "" {
+		// The managed banner goes AFTER the activation frontmatter so the `---`
+		// fence stays at byte 0 (Windsurf only parses frontmatter at the top of
+		// the file). Ingest strips the frontmatter and capture strips the banner,
+		// so both round-trip cleanly out of the canonical body.
+		body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, memoryRuleFile, banner)
 		return []adapter.FileOp{{
 			Action:        "write",
 			Path:          filepath.Join(p.RulesDir, memoryRuleFile),
@@ -50,6 +55,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, [
 			Reason:    "no Windsurf rules target at this scope",
 		}}, nil
 	}
+	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.GlobalRules), banner)
 	return []adapter.FileOp{{
 		Action:        "write",
 		Path:          p.GlobalRules,

--- a/internal/adapter/windsurf/render_test.go
+++ b/internal/adapter/windsurf/render_test.go
@@ -63,8 +63,8 @@ func TestRender_UserScope_MCPGlobalRulesAndWorkflows(t *testing.T) {
 	if memOp == nil {
 		t.Fatalf("global_rules.md op missing at user scope: %+v", ops)
 	}
-	if string(memOp.Content) != "# mem\n" {
-		t.Fatalf("global rules must be the verbatim body: %q", memOp.Content)
+	if source.StripManagedBanner(string(memOp.Content)) != "# mem\n" {
+		t.Fatalf("global rules must be the verbatim body under the managed banner: %q", memOp.Content)
 	}
 	// commands → global workflows.
 	cmdOp := findOp(ops, filepath.Join(".codeium", "windsurf", "global_workflows", "deploy.md"))
@@ -120,8 +120,10 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	if memOp == nil {
 		t.Fatal("rules/agentsync.md op missing at project scope")
 	}
-	if string(memOp.Content) != "---\ntrigger: always_on\n---\n\n# Rules\n\nBe concise.\n" {
-		t.Fatalf("memory rule must carry trigger: always_on frontmatter: %q", memOp.Content)
+	// The activation frontmatter must stay at byte 0; the managed banner sits
+	// after it and strips back out to leave frontmatter + verbatim body.
+	if source.StripManagedBanner(string(memOp.Content)) != "---\ntrigger: always_on\n---\n\n# Rules\n\nBe concise.\n" {
+		t.Fatalf("memory rule must carry trigger: always_on frontmatter under the managed banner: %q", memOp.Content)
 	}
 	// Command → .windsurf/workflows/deploy.md (plain body; frontmatter dropped).
 	cmdOp := findOp(ops, ".windsurf/workflows/deploy.md")

--- a/internal/adapter/windsurf/render_test.go
+++ b/internal/adapter/windsurf/render_test.go
@@ -63,7 +63,7 @@ func TestRender_UserScope_MCPGlobalRulesAndWorkflows(t *testing.T) {
 	if memOp == nil {
 		t.Fatalf("global_rules.md op missing at user scope: %+v", ops)
 	}
-	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner prefix on global rules: %q", memOp.Content)
 	}
 	if source.StripManagedBanner(string(memOp.Content)) != "# mem\n" {
@@ -128,7 +128,7 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	if !strings.HasPrefix(string(memOp.Content), "---\ntrigger: always_on\n---\n") {
 		t.Fatalf("activation frontmatter must stay at byte 0: %q", memOp.Content)
 	}
-	if !strings.Contains(string(memOp.Content), "<!-- agentsync:managed -->") {
+	if !strings.Contains(string(memOp.Content), "<!-- agentsync:managed memory-banner -->") {
 		t.Fatalf("expected managed banner after the frontmatter: %q", memOp.Content)
 	}
 	if source.StripManagedBanner(string(memOp.Content)) != "---\ntrigger: always_on\n---\n\n# Rules\n\nBe concise.\n" {

--- a/internal/adapter/windsurf/render_test.go
+++ b/internal/adapter/windsurf/render_test.go
@@ -63,6 +63,9 @@ func TestRender_UserScope_MCPGlobalRulesAndWorkflows(t *testing.T) {
 	if memOp == nil {
 		t.Fatalf("global_rules.md op missing at user scope: %+v", ops)
 	}
+	if !strings.HasPrefix(string(memOp.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner prefix on global rules: %q", memOp.Content)
+	}
 	if source.StripManagedBanner(string(memOp.Content)) != "# mem\n" {
 		t.Fatalf("global rules must be the verbatim body under the managed banner: %q", memOp.Content)
 	}
@@ -122,6 +125,12 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	}
 	// The activation frontmatter must stay at byte 0; the managed banner sits
 	// after it and strips back out to leave frontmatter + verbatim body.
+	if !strings.HasPrefix(string(memOp.Content), "---\ntrigger: always_on\n---\n") {
+		t.Fatalf("activation frontmatter must stay at byte 0: %q", memOp.Content)
+	}
+	if !strings.Contains(string(memOp.Content), "<!-- agentsync:managed -->") {
+		t.Fatalf("expected managed banner after the frontmatter: %q", memOp.Content)
+	}
 	if source.StripManagedBanner(string(memOp.Content)) != "---\ntrigger: always_on\n---\n\n# Rules\n\nBe concise.\n" {
 		t.Fatalf("memory rule must carry trigger: always_on frontmatter under the managed banner: %q", memOp.Content)
 	}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1075,14 +1075,20 @@ func importLSP(io *importIO, home string, c source.Canonical, name string) ([]st
 }
 
 func importMemory(io *importIO, home string, c source.Canonical) ([]string, error) {
+	// Backstop: every adapter's ingest already strips the agentsync managed-file
+	// banner (it has no canonical home), but strip again here at the write-back
+	// funnel so the notice can never reach memory/AGENTS.md regardless of how the
+	// canonical was assembled. It is re-injected on the next render and must not
+	// compound. (No-op when the banner is already absent.)
+	c.Memory.Body = source.StripManagedBanner(c.Memory.Body)
 	// Memory is a single block, not a named collection; nothing to write when
 	// the agent carries no memory (the common case during a full-agent import).
 	if strings.TrimSpace(c.Memory.Body) == "" {
 		return nil, nil
 	}
-	// The ingested memory is the rendered destination file. If apply wrote
-	// fragment markers, reverse them back into AGENTS.md + the fragment files so
-	// the round-trip is not lossy; otherwise fall back to the guard.
+	// If apply also wrote fragment markers, reverse them back into AGENTS.md +
+	// the fragment files so the round-trip is not lossy; otherwise fall back to
+	// the guard.
 	mem, hadMarkers, err := source.CollapseMemoryMarkers(c.Memory.Body)
 	switch {
 	case err != nil:

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
 )
 
 // mcpKeySHA returns the seeded state hash for /mcpServers/<id>, or "".
@@ -364,6 +366,48 @@ func TestImport_RejectsTraversalSelector(t *testing.T) {
 
 // TestImport_MCPFromClaude verifies that import claude:mcp:<id> reads the MCP
 // server from .claude.json and writes it to the canonical source.
+// TestImport_MemoryStripsBanner: importing a native memory file that carries the
+// agentsync managed-file banner writes the banner-free body to the canonical
+// source — the banner must never round-trip back into memory/AGENTS.md.
+func TestImport_MemoryStripsBanner(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := "# My rules\n\nBe concise.\n"
+	native := source.RenderManagedMemory(body, nil, "CLAUDE.md", true) // banner + body, as apply renders it
+	if !strings.Contains(native, "agentsync:managed") {
+		t.Fatal("test setup: expected a banner in native content")
+	}
+	memPath := filepath.Join(tmp, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(memPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(memPath, []byte(native), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "import", "claude:memory"); err != nil {
+		t.Fatalf("import claude:memory: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, ".agentsync", "memory", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("canonical memory not written: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("canonical memory should be the banner-free body; got:\n%q", got)
+	}
+	if strings.Contains(string(got), "agentsync:managed") || strings.Contains(string(got), "Managed by [agentsync]") {
+		t.Fatalf("banner leaked into canonical memory:\n%s", got)
+	}
+}
+
 func TestImport_MCPFromClaude(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -408,6 +408,47 @@ func TestImport_MemoryStripsBanner(t *testing.T) {
 	}
 }
 
+// TestImport_MemoryRejectsReservedMarker: importing a native memory file that
+// carries a user-authored block in the reserved `agentsync:managed` namespace is
+// rejected at the capture funnel (not silently stripped), so the reserved marker
+// never lands in the canonical source.
+func TestImport_MemoryRejectsReservedMarker(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A user-authored block reusing the reserved managed markers — NOT agentsync's
+	// banner — so the strip preserves it and the reserved-marker guard must reject.
+	native := "# My rules\n\n<!-- agentsync:managed memory-banner -->\nhand-written, not the banner\n<!-- /agentsync:managed memory-banner -->\n"
+	memPath := filepath.Join(tmp, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(memPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(memPath, []byte(native), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:memory")
+	combined := out
+	if err != nil {
+		combined += err.Error()
+	}
+	if !strings.Contains(combined, "reserved marker") {
+		t.Fatalf("import should surface the reserved-marker error; err=%v out=%s", err, out)
+	}
+	// The reserved content must NOT have been persisted to the canonical source.
+	if data, rerr := os.ReadFile(filepath.Join(tmp, ".agentsync", "memory", "AGENTS.md")); rerr == nil {
+		if strings.Contains(string(data), "agentsync:managed") {
+			t.Fatalf("reserved marker leaked into canonical:\n%s", data)
+		}
+	}
+}
+
 func TestImport_MCPFromClaude(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -735,6 +735,11 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	// fragments). With no markers but a fragment-composed source, writing back
 	// would inline every @import and orphan the fragments — refuse.
 	if filepath.ToSlash(srcID) == "memory/AGENTS.md" {
+		// The rendered memory carries the agentsync managed-file banner
+		// (RenderManagedMemory). Strip it before anything else so it never enters
+		// the canonical source — both the fragment-marker reversal AND the plain
+		// verbatim fall-through below then operate on banner-free content.
+		data = []byte(source.StripManagedBanner(string(data)))
 		mem, hadMarkers, cerr := source.CollapseMemoryMarkers(string(data))
 		switch {
 		case cerr != nil:

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -79,8 +79,10 @@ func Discover(start string) (root string, found bool, err error) {
 //   - Memory: base body then project body, concatenated (project appended).
 //   - Plugins / Marketplaces: project entries are not modeled at project scope in
 //     v1 and are inherited from base unchanged (see the migration note in
-//     docs/architecture.md). Config (Updates/Secrets) is inherited from base
-//     unless the project declares its own non-zero values.
+//     docs/architecture.md). Config (Updates/Secrets/Memory) is inherited from
+//     base unless the project declares its own non-zero values; the effective
+//     [memory] setting is also propagated onto the stored project overlay so
+//     project-scope render honours a user-level managed-banner opt-out.
 func Merge(base, proj source.Canonical) source.Canonical {
 	out := base // shallow copy; every slice/map we touch is replaced, not mutated
 
@@ -97,6 +99,9 @@ func Merge(base, proj source.Canonical) source.Canonical {
 	if proj.Config.Secrets != (source.SecretsConfig{}) {
 		out.Config.Secrets = proj.Config.Secrets
 	}
+	if proj.Config.Memory != (source.MemoryConfig{}) {
+		out.Config.Memory = proj.Config.Memory
+	}
 
 	out.MCPServers = overlayByKey(base.MCPServers, proj.MCPServers, func(m source.MCPServer) string { return m.ID })
 	out.LSPServers = overlayByKey(base.LSPServers, proj.LSPServers, func(l source.LSPServer) string { return l.ID })
@@ -112,6 +117,11 @@ func Merge(base, proj source.Canonical) source.Canonical {
 	// handle c.Project; this was simply never set.
 	projCopy := proj
 	projCopy.Project = nil // prevent accidental nesting if proj itself came from a Merge
+	// Project-scope render reads renderC.Config.Memory off this overlay (renderC =
+	// *c.Project), so it must carry the EFFECTIVE banner setting: an explicit
+	// project [memory] override, else the inherited user setting. Without this a
+	// user-level `banner = false` would silently fail to reach project files.
+	projCopy.Config.Memory = out.Config.Memory
 	out.Project = &projCopy
 
 	return out

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -258,6 +258,30 @@ func TestMerge_MemoryProjectOnly(t *testing.T) {
 	}
 }
 
+// TestMerge_MemoryBannerInheritance: the stored project overlay inherits the
+// effective [memory] banner setting (project-scope render reads it off
+// out.Project), so a user-level opt-out reaches project files; an explicit
+// project setting overrides the inherited one.
+func TestMerge_MemoryBannerInheritance(t *testing.T) {
+	off, on := false, true
+	base := source.Canonical{Config: source.Config{Memory: source.MemoryConfig{Banner: &off}}}
+
+	// Project unset → overlay inherits the user's banner=false.
+	out := project.Merge(base, source.Canonical{})
+	if out.Project == nil || out.Project.Config.Memory.Banner == nil || *out.Project.Config.Memory.Banner {
+		t.Fatalf("project overlay should inherit user banner=false; got %+v", out.Project.Config.Memory)
+	}
+	if out.Config.MemoryBannerEnabled() {
+		t.Fatalf("merged config should report banner disabled")
+	}
+
+	// Explicit project banner=true overrides the inherited opt-out.
+	out2 := project.Merge(base, source.Canonical{Config: source.Config{Memory: source.MemoryConfig{Banner: &on}}})
+	if out2.Project == nil || out2.Project.Config.Memory.Banner == nil || !*out2.Project.Config.Memory.Banner {
+		t.Fatalf("explicit project banner=true should override; got %+v", out2.Project.Config.Memory)
+	}
+}
+
 func TestMerge_DoesNotMutateBase(t *testing.T) {
 	base := source.Canonical{MCPServers: []source.MCPServer{
 		{ID: "existing", Server: source.MCPServerSpec{Command: "cmd"}},

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -572,5 +572,10 @@ func loadMemory(fs afero.Fs, home string) (Memory, error) {
 	if werr != nil {
 		return m, fmt.Errorf("read memory/fragments: %w", werr)
 	}
+	// Reject a canonical that uses the reserved managed-banner marker (see
+	// checkReservedMarkers): it would collide with the banner's reversible markers.
+	if err := checkReservedMarkers(m.Body, m.Fragments); err != nil {
+		return m, err
+	}
 	return m, nil
 }

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -115,26 +115,57 @@ func expandMemoryImports(body string, fragments map[string]string, visiting map[
 // blockquote) so an agent reading the rendered CLAUDE.md/AGENTS.md sees the
 // notice; the markers themselves are HTML comments the agent ignores.
 //
-// The token "agentsync:managed" is RESERVED: if the canonical memory already
-// contains it, RenderManagedMemory skips injection (collision guard, mirroring
-// ExpandMemoryImports' marker-collision handling) so a second banner can't nest
-// and StripManagedBanner can't mis-bound a user's literal.
+// The token "agentsync:managed" is RESERVED: canonical memory (the AGENTS.md body
+// or any fragment) must not contain it, and checkReservedMarkers (called from
+// loadMemory and WriteMemory) rejects a canonical that does — with a message
+// telling the user to remove/rename the offending content — rather than letting it
+// collide with the banner's markers. StripManagedBanner additionally anchors on
+// the banner's lead line (managedBannerLead), not the bare markers, so even a
+// hand-edited native file that happens to carry a user-authored
+// `<!-- agentsync:managed -->` block has its content preserved (the write-back
+// then surfaces the reserved-token error) — it is never silently deleted.
 const managedMarkerToken = "agentsync:managed"
 
 const (
 	managedStartMarker = "<!-- agentsync:managed -->"
 	managedEndMarker   = "<!-- /agentsync:managed -->"
+	// managedBannerLead is the fixed opening of the banner body (everything before
+	// the per-file name). StripManagedBanner anchors on it so it removes ONLY
+	// agentsync's own banner; managedBanner builds from the same constant so the
+	// two halves can never drift.
+	managedBannerLead = "> **Managed by [agentsync](https://agentsync.cc)"
 )
 
-// managedBannerRe matches a whole injected banner block — the markers, the body
-// between them, and the blank line that separates it from the memory content —
-// anywhere in the file. `(?s)` lets `.` span lines; `.*?` is non-greedy so each
-// block is bounded minimally; `\n{0,2}` consumes the trailing separator we add
-// (and tolerates a hand-removed blank line). ReplaceAll over it makes
-// StripManagedBanner idempotent and robust to a (theoretical) double banner.
+// managedBannerRe matches a whole injected banner block — the markers, the banner
+// body between them, and the blank line that separates it from the memory content.
+// It anchors on managedBannerLead immediately after the start marker, so it only
+// matches agentsync's own banner, never an arbitrary user-authored
+// `<!-- agentsync:managed -->` block. `(?s)` lets `.` span lines; `.*?` is
+// non-greedy so the block is bounded minimally; the `\r?\n` / `(?:\r?\n){0,2}`
+// tolerate CRLF line endings and consume the trailing separator the renderer adds
+// (and a hand-removed blank line). ReplaceAll makes StripManagedBanner idempotent.
 var managedBannerRe = regexp.MustCompile(
-	`(?s)` + regexp.QuoteMeta(managedStartMarker) + `.*?` + regexp.QuoteMeta(managedEndMarker) + `\n{0,2}`,
+	`(?s)` + regexp.QuoteMeta(managedStartMarker) + `\r?\n` + regexp.QuoteMeta(managedBannerLead) +
+		`.*?` + regexp.QuoteMeta(managedEndMarker) + `(?:\r?\n){0,2}`,
 )
+
+// checkReservedMarkers rejects canonical memory that contains the reserved
+// managed-banner token. The token is owned by the managed-file banner
+// (RenderManagedMemory); a body or fragment carrying it would collide with the
+// banner's reversible markers, so agentsync errors and asks the user to fix it
+// rather than silently degrading. Called from loadMemory (authoring path) and
+// WriteMemory (capture path) so the violation surfaces at both boundaries.
+func checkReservedMarkers(body string, fragments map[string]string) error {
+	if strings.Contains(body, managedMarkerToken) {
+		return fmt.Errorf("memory/AGENTS.md contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text", managedMarkerToken)
+	}
+	for name, content := range fragments {
+		if strings.Contains(content, managedMarkerToken) {
+			return fmt.Errorf("memory fragment %q contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text (or rename the fragment if the marker is in its name)", name, managedMarkerToken)
+		}
+	}
+	return nil
+}
 
 // MemoryBannerEnabled reports whether the managed-file banner should be rendered
 // into memory files for this config. It is ON by default; only an explicit
@@ -150,7 +181,7 @@ func (cfg Config) MemoryBannerEnabled() bool {
 // thrash the classifier or, worse, feed mutable data into hashed content.
 func managedBanner(destFile string) string {
 	return managedStartMarker + "\n" +
-		"> **Managed by [agentsync](https://agentsync.cc) — do not edit `" + destFile + "` directly.**\n" +
+		managedBannerLead + " — do not edit `" + destFile + "` directly.**\n" +
 		"> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant\n" +
 		"> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.\n" +
 		"> Direct edits here are reported as drift and overwritten on the next apply.\n" +
@@ -166,8 +197,9 @@ func managedBanner(destFile string) string {
 // agents.
 //
 // Returns plain expansion (no banner) when banner is false, destFile is empty,
-// or the memory already contains the reserved managed marker token (collision
-// guard). Callers guard `body == ""` before calling, so the banner is only ever
+// or the memory already contains the reserved managed marker token (a belt-and-
+// suspenders guard; checkReservedMarkers already rejects such a canonical at load
+// time). Callers guard `body == ""` before calling, so the banner is only ever
 // attached to a non-empty memory file.
 func RenderManagedMemory(body string, fragments map[string]string, destFile string, banner bool) string {
 	expanded := ExpandMemoryImports(body, fragments)
@@ -181,10 +213,12 @@ func RenderManagedMemory(body string, fragments map[string]string, destFile stri
 // injects, returning the memory content without it. It is the inverse half that
 // keeps the banner out of the canonical source: capture (import/reconcile) calls
 // it on a rendered memory file BEFORE CollapseMemoryMarkers, so neither the
-// banner nor the markers reach memory/AGENTS.md. It is idempotent and a no-op on
-// content that carries no banner.
+// banner nor the markers reach memory/AGENTS.md. It matches only agentsync's own
+// banner (anchored on managedBannerLead), so a user-authored
+// `<!-- agentsync:managed -->` block is left untouched — never silently deleted.
+// It is idempotent and a no-op on content that carries no banner.
 func StripManagedBanner(s string) string {
-	if !strings.Contains(s, managedMarkerToken) {
+	if !strings.Contains(s, managedBannerLead) {
 		return s
 	}
 	return managedBannerRe.ReplaceAllString(s, "")

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -115,39 +115,53 @@ func expandMemoryImports(body string, fragments map[string]string, visiting map[
 // blockquote) so an agent reading the rendered CLAUDE.md/AGENTS.md sees the
 // notice; the markers themselves are HTML comments the agent ignores.
 //
-// The token "agentsync:managed" is RESERVED: canonical memory (the AGENTS.md body
-// or any fragment) must not contain it, and checkReservedMarkers (called from
-// loadMemory and WriteMemory) rejects a canonical that does — with a message
-// telling the user to remove/rename the offending content — rather than letting it
-// collide with the banner's markers. StripManagedBanner additionally anchors on
-// the banner's lead line (managedBannerLead), not the bare markers, so even a
-// hand-edited native file that happens to carry a user-authored
-// `<!-- agentsync:managed -->` block has its content preserved (the write-back
-// then surfaces the reserved-token error) — it is never silently deleted.
-const managedMarkerToken = "agentsync:managed"
+// The namespace "agentsync:managed" is RESERVED. Each managed marker carries its
+// own identifier AFTER the namespace (here "memory-banner"), so if agentsync adds
+// more managed markers in future, each parses unambiguously and bidirectionally —
+// mirroring the per-name fragment markers above. Canonical memory (the AGENTS.md
+// body or any fragment) must not contain the namespace, and checkReservedMarkers
+// (called from loadMemory and WriteMemory) rejects a canonical that does — with a
+// message telling the user to remove/rename the offending content — rather than
+// letting it collide with the banner's markers. StripManagedBanner matches
+// agentsync's FULL rendered banner (derived from managedBannerFmt below), not the
+// bare markers, so a hand-edited native file carrying a user-authored
+// `<!-- agentsync:managed … -->` block — even one that begins like the banner — is
+// never stripped: it is left for checkReservedMarkers to reject loudly, never
+// silently deleted.
+const managedMarkerNamespace = "agentsync:managed"
 
 const (
-	managedStartMarker = "<!-- agentsync:managed -->"
-	managedEndMarker   = "<!-- /agentsync:managed -->"
-	// managedBannerLead is the fixed opening of the banner body (everything before
-	// the per-file name). StripManagedBanner anchors on it so it removes ONLY
-	// agentsync's own banner; managedBanner builds from the same constant so the
-	// two halves can never drift.
-	managedBannerLead = "> **Managed by [agentsync](https://agentsync.cc)"
+	managedStartMarker = "<!-- " + managedMarkerNamespace + " memory-banner -->"
+	managedEndMarker   = "<!-- /" + managedMarkerNamespace + " memory-banner -->"
+	// managedBannerFmt is the banner with a single %s for the destination file
+	// name. managedBanner renders it and managedBannerRe is DERIVED from it (see
+	// compileManagedBannerRe), so the rendered banner and the pattern that strips
+	// it are guaranteed to match the same text — they can never drift.
+	managedBannerFmt = managedStartMarker + "\n" +
+		"> **Managed by [agentsync](https://agentsync.cc) — do not edit `%s` directly.**\n" +
+		"> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant\n" +
+		"> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.\n" +
+		"> Direct edits here are reported as drift and overwritten on the next apply.\n" +
+		managedEndMarker + "\n"
 )
 
-// managedBannerRe matches a whole injected banner block — the markers, the banner
-// body between them, and the blank line that separates it from the memory content.
-// It anchors on managedBannerLead immediately after the start marker, so it only
-// matches agentsync's own banner, never an arbitrary user-authored
-// `<!-- agentsync:managed -->` block. `(?s)` lets `.` span lines; `.*?` is
-// non-greedy so the block is bounded minimally; the `\r?\n` / `(?:\r?\n){0,2}`
-// tolerate CRLF line endings and consume the trailing separator the renderer adds
-// (and a hand-removed blank line). ReplaceAll makes StripManagedBanner idempotent.
-var managedBannerRe = regexp.MustCompile(
-	`(?s)` + regexp.QuoteMeta(managedStartMarker) + `\r?\n` + regexp.QuoteMeta(managedBannerLead) +
-		`.*?` + regexp.QuoteMeta(managedEndMarker) + `(?:\r?\n){0,2}`,
-)
+// managedBannerRe matches agentsync's full rendered banner: every static line
+// verbatim, the per-file name (%s) as a non-newline wildcard, CRLF-tolerant, plus
+// the blank-line separator RenderManagedMemory appends. It is derived from
+// managedBannerFmt so it tracks the banner text automatically. Matching the WHOLE
+// banner (not just the markers or its lead line) is what makes StripManagedBanner
+// safe: a block that differs from the banner in any static line is not matched, so
+// a user-authored marker block is preserved rather than silently deleted.
+var managedBannerRe = compileManagedBannerRe()
+
+func compileManagedBannerRe() *regexp.Regexp {
+	body := strings.TrimSuffix(managedBannerFmt, "\n") // drop the template's own trailing newline
+	pre, post, _ := strings.Cut(body, "%s")
+	// Quote each literal half and make every embedded newline CRLF-tolerant; the
+	// %s (filename) becomes a non-newline run; consume the trailing separator.
+	quote := func(s string) string { return strings.ReplaceAll(regexp.QuoteMeta(s), "\n", `\r?\n`) }
+	return regexp.MustCompile(quote(pre) + `[^\r\n]*` + quote(post) + `(?:\r?\n){0,2}`)
+}
 
 // checkReservedMarkers rejects canonical memory that contains the reserved
 // managed-banner token. The token is owned by the managed-file banner
@@ -156,12 +170,12 @@ var managedBannerRe = regexp.MustCompile(
 // rather than silently degrading. Called from loadMemory (authoring path) and
 // WriteMemory (capture path) so the violation surfaces at both boundaries.
 func checkReservedMarkers(body string, fragments map[string]string) error {
-	if strings.Contains(body, managedMarkerToken) {
-		return fmt.Errorf("memory/AGENTS.md contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text", managedMarkerToken)
+	if strings.Contains(body, managedMarkerNamespace) {
+		return fmt.Errorf("memory/AGENTS.md contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text", managedMarkerNamespace)
 	}
 	for name, content := range fragments {
-		if strings.Contains(content, managedMarkerToken) {
-			return fmt.Errorf("memory fragment %q contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text (or rename the fragment if the marker is in its name)", name, managedMarkerToken)
+		if strings.Contains(content, managedMarkerNamespace) {
+			return fmt.Errorf("memory fragment %q contains the reserved marker %q, which is owned by agentsync's managed-file banner; remove or rephrase that text (or rename the fragment if the marker is in its name)", name, managedMarkerNamespace)
 		}
 	}
 	return nil
@@ -180,17 +194,12 @@ func (cfg Config) MemoryBannerEnabled() bool {
 // rendered file, so a banner that varied (a version, a timestamp) would either
 // thrash the classifier or, worse, feed mutable data into hashed content.
 func managedBanner(destFile string) string {
-	return managedStartMarker + "\n" +
-		managedBannerLead + " — do not edit `" + destFile + "` directly.**\n" +
-		"> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant\n" +
-		"> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.\n" +
-		"> Direct edits here are reported as drift and overwritten on the next apply.\n" +
-		managedEndMarker + "\n"
+	return fmt.Sprintf(managedBannerFmt, destFile)
 }
 
 // RenderManagedMemory expands fragment imports (see ExpandMemoryImports) and,
 // when banner is true, PREPENDS the agentsync managed-file notice naming
-// destFile. The banner is wrapped in reversible markers (see managedMarkerToken)
+// destFile. The banner is wrapped in reversible markers (see managedMarkerNamespace)
 // so StripManagedBanner removes it on capture — it is therefore never part of
 // the canonical memory source and never compounds across applies. Every adapter
 // renders memory through this one helper so the notice is byte-identical across
@@ -203,7 +212,7 @@ func managedBanner(destFile string) string {
 // attached to a non-empty memory file.
 func RenderManagedMemory(body string, fragments map[string]string, destFile string, banner bool) string {
 	expanded := ExpandMemoryImports(body, fragments)
-	if !banner || destFile == "" || strings.Contains(expanded, managedMarkerToken) {
+	if !banner || destFile == "" || strings.Contains(expanded, managedMarkerNamespace) {
 		return expanded
 	}
 	return managedBanner(destFile) + "\n" + expanded
@@ -213,12 +222,13 @@ func RenderManagedMemory(body string, fragments map[string]string, destFile stri
 // injects, returning the memory content without it. It is the inverse half that
 // keeps the banner out of the canonical source: capture (import/reconcile) calls
 // it on a rendered memory file BEFORE CollapseMemoryMarkers, so neither the
-// banner nor the markers reach memory/AGENTS.md. It matches only agentsync's own
-// banner (anchored on managedBannerLead), so a user-authored
-// `<!-- agentsync:managed -->` block is left untouched — never silently deleted.
-// It is idempotent and a no-op on content that carries no banner.
+// banner nor the markers reach memory/AGENTS.md. It matches only agentsync's full
+// rendered banner (managedBannerRe), so a user-authored `<!-- agentsync:managed -->`
+// block — even one that opens like the banner — is left untouched and never
+// silently deleted (checkReservedMarkers rejects it loudly instead). It is
+// idempotent and a no-op on content that carries no banner.
 func StripManagedBanner(s string) string {
-	if !strings.Contains(s, managedBannerLead) {
+	if !strings.Contains(s, managedStartMarker) {
 		return s
 	}
 	return managedBannerRe.ReplaceAllString(s, "")

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -107,6 +107,89 @@ func expandMemoryImports(body string, fragments map[string]string, visiting map[
 	})
 }
 
+// Managed-banner markers. Like the fragment markers above, these are reversible
+// HTML-comment delimiters: RenderManagedMemory injects the agentsync "managed
+// file" notice inside them on render, and StripManagedBanner removes the whole
+// block on capture (import/reconcile) so it NEVER lands in the canonical memory
+// source. The banner body between the markers is human-readable Markdown (a
+// blockquote) so an agent reading the rendered CLAUDE.md/AGENTS.md sees the
+// notice; the markers themselves are HTML comments the agent ignores.
+//
+// The token "agentsync:managed" is RESERVED: if the canonical memory already
+// contains it, RenderManagedMemory skips injection (collision guard, mirroring
+// ExpandMemoryImports' marker-collision handling) so a second banner can't nest
+// and StripManagedBanner can't mis-bound a user's literal.
+const managedMarkerToken = "agentsync:managed"
+
+const (
+	managedStartMarker = "<!-- agentsync:managed -->"
+	managedEndMarker   = "<!-- /agentsync:managed -->"
+)
+
+// managedBannerRe matches a whole injected banner block — the markers, the body
+// between them, and the blank line that separates it from the memory content —
+// anywhere in the file. `(?s)` lets `.` span lines; `.*?` is non-greedy so each
+// block is bounded minimally; `\n{0,2}` consumes the trailing separator we add
+// (and tolerates a hand-removed blank line). ReplaceAll over it makes
+// StripManagedBanner idempotent and robust to a (theoretical) double banner.
+var managedBannerRe = regexp.MustCompile(
+	`(?s)` + regexp.QuoteMeta(managedStartMarker) + `.*?` + regexp.QuoteMeta(managedEndMarker) + `\n{0,2}`,
+)
+
+// MemoryBannerEnabled reports whether the managed-file banner should be rendered
+// into memory files for this config. It is ON by default; only an explicit
+// `[memory] banner = false` in agentsync.toml disables it.
+func (cfg Config) MemoryBannerEnabled() bool {
+	return cfg.Memory.Banner == nil || *cfg.Memory.Banner
+}
+
+// managedBanner is the agentsync "managed file" notice prepended to a rendered
+// memory file, naming destFile (e.g. "CLAUDE.md"). It is STATIC apart from the
+// filename so it hashes identically on every render — drift compares the whole
+// rendered file, so a banner that varied (a version, a timestamp) would either
+// thrash the classifier or, worse, feed mutable data into hashed content.
+func managedBanner(destFile string) string {
+	return managedStartMarker + "\n" +
+		"> **Managed by [agentsync](https://agentsync.cc) — do not edit `" + destFile + "` directly.**\n" +
+		"> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant\n" +
+		"> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.\n" +
+		"> Direct edits here are reported as drift and overwritten on the next apply.\n" +
+		managedEndMarker + "\n"
+}
+
+// RenderManagedMemory expands fragment imports (see ExpandMemoryImports) and,
+// when banner is true, PREPENDS the agentsync managed-file notice naming
+// destFile. The banner is wrapped in reversible markers (see managedMarkerToken)
+// so StripManagedBanner removes it on capture — it is therefore never part of
+// the canonical memory source and never compounds across applies. Every adapter
+// renders memory through this one helper so the notice is byte-identical across
+// agents.
+//
+// Returns plain expansion (no banner) when banner is false, destFile is empty,
+// or the memory already contains the reserved managed marker token (collision
+// guard). Callers guard `body == ""` before calling, so the banner is only ever
+// attached to a non-empty memory file.
+func RenderManagedMemory(body string, fragments map[string]string, destFile string, banner bool) string {
+	expanded := ExpandMemoryImports(body, fragments)
+	if !banner || destFile == "" || strings.Contains(expanded, managedMarkerToken) {
+		return expanded
+	}
+	return managedBanner(destFile) + "\n" + expanded
+}
+
+// StripManagedBanner removes the managed-file banner block(s) RenderManagedMemory
+// injects, returning the memory content without it. It is the inverse half that
+// keeps the banner out of the canonical source: capture (import/reconcile) calls
+// it on a rendered memory file BEFORE CollapseMemoryMarkers, so neither the
+// banner nor the markers reach memory/AGENTS.md. It is idempotent and a no-op on
+// content that carries no banner.
+func StripManagedBanner(s string) string {
+	if !strings.Contains(s, managedMarkerToken) {
+		return s
+	}
+	return managedBannerRe.ReplaceAllString(s, "")
+}
+
 // CollapseMemoryMarkers reverses ExpandMemoryImports' marker emission: it parses
 // a rendered memory file back into memory/AGENTS.md (with `@import` directives
 // restored where each fragment block was) plus the fragment files. It is how

--- a/internal/source/memory.go
+++ b/internal/source/memory.go
@@ -150,8 +150,13 @@ const (
 // the blank-line separator RenderManagedMemory appends. It is derived from
 // managedBannerFmt so it tracks the banner text automatically. Matching the WHOLE
 // banner (not just the markers or its lead line) is what makes StripManagedBanner
-// safe: a block that differs from the banner in any static line is not matched, so
-// a user-authored marker block is preserved rather than silently deleted.
+// safe: a block that differs from the banner in any STATIC line is not matched, so
+// a user-authored marker block is preserved rather than silently deleted. (The one
+// non-static span is the filename wildcard, so a block byte-identical to the banner
+// except for the file it names is still stripped — but such a block can never reach
+// the canonical source: checkReservedMarkers rejects the reserved namespace at both
+// load and capture, and only the boilerplate notice itself is matched, never the
+// user prose around it.)
 var managedBannerRe = compileManagedBannerRe()
 
 func compileManagedBannerRe() *regexp.Regexp {

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -209,8 +209,8 @@ func TestRenderManagedMemory_PrependsBanner(t *testing.T) {
 	got := source.RenderManagedMemory(body, nil, "CLAUDE.md", true)
 
 	for _, want := range []string{
-		"<!-- agentsync:managed -->",
-		"<!-- /agentsync:managed -->",
+		"<!-- agentsync:managed memory-banner -->",
+		"<!-- /agentsync:managed memory-banner -->",
 		"do not edit `CLAUDE.md` directly",
 		".agentsync/memory/AGENTS.md",
 		"agentsync apply",
@@ -219,13 +219,13 @@ func TestRenderManagedMemory_PrependsBanner(t *testing.T) {
 			t.Fatalf("banner missing %q in:\n%s", want, got)
 		}
 	}
-	if !strings.HasPrefix(got, "<!-- agentsync:managed -->") {
-		t.Fatalf("banner must be prepended; got prefix %q", got[:min(40, len(got))])
+	if !strings.HasPrefix(got, "<!-- agentsync:managed memory-banner -->") {
+		t.Fatalf("banner must be prepended; got prefix %q", got[:min(48, len(got))])
 	}
 	if !strings.Contains(got, "Be concise.") {
 		t.Fatalf("memory body dropped: %s", got)
 	}
-	if strings.Index(got, "<!-- /agentsync:managed -->") > strings.Index(got, "Be concise.") {
+	if strings.Index(got, "<!-- /agentsync:managed memory-banner -->") > strings.Index(got, "Be concise.") {
 		t.Fatalf("banner must precede the body: %s", got)
 	}
 }
@@ -352,18 +352,28 @@ func TestManagedBanner_ArtifactRoundTrip(t *testing.T) {
 
 // TestStripManagedBanner_PreservesUserAuthoredBlock is the regression for the
 // strip/render ownership asymmetry (PR #91 review): StripManagedBanner must
-// remove ONLY agentsync's own banner (anchored on its lead line), never an
-// arbitrary user-authored <!-- agentsync:managed --> block — deleting the latter
-// would be a silent data loss on capture.
+// remove ONLY agentsync's own full banner, never an arbitrary user-authored
+// block in the reserved namespace — deleting the latter would be a silent data
+// loss on capture. Because the strip matches the WHOLE banner, even a block that
+// reuses the exact managed markers but differs in body is preserved (and then
+// rejected loudly by checkReservedMarkers, not deleted).
 func TestStripManagedBanner_PreservesUserAuthoredBlock(t *testing.T) {
-	// A user's own block: same markers, but NOT the agentsync banner body.
-	user := "# Memory\n\n<!-- agentsync:managed -->\nmy own notes here\n<!-- /agentsync:managed -->\n\nrest\n"
-	if got := source.StripManagedBanner(user); got != user {
-		t.Fatalf("user-authored marker block must be preserved verbatim:\n got %q\nwant %q", got, user)
+	cases := map[string]string{
+		// Bare markers (old namespace style), arbitrary body.
+		"bare markers": "# Memory\n\n<!-- agentsync:managed -->\nmy own notes here\n<!-- /agentsync:managed -->\n\nrest\n",
+		// The EXACT managed markers agentsync renders, but a body that is NOT the banner.
+		"exact markers": "# Memory\n\n<!-- agentsync:managed memory-banner -->\nmy own notes here\n<!-- /agentsync:managed memory-banner -->\n\nrest\n",
+		// Body that even opens like the banner's first line but then diverges.
+		"banner-like opener": "<!-- agentsync:managed memory-banner -->\n> **Managed by [agentsync](https://agentsync.cc) but I rewrote the rest**\n<!-- /agentsync:managed memory-banner -->\nkeep me\n",
+	}
+	for name, user := range cases {
+		if got := source.StripManagedBanner(user); got != user {
+			t.Fatalf("%s: user-authored block must be preserved verbatim:\n got %q\nwant %q", name, got, user)
+		}
 	}
 	// agentsync's own banner IS stripped (and only it).
 	withBanner := source.RenderManagedMemory("# Memory\nbody\n", nil, "CLAUDE.md", true)
-	if !strings.Contains(withBanner, "agentsync:managed") {
+	if !strings.Contains(withBanner, "agentsync:managed memory-banner") {
 		t.Fatalf("expected a banner to strip: %q", withBanner)
 	}
 	if got := source.StripManagedBanner(withBanner); got != "# Memory\nbody\n" {

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
@@ -176,6 +178,175 @@ func TestCollapseMemoryMarkers_NoMarkers(t *testing.T) {
 	_, had, err := source.CollapseMemoryMarkers("# Memory\nplain body\n")
 	if had || err != nil {
 		t.Fatalf("expected had=false err=nil, got had=%v err=%v", had, err)
+	}
+}
+
+// boolPtr is a local helper for the *bool banner setting.
+func boolPtr(b bool) *bool { return &b }
+
+// TestMemoryBannerEnabled: unset (nil) defaults ON; explicit true/false honoured.
+func TestMemoryBannerEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  source.Config
+		want bool
+	}{
+		{"unset defaults on", source.Config{}, true},
+		{"explicit true", source.Config{Memory: source.MemoryConfig{Banner: boolPtr(true)}}, true},
+		{"explicit false", source.Config{Memory: source.MemoryConfig{Banner: boolPtr(false)}}, false},
+	}
+	for _, tc := range cases {
+		if got := tc.cfg.MemoryBannerEnabled(); got != tc.want {
+			t.Errorf("%s: MemoryBannerEnabled() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRenderManagedMemory_PrependsBanner: the banner is emitted, names the
+// destination file, sits BEFORE the memory body, and the body survives intact.
+func TestRenderManagedMemory_PrependsBanner(t *testing.T) {
+	body := "# My memory\n\nBe concise.\n"
+	got := source.RenderManagedMemory(body, nil, "CLAUDE.md", true)
+
+	for _, want := range []string{
+		"<!-- agentsync:managed -->",
+		"<!-- /agentsync:managed -->",
+		"do not edit `CLAUDE.md` directly",
+		".agentsync/memory/AGENTS.md",
+		"agentsync apply",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("banner missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.HasPrefix(got, "<!-- agentsync:managed -->") {
+		t.Fatalf("banner must be prepended; got prefix %q", got[:min(40, len(got))])
+	}
+	if !strings.Contains(got, "Be concise.") {
+		t.Fatalf("memory body dropped: %s", got)
+	}
+	if strings.Index(got, "<!-- /agentsync:managed -->") > strings.Index(got, "Be concise.") {
+		t.Fatalf("banner must precede the body: %s", got)
+	}
+}
+
+// TestRenderManagedMemory_SuppressedWhenDisabledOrEmpty: no banner when the
+// setting is off, the destination name is empty, or the memory already contains
+// the reserved managed token (collision guard).
+func TestRenderManagedMemory_SuppressedWhenDisabledOrEmpty(t *testing.T) {
+	body := "# Memory\nplain\n"
+	cases := []struct {
+		name     string
+		body     string
+		destFile string
+		banner   bool
+	}{
+		{"disabled", body, "CLAUDE.md", false},
+		{"empty dest name", body, "", true},
+		{"collision", "# Memory\nsee <!-- agentsync:managed --> note\n", "CLAUDE.md", true},
+	}
+	for _, tc := range cases {
+		got := source.RenderManagedMemory(tc.body, nil, tc.destFile, tc.banner)
+		if strings.Contains(got, "Managed by [agentsync]") {
+			t.Errorf("%s: banner should be suppressed, got:\n%s", tc.name, got)
+		}
+	}
+}
+
+// TestManagedBanner_RoundTripPlain proves a banner-prefixed plain memory file
+// strips back to EXACTLY the expanded body (byte-for-byte) — the property that
+// keeps the notice out of the canonical source.
+func TestManagedBanner_RoundTripPlain(t *testing.T) {
+	body := "# Memory\n\nLine one.\nLine two.\n"
+	rendered := source.RenderManagedMemory(body, nil, "AGENTS.md", true)
+	if !strings.Contains(rendered, "agentsync:managed") {
+		t.Fatalf("expected a banner: %s", rendered)
+	}
+	got := source.StripManagedBanner(rendered)
+	if got != body {
+		t.Fatalf("strip did not recover body byte-for-byte:\n got %q\nwant %q", got, body)
+	}
+}
+
+// TestStripManagedBanner_NoopAndIdempotent: stripping content with no banner is
+// a no-op, and stripping is idempotent.
+func TestStripManagedBanner_NoopAndIdempotent(t *testing.T) {
+	plain := "# Memory\nno banner here\n"
+	if got := source.StripManagedBanner(plain); got != plain {
+		t.Fatalf("no-op strip changed content: %q", got)
+	}
+	rendered := source.RenderManagedMemory("# M\nbody\n", nil, "CLAUDE.md", true)
+	once := source.StripManagedBanner(rendered)
+	twice := source.StripManagedBanner(once)
+	if once != twice {
+		t.Fatalf("strip not idempotent:\n once %q\ntwice %q", once, twice)
+	}
+}
+
+// TestManagedBanner_ArtifactRoundTrip is the fidelity guard (CLAUDE.md: anchor
+// to the on-disk artifact, not the parsed model). It starts from a spec-complete
+// memory tree on disk (AGENTS.md with an @import + a real fragment file), renders
+// it to a destination WITH the banner enabled, captures it back the way
+// import/reconcile do (StripManagedBanner → CollapseMemoryMarkers → WriteMemory),
+// and asserts the rebuilt canonical files are byte-identical to the originals —
+// and that the banner leaked into neither.
+func TestManagedBanner_ArtifactRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	memDir := filepath.Join(home, "memory")
+	fragDir := filepath.Join(memDir, "fragments")
+	if err := os.MkdirAll(fragDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Import sits last (a blank line immediately after an @import is consumed by
+	// expansion's `\s*$` — a documented fragment limitation, see memory.go — and
+	// is orthogonal to the banner under test here).
+	bodyOnDisk := "# Memory\n\nProject conventions.\n\n@import ./fragments/style.md\n"
+	fragOnDisk := "Be concise.\n"
+	if err := os.WriteFile(filepath.Join(memDir, "AGENTS.md"), []byte(bodyOnDisk), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fragDir, "style.md"), []byte(fragOnDisk), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Render to a destination file with the banner on (the default).
+	rendered := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, "CLAUDE.md", true)
+	if !strings.Contains(rendered, "agentsync:managed") || !strings.Contains(rendered, "agentsync:fragment style.md") {
+		t.Fatalf("rendered file missing banner and/or fragment markers:\n%s", rendered)
+	}
+
+	// Capture it back exactly as import/reconcile do.
+	stripped := source.StripManagedBanner(rendered)
+	if strings.Contains(stripped, "agentsync:managed") {
+		t.Fatalf("banner survived strip:\n%s", stripped)
+	}
+	mem, had, err := source.CollapseMemoryMarkers(stripped)
+	if err != nil || !had {
+		t.Fatalf("collapse: had=%v err=%v", had, err)
+	}
+
+	out := t.TempDir()
+	if err := source.WriteMemory(out, mem); err != nil {
+		t.Fatalf("write memory: %v", err)
+	}
+	gotBody, _ := os.ReadFile(filepath.Join(out, "memory", "AGENTS.md"))
+	gotFrag, _ := os.ReadFile(filepath.Join(out, "memory", "fragments", "style.md"))
+	if string(gotBody) != bodyOnDisk {
+		t.Fatalf("AGENTS.md round-trip drift:\n got %q\nwant %q", gotBody, bodyOnDisk)
+	}
+	if string(gotFrag) != fragOnDisk {
+		t.Fatalf("fragment round-trip drift:\n got %q\nwant %q", gotFrag, fragOnDisk)
+	}
+	// The banner must have leaked into NEITHER canonical file.
+	for name, data := range map[string][]byte{"AGENTS.md": gotBody, "style.md": gotFrag} {
+		if strings.Contains(string(data), "agentsync:managed") || strings.Contains(string(data), "Managed by [agentsync]") {
+			t.Fatalf("managed banner leaked into canonical %s:\n%s", name, data)
+		}
 	}
 }
 

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -391,6 +391,19 @@ func TestStripManagedBanner_CRLF(t *testing.T) {
 	}
 }
 
+// TestStripManagedBanner_CrossFilename locks the filename-wildcard contract: a
+// banner strips back to the clean body regardless of which file it names, so
+// capture works for every agent's destination (CLAUDE.md, GEMINI.md, the rule
+// files, …) without the stripper knowing the name.
+func TestStripManagedBanner_CrossFilename(t *testing.T) {
+	for _, name := range []string{"CLAUDE.md", "AGENTS.md", "GEMINI.md", "agentsync.md", "global_rules.md"} {
+		rendered := source.RenderManagedMemory("# Body\n\nkeep me\n", nil, name, true)
+		if got := source.StripManagedBanner(rendered); got != "# Body\n\nkeep me\n" {
+			t.Fatalf("%s: strip did not recover body: %q", name, got)
+		}
+	}
+}
+
 // TestRenderManagedMemory_Deterministic underpins the "banner never manufactures
 // drift" claim: the rendered bytes are identical across calls (no timestamp or
 // other nondeterminism), so the re-render / last-applied / on-disk hashes the

--- a/internal/source/memory_test.go
+++ b/internal/source/memory_test.go
@@ -350,6 +350,98 @@ func TestManagedBanner_ArtifactRoundTrip(t *testing.T) {
 	}
 }
 
+// TestStripManagedBanner_PreservesUserAuthoredBlock is the regression for the
+// strip/render ownership asymmetry (PR #91 review): StripManagedBanner must
+// remove ONLY agentsync's own banner (anchored on its lead line), never an
+// arbitrary user-authored <!-- agentsync:managed --> block — deleting the latter
+// would be a silent data loss on capture.
+func TestStripManagedBanner_PreservesUserAuthoredBlock(t *testing.T) {
+	// A user's own block: same markers, but NOT the agentsync banner body.
+	user := "# Memory\n\n<!-- agentsync:managed -->\nmy own notes here\n<!-- /agentsync:managed -->\n\nrest\n"
+	if got := source.StripManagedBanner(user); got != user {
+		t.Fatalf("user-authored marker block must be preserved verbatim:\n got %q\nwant %q", got, user)
+	}
+	// agentsync's own banner IS stripped (and only it).
+	withBanner := source.RenderManagedMemory("# Memory\nbody\n", nil, "CLAUDE.md", true)
+	if !strings.Contains(withBanner, "agentsync:managed") {
+		t.Fatalf("expected a banner to strip: %q", withBanner)
+	}
+	if got := source.StripManagedBanner(withBanner); got != "# Memory\nbody\n" {
+		t.Fatalf("agentsync banner not stripped to clean body: %q", got)
+	}
+}
+
+// TestStripManagedBanner_CRLF: the banner strips cleanly even with CRLF line
+// endings (a Windows-authored or editor-rewritten native file).
+func TestStripManagedBanner_CRLF(t *testing.T) {
+	lf := source.RenderManagedMemory("# Body\n", nil, "CLAUDE.md", true)
+	crlf := strings.ReplaceAll(lf, "\n", "\r\n")
+	if got := source.StripManagedBanner(crlf); got != "# Body\r\n" {
+		t.Fatalf("CRLF strip left residue: %q", got)
+	}
+}
+
+// TestRenderManagedMemory_Deterministic underpins the "banner never manufactures
+// drift" claim: the rendered bytes are identical across calls (no timestamp or
+// other nondeterminism), so the re-render / last-applied / on-disk hashes the
+// drift classifier compares stay equal for an untouched file.
+func TestRenderManagedMemory_Deterministic(t *testing.T) {
+	body := "# Memory\n\n@import ./fragments/x.md\n"
+	frags := map[string]string{"x.md": "be terse\n"}
+	a := source.RenderManagedMemory(body, frags, "CLAUDE.md", true)
+	b := source.RenderManagedMemory(body, frags, "CLAUDE.md", true)
+	if a != b {
+		t.Fatalf("render not deterministic:\n a=%q\n b=%q", a, b)
+	}
+}
+
+// TestLoad_RejectsReservedMarker enforces the reserved-token contract (PR #91
+// review): canonical memory — the AGENTS.md body OR a fragment — must not contain
+// the managed-banner marker, or it would collide with the banner's reversible
+// markers. Load surfaces it as a clear error instead of silently degrading.
+func TestLoad_RejectsReservedMarker(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		fragment string // written to fragments/bad.md when non-empty
+	}{
+		{"in body", "# M\nsee <!-- agentsync:managed --> here\n", ""},
+		{"in fragment", "# M\n", "oops <!-- agentsync:managed -->\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			fragDir := filepath.Join(home, "memory", "fragments")
+			if err := os.MkdirAll(fragDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(home, "memory", "AGENTS.md"), []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if tc.fragment != "" {
+				if err := os.WriteFile(filepath.Join(fragDir, "bad.md"), []byte(tc.fragment), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := source.Load(afero.NewOsFs(), home); err == nil || !strings.Contains(err.Error(), "reserved marker") {
+				t.Fatalf("Load should reject the reserved marker; got err=%v", err)
+			}
+		})
+	}
+}
+
+// TestWriteMemory_RejectsReservedMarker: the capture funnel (import/reconcile →
+// WriteMemory) refuses to persist the reserved managed-banner marker into the
+// canonical source, so a hand-edited native file carrying it errors loudly rather
+// than corrupting memory/.
+func TestWriteMemory_RejectsReservedMarker(t *testing.T) {
+	home := t.TempDir()
+	if err := source.WriteMemory(home, source.Memory{Body: "x <!-- agentsync:managed --> y\n"}); err == nil ||
+		!strings.Contains(err.Error(), "reserved marker") {
+		t.Fatalf("WriteMemory should reject the reserved marker; got err=%v", err)
+	}
+}
+
 // TestExpandMemoryImports_MarkerCollision: a fragment whose content already
 // contains the marker token disables markers entirely (plain expansion), so a
 // reverse parse can't be corrupted.

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -29,6 +29,18 @@ type Config struct {
 	Agents  map[string]Agent `toml:"agents"`
 	Updates UpdateDefaults   `toml:"updates"`
 	Secrets SecretsConfig    `toml:"secrets"`
+	Memory  MemoryConfig     `toml:"memory"`
+}
+
+// MemoryConfig mirrors the [memory] table in agentsync.toml.
+type MemoryConfig struct {
+	// Banner controls the agentsync "managed file" notice prepended to every
+	// rendered memory file (CLAUDE.md, AGENTS.md, …) — see RenderManagedMemory.
+	// It is ON by default; set `banner = false` to opt out. The field is a *bool
+	// so "unset" (nil → default-on) is distinguishable from "explicitly false",
+	// which the project-overlay merge needs to tell an explicit project override
+	// from an inherited default.
+	Banner *bool `toml:"banner,omitempty"`
 }
 
 type Agent struct {
@@ -186,6 +198,6 @@ type LSPServerSpec struct {
 
 // Memory mirrors memory/AGENTS.md and memory/fragments/.
 type Memory struct {
-	Body      string            // resolved AGENTS.md after @import expansion
-	Fragments map[string]string // body, keyed by slash path under memory/fragments/ (loaded recursively)
+	Body      string            // raw AGENTS.md (with @import directives); expansion happens at render via ExpandMemoryImports
+	Fragments map[string]string // fragment body, keyed by slash path under memory/fragments/ (loaded recursively)
 }

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -283,6 +283,12 @@ func WriteLSP(home string, ls LSPServer) error {
 // expanded body would inline every @import and orphan the fragment files; the
 // caller surfaces it rather than flatten silently.
 func WriteMemory(home string, m Memory) error {
+	// Refuse to persist the reserved managed-banner marker into the canonical
+	// source (see checkReservedMarkers): a captured native edit that carries it
+	// surfaces here as a clear error instead of corrupting memory/.
+	if err := checkReservedMarkers(m.Body, m.Fragments); err != nil {
+		return err
+	}
 	if len(m.Fragments) == 0 && MemoryHasFragments(home) {
 		return fmt.Errorf("refusing to overwrite memory/AGENTS.md: canonical memory is composed of fragments/ and the value to write carries none (the expanded memory could not be reversed) — persisting it would inline every @import and orphan the fragment files; edit memory/ directly")
 	}

--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -75,6 +75,36 @@ Edit a fragment once and every agent's memory updates on the next `apply`.
 	`status`/`diff` and you fold it in by hand.
 </Aside>
 
+## The managed-file banner
+
+Every rendered memory file is prepended with a short agentsync notice — a
+blockquote naming the file and pointing edits back at the canonical source:
+
+```markdown title="~/.claude/CLAUDE.md (rendered by apply)"
+<!-- agentsync:managed -->
+> **Managed by [agentsync](https://agentsync.cc) — do not edit `CLAUDE.md` directly.**
+> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant
+> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.
+> Direct edits here are reported as drift and overwritten on the next apply.
+<!-- /agentsync:managed -->
+
+# Coding conventions
+…
+```
+
+It nudges an agent (or a teammate) editing the native file toward the canonical
+source instead.
+
+<Aside type="note" title="The banner never enters your canonical source">
+	The banner is written by agentsync, not stored in `memory/AGENTS.md`. It is
+	wrapped in `<!-- agentsync:managed -->` markers, stripped on `import`/`reconcile`
+	(and on ingest), and re-rendered on every `apply` — so it never compounds, and
+	because the text is static it never shows up as drift. It is on by default; opt
+	out with `[memory] banner = false` in `agentsync.toml` (see the
+	[configuration reference](/reference/configuration/)). The first `apply` after
+	upgrading adds the banner to existing memory files — a one-time `pending`.
+</Aside>
+
 ## Per-agent rendering
 
 | Agent | Native memory file |

--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -81,12 +81,12 @@ Every rendered memory file is prepended with a short agentsync notice — a
 blockquote naming the file and pointing edits back at the canonical source:
 
 ```markdown title="~/.claude/CLAUDE.md (rendered by apply)"
-<!-- agentsync:managed -->
+<!-- agentsync:managed memory-banner -->
 > **Managed by [agentsync](https://agentsync.cc) — do not edit `CLAUDE.md` directly.**
 > To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant
 > `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.
 > Direct edits here are reported as drift and overwritten on the next apply.
-<!-- /agentsync:managed -->
+<!-- /agentsync:managed memory-banner -->
 
 # Coding conventions
 …
@@ -97,8 +97,8 @@ source instead.
 
 <Aside type="note" title="The banner never enters your canonical source">
 	The banner is written by agentsync, not stored in `memory/AGENTS.md`. It is
-	wrapped in `<!-- agentsync:managed -->` markers, stripped on `import`/`reconcile`
-	(and on ingest), and re-rendered on every `apply` — so it never compounds, and
+	wrapped in `<!-- agentsync:managed memory-banner -->` markers, stripped on
+	`import`/`reconcile` (and on ingest), and re-rendered on every `apply` — so it never compounds, and
 	because the text is static it never shows up as drift. It is on by default; opt
 	out with `[memory] banner = false` in `agentsync.toml` (see the
 	[configuration reference](/reference/configuration/)). The first `apply` after

--- a/website/src/content/docs/guides/memory.mdx
+++ b/website/src/content/docs/guides/memory.mdx
@@ -105,6 +105,14 @@ source instead.
 	upgrading adds the banner to existing memory files — a one-time `pending`.
 </Aside>
 
+<Aside type="caution" title="`agentsync:managed` is a reserved marker">
+	If your `memory/AGENTS.md` or a fragment contains the literal
+	`agentsync:managed` marker, agentsync errors and asks you to remove it, so it
+	can't collide with the banner. Capture is conservative in the other direction
+	too: it strips only agentsync's own banner, so any other content you keep is
+	never deleted.
+</Aside>
+
 ## Per-agent rendering
 
 | Agent | Native memory file |

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration & layout
-description: The ~/.agentsync/ directory layout and the agentsync.toml schema — agents, update defaults, and the secrets backend.
+description: The ~/.agentsync/ directory layout and the agentsync.toml schema — agents, update defaults, the secrets backend, and memory rendering options.
 sidebar:
   order: 2
 ---
@@ -16,7 +16,7 @@ parse these files *are* the canonical model.
 <FileTree>
 
 - ~/.agentsync/
-  - agentsync.toml agents, update defaults, secrets backend
+  - agentsync.toml agents, update defaults, secrets backend, [memory] banner
   - mcp/
     - **github.toml** one MCP server per file
   - lsp/
@@ -69,7 +69,18 @@ enabled = true
 backend       = "age"
 recipient     = "age1…"                              # public key, safe to commit
 identity_file = "${env:HOME}/.config/agentsync/age.key"  # private key, per-machine
+
+# Memory rendering options.
+[memory]
+banner = true   # default; set false to omit the managed-file banner from
+                # rendered memory files (CLAUDE.md, AGENTS.md, …)
 ```
+
+The `[memory] banner` notice that agentsync prepends to each rendered memory file
+points edits back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. It lives
+only in the rendered file (stripped on capture, never written to your canonical
+source) and is on unless you set `banner = false`. See the
+[memory guide](/guides/memory/#the-managed-file-banner).
 
 <Aside type="note">
 	Use the CLI (`agentsync agent add`, `agentsync secrets set`, …) and let it write


### PR DESCRIPTION
## What

Every rendered memory file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, the breadth-tier rules files, …) now carries a short banner naming the file and pointing edits back at the canonical source:

```markdown
<!-- agentsync:managed -->
> **Managed by [agentsync](https://agentsync.cc) — do not edit `CLAUDE.md` directly.**
> To change it, edit `.agentsync/memory/AGENTS.md` (or the relevant
> `.agentsync/memory/fragments/*.md` fragment) and run `agentsync apply`.
> Direct edits here are reported as drift and overwritten on the next apply.
<!-- /agentsync:managed -->
```

The goal: an enforced agentsync-awareness so an agent (or teammate) editing the native file is nudged toward the canonical source instead of making a rogue direct edit.

**Settings (chosen up front):** on by default (`[memory] banner = false` to opt out), prepended at the top, filename-aware wording.

## How it stays safe in the bidirectional model

The core hazard was a self-injected banner leaking back into the canonical `memory/AGENTS.md` and compounding on every apply. The design mirrors the existing fragment-marker round-trip:

- **One render chokepoint** — all 31 adapters now assemble memory through `source.RenderManagedMemory` (wraps `ExpandMemoryImports`), so the banner is byte-identical across agents. Windsurf's activation frontmatter stays at byte 0; the banner sits after it.
- **Stripped on the way back** — wrapped in reversible `<!-- agentsync:managed -->` markers and removed by `source.StripManagedBanner` in each adapter's ingest (the inverse of render, like Windsurf's frontmatter strip) **and** as a backstop at the `import`/`reconcile` write-back funnels (reconcile reads the dest raw, no ingest). So it never enters the canonical source and never compounds.
- **No false drift** — the banner text is static (only the filename varies), so it hashes identically across re-render / state / disk; an untouched file still classifies `InSync`.
- **Config** — on by default; `[memory] banner = false` in `agentsync.toml` opts out. The project overlay inherits the effective user setting unless it sets its own.

## Behavior change

The first `apply` after this lands rewrites managed memory files to add the banner — a one-time `pending` in `status`, then stable.

## Tests

- Source-level units + an **artifact-anchored round-trip** (on-disk fixture with `@import` + fragment → render → strip → collapse → write → byte-identical, with the banner present in neither canonical file).
- Adapter ingest round-trips now exercise banner-on render → ingest-strip; render exact-content assertions updated to strip the banner.
- Full suite green: 26 internal packages, e2e, BDD, `golangci-lint` 0 issues, gofumpt/`go mod tidy` clean.

## Docs (updated in the same commit)

`docs/concepts.md`, `docs/architecture.md`, `docs/components.md`, `docs/user-guide.md`, `CHANGELOG.md`, and the website memory guide + configuration reference.

## Note on dogfooding

This repo is agentsync-managed, so its own `CLAUDE.md`/`AGENTS.md` won't show the banner until someone runs `agentsync apply --scope project` to re-render them — deliberately left as a separate, explicit step rather than folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xvvan2aDifmSpjhAwic1yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvvan2aDifmSpjhAwic1yg)_