### PR TITLE
fix(explain): scope coverage to the named plugin, not the global union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **`explain` describes every component kind a plugin hosts, not just MCP +
+  commands.** Each agent row's count tail previously read `N mcp · N commands`
+  even for a plugin that ships only skills, subagents, hooks, or an LSP server —
+  so an LSP-only plugin reported a misleading `0 mcp · 0 commands`. The tail now
+  lists every non-zero kind it hosts for that agent (`mcp`, `commands`, `skills`,
+  `subagents`, `hooks`, `lsp`), e.g. `1 mcp · 2 skills · 1 lsp`; a plugin that
+  contributes nothing to an agent reads `no components`. The counts describe the
+  inventory (what the plugin hosts, MCP/LSP honouring each server's
+  `enabled`/`agents` targeting) — a hosted component the agent cannot translate is
+  still counted and reported under `(N skipped)`. `explain --json` rows gain the
+  matching `skills`, `subagents`, `hooks`, and `lsp` integer fields alongside the
+  existing `mcp`/`commands` (`render.PluginRow`). Coverage now derives `partial`
+  vs `none` from whether the adapter actually rendered anything for the agent
+  (rather than from `mcp`/`commands` alone), fixing a latent case where a plugin
+  whose skills rendered but whose hook was skipped was mislabeled `none`.
+
 - **`explain` itemizes skipped components.** A `◐ partial` row that reports
   `(N skipped)` is no longer a dead end: each skipped component is now listed
   beneath the agent row as an itemized `<component> <name>  <reason>` line (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,22 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   gains a `skipDetails` array
   (`{component, name, reason}`) on every `explain --json` row. The translation
   report carries the detail end-to-end (`render.PluginRow.SkipDetails`) rather
-  than collapsing skips to a bare count; the same global attribution caveat as
-  the counts applies (the flattened canonical model does not tag a component with
-  its origin plugin, so the skips shown are the agent's across the whole model).
+  than collapsing skips to a bare count, and the counts/skips are scoped to the
+  named plugin (see the `explain` fix below).
+
+### Fixed
+
+- **`explain <plugin>` now reports only that plugin's components.** `explain`
+  previously stamped the *global* translation result onto every plugin row: the
+  MCP/command counts and the `(N skipped)` itemization were computed from the
+  flattened union of every installed plugin, so e.g. `agentsync explain
+  notion@…` listed skipped subagents and LSP servers that belonged to entirely
+  different plugins. `explain` now re-projects each requested plugin in isolation
+  (`marketplace.ProjectInstalled`) and builds its coverage row from only that
+  plugin's own components, so each row — counts, coverage glyph, and skip
+  details, in both text and `--json` — reflects exactly the plugin named.
+  (`apply`/`verify`'s end-of-run report still shows the per-agent summary across
+  the whole model.)
 
 - **Managed-file banner on rendered memory.** Every rendered memory file
   (`CLAUDE.md`, `AGENTS.md`, …) is now prepended with a short agentsync notice

--- a/docs/components.md
+++ b/docs/components.md
@@ -321,7 +321,9 @@ Persists last-applied hashes and plugin/marketplace pins to
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin
 manifests into canonical components.
 - **Key:** `Marketplace`, `PluginEntry`, `Source`, `PluginManifest`;
-  `ProjectionResult`; `Project`/`ProjectWithReader`; `Fetcher` (interface) with
+  `ProjectionResult`; `Project`/`ProjectWithReader`; `ProjectInstalled`
+  (one installed plugin in isolation — lets `explain <id>` attribute coverage to
+  the named plugin rather than the flattened union); `Fetcher` (interface) with
   `GitFetcher`/`NPMFetcher`/`RelativeFetcher`; `LoadProjected`/
   `LoadProjectedLenient`/`LoadProjectedExcluding`.
 - **Depends on:** source, log.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -378,15 +378,25 @@ skipped — and the report tells you exactly which:
 
 ```
 ▸ atlassian@anthropic
-  → claude    ✓ full        1 mcp · 5 commands
-  → codex     ◐ partial     1 mcp · 5 commands  (1 skipped)
+  → claude    ✓ full        1 mcp · 5 commands · 1 lsp
+  → codex     ◐ partial     1 mcp · 5 commands · 1 lsp  (1 skipped)
       • lsp atlassian-lsp  Codex has no LSP configuration concept
 ```
 
+Each row's count tail lists every component kind the plugin hosts for that agent
+— MCP servers, commands, skills, subagents, hooks, and LSP servers (only the
+non-zero kinds are shown) — so the inventory is fully descriptive, not just `mcp`
++ `commands`. The counts describe what the plugin *hosts*; the coverage glyph and
+any `(N skipped)` note describe what the agent could *do* with it. So above,
+Codex still shows `1 lsp` (the plugin hosts one) but `✗`-skips it — an LSP-only
+plugin on Codex reads `✗ none  1 lsp`, telling you both what is there and that
+none of it landed.
+
 A `◐ partial` row is never a dead end: every skipped component is itemized
 beneath it (what it is, and why that agent could not translate it), so you can
-see exactly what loss `apply` would incur. `--json` carries the same breakdown
-under each row's `skipDetails` array.
+see exactly what loss `apply` would incur. `--json` carries the same breakdown —
+the per-kind counts (`mcp`, `commands`, `skills`, `subagents`, `hooks`, `lsp`)
+plus the `skipDetails` array — on every row.
 
 Inspect any plugin's coverage without applying:
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
-	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
@@ -223,11 +222,6 @@ func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wan
 	sort.Strings(agents)
 
 	reg := registryFactory()
-	statePath := filepath.Join(home, ".state", "targets.json")
-	s, err := state.Load(statePath)
-	if err != nil {
-		return err
-	}
 
 	if jsonOut {
 		// One combined report whose rows cover exactly the requested plugins,
@@ -235,7 +229,7 @@ func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wan
 		// computed from its own components.
 		var report render.TranslationReport
 		for _, pl := range wanted {
-			pr, err := explainPluginReport(fs, c, pl, agents, reg, s, home, pluginCacheRoot)
+			pr, err := explainPluginReport(fs, c, pl, agents, reg, home, pluginCacheRoot)
 			if err != nil {
 				return err
 			}
@@ -257,7 +251,7 @@ func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wan
 		}
 		emitPluginHeader(w, p, pl)
 
-		report, err := explainPluginReport(fs, c, pl, agents, reg, s, home, pluginCacheRoot)
+		report, err := explainPluginReport(fs, c, pl, agents, reg, home, pluginCacheRoot)
 		if err != nil {
 			return err
 		}
@@ -278,7 +272,16 @@ func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wan
 //
 // A disabled plugin contributes nothing: BuildReport emits its single
 // disabled-marker row from c.Plugins alone, so no projection or plan is needed.
-func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agents []string, reg *adapter.Registry, s *state.Targets, home, pluginCacheRoot string) (render.TranslationReport, error) {
+//
+// State is deliberately NOT threaded into render.Plan here (nil): explain is
+// read-only, and a nil state makes the per-agent ops exactly the adapter's
+// rendered ops, with no apply-time OwnedKeys/orphan-cleanup synthesis. BuildReport
+// derives the partial-vs-none coverage from whether anything rendered
+// (len(ops) > 0), so a stray orphan-cleanup op (one would be synthesized for every
+// key a prior apply owns but this single-plugin scope no longer renders) must not
+// be allowed to masquerade as a real render and flip a fully-skipped plugin's
+// "none" to "partial".
+func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agents []string, reg *adapter.Registry, home, pluginCacheRoot string) (render.TranslationReport, error) {
 	scoped := c
 	scoped.Plugins = []source.Plugin{pl}
 	if pl.Plugin.Disabled {
@@ -303,7 +306,7 @@ func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agen
 	scoped.Hooks = proj.Hooks
 	scoped.LSPServers = proj.LSPServers
 
-	plan, err := render.Plan(secrets.ForRender(scoped), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
+	plan, err := render.Plan(secrets.ForRender(scoped), reg, agents, adapter.ScopeUser, "", nil, paths.HomeDir(paths.OSEnv{}))
 	if err != nil {
 		return render.TranslationReport{}, err
 	}
@@ -347,7 +350,7 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 		// before coloring so ANSI never shifts the count column), then a
 		// faint count tail with an optional skip note.
 		mark := color(ui.Pad(glyph+" "+row.Coverage, 12))
-		tail := p.Faint(fmt.Sprintf("%d mcp · %d commands", row.MCP, row.Commands))
+		tail := p.Faint(componentInventory(row))
 		if row.Skips > 0 {
 			tail += "  " + p.Yellow(fmt.Sprintf("(%d skipped)", row.Skips))
 		}
@@ -360,6 +363,42 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 		// (what it is, and why the agent could not translate it) beneath the row.
 		emitSkipDetails(w, p, row.SkipDetails)
 	}
+}
+
+// componentInventory renders the faint count tail describing what the plugin
+// hosts for this agent — every component kind, not just MCP + commands, so a
+// plugin that ships (say) only an LSP server or only skills is no longer reported
+// as a bare "0 mcp · 0 commands". Only non-zero kinds are listed, in a stable
+// order, joined by " · "; a plugin that contributes nothing to this agent reads
+// "no components". The counts describe the inventory; the coverage glyph and any
+// "(N skipped)" note describe what the agent could do with it.
+func componentInventory(row render.PluginRow) string {
+	parts := make([]string, 0, 6)
+	// one/many give per-count labels; the abbreviations mcp/lsp are invariant.
+	for _, c := range []struct {
+		n         int
+		one, many string
+	}{
+		{row.MCP, "mcp", "mcp"},
+		{row.Commands, "command", "commands"},
+		{row.Skills, "skill", "skills"},
+		{row.Subagents, "subagent", "subagents"},
+		{row.Hooks, "hook", "hooks"},
+		{row.LSP, "lsp", "lsp"},
+	} {
+		if c.n <= 0 {
+			continue
+		}
+		label := c.many
+		if c.n == 1 {
+			label = c.one
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", c.n, label))
+	}
+	if len(parts) == 0 {
+		return "no components"
+	}
+	return strings.Join(parts, " · ")
 }
 
 // emitSkipDetails lists each skipped component under its agent row as a faint,

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -49,9 +49,10 @@ func newExplainCmd() *cobra.Command {
 
 			home := paths.AgentsyncHome(paths.OSEnv{})
 			pluginCacheRoot := filepath.Join(home, ".state", "cache", "plugins")
+			fs := afero.NewOsFs()
 			// Read-only: a strict plugin.json/entry conflict degrades to a
 			// warning + entry-wins so explain still shows coverage.
-			c, err := marketplace.LoadProjectedLenient(afero.NewOsFs(), home, pluginCacheRoot, nil)
+			c, err := marketplace.LoadProjectedLenient(fs, home, pluginCacheRoot, nil)
 			if err != nil {
 				return err
 			}
@@ -78,7 +79,7 @@ func newExplainCmd() *cobra.Command {
 				return runExplainEmpty(p, jsonOut)
 			}
 
-			return runExplain(cmd.OutOrStdout(), p, c, wanted, home, jsonOut)
+			return runExplain(cmd.OutOrStdout(), p, fs, c, wanted, home, pluginCacheRoot, jsonOut)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "structured JSON output")
@@ -202,7 +203,15 @@ func runExplainEmpty(p *ui.Printer, jsonOut bool) error {
 // is reported under a styled header (id, version, disabled marker); the per-
 // agent rows reuse the same PrintTextStyled body apply uses, so the visual
 // vocabulary stays consistent.
-func runExplain(w io.Writer, p *ui.Printer, c source.Canonical, wanted []source.Plugin, home string, jsonOut bool) error {
+//
+// Crucially, each plugin's coverage is computed from THAT plugin's own projected
+// components, not from the flattened union of every installed plugin. The
+// projected canonical concatenates all plugins' components with no origin tag, so
+// a report built from it would stamp the same global MCP/command counts and skips
+// onto every plugin row — `explain notion` would show another plugin's skipped
+// subagents/LSPs. We re-project each requested plugin in isolation
+// (marketplace.ProjectInstalled) and build its plan from only those components.
+func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wanted []source.Plugin, home, pluginCacheRoot string, jsonOut bool) error {
 	// Collect enabled agents. Sort so `--json` row order is deterministic
 	// (PrintJSON emits rows in this slice order verbatim).
 	var agents []string
@@ -220,21 +229,18 @@ func runExplain(w io.Writer, p *ui.Printer, c source.Canonical, wanted []source.
 		return err
 	}
 
-	// One shared plan over the full canonical: every plugin-row in the
-	// report already reads from the same per-agent op set today (BuildReport
-	// attributes counts globally — see its doc-comment). Planning per
-	// plugin would not change a row's numbers and would multiply work.
-	plan, err := render.Plan(secrets.ForRender(c), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
-	if err != nil {
-		return err
-	}
-
 	if jsonOut {
-		// Build one combined report whose rows cover exactly the requested
-		// plugins, in the order resolveExplainTargets returned them.
-		filtered := c
-		filtered.Plugins = wanted
-		report := render.BuildReport(filtered, plan, agents)
+		// One combined report whose rows cover exactly the requested plugins,
+		// in the order resolveExplainTargets returned them — each plugin's rows
+		// computed from its own components.
+		var report render.TranslationReport
+		for _, pl := range wanted {
+			pr, err := explainPluginReport(fs, c, pl, agents, reg, s, home, pluginCacheRoot)
+			if err != nil {
+				return err
+			}
+			report.Rows = append(report.Rows, pr.Rows...)
+		}
 		return report.PrintJSON(w)
 	}
 
@@ -251,15 +257,52 @@ func runExplain(w io.Writer, p *ui.Printer, c source.Canonical, wanted []source.
 		}
 		emitPluginHeader(w, p, pl)
 
-		filtered := c
-		filtered.Plugins = []source.Plugin{pl}
-		report := render.BuildReport(filtered, plan, agents)
+		report, err := explainPluginReport(fs, c, pl, agents, reg, s, home, pluginCacheRoot)
+		if err != nil {
+			return err
+		}
 		// The report already groups by plugin and renders one row per
 		// agent — emit it stripped of its own "plugin: …" header to avoid
 		// duplicating the one we just printed.
 		emitReportBody(w, p, report)
 	}
 	return nil
+}
+
+// explainPluginReport builds the translation report for a SINGLE plugin, scoped
+// to that plugin's own components. It re-projects the plugin in isolation and
+// plans over a canonical carrying only those components, so the resulting
+// coverage/skip rows reflect what this plugin contributes — never the flattened
+// union of every installed plugin. The base config (enabled agents, settings) is
+// preserved from c; only the component slices and the Plugins list are narrowed.
+//
+// A disabled plugin contributes nothing: BuildReport emits its single
+// disabled-marker row from c.Plugins alone, so no projection or plan is needed.
+func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agents []string, reg *adapter.Registry, s *state.Targets, home, pluginCacheRoot string) (render.TranslationReport, error) {
+	scoped := c
+	scoped.Plugins = []source.Plugin{pl}
+	if pl.Plugin.Disabled {
+		return render.BuildReport(scoped, render.RenderPlan{}, agents), nil
+	}
+
+	proj, _, err := marketplace.ProjectInstalled(fs, home, pluginCacheRoot, pl, true)
+	if err != nil {
+		return render.TranslationReport{}, err
+	}
+	// Replace (not append to) the flattened component lists with only this
+	// plugin's, so the plan and the report's counts cover this plugin alone.
+	scoped.MCPServers = proj.MCPServers
+	scoped.Skills = proj.Skills
+	scoped.Subagents = proj.Subagents
+	scoped.Commands = proj.Commands
+	scoped.Hooks = proj.Hooks
+	scoped.LSPServers = proj.LSPServers
+
+	plan, err := render.Plan(secrets.ForRender(scoped), reg, agents, adapter.ScopeUser, "", s, paths.HomeDir(paths.OSEnv{}))
+	if err != nil {
+		return render.TranslationReport{}, err
+	}
+	return render.BuildReport(scoped, plan, agents), nil
 }
 
 // emitPluginHeader prints a styled "▸ <id>  v<version>  (disabled)" line.

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -285,6 +285,11 @@ func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agen
 		return render.BuildReport(scoped, render.RenderPlan{}, agents), nil
 	}
 
+	// The ok flag is intentionally ignored: ProjectInstalled returns ok=false
+	// only when projection is skipped wholesale (empty pluginCacheRoot, which
+	// explain never passes) or for a disabled plugin (already handled above). In
+	// any such case proj is the zero value, so the assignments below correctly
+	// yield an empty-component report rather than the stale flattened union.
 	proj, _, err := marketplace.ProjectInstalled(fs, home, pluginCacheRoot, pl, true)
 	if err != nil {
 		return render.TranslationReport{}, err

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -57,6 +57,7 @@ func TestComponentInventory(t *testing.T) {
 		{"subagent singular", render.PluginRow{Subagents: 1}, "1 subagent"},
 		{"subagents plural", render.PluginRow{Subagents: 2}, "2 subagents"},
 		{"skill/hook singular", render.PluginRow{Skills: 1, Hooks: 1}, "1 skill · 1 hook"},
+		{"skills/hooks plural", render.PluginRow{Skills: 2, Hooks: 2}, "2 skills · 2 hooks"},
 		{
 			"order and join",
 			render.PluginRow{MCP: 1, Commands: 2, Skills: 3, Subagents: 1, Hooks: 1, LSP: 1},

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -37,6 +37,41 @@ func TestSkipLabel(t *testing.T) {
 	}
 }
 
+// TestComponentInventory pins the descriptive count tail: every non-zero kind is
+// listed in a stable order, with correct singular/plural (the mcp/lsp
+// abbreviations stay invariant), and a row that hosts nothing for the agent reads
+// "no components".
+func TestComponentInventory(t *testing.T) {
+	tests := []struct {
+		name string
+		row  render.PluginRow
+		want string
+	}{
+		{"empty", render.PluginRow{}, "no components"},
+		{"one mcp invariant", render.PluginRow{MCP: 1}, "1 mcp"},
+		{"two mcp invariant", render.PluginRow{MCP: 2}, "2 mcp"},
+		{"one lsp invariant", render.PluginRow{LSP: 1}, "1 lsp"},
+		{"two lsp invariant", render.PluginRow{LSP: 2}, "2 lsp"},
+		{"command singular", render.PluginRow{Commands: 1}, "1 command"},
+		{"commands plural", render.PluginRow{Commands: 3}, "3 commands"},
+		{"subagent singular", render.PluginRow{Subagents: 1}, "1 subagent"},
+		{"subagents plural", render.PluginRow{Subagents: 2}, "2 subagents"},
+		{"skill/hook singular", render.PluginRow{Skills: 1, Hooks: 1}, "1 skill · 1 hook"},
+		{
+			"order and join",
+			render.PluginRow{MCP: 1, Commands: 2, Skills: 3, Subagents: 1, Hooks: 1, LSP: 1},
+			"1 mcp · 2 commands · 3 skills · 1 subagent · 1 hook · 1 lsp",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := componentInventory(tc.row); got != tc.want {
+				t.Errorf("componentInventory(%+v) = %q, want %q", tc.row, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestEmitSkipDetails_EmptyIsNoOp asserts a row with no skips emits nothing —
 // no stray bullet, no blank line.
 func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -645,6 +645,106 @@ func TestExplain_DisabledPluginRendersMarker(t *testing.T) {
 	}
 }
 
+// TestExplain_DescribesAllComponentKinds is the regression for the count tail
+// being limited to "N mcp · N commands": a plugin that ships only an LSP server
+// must report it. With claude (renders the LSP → full) and codex (no LSP concept
+// → none) both enabled, every row must surface "lsp" in its inventory — including
+// codex's "none" row, where the LSP is hosted but skipped — so the user can see
+// what the plugin hosts regardless of per-agent coverage.
+func TestExplain_DescribesAllComponentKinds(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainLSPOnlyFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range []string{"claude", "codex"} {
+		if _, err := runCLI(t, env, "agent", "add", a); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "install", "lsponly@lsp-mp"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "explain", "lsponly@lsp-mp")
+	if err != nil {
+		t.Fatalf("explain: %v\n%s", err, out)
+	}
+	// The plugin hosts no MCP and no commands, so the OLD tail would have read
+	// "0 mcp · 0 commands" and never mentioned the LSP. It must now say "lsp".
+	if !strings.Contains(out, "lsp") {
+		t.Errorf("explain should describe the hosted LSP server; got:\n%s", out)
+	}
+	if strings.Contains(out, "0 mcp") {
+		t.Errorf("explain should not pad the tail with zero-count kinds; got:\n%s", out)
+	}
+
+	// JSON carries every per-row count, with the LSP populated on both rows.
+	outJSON, err := runCLI(t, env, "explain", "lsponly@lsp-mp", "--json")
+	if err != nil {
+		t.Fatalf("explain --json: %v\n%s", err, outJSON)
+	}
+	var parsed struct {
+		Rows []struct {
+			Agent    string `json:"agent"`
+			Coverage string `json:"coverage"`
+			MCP      int    `json:"mcp"`
+			LSP      int    `json:"lsp"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(outJSON), &parsed); err != nil {
+		t.Fatalf("explain --json not valid JSON: %v\n%s", err, outJSON)
+	}
+	got := map[string]struct {
+		cov      string
+		mcp, lsp int
+	}{}
+	for _, r := range parsed.Rows {
+		got[r.Agent] = struct {
+			cov      string
+			mcp, lsp int
+		}{r.Coverage, r.MCP, r.LSP}
+	}
+	if g := got["claude"]; g.lsp != 1 || g.mcp != 0 || g.cov != "full" {
+		t.Errorf("claude row = %+v; want lsp=1 mcp=0 coverage=full", g)
+	}
+	// Codex hosts the LSP (lsp=1) but cannot translate it → renders nothing → none.
+	if g := got["codex"]; g.lsp != 1 || g.cov != "none" {
+		t.Errorf("codex row = %+v; want lsp=1 coverage=none", g)
+	}
+}
+
+// setupExplainLSPOnlyFixture builds a marketplace whose single plugin ships only
+// an LSP server (no MCP, no commands) — the shape that exposed the truncated
+// "0 mcp · 0 commands" tail.
+func setupExplainLSPOnlyFixture(t *testing.T, tmp string) string {
+	t.Helper()
+	fixture := filepath.Join(tmp, "fixture-marketplace-explain-lsponly")
+	if err := os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+		[]byte(`{"name":"lsp-mp","owner":{"name":"x"},"plugins":[{"name":"lsponly","source":"./plugins/lsponly"}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	plugDir := filepath.Join(fixture, "plugins", "lsponly", ".claude-plugin")
+	if err := os.MkdirAll(plugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugDir, "plugin.json"),
+		[]byte(`{"name":"lsponly","version":"1.0.0","lspServers":{"typescript":{"command":"typescript-language-server"}}}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
 // setupExplainCrossPluginFixture builds a marketplace with two installable
 // plugins used by the cross-plugin scoping regression: "clean" ships a single
 // MCP server (Codex renders it fully), "noisy" ships an MCP plus two components

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -478,13 +478,16 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 		}
 	}
 
-	// Explaining the clean plugin must not inherit the noisy plugin's LSP skip.
+	// Explaining the clean plugin must not inherit any of the noisy plugin's
+	// skips (its LSP nor its subagent — the two leak shapes from the bug report).
 	out, err := runCLI(t, env, "explain", "clean@cross-mp")
 	if err != nil {
 		t.Fatalf("explain clean: %v\n%s", err, out)
 	}
-	if strings.Contains(out, "skipped") || strings.Contains(out, "lsp") {
-		t.Errorf("explain clean@cross-mp leaked another plugin's skip; got:\n%s", out)
+	for _, leak := range []string{"skipped", "lsp", "subagent", "reviewer"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("explain clean@cross-mp leaked the noisy plugin's %q; got:\n%s", leak, out)
+		}
 	}
 	if !strings.Contains(out, "full") {
 		t.Errorf("explain clean@cross-mp should be full coverage; got:\n%s", out)
@@ -527,8 +530,9 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 		}
 	}
 
-	// Inverse: the noisy plugin still surfaces ITS OWN lsp skip, so the scoping
-	// narrows attribution rather than hiding skips wholesale.
+	// Inverse: the noisy plugin still surfaces ITS OWN skips (both the lsp and the
+	// subagent), so the scoping narrows attribution rather than hiding skips
+	// wholesale.
 	outNoisy, err := runCLI(t, env, "explain", "noisy@cross-mp")
 	if err != nil {
 		t.Fatalf("explain noisy: %v\n%s", err, outNoisy)
@@ -536,13 +540,119 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 	if !strings.Contains(outNoisy, "lsp") || !strings.Contains(outNoisy, "Codex has no LSP configuration concept") {
 		t.Errorf("explain noisy@cross-mp should surface its own lsp skip; got:\n%s", outNoisy)
 	}
+	if !strings.Contains(outNoisy, "subagent-frontmatter") || !strings.Contains(outNoisy, "reviewer") {
+		t.Errorf("explain noisy@cross-mp should surface its own subagent skip; got:\n%s", outNoisy)
+	}
+}
+
+// TestExplain_AllAttributesPerRow proves the per-plugin scoping holds in the
+// COMBINED report too: `explain --all` over a clean + noisy plugin must give each
+// plugin its own row counts/skips — the noisy plugin's LSP and subagent skips
+// must not bleed onto the clean plugin's row even though both rows share one
+// report. This is the multi-plugin code path the single-plugin regression does
+// not exercise.
+func TestExplain_AllAttributesPerRow(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainCrossPluginFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"clean@cross-mp", "noisy@cross-mp"} {
+		if _, err := runCLI(t, env, "plugin", "install", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := runCLI(t, env, "explain", "--all", "--json")
+	if err != nil {
+		t.Fatalf("explain --all --json: %v\n%s", err, out)
+	}
+	var parsed struct {
+		Rows []struct {
+			Plugin      string `json:"plugin"`
+			MCP         int    `json:"mcp"`
+			Skips       int    `json:"skips"`
+			SkipDetails []struct {
+				Component string `json:"component"`
+			} `json:"skipDetails"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("explain --all --json not valid JSON: %v\n%s", err, out)
+	}
+	var sawClean, sawNoisy bool
+	for _, r := range parsed.Rows {
+		switch r.Plugin {
+		case "clean@cross-mp":
+			sawClean = true
+			if r.MCP != 1 || r.Skips != 0 || len(r.SkipDetails) != 0 {
+				t.Errorf("clean row in --all leaked noisy's components: mcp=%d skips=%d details=%+v",
+					r.MCP, r.Skips, r.SkipDetails)
+			}
+		case "noisy@cross-mp":
+			sawNoisy = true
+			// noisy owns exactly its two skips (lsp + subagent-frontmatter).
+			if r.MCP != 1 || r.Skips != 2 {
+				t.Errorf("noisy row in --all has wrong own counts: mcp=%d skips=%d (want mcp=1 skips=2)",
+					r.MCP, r.Skips)
+			}
+		}
+	}
+	if !sawClean || !sawNoisy {
+		t.Fatalf("--all missing a plugin row (clean=%v noisy=%v):\n%s", sawClean, sawNoisy, out)
+	}
+}
+
+// TestExplain_DisabledPluginRendersMarker confirms a plugin disabled via
+// `plugin disable` still explains cleanly through the per-plugin path: it renders
+// the disabled marker (no agent rows, no crash) rather than projecting and
+// planning over the (now suppressed) plugin.
+func TestExplain_DisabledPluginRendersMarker(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "install", "demo@test-mp"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "disable", "demo"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "explain", "demo@test-mp")
+	if err != nil {
+		t.Fatalf("explain disabled: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("explain of a disabled plugin should show the disabled marker; got:\n%s", out)
+	}
 }
 
 // setupExplainCrossPluginFixture builds a marketplace with two installable
 // plugins used by the cross-plugin scoping regression: "clean" ships a single
-// MCP server (Codex renders it fully), "noisy" ships an MCP plus an LSP server
-// Codex cannot translate (it skips the LSP). With both installed, explaining one
-// must not surface the other's components.
+// MCP server (Codex renders it fully), "noisy" ships an MCP plus two components
+// Codex cannot fully translate — an LSP server (no LSP concept) and a subagent
+// (Codex agents are TOML; the markdown `name` frontmatter is dropped). Both of
+// noisy's skips mirror the real-world report (leaked subagents *and* LSPs). With
+// both plugins installed, explaining one must not surface the other's components
+// or skips.
 func setupExplainCrossPluginFixture(t *testing.T, tmp string) string {
 	t.Helper()
 	fixture := filepath.Join(tmp, "fixture-marketplace-explain-cross")
@@ -572,7 +682,17 @@ func setupExplainCrossPluginFixture(t *testing.T, tmp string) string {
 	if err := os.WriteFile(filepath.Join(noisyDir, "plugin.json"),
 		[]byte(`{"name":"noisy","version":"1.0.0",`+
 			`"mcpServers":{"noisy-mcp":{"command":"echo","args":["hi"]}},`+
-			`"lspServers":{"noisy-lsp":{"command":"lang-server"}}}`),
+			`"lspServers":{"noisy-lsp":{"command":"lang-server"}},`+
+			`"agents":["./agents/reviewer.md"]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsDir := filepath.Join(fixture, "plugins", "noisy", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "reviewer.md"),
+		[]byte("---\nname: reviewer\ndescription: reviews code\n---\nReview carefully.\n"),
 		0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -445,6 +445,140 @@ func TestExplain_ListsSkips(t *testing.T) {
 	}
 }
 
+// TestExplain_ScopesToNamedPlugin is the regression for cross-plugin leakage:
+// `explain <id>` must report only the named plugin's own components, never the
+// flattened union of every installed plugin. Before the fix, explain stamped the
+// global translation result onto every plugin row, so explaining one plugin
+// listed MCP counts and skipped components (subagents, LSPs) that belonged to a
+// different installed plugin.
+//
+// The fixture installs two plugins: "clean" (one MCP server Codex renders fully)
+// and "noisy" (one MCP plus an LSP server Codex cannot translate and skips).
+// Explaining "clean" must show full coverage, exactly one MCP, and no skips — the
+// noisy plugin's second MCP and its LSP skip must not leak in. The inverse
+// (explaining "noisy" surfaces its OWN lsp skip) confirms scoping narrows
+// attribution rather than suppressing skips wholesale.
+func TestExplain_ScopesToNamedPlugin(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := setupExplainCrossPluginFixture(t, tmp)
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"clean@cross-mp", "noisy@cross-mp"} {
+		if _, err := runCLI(t, env, "plugin", "install", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Explaining the clean plugin must not inherit the noisy plugin's LSP skip.
+	out, err := runCLI(t, env, "explain", "clean@cross-mp")
+	if err != nil {
+		t.Fatalf("explain clean: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "skipped") || strings.Contains(out, "lsp") {
+		t.Errorf("explain clean@cross-mp leaked another plugin's skip; got:\n%s", out)
+	}
+	if !strings.Contains(out, "full") {
+		t.Errorf("explain clean@cross-mp should be full coverage; got:\n%s", out)
+	}
+
+	// JSON: clean's rows must carry exactly one MCP, full coverage, and zero skips.
+	outJSON, err := runCLI(t, env, "explain", "clean@cross-mp", "--json")
+	if err != nil {
+		t.Fatalf("explain clean --json: %v\n%s", err, outJSON)
+	}
+	var parsed struct {
+		Rows []struct {
+			Plugin      string `json:"plugin"`
+			Coverage    string `json:"coverage"`
+			MCP         int    `json:"mcp"`
+			Skips       int    `json:"skips"`
+			SkipDetails []struct {
+				Component string `json:"component"`
+			} `json:"skipDetails"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(outJSON), &parsed); err != nil {
+		t.Fatalf("explain clean --json not valid JSON: %v\n%s", err, outJSON)
+	}
+	if len(parsed.Rows) == 0 {
+		t.Fatalf("explain clean --json returned zero rows:\n%s", outJSON)
+	}
+	for _, r := range parsed.Rows {
+		if r.Plugin != "clean@cross-mp" {
+			t.Errorf("explain clean@cross-mp returned a row for %q", r.Plugin)
+		}
+		if r.MCP != 1 {
+			t.Errorf("explain clean@cross-mp mcp = %d; want 1 (noisy's mcp must not leak in)", r.MCP)
+		}
+		if r.Skips != 0 || len(r.SkipDetails) != 0 {
+			t.Errorf("explain clean@cross-mp row has leaked skips: skips=%d details=%+v", r.Skips, r.SkipDetails)
+		}
+		if r.Coverage != "full" {
+			t.Errorf("explain clean@cross-mp coverage = %q; want full", r.Coverage)
+		}
+	}
+
+	// Inverse: the noisy plugin still surfaces ITS OWN lsp skip, so the scoping
+	// narrows attribution rather than hiding skips wholesale.
+	outNoisy, err := runCLI(t, env, "explain", "noisy@cross-mp")
+	if err != nil {
+		t.Fatalf("explain noisy: %v\n%s", err, outNoisy)
+	}
+	if !strings.Contains(outNoisy, "lsp") || !strings.Contains(outNoisy, "Codex has no LSP configuration concept") {
+		t.Errorf("explain noisy@cross-mp should surface its own lsp skip; got:\n%s", outNoisy)
+	}
+}
+
+// setupExplainCrossPluginFixture builds a marketplace with two installable
+// plugins used by the cross-plugin scoping regression: "clean" ships a single
+// MCP server (Codex renders it fully), "noisy" ships an MCP plus an LSP server
+// Codex cannot translate (it skips the LSP). With both installed, explaining one
+// must not surface the other's components.
+func setupExplainCrossPluginFixture(t *testing.T, tmp string) string {
+	t.Helper()
+	fixture := filepath.Join(tmp, "fixture-marketplace-explain-cross")
+	if err := os.MkdirAll(filepath.Join(fixture, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, ".claude-plugin", "marketplace.json"),
+		[]byte(`{"name":"cross-mp","owner":{"name":"x"},"plugins":[`+
+			`{"name":"clean","source":"./plugins/clean"},`+
+			`{"name":"noisy","source":"./plugins/noisy"}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	cleanDir := filepath.Join(fixture, "plugins", "clean", ".claude-plugin")
+	if err := os.MkdirAll(cleanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanDir, "plugin.json"),
+		[]byte(`{"name":"clean","version":"1.0.0","mcpServers":{"clean-mcp":{"command":"echo","args":["hi"]}}}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	noisyDir := filepath.Join(fixture, "plugins", "noisy", ".claude-plugin")
+	if err := os.MkdirAll(noisyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(noisyDir, "plugin.json"),
+		[]byte(`{"name":"noisy","version":"1.0.0",`+
+			`"mcpServers":{"noisy-mcp":{"command":"echo","args":["hi"]}},`+
+			`"lspServers":{"noisy-lsp":{"command":"lang-server"}}}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
 // setupExplainSkipFixture builds a marketplace whose single plugin ships an MCP
 // server, an LSP server, and a hook on a lifecycle event Codex does not
 // recognize. Codex renders the MCP but skips the LSP (no LSP concept) and the

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -72,32 +72,12 @@ func loadProjected(fs afero.Fs, home, pluginCacheRoot string, disabled []string,
 		disabledByProject[id] = true
 	}
 	for _, pl := range c.Plugins {
-		if pl.Plugin.Disabled {
-			// `plugin disable <id>` — skip projection entirely.
-			continue
-		}
-		if disabledByProject[pl.ID] {
-			// Disabled by the active project tree (plugins/<id>.toml
-			// disabled = true) — skip projection so its components never
-			// render in this repo.
-			continue
-		}
-		id, mpName := splitPluginRefPkg(pl.Plugin.ID)
-		if id == "" {
-			id = pl.ID
-		}
-		// Defense-in-depth: a hand-edited plugins/<id>.toml whose id contains
-		// "../" must not let plugin.json reads escape the cache root.
-		if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
-			return c, fmt.Errorf("project plugin %q: id contains a path-traversal component", id)
-		}
-		pluginDir := filepath.Join(pluginCacheRoot, id)
-		if err := verifyPluginManifestSHA(fs, pluginDir, pl.Plugin.ManifestSHA, id); err != nil {
-			return c, err
-		}
-		proj, perr := projectWithFuncs(resolveInstalledEntry(home, id, mpName), pluginDir, os.ReadFile, os.ReadDir, lenient)
+		proj, ok, perr := projectOnePlugin(fs, home, pluginCacheRoot, pl, disabledByProject, lenient)
 		if perr != nil {
-			return c, fmt.Errorf("project plugin %s: %w", id, perr)
+			return c, perr
+		}
+		if !ok {
+			continue
 		}
 		c.MCPServers = append(c.MCPServers, proj.MCPServers...)
 		c.Skills = append(c.Skills, proj.Skills...)
@@ -110,6 +90,61 @@ func loadProjected(fs afero.Fs, home, pluginCacheRoot string, disabled []string,
 		return c, err
 	}
 	return c, nil
+}
+
+// ProjectInstalled projects ONE installed plugin's components in isolation,
+// running the exact per-plugin step loadProjected uses (disabled check,
+// id-traversal guard, manifest-SHA verification, plugin.json + marketplace-entry
+// union). ok is false when the plugin contributes nothing this load (it is
+// disabled via `plugin disable`).
+//
+// It exists so a diagnostic command can attribute components to the plugin that
+// actually contributes them instead of to the flattened union. The projected
+// canonical (LoadProjected) concatenates every plugin's components into one set
+// of flat slices with no origin-plugin tag, so a row built from that whole model
+// cannot tell which plugin a component (or skip) came from. `explain <id>` builds
+// a per-plugin plan from this projection rather than slicing the global
+// canonical, so its coverage/skip rows reflect only the named plugin.
+//
+// lenient mirrors LoadProjectedLenient (a strict plugin.json/entry conflict
+// degrades to entry-wins + a logged warning rather than a hard error), which is
+// what the read-only/diagnostic callers want.
+func ProjectInstalled(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugin, lenient bool) (ProjectionResult, bool, error) {
+	if pluginCacheRoot == "" {
+		return ProjectionResult{}, false, nil
+	}
+	return projectOnePlugin(fs, home, pluginCacheRoot, pl, nil, lenient)
+}
+
+// projectOnePlugin projects a single installed plugin into its ProjectionResult.
+// It is the one per-plugin projection step, shared by the flattening load
+// (loadProjected) and the per-plugin diagnostic path (ProjectInstalled), so the
+// two can never derive different components for the same plugin. ok is false when
+// the plugin contributes nothing this load: it is disabled via `plugin disable`
+// (pl.Plugin.Disabled), or disabled by the active project tree
+// (disabledByProject[pl.ID], the plugins/<id>.toml `disabled = true` flag).
+func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugin, disabledByProject map[string]bool, lenient bool) (ProjectionResult, bool, error) {
+	if pl.Plugin.Disabled || disabledByProject[pl.ID] {
+		return ProjectionResult{}, false, nil
+	}
+	id, mpName := splitPluginRefPkg(pl.Plugin.ID)
+	if id == "" {
+		id = pl.ID
+	}
+	// Defense-in-depth: a hand-edited plugins/<id>.toml whose id contains
+	// "../" must not let plugin.json reads escape the cache root.
+	if strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") {
+		return ProjectionResult{}, false, fmt.Errorf("project plugin %q: id contains a path-traversal component", id)
+	}
+	pluginDir := filepath.Join(pluginCacheRoot, id)
+	if err := verifyPluginManifestSHA(fs, pluginDir, pl.Plugin.ManifestSHA, id); err != nil {
+		return ProjectionResult{}, false, err
+	}
+	proj, perr := projectWithFuncs(resolveInstalledEntry(home, id, mpName), pluginDir, os.ReadFile, os.ReadDir, lenient)
+	if perr != nil {
+		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, perr)
+	}
+	return proj, true, nil
 }
 
 // checkProjectedConflicts surfaces a silent cross-source hijack. The projected

--- a/internal/marketplace/loadprojected_test.go
+++ b/internal/marketplace/loadprojected_test.go
@@ -163,6 +163,66 @@ func TestLoadProjectedExcluding_UnknownIDIsNoOp(t *testing.T) {
 	}
 }
 
+// TestProjectInstalled_ScopesToOnePlugin is the unit-level guard for the
+// per-plugin projection entry point `explain <id>` builds on: it must project
+// ONLY the named plugin's components, never the cross-plugin union the flattening
+// LoadProjected returns. Two plugins are installed; projecting one must surface
+// its own MCP server and not the other's.
+func TestProjectInstalled_ScopesToOnePlugin(t *testing.T) {
+	home, cache := twoPluginFixture(t,
+		`{"name":"a","mcpServers":{"a-srv":{"command":"x"}}}`,
+		`{"name":"b","mcpServers":{"b-srv":{"command":"y"}}}`)
+
+	plA := source.Plugin{ID: "a", Plugin: source.PluginSpec{ID: "a@m", Version: "1"}}
+	proj, ok, err := marketplace.ProjectInstalled(afero.NewOsFs(), home, cache, plA, true)
+	if err != nil {
+		t.Fatalf("ProjectInstalled(a): %v", err)
+	}
+	if !ok {
+		t.Fatal("ProjectInstalled(a): ok=false; want true for an installed, enabled plugin")
+	}
+	if !mcpIDs(proj.MCPServers)["a-srv"] {
+		t.Errorf("ProjectInstalled(a) missing its own server: %v", mcpIDs(proj.MCPServers))
+	}
+	if mcpIDs(proj.MCPServers)["b-srv"] {
+		t.Errorf("ProjectInstalled(a) leaked plugin b's server: %v", mcpIDs(proj.MCPServers))
+	}
+}
+
+// TestProjectInstalled_DisabledContributesNothing pins the ok=false arm: a
+// plugin disabled via `plugin disable` projects nothing, so explain never plans
+// over its components.
+func TestProjectInstalled_DisabledContributesNothing(t *testing.T) {
+	home, cache := writeProjFixture(t,
+		"[plugin]\nid = \"d@m\"\nversion = \"1\"\n", "d",
+		`{"name":"d","mcpServers":{"d-srv":{"command":"x"}}}`)
+	pl := source.Plugin{ID: "d", Plugin: source.PluginSpec{ID: "d@m", Version: "1", Disabled: true}}
+	proj, ok, err := marketplace.ProjectInstalled(afero.NewOsFs(), home, cache, pl, true)
+	if err != nil {
+		t.Fatalf("ProjectInstalled(disabled): %v", err)
+	}
+	if ok {
+		t.Error("ProjectInstalled(disabled): ok=true; want false")
+	}
+	if len(proj.MCPServers) != 0 {
+		t.Errorf("ProjectInstalled(disabled) projected components: %v", mcpIDs(proj.MCPServers))
+	}
+}
+
+// TestProjectInstalled_EmptyCacheRootSkips mirrors LoadProjected's empty-root
+// skip: with no plugin cache root there is nothing to project — ok=false, no
+// error.
+func TestProjectInstalled_EmptyCacheRootSkips(t *testing.T) {
+	pl := source.Plugin{ID: "x", Plugin: source.PluginSpec{ID: "x@m", Version: "1"}}
+	proj, ok, err := marketplace.ProjectInstalled(afero.NewOsFs(), t.TempDir(), "", pl, true)
+	if err != nil {
+		t.Fatalf("ProjectInstalled(empty root): %v", err)
+	}
+	if ok || len(proj.MCPServers) != 0 {
+		t.Errorf("empty cache root must contribute nothing; ok=%v servers=%v", ok, mcpIDs(proj.MCPServers))
+	}
+}
+
 func mcpIDs(servers []source.MCPServer) map[string]bool {
 	ids := map[string]bool{}
 	for _, m := range servers {

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -21,10 +21,21 @@ type PluginRow struct {
 	Agent  string `json:"agent"`
 	// Coverage is "full", "partial", or "none".
 	Coverage string `json:"coverage"`
-	// MCP is the number of MCP servers rendered for this plugin×agent pair.
-	MCP int `json:"mcp"`
-	// Commands is the number of slash commands rendered.
-	Commands int `json:"commands"`
+	// MCP, Commands, Skills, Subagents, Hooks, and LSP count the components the
+	// plugin (or whole model) hosts that target this agent — the inventory, so
+	// the report is descriptive of everything the plugin ships, not just MCP +
+	// commands. MCP and LSP honour each server's `enabled`/`agents` targeting
+	// (a server scoped to other agents is not counted here); the markdown
+	// component kinds (commands/skills/subagents) and hooks have no per-agent
+	// allowlist, so their counts are the model's totals. These describe what is
+	// hosted, NOT what successfully rendered: a hosted component the adapter
+	// cannot translate is still counted here and reported under Skips below.
+	MCP       int `json:"mcp"`
+	Commands  int `json:"commands"`
+	Skills    int `json:"skills"`
+	Subagents int `json:"subagents"`
+	Hooks     int `json:"hooks"`
+	LSP       int `json:"lsp"`
 	// Skips is the number of components the adapter explicitly skipped.
 	Skips int `json:"skips"`
 	// SkipDetails enumerates the components behind Skips — what the adapter
@@ -164,14 +175,18 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 }
 
 // BuildReport constructs a TranslationReport from the canonical model and a
-// RenderPlan: one row per plugin (c.Plugins) × agent. Each row's counts come
-// from the model — MCP servers that target the agent (countMCPServers) and
-// len(c.Commands) — and its skips from plan.PerAgent[agent].Skips.
+// RenderPlan: one row per plugin (c.Plugins) × agent. Each row carries the
+// per-agent component inventory (countMCPServers / countLSPServers honour
+// enabled+agent targeting; commands/skills/subagents/hooks are model totals) and
+// the skips from plan.PerAgent[agent].Skips.
 //
-// coverage = full when skips==0, partial when skips>0 but something rendered
-// (mcp>0 || commands>0), none otherwise. A disabled plugin yields a single
-// disabled-marker row. With no plugins installed, one "(base)" row per agent
-// summarizes the whole canonical.
+// coverage = full when skips==0; otherwise partial when the adapter still
+// rendered something for the agent (plan ops non-empty), none when every hosted
+// component was skipped. The rendered signal is the plan's ops, not the inventory
+// counts — a hosted-but-unsupported component (e.g. an LSP server on an agent
+// with no LSP concept) is counted in the inventory yet renders nothing, so its
+// row is "none". A disabled plugin yields a single disabled-marker row. With no
+// plugins installed, one "(base)" row per agent summarizes the whole canonical.
 //
 // BuildReport does NOT itself correlate a component to its origin plugin — the
 // projected canonical is flattened with no origin tag. Attribution is therefore
@@ -184,45 +199,26 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 func BuildReport(c source.Canonical, plan RenderPlan, agents []string) TranslationReport {
 	var report TranslationReport
 
-	// Index each plugin by the MCP server IDs it contributes.
-	// We use Plugins from the canonical model; the MCP server IDs are the keys
-	// we expect to see in the rendered ops.
+	// The canonical is flattened (no origin-plugin tag), so the per-agent counts
+	// are computed over whatever model the caller scoped: apply/verify pass the
+	// whole model (one global summary repeated per plugin row), while `explain
+	// <id>` passes a model holding only one re-projected plugin's components.
 	//
-	// Because plugin projection injects MCPServers with the same IDs as in
-	// plugin.json, we can match ops by SourceID prefix or by looking at the
-	// op's content for the server key.  The simplest approach: for each plugin
-	// record a label and count how many MCP servers with that label appeared.
-
-	// Build per-plugin MCP server name sets from the canonical MCPServers.
-	// We can't directly correlate which MCPServer came from which plugin here
-	// (projection flattens them); instead we show aggregate counts per agent
-	// for each installed plugin as a summary row.
-	//
-	// The report is per-installed-plugin.  If there are no plugins, we emit a
-	// summary row per agent with the global count.
+	// With no plugins installed we emit one "(base)" row per agent over the whole
+	// canonical; otherwise one row per plugin × agent.
 
 	if len(c.Plugins) == 0 {
-		// No plugins installed — emit one row per agent for the global canonical.
 		for _, agName := range agents {
 			res, ok := plan.PerAgent[agName]
 			if !ok {
 				continue
 			}
-			row := PluginRow{
-				Plugin:      "(base)",
-				Agent:       agName,
-				MCP:         countMCPServers(c, agName),
-				Commands:    len(c.Commands),
-				Skips:       len(res.Skips),
-				SkipDetails: skipDetails(res.Skips),
-			}
-			row.Coverage = computeCoverage(row)
+			row := reportRow("(base)", agName, c, res)
 			report.Rows = append(report.Rows, row)
 		}
 		return report
 	}
 
-	// One row per plugin × agent.
 	for _, plug := range c.Plugins {
 		label := plug.Plugin.ID
 		if label == "" {
@@ -244,32 +240,44 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			if !ok {
 				continue
 			}
-			// Counts/skips are attributed per the canonical+plan passed in (see
-			// the doc-comment). apply/verify pass the whole flattened model, so
-			// every plugin row carries the same global numbers; `explain <id>`
-			// passes a model+plan scoped to one re-projected plugin, so its row
-			// reflects only that plugin's components.
-			row := PluginRow{
-				Plugin:      label,
-				Agent:       agName,
-				MCP:         countMCPServers(c, agName),
-				Commands:    len(c.Commands),
-				Skips:       len(res.Skips),
-				SkipDetails: skipDetails(res.Skips),
-			}
-			row.Coverage = computeCoverage(row)
-			report.Rows = append(report.Rows, row)
+			report.Rows = append(report.Rows, reportRow(label, agName, c, res))
 		}
 	}
 	return report
 }
 
-// computeCoverage derives the coverage string from a PluginRow's counts.
-func computeCoverage(row PluginRow) string {
+// reportRow builds one plugin×agent row: the per-agent component inventory
+// (counts of what the model hosts for agName), the skip tally + details, and the
+// derived coverage. c is whatever model the caller scoped (whole model or one
+// plugin); res is that agent's render result.
+func reportRow(label, agName string, c source.Canonical, res AgentResult) PluginRow {
+	row := PluginRow{
+		Plugin:      label,
+		Agent:       agName,
+		MCP:         countMCPServers(c, agName),
+		LSP:         countLSPServers(c, agName),
+		Commands:    len(c.Commands),
+		Skills:      len(c.Skills),
+		Subagents:   len(c.Subagents),
+		Hooks:       len(c.Hooks),
+		Skips:       len(res.Skips),
+		SkipDetails: skipDetails(res.Skips),
+	}
+	row.Coverage = computeCoverage(row, len(res.Ops) > 0)
+	return row
+}
+
+// computeCoverage derives the coverage string. full = nothing skipped. Otherwise
+// partial when the adapter still rendered something for this agent (rendered),
+// none when every hosted component was skipped (or there was nothing to render).
+// The rendered signal comes from the plan's ops — NOT from the inventory counts,
+// which include hosted-but-skipped components (e.g. an LSP server on an agent with
+// no LSP concept is counted in row.LSP yet renders nothing, so its row is "none").
+func computeCoverage(row PluginRow, rendered bool) string {
 	if row.Skips == 0 {
 		return "full"
 	}
-	if row.MCP > 0 || row.Commands > 0 {
+	if rendered {
 		return "partial"
 	}
 	return "none"
@@ -287,6 +295,22 @@ func countMCPServers(c source.Canonical, agent string) int {
 			continue
 		}
 		if targetsAgent(m.Server.Agents, agent) {
+			n++
+		}
+	}
+	return n
+}
+
+// countLSPServers mirrors countMCPServers for LSP servers — LSPServerSpec carries
+// the same source-only enabled/agents targeting fields, so a server disabled or
+// scoped to other agents is not counted for this agent.
+func countLSPServers(c source.Canonical, agent string) int {
+	n := 0
+	for _, l := range c.LSPServers {
+		if l.Spec.Enabled != nil && !*l.Spec.Enabled {
+			continue
+		}
+		if targetsAgent(l.Spec.Agents, agent) {
 			n++
 		}
 	}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -29,10 +29,12 @@ type PluginRow struct {
 	Skips int `json:"skips"`
 	// SkipDetails enumerates the components behind Skips — what the adapter
 	// could not translate, and why — so a "(N skipped)" tally is never a dead
-	// end. Same global attribution as the counts: because the canonical model
-	// is flattened (projection does not tag a component with its origin
-	// plugin), these are the agent's skips across the whole model, surfaced
-	// under every plugin row rather than narrowed to one plugin.
+	// end. Attribution follows the canonical+plan passed to BuildReport (see its
+	// doc): when the caller passes the whole flattened model (apply/verify), the
+	// skips are the agent's across every component and are repeated under each
+	// plugin row; when the caller passes a per-plugin-scoped model (`explain
+	// <id>`, which re-projects one plugin in isolation), they are narrowed to
+	// that plugin's own components.
 	SkipDetails []SkipDetail `json:"skipDetails,omitempty"`
 	// Disabled is true when the plugin is disabled for this scope (e.g. by a
 	// project marker's [plugins] disabled). Its components are not rendered.
@@ -162,17 +164,23 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 }
 
 // BuildReport constructs a TranslationReport from the canonical model and a
-// RenderPlan.  It associates ops/skips with plugins by matching MCP server IDs
-// contributed by each plugin.
+// RenderPlan: one row per plugin (c.Plugins) × agent. Each row's counts come
+// from the model — MCP servers that target the agent (countMCPServers) and
+// len(c.Commands) — and its skips from plan.PerAgent[agent].Skips.
 //
-// For each plugin P and each agent A:
-//   - count MCP servers that appear in plan.PerAgent[A].Ops whose SourceID
-//     matches one of P's components.
-//   - coverage = full if skips==0 && mcp>0 (or no components), partial if
-//     skips>0 && mcp>0, none if mcp==0.
+// coverage = full when skips==0, partial when skips>0 but something rendered
+// (mcp>0 || commands>0), none otherwise. A disabled plugin yields a single
+// disabled-marker row. With no plugins installed, one "(base)" row per agent
+// summarizes the whole canonical.
 //
-// Plugins with no canonical entries (not yet cached) still generate rows with
-// coverage=none so the operator can see what's missing.
+// BuildReport does NOT itself correlate a component to its origin plugin — the
+// projected canonical is flattened with no origin tag. Attribution is therefore
+// the caller's choice of what model+plan to pass:
+//   - apply/verify pass the whole flattened model, so every plugin row carries
+//     the same global counts/skips (the documented summary behavior).
+//   - `explain <id>` re-projects ONE plugin in isolation
+//     (marketplace.ProjectInstalled) and passes a model+plan holding only that
+//     plugin's components, so its row reflects that plugin alone.
 func BuildReport(c source.Canonical, plan RenderPlan, agents []string) TranslationReport {
 	var report TranslationReport
 
@@ -236,9 +244,11 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			if !ok {
 				continue
 			}
-			// For now we attribute all ops/skips equally to each plugin row
-			// since the canonical model is flattened.  A future version can
-			// tag ops with their origin plugin.
+			// Counts/skips are attributed per the canonical+plan passed in (see
+			// the doc-comment). apply/verify pass the whole flattened model, so
+			// every plugin row carries the same global numbers; `explain <id>`
+			// passes a model+plan scoped to one re-projected plugin, so its row
+			// reflects only that plugin's components.
 			row := PluginRow{
 				Plugin:      label,
 				Agent:       agName,

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -439,10 +439,12 @@ func TestBuildReport_InventoryCountsAllKinds(t *testing.T) {
 	}
 }
 
-// TestBuildReport_CoverageNoneWhenNothingRendered: a plugin that hosts only a
-// component the agent cannot translate (an LSP server on Codex) renders nothing,
-// so the row is "none" — even though the LSP is counted in the inventory. This is
-// the user-visible behavior for an LSP-only plugin on a non-LSP agent.
+// TestBuildReport_CoverageNoneWhenNothingRendered pins the user-visible behavior
+// for an LSP-only plugin on a non-LSP agent: the LSP is counted in the inventory
+// (LSP=1) yet renders nothing, so the row is "none". This case reads the same
+// under the old (mcp/commands) and new (rendered) coverage logic — it guards the
+// inventory count + the none-case, NOT the rendered-vs-counts distinction (that
+// is TestBuildReport_CoveragePartialWhenSomethingRendered's job).
 func TestBuildReport_CoverageNoneWhenNothingRendered(t *testing.T) {
 	c := source.Canonical{
 		LSPServers: []source.LSPServer{{ID: "l"}},
@@ -486,5 +488,65 @@ func TestBuildReport_CoveragePartialWhenSomethingRendered(t *testing.T) {
 	}
 	if row.Coverage != "partial" {
 		t.Errorf("coverage = %q, want partial (a skill rendered; only the hook was skipped)", row.Coverage)
+	}
+}
+
+// TestBuildReport_BaseCoverageFromRendered locks the rendered-based coverage on
+// the "(base)" (no-plugins) branch too — the path apply/apply --dry-run summarize
+// through. The computeCoverage change is shared by every BuildReport caller, but
+// the other coverage tests all exercise the per-plugin branch; this pins that the
+// base branch derives partial/none from the plan's ops identically.
+func TestBuildReport_BaseCoverageFromRendered(t *testing.T) {
+	c := source.Canonical{Skills: []source.Skill{{Name: "s"}}} // no Plugins → "(base)"
+	rendered := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"codex": {
+			Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "replace"}},
+			Skips: []adapter.Skip{{Component: "hook", Reason: "unknown event"}},
+		},
+	}}
+	if row := render.BuildReport(c, rendered, []string{"codex"}).Rows[0]; row.Plugin != "(base)" || row.Coverage != "partial" {
+		t.Errorf("base row = {plugin:%q coverage:%q}, want {(base) partial}", row.Plugin, row.Coverage)
+	}
+	nothing := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Reason: "no LSP concept"}}},
+	}}
+	if row := render.BuildReport(c, nothing, []string{"codex"}).Rows[0]; row.Coverage != "none" {
+		t.Errorf("base row coverage = %q, want none (nothing rendered)", row.Coverage)
+	}
+}
+
+// TestBuildReport_CountsHonorTargeting exercises the enabled/agents filtering in
+// countMCPServers and countLSPServers: a server scoped to other agents, or
+// disabled, is not counted for this agent. Without this, a plugin's MCP/LSP
+// server scoped to claude could be silently counted on codex's row.
+func TestBuildReport_CountsHonorTargeting(t *testing.T) {
+	off := false
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "claude-only", Server: source.MCPServerSpec{Agents: []string{"claude"}}},
+			{ID: "disabled", Server: source.MCPServerSpec{Enabled: &off}},
+			{ID: "all"},
+		},
+		LSPServers: []source.LSPServer{
+			{ID: "lsp-claude", Spec: source.LSPServerSpec{Agents: []string{"claude"}}},
+			{ID: "lsp-off", Spec: source.LSPServerSpec{Enabled: &off}},
+			{ID: "lsp-all"},
+		},
+	}
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+		"codex":  {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-toml-keys"}}},
+	}}
+	byAgent := map[string]render.PluginRow{}
+	for _, r := range render.BuildReport(c, plan, []string{"claude", "codex"}).Rows {
+		byAgent[r.Agent] = r
+	}
+	// claude: claude-only + all = 2 mcp; lsp-claude + lsp-all = 2 lsp (disabled excluded).
+	if g := byAgent["claude"]; g.MCP != 2 || g.LSP != 2 {
+		t.Errorf("claude counts = mcp %d lsp %d; want mcp 2 lsp 2", g.MCP, g.LSP)
+	}
+	// codex: only the untargeted "all"/"lsp-all" reach it = 1 mcp, 1 lsp.
+	if g := byAgent["codex"]; g.MCP != 1 || g.LSP != 1 {
+		t.Errorf("codex counts = mcp %d lsp %d; want mcp 1 lsp 1", g.MCP, g.LSP)
 	}
 }

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -396,3 +396,95 @@ func TestBuildReport_CountsItemsNotOps(t *testing.T) {
 		t.Fatalf("Commands = %d, want 0 (memory must not be counted as a command)", row.Commands)
 	}
 }
+
+// TestBuildReport_InventoryCountsAllKinds pins that a row describes EVERY
+// component kind the model hosts for the agent, not just MCP + commands — so a
+// plugin shipping skills / subagents / hooks / an LSP server is no longer
+// reported as a bare "0 mcp · 0 commands".
+func TestBuildReport_InventoryCountsAllKinds(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "m"}},
+		LSPServers: []source.LSPServer{{ID: "l"}},
+		Commands:   []source.Command{{Name: "c"}},
+		Skills:     []source.Skill{{Name: "s"}},
+		Subagents:  []source.Subagent{{Name: "a"}},
+		Hooks:      []source.Hook{{Event: "PreToolUse"}},
+		Plugins:    []source.Plugin{{ID: "demo", Plugin: source.PluginSpec{ID: "demo@mp"}}},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"claude"})
+	if len(report.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(report.Rows))
+	}
+	row := report.Rows[0]
+	for _, tc := range []struct {
+		got  int
+		want int
+		name string
+	}{
+		{row.MCP, 1, "mcp"},
+		{row.LSP, 1, "lsp"},
+		{row.Commands, 1, "commands"},
+		{row.Skills, 1, "skills"},
+		{row.Subagents, 1, "subagents"},
+		{row.Hooks, 1, "hooks"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("row.%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestBuildReport_CoverageNoneWhenNothingRendered: a plugin that hosts only a
+// component the agent cannot translate (an LSP server on Codex) renders nothing,
+// so the row is "none" — even though the LSP is counted in the inventory. This is
+// the user-visible behavior for an LSP-only plugin on a non-LSP agent.
+func TestBuildReport_CoverageNoneWhenNothingRendered(t *testing.T) {
+	c := source.Canonical{
+		LSPServers: []source.LSPServer{{ID: "l"}},
+		Plugins:    []source.Plugin{{ID: "demo", Plugin: source.PluginSpec{ID: "demo@mp"}}},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Name: "l", Reason: "no LSP concept"}}},
+		},
+	}
+	row := render.BuildReport(c, plan, []string{"codex"}).Rows[0]
+	if row.LSP != 1 {
+		t.Errorf("LSP = %d, want 1 (the hosted server is still counted)", row.LSP)
+	}
+	if row.Coverage != "none" {
+		t.Errorf("coverage = %q, want none (nothing rendered)", row.Coverage)
+	}
+}
+
+// TestBuildReport_CoveragePartialWhenSomethingRendered is the regression for a
+// latent bug the inventory change exposed: coverage was derived from
+// (mcp>0||commands>0), so a plugin whose skills rendered but whose (say) hook was
+// skipped was mislabeled "none" despite real output. Coverage now keys off
+// whether the plan rendered any op, so this is correctly "partial".
+func TestBuildReport_CoveragePartialWhenSomethingRendered(t *testing.T) {
+	c := source.Canonical{
+		Skills:  []source.Skill{{Name: "s"}},
+		Plugins: []source.Plugin{{ID: "demo", Plugin: source.PluginSpec{ID: "demo@mp"}}},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"codex": {
+				Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "replace"}}, // the skill rendered
+				Skips: []adapter.Skip{{Component: "hook", Name: "x", Reason: "unknown event"}},
+			},
+		},
+	}
+	row := render.BuildReport(c, plan, []string{"codex"}).Rows[0]
+	if row.Skills != 1 {
+		t.Errorf("Skills = %d, want 1", row.Skills)
+	}
+	if row.Coverage != "partial" {
+		t.Errorf("coverage = %q, want partial (a skill rendered; only the hook was skipped)", row.Coverage)
+	}
+}


