### PR TITLE
feat(explain): itemize skipped components instead of a bare count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 - **`explain` itemizes skipped components.** A `◐ partial` row that reports
   `(N skipped)` is no longer a dead end: each skipped component is now listed
-  beneath the agent row as a faint `<component> <name>  <reason>` line — what the
-  agent could not translate, and why (e.g. `lsp atlassian-lsp  Codex has no LSP
-  configuration concept`). The structured surface gains a `skipDetails` array
+  beneath the agent row as an itemized `<component> <name>  <reason>` line (the
+  reason rendered faint) — what the agent could not translate, and why (e.g. `lsp
+  atlassian-lsp  Codex has no LSP configuration concept`). The structured surface
+  gains a `skipDetails` array
   (`{component, name, reason}`) on every `explain --json` row. The translation
   report carries the detail end-to-end (`render.PluginRow.SkipDetails`) rather
   than collapsing skips to a bare count; the same global attribution caveat as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **`explain` itemizes skipped components.** A `◐ partial` row that reports
+  `(N skipped)` is no longer a dead end: each skipped component is now listed
+  beneath the agent row as a faint `<component> <name>  <reason>` line — what the
+  agent could not translate, and why (e.g. `lsp atlassian-lsp  Codex has no LSP
+  configuration concept`). The structured surface gains a `skipDetails` array
+  (`{component, name, reason}`) on every `explain --json` row. The translation
+  report carries the detail end-to-end (`render.PluginRow.SkipDetails`) rather
+  than collapsing skips to a bare count; the same global attribution caveat as
+  the counts applies (the flattened canonical model does not tag a component with
+  its origin plugin, so the skips shown are the agent's across the whole model).
+
 - **Managed-file banner on rendered memory.** Every rendered memory file
   (`CLAUDE.md`, `AGENTS.md`, …) is now prepended with a short agentsync notice
   naming the file and pointing edits back at `.agentsync/memory/AGENTS.md` +

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -377,10 +377,16 @@ LSP servers). Each is translated independently per agent — fully, lossily, or
 skipped — and the report tells you exactly which:
 
 ```
-plugin: atlassian@anthropic
-  claude    ✓ full    (1 mcp, 5 commands)
-  opencode  ◐ partial (1 mcp; 5 commands → projected)
+▸ atlassian@anthropic
+  → claude    ✓ full        1 mcp · 5 commands
+  → codex     ◐ partial     1 mcp · 5 commands  (1 skipped)
+      • lsp atlassian-lsp  Codex has no LSP configuration concept
 ```
+
+A `◐ partial` row is never a dead end: every skipped component is itemized
+beneath it (what it is, and why that agent could not translate it), so you can
+see exactly what loss `apply` would incur. `--json` carries the same breakdown
+under each row's `skipDetails` array.
 
 Inspect any plugin's coverage without applying:
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -308,7 +308,41 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 			p.Bold(ui.Pad(row.Agent, 10)),
 			mark,
 			tail)
+		// "(N skipped)" is a dead end on its own — list each skipped component
+		// (what it is, and why the agent could not translate it) beneath the row.
+		emitSkipDetails(w, p, row.SkipDetails)
 	}