### PR DESCRIPTION
## The bug

`agentsync explain <plugin-id>` reported the **global** translation result under whatever plugin you named — MCP/command counts and the `(N skipped)` itemization came from *every* installed plugin, not just the one asked about. In the wild, `explain notion@claude-plugins-official` listed skipped subagents from the Vercel plugin and two LSP servers from another plugin entirely:

```
▸ notion@claude-plugins-official
  → claude      ✓ full        1 mcp · 5 commands
  → codex       ◐ partial     1 mcp · 5 commands  (5 skipped)
      • subagent-frontmatter ai-architect           …dropped name
      • subagent-frontmatter deployment-expert       …dropped name
      • subagent-frontmatter performance-optimizer   …dropped name
      • lsp csharp-ls                                 Codex has no LSP configuration concept
      • lsp typescript                                Codex has no LSP configuration concept
```

None of those components belong to the notion plugin.

## Root cause

Plugin projection (`marketplace.loadProjected`) flattens every installed plugin's components into shared slices on the canonical model (`c.MCPServers`, `c.Commands`, `c.Subagents`, `c.LSPServers`, …) **with no origin-plugin tag**. `render.BuildReport` then attributes globally — it counts `countMCPServers(c, …)`, `len(c.Commands)`, and the agent's entire `plan.PerAgent[agent].Skips`, stamping those same numbers onto *every* plugin row. So `explain`'s `filtered.Plugins = []source.Plugin{pl}` only changed which label got a row, never the counts/skips shown.

## The fix

`explain` now re-projects each requested plugin **in isolation** and builds its coverage row from only that plugin's own components:

- Extract the per-plugin projection step `loadProjected` already runs into a shared `projectOnePlugin`, exposed as `marketplace.ProjectInstalled`, so the flattening load and the diagnostic path can't derive different components for one plugin.
- New `explainPluginReport` plans + reports over a canonical narrowed to one plugin's components, in both text and `--json`. Disabled plugins still short-circuit to the disabled-marker row.
- Correct the now-stale global-attribution notes in `render/report.go` (the doc described `SourceID` matching that never existed): attribution follows the canonical+plan the caller passes — `apply`/`verify` pass the whole model (global summary, unchanged); `explain` passes a per-plugin model.
- Docs kept in sync: `CHANGELOG.md` (corrected the unreleased entry's false caveat + added a `Fixed` entry) and `docs/components.md` (lists the new `ProjectInstalled`).

## Verification

- New regression test `TestExplain_ScopesToNamedPlugin`: two installed plugins, one clean and one shipping an LSP Codex skips. Explaining the clean plugin must show exactly its own MCP and **no** skips, while the noisy plugin still surfaces its own LSP skip. Confirmed it **fails on the old behavior** (reproduces the symptom: clean plugin showed `2 mcp` and the other plugin's `lsp` skip) and **passes with the fix**.
- Full suite green (`go test ./...`), `golangci-lint run ./...` 0 issues, gofumpt clean, no `go.mod`/`go.sum` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRTJjGskH26Sp2KhHwHoLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRTJjGskH26Sp2KhHwHoLT)_