+}
+
+// emitSkipDetails lists each skipped component under its agent row as a faint,
+// indented "<component> <name>  <reason>" line so the "(N skipped)" tally is
+// explained rather than opaque. Reasons are aligned by padding the
+// component+name column to its widest entry.
+func emitSkipDetails(w io.Writer, p *ui.Printer, skips []render.SkipDetail) {
+	if len(skips) == 0 {
+		return
+	}
+	width := 0
+	for _, s := range skips {
+		if n := visibleLen(skipLabel(s)); n > width {
+			width = n
+		}
+	}
+	for _, s := range skips {
+		fmt.Fprintf(w, "      %s %s  %s\n",
+			p.Yellow(ui.GlyphInfo),
+			ui.Pad(skipLabel(s), width),
+			p.Faint(s.Reason))
+	}
+}
+
+// skipLabel renders "<component> <name>" for a skipped item, or just the
+// component when the skip has no name (e.g. an unrecognized hook event).
+func skipLabel(s render.SkipDetail) string {
+	if s.Name == "" {
+		return s.Component
+	}
+	return s.Component + " " + s.Name
 }
 
 // coverageGlyphAndColor maps a coverage string to a glyph + semantic color

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// ansiSeq matches an SGR escape (color/bold/faint reset) so a test can measure
+// the *visible* layout of styled output independent of the color codes.
+var ansiSeq = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string { return ansiSeq.ReplaceAllString(s, "") }
+
+// TestSkipLabel covers both arms of skipLabel: a named skip renders
+// "<component> <name>", and an unnamed one (e.g. an unrecognized hook event
+// with no name) falls back to the bare component.
+func TestSkipLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   render.SkipDetail
+		want string
+	}{
+		{"named", render.SkipDetail{Component: "lsp", Name: "gopls"}, "lsp gopls"},
+		{"unnamed", render.SkipDetail{Component: "hook"}, "hook"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := skipLabel(tc.in); got != tc.want {
+				t.Errorf("skipLabel(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmitSkipDetails_EmptyIsNoOp asserts a row with no skips emits nothing —
+// no stray bullet, no blank line.
+func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), nil)
+	if buf.Len() != 0 {
+		t.Errorf("emitSkipDetails(nil) wrote %q, want nothing", buf.String())
+	}
+}
+
+// TestEmitSkipDetails_ColumnsAlignUnderColor is the regression guard for the
+// padding-before-color contract: the reason column must start at the same
+// visible offset for every skip line even though the lines carry ANSI (a yellow
+// bullet, a faint reason) and the labels differ wildly in width. If padding were
+// ever computed on the *styled* string, the escape bytes would be counted as
+// width and the columns would skew — stripping ANSI and comparing the reason
+// offsets catches that.
+func TestEmitSkipDetails_ColumnsAlignUnderColor(t *testing.T) {
+	skips := []render.SkipDetail{
+		{Component: "lsp", Name: "x", Reason: "no LSP concept"},
+		{Component: "subagent-frontmatter", Name: "reviewer", Reason: "dropped tools allowlist"},
+	}
+	var buf bytes.Buffer
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorAlways), skips)
+
+	raw := buf.String()
+	if !strings.Contains(raw, "\x1b[") {
+		t.Fatalf("ColorAlways produced no ANSI; the colored path is untested:\n%q", raw)
+	}
+
+	lines := strings.Split(strings.TrimRight(raw, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 skip lines, got %d:\n%q", len(lines), raw)
+	}
+	offsets := make([]int, len(lines))
+	for i, line := range lines {
+		plain := stripANSI(line)
+		reason := skips[i].Reason
+		idx := strings.Index(plain, reason)
+		if idx < 0 {
+			t.Fatalf("line %d missing reason %q after stripping ANSI: %q", i, reason, plain)
+		}
+		// The shorter label must be padded so its reason lands in the same
+		// column as the longer one's.
+		if !strings.Contains(plain, skipLabel(skips[i])) {
+			t.Errorf("line %d missing label %q: %q", i, skipLabel(skips[i]), plain)
+		}
+		offsets[i] = idx
+	}
+	if offsets[0] != offsets[1] {
+		t.Errorf("reason columns not aligned: offsets %v\n%q", offsets, raw)
+	}
+}

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -47,6 +47,22 @@ func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 	}
 }
 
+// TestEmitSkipDetails_UnnamedComponentOnly exercises the empty-Name skip
+// through the full emitSkipDetails formatting path (not just skipLabel): a skip
+// with no name must render as a bare "<bullet> <component>  <reason>" line with
+// no dangling separator. ColorNever lets us pin the exact bytes.
+func TestEmitSkipDetails_UnnamedComponentOnly(t *testing.T) {
+	var buf bytes.Buffer
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), []render.SkipDetail{
+		{Component: "hook", Reason: "unknown event"},
+	})
+	got := buf.String()
+	want := "      " + ui.GlyphInfo + " hook  unknown event\n"
+	if got != want {
+		t.Errorf("emitSkipDetails(unnamed) = %q, want %q", got, want)
+	}
+}
+
 // TestEmitSkipDetails_ColumnsAlignUnderColor is the regression guard for the
 // padding-before-color contract: the reason column must start at the same
 // visible offset for every skip line even though the lines carry ANSI (a yellow

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -373,6 +373,100 @@ func TestExplain_FlagConflicts(t *testing.T) {
 	}
 }
 
+// TestExplain_ListsSkips verifies that explain does not stop at a bare
+// "(N skipped)" tally — it lists each skipped component (label + reason) under
+// the agent row, in both text and JSON. The fixture ships an LSP server, which
+// Codex always skips (no LSP concept), so the skip is deterministic.
+func TestExplain_ListsSkips(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainSkipFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "install", "skipdemo@skip-mp"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "explain", "skipdemo@skip-mp")
+	if err != nil {
+		t.Fatalf("explain: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "skipped") {
+		t.Fatalf("expected a skipped tally; got:\n%s", out)
+	}
+	// The skip must be itemized, not just counted: the component and its reason.
+	if !strings.Contains(out, "lsp") {
+		t.Errorf("explain should name the skipped lsp component; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Codex has no LSP configuration concept") {
+		t.Errorf("explain should print the skip reason; got:\n%s", out)
+	}
+
+	// JSON carries the same detail under skipDetails.
+	outJSON, err := runCLI(t, env, "explain", "skipdemo@skip-mp", "--json")
+	if err != nil {
+		t.Fatalf("explain --json: %v\n%s", err, outJSON)
+	}
+	var parsed struct {
+		Rows []struct {
+			SkipDetails []struct {
+				Component string `json:"component"`
+				Reason    string `json:"reason"`
+			} `json:"skipDetails"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(outJSON), &parsed); err != nil {
+		t.Fatalf("explain --json not valid JSON: %v\n%s", err, outJSON)
+	}
+	found := false
+	for _, r := range parsed.Rows {
+		for _, sd := range r.SkipDetails {
+			if sd.Component == "lsp" && strings.Contains(sd.Reason, "no LSP configuration concept") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("explain --json missing the lsp skipDetail; got:\n%s", outJSON)
+	}
+}
+
+// setupExplainSkipFixture builds a marketplace whose single plugin ships an MCP
+// server plus an LSP server. Codex renders the MCP but skips the LSP, giving the
+// skip-listing test a deterministic partial-coverage row.
+func setupExplainSkipFixture(t *testing.T, tmp string) string {
+	t.Helper()
+	fixture := filepath.Join(tmp, "fixture-marketplace-explain-skip")
+	if err := os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+		[]byte(`{"name":"skip-mp","owner":{"name":"x"},"plugins":[{"name":"skipdemo","source":"./plugins/skipdemo"}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	plugDir := filepath.Join(fixture, "plugins", "skipdemo", ".claude-plugin")
+	if err := os.MkdirAll(plugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugDir, "plugin.json"),
+		[]byte(`{"name":"skipdemo","version":"1.0.0",`+
+			`"mcpServers":{"skip-mcp":{"command":"echo","args":["hi"]}},`+
+			`"lspServers":{"skip-lsp":{"command":"lang-server"}}}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
 // setupExplainFixture creates a minimal local marketplace with a single demo plugin.
 func setupExplainFixture(t *testing.T, tmp string) string {
 	t.Helper()

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -375,8 +375,10 @@ func TestExplain_FlagConflicts(t *testing.T) {
 
 // TestExplain_ListsSkips verifies that explain does not stop at a bare
 // "(N skipped)" tally — it lists each skipped component (label + reason) under
-// the agent row, in both text and JSON. The fixture ships an LSP server, which
-// Codex always skips (no LSP concept), so the skip is deterministic.
+// the agent row, in both text and JSON. The fixture ships an LSP server and a
+// hook on a lifecycle event Codex does not recognize; Codex skips both
+// deterministically (no LSP concept; unknown event), so the row is a stable
+// two-skip partial.
 func TestExplain_ListsSkips(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
@@ -419,6 +421,7 @@ func TestExplain_ListsSkips(t *testing.T) {
 		Rows []struct {
 			SkipDetails []struct {
 				Component string `json:"component"`
+				Name      string `json:"name"`
 				Reason    string `json:"reason"`
 			} `json:"skipDetails"`
 		} `json:"rows"`
@@ -426,22 +429,27 @@ func TestExplain_ListsSkips(t *testing.T) {
 	if err := json.Unmarshal([]byte(outJSON), &parsed); err != nil {
 		t.Fatalf("explain --json not valid JSON: %v\n%s", err, outJSON)
 	}
-	found := false
+	var lsp, hook bool
 	for _, r := range parsed.Rows {
 		for _, sd := range r.SkipDetails {
 			if sd.Component == "lsp" && strings.Contains(sd.Reason, "no LSP configuration concept") {
-				found = true
+				lsp = true
+			}
+			if sd.Component == "hook" && strings.Contains(sd.Reason, "does not recognize this lifecycle event") {
+				hook = true
 			}
 		}
 	}
-	if !found {
-		t.Errorf("explain --json missing the lsp skipDetail; got:\n%s", outJSON)
+	if !lsp || !hook {
+		t.Errorf("explain --json missing skipDetails (lsp=%v hook=%v); got:\n%s", lsp, hook, outJSON)
 	}
 }
 
 // setupExplainSkipFixture builds a marketplace whose single plugin ships an MCP
-// server plus an LSP server. Codex renders the MCP but skips the LSP, giving the
-// skip-listing test a deterministic partial-coverage row.
+// server, an LSP server, and a hook on a lifecycle event Codex does not
+// recognize. Codex renders the MCP but skips the LSP (no LSP concept) and the
+// hook (unknown event), giving the skip-listing test a deterministic two-skip
+// partial-coverage row.
 func setupExplainSkipFixture(t *testing.T, tmp string) string {
 	t.Helper()
 	fixture := filepath.Join(tmp, "fixture-marketplace-explain-skip")
@@ -460,7 +468,8 @@ func setupExplainSkipFixture(t *testing.T, tmp string) string {
 	if err := os.WriteFile(filepath.Join(plugDir, "plugin.json"),
 		[]byte(`{"name":"skipdemo","version":"1.0.0",`+
 			`"mcpServers":{"skip-mcp":{"command":"echo","args":["hi"]}},`+
-			`"lspServers":{"skip-lsp":{"command":"lang-server"}}}`),
+			`"lspServers":{"skip-lsp":{"command":"lang-server"}},`+
+			`"hooks":{"SessionEnd":"echo bye"}}`),
 		0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"sort"
 
+	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
@@ -26,9 +27,37 @@ type PluginRow struct {
 	Commands int `json:"commands"`
 	// Skips is the number of components the adapter explicitly skipped.
 	Skips int `json:"skips"`
+	// SkipDetails enumerates the components behind Skips — what the adapter
+	// could not translate, and why — so a "(N skipped)" tally is never a dead
+	// end. Same global attribution as the counts: because the canonical model
+	// is flattened (projection does not tag a component with its origin
+	// plugin), these are the agent's skips across the whole model, surfaced
+	// under every plugin row rather than narrowed to one plugin.
+	SkipDetails []SkipDetail `json:"skipDetails,omitempty"`
 	// Disabled is true when the plugin is disabled for this scope (e.g. by a
 	// project marker's [plugins] disabled). Its components are not rendered.
 	Disabled bool `json:"disabled,omitempty"`
+}
+
+// SkipDetail names one component an adapter could not translate, with the
+// human reason it was skipped. It mirrors adapter.Skip but carries JSON tags
+// for the report's machine-readable surface.
+type SkipDetail struct {
+	Component string `json:"component"`
+	Name      string `json:"name,omitempty"`
+	Reason    string `json:"reason"`
+}
+
+// skipDetails converts an adapter's []Skip into the report's JSON-tagged form.
+func skipDetails(skips []adapter.Skip) []SkipDetail {
+	if len(skips) == 0 {
+		return nil
+	}
+	out := make([]SkipDetail, len(skips))
+	for i, s := range skips {
+		out[i] = SkipDetail{Component: s.Component, Name: s.Name, Reason: s.Reason}
+	}
+	return out
 }
 
 // TranslationReport holds all plugin×agent rows.
@@ -172,11 +201,12 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 				continue
 			}
 			row := PluginRow{
-				Plugin:   "(base)",
-				Agent:    agName,
-				MCP:      countMCPServers(c, agName),
-				Commands: len(c.Commands),
-				Skips:    len(res.Skips),
+				Plugin:      "(base)",
+				Agent:       agName,
+				MCP:         countMCPServers(c, agName),
+				Commands:    len(c.Commands),
+				Skips:       len(res.Skips),
+				SkipDetails: skipDetails(res.Skips),
 			}
 			row.Coverage = computeCoverage(row)
 			report.Rows = append(report.Rows, row)
@@ -210,11 +240,12 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			// since the canonical model is flattened.  A future version can
 			// tag ops with their origin plugin.
 			row := PluginRow{
-				Plugin:   label,
-				Agent:    agName,
-				MCP:      countMCPServers(c, agName),
-				Commands: len(c.Commands),
-				Skips:    len(res.Skips),
+				Plugin:      label,
+				Agent:       agName,
+				MCP:         countMCPServers(c, agName),
+				Commands:    len(c.Commands),
+				Skips:       len(res.Skips),
+				SkipDetails: skipDetails(res.Skips),
 			}
 			row.Coverage = computeCoverage(row)
 			report.Rows = append(report.Rows, row)

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -133,6 +133,70 @@ func TestBuildReport_PartialCoverage(t *testing.T) {
 	}
 }
 
+// TestBuildReport_SkipDetails verifies that each skipped component's detail
+// (component, name, reason) is carried into the row, not just the count — and
+// that it survives JSON round-trip with the lowercase keys the CLI surface
+// promises. This is what lets `explain` list what is skipped instead of a bare
+// "(N skipped)".
+func TestBuildReport_SkipDetails(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github"}},
+		Plugins: []source.Plugin{
+			{ID: "demo", Plugin: source.PluginSpec{ID: "demo@test-mp"}},
+		},
+	}
+	skips := []adapter.Skip{
+		{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"},
+		{Component: "hook", Name: "SessionEnd", Reason: "Codex does not recognize this lifecycle event"},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"codex": {
+				Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "merge-toml-keys"}},
+				Skips: skips,
+			},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"codex"})
+	if len(report.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(report.Rows))
+	}
+	row := report.Rows[0]
+	if row.Skips != 2 {
+		t.Errorf("Skips = %d, want 2", row.Skips)
+	}
+	if len(row.SkipDetails) != 2 {
+		t.Fatalf("SkipDetails len = %d, want 2: %+v", len(row.SkipDetails), row.SkipDetails)
+	}
+	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}) {
+		t.Errorf("SkipDetails[0] = %+v, want the gopls lsp skip", row.SkipDetails[0])
+	}
+
+	// JSON surface: lowercase component/name/reason keys under skipDetails.
+	var buf bytes.Buffer
+	if err := report.PrintJSON(&buf); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	var parsed struct {
+		Rows []struct {
+			SkipDetails []struct {
+				Component string `json:"component"`
+				Name      string `json:"name"`
+				Reason    string `json:"reason"`
+			} `json:"skipDetails"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	if len(parsed.Rows) != 1 || len(parsed.Rows[0].SkipDetails) != 2 {
+		t.Fatalf("JSON skipDetails not emitted: %s", buf.String())
+	}
+	if parsed.Rows[0].SkipDetails[1].Reason != "Codex does not recognize this lifecycle event" {
+		t.Errorf("JSON skipDetails[1].reason = %q", parsed.Rows[0].SkipDetails[1].Reason)
+	}
+}
+
 func TestTranslationReport_PrintText(t *testing.T) {
 	c := source.Canonical{
 		Plugins: []source.Plugin{

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -197,6 +197,67 @@ func TestBuildReport_SkipDetails(t *testing.T) {
 	}
 }
 
+// TestBuildReport_SkipDetails_BaseBranch covers the no-plugins "(base)" branch
+// of BuildReport, which carries skip detail identically to the per-plugin
+// branch. Without this, the base-branch SkipDetails assignment is unexercised.
+func TestBuildReport_SkipDetails_BaseBranch(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github"}},
+		// No Plugins → BuildReport takes the "(base)" branch.
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"codex": {
+				Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "merge-toml-keys"}},
+				Skips: []adapter.Skip{{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}},
+			},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"codex"})
+	if len(report.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(report.Rows))
+	}
+	row := report.Rows[0]
+	if row.Plugin != "(base)" {
+		t.Fatalf("plugin = %q, want (base) — this test must hit the no-plugins branch", row.Plugin)
+	}
+	if row.Skips != 1 || len(row.SkipDetails) != 1 {
+		t.Fatalf("base-branch skips not carried: Skips=%d SkipDetails=%+v", row.Skips, row.SkipDetails)
+	}
+	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}) {
+		t.Errorf("SkipDetails[0] = %+v, want the gopls lsp skip", row.SkipDetails[0])
+	}
+}
+
+// TestBuildReport_SkipDetails_OmittedWhenEmpty pins the omitempty contract: a
+// row with zero skips must carry a nil SkipDetails AND emit no "skipDetails"
+// key in JSON. A regression making skipDetails() return a non-nil empty slice
+// would leak "skipDetails":[] onto every full-coverage row; this fails it.
+func TestBuildReport_SkipDetails_OmittedWhenEmpty(t *testing.T) {
+	c := source.Canonical{
+		Plugins: []source.Plugin{{ID: "demo", Plugin: source.PluginSpec{ID: "demo@test-mp"}}},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}}, // no skips
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"claude"})
+	if len(report.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(report.Rows))
+	}
+	if report.Rows[0].SkipDetails != nil {
+		t.Errorf("SkipDetails = %+v, want nil for a no-skip row", report.Rows[0].SkipDetails)
+	}
+	var buf bytes.Buffer
+	if err := report.PrintJSON(&buf); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	if strings.Contains(buf.String(), "skipDetails") {
+		t.Errorf("a no-skip row must omit the skipDetails key; got:\n%s", buf.String())
+	}
+}
+
 func TestTranslationReport_PrintText(t *testing.T) {
 	c := source.Canonical{
 		Plugins: []source.Plugin{

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -202,8 +202,12 @@ agentsync update --apply --auto-safe
 Prints per-agent translation coverage for one or more installed plugins, without
 applying. Pass space-separated plugin ids to explain just those, `--all` to
 explain every installed plugin, or `--list` to print just the set of installed
-ids (a quick reminder of what you can pass). Add `--json` for machine-readable
-output (rows for plugin/agent coverage, or a `plugins` array under `--list`).
+ids (a quick reminder of what you can pass). A `◐ partial` row that reports
+`(N skipped)` itemizes each skipped component beneath it (its label and the
+reason that agent could not translate it), so the tally is never a dead end. Add
+`--json` for machine-readable output (rows for plugin/agent coverage — each with
+a `skipDetails` array of `{component, name, reason}` — or a `plugins` array under
+`--list`).
 
 ```bash
 agentsync explain atlassian@anthropic


### PR DESCRIPTION
## What & why

`agentsync explain` reported `(N skipped)` with no indication of *what* was dropped — a dead end. The skip detail (`component`, `name`, `reason`) existed all along in `adapter.Skip`, but `render.BuildReport` collapsed `AgentResult.Skips` down to `len(...)` before `explain` ever saw it.

Now `explain` lists each skipped component beneath its agent row:

```
▸ skipdemo@skip-mp
  → claude      ✓ full        1 mcp · 0 commands
  → codex       ◐ partial     1 mcp · 0 commands  (2 skipped)
      • hook SessionEnd  Codex does not recognize this lifecycle event
      • lsp skip-lsp     Codex has no LSP configuration concept
```

A `✓ full` row (0 skips) stays clean — no listing.

## Changes

- **`internal/render/report.go`** — `PluginRow` gains a `SkipDetails []SkipDetail` field (`{component, name, reason}`, JSON-tagged), populated from the adapter skips in both `BuildReport` branches. The detail is carried end-to-end instead of discarded.
- **`internal/cli/explain.go`** — text output itemizes each skip (reasons aligned by padding the component+name column); `--json` emits a `skipDetails` array per row.
- **Docs** — `docs/user-guide.md` and `website/.../reference/cli.mdx` updated in the same commit; `CHANGELOG.md` `[Unreleased]` notes it.
- **Tests** — `TestBuildReport_SkipDetails` (render, incl. JSON round-trip) and `TestExplain_ListsSkips` (CLI, driving a real Codex LSP+hook skip end-to-end through the binary).

## Caveat (documented, not papered over)

The skip *counts* in `explain` were already attributed **globally per-agent**, not per-plugin — the canonical model is flattened, so projection doesn't tag a component with its origin plugin. The new listing inherits that same imprecision (it's the agent's skips across the whole model, surfaced under each plugin row). This is documented on the `SkipDetails` field and in the CHANGELOG. True per-plugin attribution would require threading provenance through projection → canonical → render — a larger, separate change.

## Verification

- `go build ./...`, `go vet`, `gofmt`/`gofumpt` clean, `golangci-lint` (forced `go1.26.2` toolchain) → 0 issues.
- `internal/render` + `internal/cli` test packages pass. (Run with the container bypass — the hermetic Docker runner can't start in the cloud sandbox, daemon unavailable. CI runs the real container.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNk7gfkFoz9Z2hBjqB8YRZ)_