### PR TITLE
fix(marketplace): discover plugin components in all conventional locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,14 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `{matcher, hooks:[{type, command}]}` shape (used by both `hooks/hooks.json` and
   inline `plugin.json` hooks), emitting one hook per command entry and dropping
   non-command hook types agentsync's command-only `Hook` model cannot represent
-  rather than projecting an empty hook.
+  rather than projecting an empty hook. Plugin component frontmatter is now read
+  the way Claude Code reads it (`source.ParseFrontmatterWithReport`, as the
+  adapter Ingest paths already do): a `description` containing bare colons —
+  valid to Claude, rejected by strict YAML with *"mapping values are not allowed
+  in this context"* — is recovered with a warning instead of aborting the whole
+  projection. (Newly surfaced by agent discovery: the official `pr-review-toolkit`
+  ships such an `agents/silent-failure-hunter.md`, which previously crashed
+  `explain --all` for every plugin once agents were discovered.)
 
 - **`explain <plugin>` now reports only that plugin's components.** `explain`
   previously stamped the *global* translation result onto every plugin row: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   locations, not just the ones plugin.json lists.** Claude Code auto-discovers a
   plugin's components from default locations — `commands/*.md`, `agents/*.md`,
   `skills/*/SKILL.md`, `.mcp.json`, `.lsp.json`, `hooks/hooks.json` — whether or
-  not `plugin.json` declares them (the manifest is optional, and a listed
-  component field *replaces* its default scan). agentsync only convention-scanned
+  not `plugin.json` declares them (the manifest is optional; a listed
+  commands/agents/mcp/lsp/hooks field *replaces* its default scan, while a listed
+  `skills` field *adds* to the always-scanned `skills/` directory, per Claude's
+  path-behavior rules). agentsync only convention-scanned
   `skills/`, so any plugin that shipped a command, subagent, MCP/LSP server, or
   hook **only** in its conventional location was silently dropped — `agentsync
   explain code-review@claude-plugins-official` reported `no components` for a
@@ -66,7 +68,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   in this context"* — is recovered with a warning instead of aborting the whole
   projection. (Newly surfaced by agent discovery: the official `pr-review-toolkit`
   ships such an `agents/silent-failure-hunter.md`, which previously crashed
-  `explain --all` for every plugin once agents were discovered.)
+  `explain --all` for every plugin once agents were discovered.) Likewise, a
+  malformed/unreadable `.mcp.json`, `.lsp.json`, or `hooks/hooks.json` now drops
+  only that file's components with a warning rather than aborting the projection,
+  so one bad config file in one plugin can't break `explain`/`apply`/`status` for
+  every installed plugin.
 
 - **`explain <plugin>` now reports only that plugin's components.** `explain`
   previously stamped the *global* translation result onto every plugin row: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,14 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   projection. (Newly surfaced by agent discovery: the official `pr-review-toolkit`
   ships such an `agents/silent-failure-hunter.md`, which previously crashed
   `explain --all` for every plugin once agents were discovered.) Likewise, a
-  malformed/unreadable `.mcp.json`, `.lsp.json`, or `hooks/hooks.json` now drops
-  only that file's components with a warning rather than aborting the projection,
-  so one bad config file in one plugin can't break `explain`/`apply`/`status` for
-  every installed plugin.
+  malformed/unreadable `.mcp.json`, `.lsp.json`, or `hooks/hooks.json` — and a
+  convention-discovered `commands/*.md`/`agents/*.md`/`skills/*/SKILL.md` whose
+  frontmatter can't be parsed even leniently (e.g. an unterminated block) or whose
+  name is a traversal attempt — now drops only that one component with a warning
+  rather than aborting the projection, so one bad file in one plugin can't break
+  `explain`/`apply`/`status` for every installed plugin. A component the plugin
+  author *explicitly listed* in `plugin.json` still fails loudly (a named-but-broken
+  component is a hard error); only proactively-discovered files are skipped.
 
 - **`explain <plugin>` now reports only that plugin's components.** `explain`
   previously stamped the *global* translation result onto every plugin row: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **Plugins now project the components they ship in their conventional default
+  locations, not just the ones plugin.json lists.** Claude Code auto-discovers a
+  plugin's components from default locations — `commands/*.md`, `agents/*.md`,
+  `skills/*/SKILL.md`, `.mcp.json`, `.lsp.json`, `hooks/hooks.json` — whether or
+  not `plugin.json` declares them (the manifest is optional, and a listed
+  component field *replaces* its default scan). agentsync only convention-scanned
+  `skills/`, so any plugin that shipped a command, subagent, MCP/LSP server, or
+  hook **only** in its conventional location was silently dropped — `agentsync
+  explain code-review@claude-plugins-official` reported `no components` for a
+  plugin that plainly ships `commands/code-review.md`, and `code-simplifier`
+  (which ships `agents/code-simplifier.md`) likewise. Projection now falls back to
+  the default location for *every* component kind agentsync models when
+  `plugin.json` does not list it — including when there is no `plugin.json` at all
+  — so those components are tracked, rendered, and reported like any other. The
+  manifest-SHA pin already hashed the whole plugin cache tree, so existing installs
+  are unaffected. As part of this, plugin hooks now parse the canonical nested
+  `{matcher, hooks:[{type, command}]}` shape (used by both `hooks/hooks.json` and
+  inline `plugin.json` hooks), emitting one hook per command entry and dropping
+  non-command hook types agentsync's command-only `Hook` model cannot represent
+  rather than projecting an empty hook.
+
 - **`explain <plugin>` now reports only that plugin's components.** `explain`
   previously stamped the *global* translation result onto every plugin row: the
   MCP/command counts and the `(N skipped)` itemization were computed from the

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -308,14 +308,19 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		discoverConventionLSP(cacheDir, readFile, pr)
 	}
 
-	skillPaths := toStringSlice(manifest.Skills)
+	// Skills: the manifest-listed skills are loaded loudly (a broken one the
+	// author named is a hard error), and the default skills/ directory is ALWAYS
+	// scanned and unioned — `skills` ADDS to the default scan (unlike
+	// commands/agents, which REPLACE it), matching Claude Code's path-behavior
+	// rules. A discovered skill that fails to load is skipped with a warning, not
+	// fatal (see appendSkillEntries): one malformed SKILL.md in one plugin must
+	// not abort projection for every installed plugin. A skill appearing in both
+	// the manifest list and the scan resolves to the same dir and collapses in
+	// resolveConflicts.
+	if err := appendSkillEntries(pr, toStringSlice(manifest.Skills), cacheDir, readFile, listDir, false); err != nil {
+		return err
+	}
 	if listDir != nil {
-		// Convention-based discovery: scan cacheDir/skills/*/SKILL.md. Unlike
-		// commands/agents — where a manifest list REPLACES the default scan —
-		// `skills` ADDS to it: the default skills/ directory is ALWAYS scanned and
-		// its skills load ALONGSIDE any the manifest lists, matching Claude Code's
-		// path-behavior rules. A skill that appears in both the manifest list and
-		// the scan resolves to the same dir and collapses in resolveConflicts.
 		discovered, err := discoverSkillDirs(filepath.Join(cacheDir, "skills"), listDir)
 		switch {
 		case errors.Is(err, errSkillSanityCap):
@@ -325,79 +330,52 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		case err != nil:
 			slog.Warn("plugin skills convention-discovery failed", "cacheDir", cacheDir, "error", err)
 		default:
-			skillPaths = append(skillPaths, discovered...)
-		}
-	}
-	for _, sk := range skillPaths {
-		p, err := resolveComponentPath(sk, cacheDir)
-		if err != nil {
-			return err
-		}
-		skill, err := loadSkillEntry(p, readFile, listDir)
-		if err != nil {
-			return fmt.Errorf("load skill %q: %w", sk, err)
-		}
-		if skill != nil {
-			pr.Skills = append(pr.Skills, *skill)
+			if err := appendSkillEntries(pr, discovered, cacheDir, readFile, listDir, true); err != nil {
+				return err
+			}
 		}
 	}
 
+	// Commands: a listed `commands` field REPLACES the default commands/ scan, an
+	// absent one falls back to it (Claude's plugin convention). Without this, a
+	// plugin that ships its command(s) only in the conventional directory (the
+	// common case — most plugins omit the manifest field, e.g. the official
+	// code-review's commands/code-review.md) projected as "no components".
 	commandPaths := toStringSlice(manifest.Commands)
+	discoveredCommands := false
 	if len(commandPaths) == 0 && listDir != nil {
-		// Convention-based discovery: when plugin.json lists no `commands`, scan
-		// the default commands/ directory. This mirrors Claude Code's plugin
-		// convention — a listed `commands` field REPLACES the default scan, an
-		// absent one falls back to it. Without this, a plugin that ships its
-		// command(s) only in the conventional directory (the overwhelmingly
-		// common case — most plugins omit the manifest field entirely, e.g. the
-		// official code-review's commands/code-review.md) projected as "no
-		// components" instead of the command it plainly ships.
 		discovered, err := discoverFlatMarkdown(filepath.Join(cacheDir, "commands"), listDir)
 		if err != nil {
 			slog.Warn("plugin commands convention-discovery failed", "cacheDir", cacheDir, "error", err)
 		} else {
 			commandPaths = discovered
+			discoveredCommands = true
 		}
 	}
-	for _, cmd := range commandPaths {
-		p, err := resolveComponentPath(cmd, cacheDir)
-		if err != nil {
-			return err
-		}
-		command, err := loadMarkdownEntry(p, readFile)
-		if err != nil {
-			return fmt.Errorf("load command %q: %w", cmd, err)
-		}
-		if command != nil {
-			pr.Commands = append(pr.Commands, source.Command{Name: command.name, Frontmatter: command.fm, Body: command.body})
-		}
+	if err := appendMarkdownComponents(commandPaths, cacheDir, readFile, discoveredCommands, "command", func(e *markdownEntry) {
+		pr.Commands = append(pr.Commands, source.Command{Name: e.name, Frontmatter: e.fm, Body: e.body})
+	}); err != nil {
+		return err
 	}
+
+	// Agents: same REPLACE convention as commands — a plugin that ships subagents
+	// only in the conventional agents/ directory (e.g. the official
+	// code-simplifier's agents/code-simplifier.md) would otherwise project nothing.
 	agentPaths := toStringSlice(manifest.Agents)
+	discoveredAgents := false
 	if len(agentPaths) == 0 && listDir != nil {
-		// Same convention-based discovery for the default agents/ directory: a
-		// plugin that ships subagents only in the conventional directory (e.g.
-		// the official code-simplifier's agents/code-simplifier.md) would
-		// otherwise project as "no components". A listed `agents` field replaces
-		// the default scan, just like commands.
 		discovered, err := discoverFlatMarkdown(filepath.Join(cacheDir, "agents"), listDir)
 		if err != nil {
 			slog.Warn("plugin agents convention-discovery failed", "cacheDir", cacheDir, "error", err)
 		} else {
 			agentPaths = discovered
+			discoveredAgents = true
 		}
 	}
-	for _, ag := range agentPaths {
-		p, err := resolveComponentPath(ag, cacheDir)
-		if err != nil {
-			return err
-		}
-		agent, err := loadMarkdownEntry(p, readFile)
-		if err != nil {
-			return fmt.Errorf("load agent %q: %w", ag, err)
-		}
-		if agent != nil {
-			pr.Subagents = append(pr.Subagents, source.Subagent{Name: agent.name, Frontmatter: agent.fm, Body: agent.body})
-		}
+	if err := appendMarkdownComponents(agentPaths, cacheDir, readFile, discoveredAgents, "agent", func(e *markdownEntry) {
+		pr.Subagents = append(pr.Subagents, source.Subagent{Name: e.name, Frontmatter: e.fm, Body: e.body})
+	}); err != nil {
+		return err
 	}
 	// Hooks: may be a string command or an object with event+command shape.
 	if manifest.Hooks != nil {
@@ -406,6 +384,71 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		// Convention-based discovery: when plugin.json carries no inline hooks,
 		// read the default hooks/hooks.json (the `{"hooks":{…}}` shape).
 		discoverConventionHooks(cacheDir, readFile, pr)
+	}
+	return nil
+}
+
+// appendMarkdownComponents loads each markdown component (command or subagent) at
+// the given paths and hands the parsed entry to add. The discovered flag selects
+// the failure policy: a convention-DISCOVERED path that fails to resolve, parse,
+// or validate is logged and skipped, because one malformed/hostile file in one
+// plugin must not abort projection for EVERY installed plugin (projection runs
+// for all of them inside explain/apply/status/diff) — the same resilience the
+// config-file discovery and the missing-file path already have. A manifest- or
+// entry-LISTED path instead propagates the error: the author named it explicitly,
+// so a broken one is a hard failure (preserving the long-standing listed-component
+// error contract).
+func appendMarkdownComponents(paths []string, cacheDir string, readFile func(string) ([]byte, error), discovered bool, kind string, add func(*markdownEntry)) error {
+	for _, ref := range paths {
+		p, err := resolveComponentPath(ref, cacheDir)
+		if err != nil {
+			if discovered {
+				slog.Warn("plugin convention-discovered component skipped (path rejected)", "kind", kind, "ref", ref, "error", err)
+				continue
+			}
+			return err
+		}
+		entry, err := loadMarkdownEntry(p, readFile)
+		if err != nil {
+			if discovered {
+				slog.Warn("plugin convention-discovered component skipped (unreadable/invalid)", "kind", kind, "ref", ref, "error", err)
+				continue
+			}
+			return fmt.Errorf("load %s %q: %w", kind, ref, err)
+		}
+		if entry != nil {
+			add(entry)
+		}
+	}
+	return nil
+}
+
+// appendSkillEntries loads each skill at the given paths into pr.Skills, applying
+// the same discovered-vs-listed failure policy as appendMarkdownComponents: a
+// convention-DISCOVERED skill whose SKILL.md is missing/malformed is skipped with
+// a warning (one bad skill must not abort projection for every plugin), while a
+// LISTED skill propagates the error loudly.
+func appendSkillEntries(pr *ProjectionResult, paths []string, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error), discovered bool) error {
+	for _, ref := range paths {
+		p, err := resolveComponentPath(ref, cacheDir)
+		if err != nil {
+			if discovered {
+				slog.Warn("plugin convention-discovered skill skipped (path rejected)", "ref", ref, "error", err)
+				continue
+			}
+			return err
+		}
+		skill, err := loadSkillEntry(p, readFile, listDir)
+		if err != nil {
+			if discovered {
+				slog.Warn("plugin convention-discovered skill skipped (unreadable/invalid)", "ref", ref, "error", err)
+				continue
+			}
+			return fmt.Errorf("load skill %q: %w", ref, err)
+		}
+		if skill != nil {
+			pr.Skills = append(pr.Skills, *skill)
+		}
 	}
 	return nil
 }

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -5,8 +5,10 @@
 // readFile function so that adapters downstream receive complete, render-ready
 // entries. Components a plugin ships in their conventional default locations
 // (skills/, commands/, agents/, .mcp.json, .lsp.json, hooks/hooks.json) are
-// convention-discovered when plugin.json does not list them — matching Claude
-// Code, which auto-discovers those defaults whether or not a manifest is present.
+// convention-discovered — matching Claude Code, which auto-discovers those
+// defaults whether or not a manifest is present. Per Claude's path-behavior
+// rules a listed commands/agents/mcp/lsp/hooks field REPLACES its default scan,
+// while a listed `skills` ADDS to the always-scanned skills/ directory.
 package marketplace
 
 import (
@@ -39,12 +41,14 @@ type ProjectionResult struct {
 //     component list; a missing plugin.json is fine (the manifest is optional —
 //     a curator-defined plugin may declare everything in the entry, and a plugin
 //     that ships only conventional directories declares nothing at all).
-//   - For each component kind the manifest does NOT list, falls back to
-//     convention-based discovery of its default location: the directory scans
-//     cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md, cacheDir/agents/*.md and
-//     the config files cacheDir/.mcp.json, cacheDir/.lsp.json,
-//     cacheDir/hooks/hooks.json. This mirrors Claude Code, where a listed
-//     component field replaces the default and an absent one falls back to it.
+//   - Convention-based discovery of each component kind's default location: the
+//     directory scans cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md,
+//     cacheDir/agents/*.md and the config files cacheDir/.mcp.json,
+//     cacheDir/.lsp.json, cacheDir/hooks/hooks.json. This mirrors Claude Code's
+//     path-behavior rules: for commands/agents/mcp/lsp/hooks a listed manifest
+//     field REPLACES the default scan (so discovery runs only when the manifest is
+//     silent), whereas `skills` ADDS to the always-scanned skills/ directory (so
+//     listed skills and conventional skills are unioned).
 //   - Then overlays any component fields on the PluginEntry itself.
 //
 // This is a UNION: plugin.json PLUS entry additions. The entry.Strict flag
@@ -271,15 +275,17 @@ func resolvePluginRootInArgs(args []string, cacheDir string) []string {
 }
 
 // applyManifest converts a PluginManifest into ProjectionResult entries.
-// listDir may be nil; when non-nil, any component kind the manifest does NOT
-// list is discovered by convention from its default location — the directory
-// scans (cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md, cacheDir/agents/*.md)
-// and the conventional config files (cacheDir/.mcp.json, cacheDir/.lsp.json,
-// cacheDir/hooks/hooks.json). A zero-value manifest (plugin.json absent) therefore
-// still discovers all of them, matching Claude Code's optional-manifest
-// auto-discovery. listDir==nil (the ProjectWithReader in-memory path) keeps
-// projection explicit-list-only, so the file-based discovery is gated on it too
-// even though it reads through readFile.
+// listDir may be nil; when non-nil, convention-based discovery fills each
+// component kind from its default location — the directory scans
+// (cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md, cacheDir/agents/*.md) and
+// the conventional config files (cacheDir/.mcp.json, cacheDir/.lsp.json,
+// cacheDir/hooks/hooks.json). For commands/agents/mcp/lsp/hooks a manifest list
+// REPLACES the scan (discovery runs only when the field is empty); `skills` is
+// always scanned and unioned (it ADDS). A zero-value manifest (plugin.json
+// absent) therefore still discovers everything, matching Claude Code's
+// optional-manifest auto-discovery. listDir==nil (the ProjectWithReader
+// in-memory path) keeps projection explicit-list-only, so the file-based
+// discovery is gated on it too even though it reads through readFile.
 func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) error {
 	if len(manifest.MCPServers) > 0 {
 		for name, raw := range manifest.MCPServers {
@@ -289,9 +295,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	} else if listDir != nil {
 		// Convention-based discovery: when plugin.json lists no mcpServers, read
 		// the default .mcp.json (the standard `{"mcpServers":{…}}` shape).
-		if err := discoverConventionMCP(cacheDir, readFile, pr); err != nil {
-			return err
-		}
+		discoverConventionMCP(cacheDir, readFile, pr)
 	}
 	if len(manifest.LSPServers) > 0 {
 		for name, raw := range manifest.LSPServers {
@@ -301,14 +305,17 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	} else if listDir != nil {
 		// Convention-based discovery: .lsp.json is a BARE name→config map (no
 		// wrapper), unlike the inline `lspServers` object — see discoverConventionLSP.
-		if err := discoverConventionLSP(cacheDir, readFile, pr); err != nil {
-			return err
-		}
+		discoverConventionLSP(cacheDir, readFile, pr)
 	}
 
 	skillPaths := toStringSlice(manifest.Skills)
-	if len(skillPaths) == 0 && listDir != nil {
-		// Convention-based discovery: scan cacheDir/skills/*/SKILL.md
+	if listDir != nil {
+		// Convention-based discovery: scan cacheDir/skills/*/SKILL.md. Unlike
+		// commands/agents — where a manifest list REPLACES the default scan —
+		// `skills` ADDS to it: the default skills/ directory is ALWAYS scanned and
+		// its skills load ALONGSIDE any the manifest lists, matching Claude Code's
+		// path-behavior rules. A skill that appears in both the manifest list and
+		// the scan resolves to the same dir and collapses in resolveConflicts.
 		discovered, err := discoverSkillDirs(filepath.Join(cacheDir, "skills"), listDir)
 		switch {
 		case errors.Is(err, errSkillSanityCap):
@@ -318,7 +325,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		case err != nil:
 			slog.Warn("plugin skills convention-discovery failed", "cacheDir", cacheDir, "error", err)
 		default:
-			skillPaths = discovered
+			skillPaths = append(skillPaths, discovered...)
 		}
 	}
 	for _, sk := range skillPaths {
@@ -398,9 +405,7 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 	} else if listDir != nil {
 		// Convention-based discovery: when plugin.json carries no inline hooks,
 		// read the default hooks/hooks.json (the `{"hooks":{…}}` shape).
-		if err := discoverConventionHooks(cacheDir, readFile, pr); err != nil {
-			return err
-		}
+		discoverConventionHooks(cacheDir, readFile, pr)
 	}
 	return nil
 }
@@ -408,64 +413,72 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 // discoverConventionMCP reads a plugin's conventional .mcp.json (the standard
 // `{"mcpServers": {…}}` document) and projects each server through the same
 // parseMCPSpec the inline plugin.json path uses, so ${CLAUDE_PLUGIN_ROOT}
-// resolution and field handling are identical. A missing file is a no-op.
-func discoverConventionMCP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
-	doc, found, err := readPluginJSON(filepath.Join(cacheDir, ".mcp.json"), readFile)
-	if err != nil || !found {
-		return err
+// resolution and field handling are identical. A missing/unreadable/malformed
+// file is a no-op (see readConventionConfig).
+func discoverConventionMCP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) {
+	doc, ok := readConventionConfig(filepath.Join(cacheDir, ".mcp.json"), readFile)
+	if !ok {
+		return
 	}
 	servers, _ := doc["mcpServers"].(map[string]any)
 	for name, raw := range servers {
 		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: parseMCPSpec(raw, cacheDir)})
 	}
-	return nil
 }
 
 // discoverConventionLSP reads a plugin's conventional .lsp.json. Unlike the
 // inline `lspServers` object, the .lsp.json file is a BARE map of language-server
 // name → config (no wrapper), per the plugin spec — so the whole document is the
-// server map. A missing file is a no-op.
-func discoverConventionLSP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
-	doc, found, err := readPluginJSON(filepath.Join(cacheDir, ".lsp.json"), readFile)
-	if err != nil || !found {
-		return err
+// server map. A missing/unreadable/malformed file is a no-op.
+func discoverConventionLSP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) {
+	doc, ok := readConventionConfig(filepath.Join(cacheDir, ".lsp.json"), readFile)
+	if !ok {
+		return
 	}
 	for name, raw := range doc {
 		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: parseLSPSpec(raw, cacheDir)})
 	}
-	return nil
 }
 
 // discoverConventionHooks reads a plugin's conventional hooks/hooks.json (the
 // `{"hooks": {…}}` document) and projects its event map through the same
-// applyHooks the inline plugin.json path uses. A missing file is a no-op.
-func discoverConventionHooks(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
-	doc, found, err := readPluginJSON(filepath.Join(cacheDir, "hooks", "hooks.json"), readFile)
-	if err != nil || !found {
-		return err
+// applyHooks the inline plugin.json path uses. A missing/unreadable/malformed
+// file, or one with no "hooks" key, is a no-op.
+func discoverConventionHooks(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) {
+	doc, ok := readConventionConfig(filepath.Join(cacheDir, "hooks", "hooks.json"), readFile)
+	if !ok {
+		return
 	}
-	if hooks, ok := doc["hooks"]; ok {
+	if hooks, found := doc["hooks"]; found {
 		applyHooks(hooks, pr, cacheDir)
 	}
-	return nil
 }
 
-// readPluginJSON reads and unmarshals one of a plugin's conventional JSON config
-// files (.mcp.json, .lsp.json, hooks/hooks.json) for convention-based discovery.
-// A missing file is not an error (found=false): a plugin need not ship every
-// conventional config.
-func readPluginJSON(path string, readFile func(string) ([]byte, error)) (doc map[string]any, found bool, err error) {
+// readConventionConfig reads and unmarshals one of a plugin's conventional JSON
+// config files (.mcp.json, .lsp.json, hooks/hooks.json) for convention-based
+// discovery. ok is false — with NO error surfaced — when the file is absent (a
+// plugin need not ship every conventional config) OR when it cannot be read or
+// parsed as a JSON object. A single malformed/unreadable config file must drop
+// only that file's components, never abort the whole projection: projection runs
+// for EVERY installed plugin inside `explain`/`apply`/`status`/`diff`, so a
+// propagated error would brick those commands for ALL plugins over one bad file
+// in one plugin — the same failure mode the lenient frontmatter parser avoids for
+// component markdown. The failure is logged, mirroring how the directory-scan
+// discovery paths (discoverFlatMarkdown/discoverSkillDirs) warn-and-skip.
+func readConventionConfig(path string, readFile func(string) ([]byte, error)) (map[string]any, bool) {
 	data, err := readFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, false, nil
+		if !os.IsNotExist(err) {
+			slog.Warn("plugin convention config unreadable; skipping", "path", path, "error", err)
 		}
-		return nil, false, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+		return nil, false
 	}
+	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return nil, false, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+		slog.Warn("plugin convention config is not a valid JSON object; skipping", "path", path, "error", err)
+		return nil, false
 	}
-	return doc, true, nil
+	return doc, true
 }
 
 // maxSkillDepth caps how many directories below skillsDir a SKILL.md may live.

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -3,7 +3,10 @@
 // model entries. Skills, commands, and subagents are fully loaded from their
 // on-disk markdown files (frontmatter + body + clean Name) via the injected
 // readFile function so that adapters downstream receive complete, render-ready
-// entries.
+// entries. Components a plugin ships in their conventional default locations
+// (skills/, commands/, agents/, .mcp.json, .lsp.json, hooks/hooks.json) are
+// convention-discovered when plugin.json does not list them — matching Claude
+// Code, which auto-discovers those defaults whether or not a manifest is present.
 package marketplace
 
 import (
@@ -33,10 +36,15 @@ type ProjectionResult struct {
 
 // Project loads the plugin's components and returns them as canonical entries:
 //   - Reads cacheDir/.claude-plugin/plugin.json (when present) for the primary
-//     component list; a missing plugin.json is fine (a curator-defined plugin
-//     may declare everything in the entry).
-//   - If the manifest lists no skills, falls back to convention-based discovery:
-//     scans cacheDir/skills/*/ for SKILL.md files.
+//     component list; a missing plugin.json is fine (the manifest is optional —
+//     a curator-defined plugin may declare everything in the entry, and a plugin
+//     that ships only conventional directories declares nothing at all).
+//   - For each component kind the manifest does NOT list, falls back to
+//     convention-based discovery of its default location: the directory scans
+//     cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md, cacheDir/agents/*.md and
+//     the config files cacheDir/.mcp.json, cacheDir/.lsp.json,
+//     cacheDir/hooks/hooks.json. This mirrors Claude Code, where a listed
+//     component field replaces the default and an absent one falls back to it.
 //   - Then overlays any component fields on the PluginEntry itself.
 //
 // This is a UNION: plugin.json PLUS entry additions. The entry.Strict flag
@@ -55,17 +63,19 @@ func Project(entry PluginEntry, cacheDir string) (ProjectionResult, error) {
 
 // ProjectWithReader is like Project but uses a caller-supplied readFile function
 // for loading plugin.json and component markdown files. This enables in-memory
-// filesystem use in tests. Convention-based discovery (skills/ directory scan)
-// is disabled when using ProjectWithReader; use Project for full behavior.
+// filesystem use in tests. Convention-based discovery (the default skills/,
+// commands/, and agents/ directory scans) is disabled when using
+// ProjectWithReader; use Project for full behavior.
 func ProjectWithReader(entry PluginEntry, cacheDir string, readFile func(string) ([]byte, error)) (ProjectionResult, error) {
 	return projectWithFuncs(entry, cacheDir, readFile, nil, false)
 }
 
 // projectWithFuncs is the internal implementation shared by Project and ProjectWithReader.
-// listDir may be nil to disable convention-based skills discovery. When lenient
-// is true, a strict-mode same-name conflict is resolved entry-wins with a logged
-// warning instead of a hard error — used by read-only/diagnostic commands that
-// must still show state (see resolveConflicts).
+// listDir may be nil to disable convention-based discovery of the default skills/,
+// commands/, and agents/ directories. When lenient is true, a strict-mode
+// same-name conflict is resolved entry-wins with a logged warning instead of a
+// hard error — used by read-only/diagnostic commands that must still show state
+// (see resolveConflicts).
 func projectWithFuncs(entry PluginEntry, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error), lenient bool) (ProjectionResult, error) {
 	var pr ProjectionResult
 
@@ -74,18 +84,23 @@ func projectWithFuncs(entry PluginEntry, cacheDir string, readFile func(string) 
 	// semantics — plugin.json PLUS entry additions/overrides — regardless of the
 	// Strict flag, so a non-strict entry never drops the plugin's own components.
 	manifestPath := filepath.Join(cacheDir, ".claude-plugin", "plugin.json")
+	var manifest PluginManifest
 	data, err := readFile(manifestPath)
-	if err != nil && !os.IsNotExist(err) {
+	switch {
+	case err != nil && !os.IsNotExist(err):
 		return pr, fmt.Errorf("read plugin.json: %w", err)
-	}
-	if err == nil {
-		var manifest PluginManifest
+	case err == nil:
 		if err := json.Unmarshal(data, &manifest); err != nil {
 			return pr, fmt.Errorf("parse plugin.json: %w", err)
 		}
-		if err := applyManifest(manifest, &pr, cacheDir, readFile, listDir); err != nil {
-			return pr, err
-		}
+	}
+	// applyManifest runs even when plugin.json is absent: the manifest is
+	// optional (Claude Code auto-discovers components in their default locations
+	// whether or not one is present), and a zero-value manifest carries no
+	// explicit component lists, so convention-based discovery of the default
+	// skills/, commands/, and agents/ directories still runs.
+	if err := applyManifest(manifest, &pr, cacheDir, readFile, listDir); err != nil {
+		return pr, err
 	}
 	if err := applyEntryOverrides(entry, &pr, cacheDir, readFile, listDir); err != nil {
 		return pr, err
@@ -256,16 +271,39 @@ func resolvePluginRootInArgs(args []string, cacheDir string) []string {
 }
 
 // applyManifest converts a PluginManifest into ProjectionResult entries.
-// listDir may be nil; when non-nil and the manifest lists no skills, skills
-// are discovered by convention from cacheDir/skills/*/SKILL.md.
+// listDir may be nil; when non-nil, any component kind the manifest does NOT
+// list is discovered by convention from its default location — the directory
+// scans (cacheDir/skills/*/SKILL.md, cacheDir/commands/*.md, cacheDir/agents/*.md)
+// and the conventional config files (cacheDir/.mcp.json, cacheDir/.lsp.json,
+// cacheDir/hooks/hooks.json). A zero-value manifest (plugin.json absent) therefore
+// still discovers all of them, matching Claude Code's optional-manifest
+// auto-discovery. listDir==nil (the ProjectWithReader in-memory path) keeps
+// projection explicit-list-only, so the file-based discovery is gated on it too
+// even though it reads through readFile.
 func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir string, readFile func(string) ([]byte, error), listDir func(string) ([]os.DirEntry, error)) error {
-	for name, raw := range manifest.MCPServers {
-		spec := parseMCPSpec(raw, cacheDir)
-		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
+	if len(manifest.MCPServers) > 0 {
+		for name, raw := range manifest.MCPServers {
+			spec := parseMCPSpec(raw, cacheDir)
+			pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: spec})
+		}
+	} else if listDir != nil {
+		// Convention-based discovery: when plugin.json lists no mcpServers, read
+		// the default .mcp.json (the standard `{"mcpServers":{…}}` shape).
+		if err := discoverConventionMCP(cacheDir, readFile, pr); err != nil {
+			return err
+		}
 	}
-	for name, raw := range manifest.LSPServers {
-		spec := parseLSPSpec(raw, cacheDir)
-		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
+	if len(manifest.LSPServers) > 0 {
+		for name, raw := range manifest.LSPServers {
+			spec := parseLSPSpec(raw, cacheDir)
+			pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: spec})
+		}
+	} else if listDir != nil {
+		// Convention-based discovery: .lsp.json is a BARE name→config map (no
+		// wrapper), unlike the inline `lspServers` object — see discoverConventionLSP.
+		if err := discoverConventionLSP(cacheDir, readFile, pr); err != nil {
+			return err
+		}
 	}
 
 	skillPaths := toStringSlice(manifest.Skills)
@@ -297,7 +335,24 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 
-	for _, cmd := range toStringSlice(manifest.Commands) {
+	commandPaths := toStringSlice(manifest.Commands)
+	if len(commandPaths) == 0 && listDir != nil {
+		// Convention-based discovery: when plugin.json lists no `commands`, scan
+		// the default commands/ directory. This mirrors Claude Code's plugin
+		// convention — a listed `commands` field REPLACES the default scan, an
+		// absent one falls back to it. Without this, a plugin that ships its
+		// command(s) only in the conventional directory (the overwhelmingly
+		// common case — most plugins omit the manifest field entirely, e.g. the
+		// official code-review's commands/code-review.md) projected as "no
+		// components" instead of the command it plainly ships.
+		discovered, err := discoverFlatMarkdown(filepath.Join(cacheDir, "commands"), listDir)
+		if err != nil {
+			slog.Warn("plugin commands convention-discovery failed", "cacheDir", cacheDir, "error", err)
+		} else {
+			commandPaths = discovered
+		}
+	}
+	for _, cmd := range commandPaths {
 		p, err := resolveComponentPath(cmd, cacheDir)
 		if err != nil {
 			return err
@@ -310,7 +365,21 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 			pr.Commands = append(pr.Commands, source.Command{Name: command.name, Frontmatter: command.fm, Body: command.body})
 		}
 	}
-	for _, ag := range toStringSlice(manifest.Agents) {
+	agentPaths := toStringSlice(manifest.Agents)
+	if len(agentPaths) == 0 && listDir != nil {
+		// Same convention-based discovery for the default agents/ directory: a
+		// plugin that ships subagents only in the conventional directory (e.g.
+		// the official code-simplifier's agents/code-simplifier.md) would
+		// otherwise project as "no components". A listed `agents` field replaces
+		// the default scan, just like commands.
+		discovered, err := discoverFlatMarkdown(filepath.Join(cacheDir, "agents"), listDir)
+		if err != nil {
+			slog.Warn("plugin agents convention-discovery failed", "cacheDir", cacheDir, "error", err)
+		} else {
+			agentPaths = discovered
+		}
+	}
+	for _, ag := range agentPaths {
 		p, err := resolveComponentPath(ag, cacheDir)
 		if err != nil {
 			return err
@@ -324,8 +393,79 @@ func applyManifest(manifest PluginManifest, pr *ProjectionResult, cacheDir strin
 		}
 	}
 	// Hooks: may be a string command or an object with event+command shape.
-	applyHooks(manifest.Hooks, pr, cacheDir)
+	if manifest.Hooks != nil {
+		applyHooks(manifest.Hooks, pr, cacheDir)
+	} else if listDir != nil {
+		// Convention-based discovery: when plugin.json carries no inline hooks,
+		// read the default hooks/hooks.json (the `{"hooks":{…}}` shape).
+		if err := discoverConventionHooks(cacheDir, readFile, pr); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// discoverConventionMCP reads a plugin's conventional .mcp.json (the standard
+// `{"mcpServers": {…}}` document) and projects each server through the same
+// parseMCPSpec the inline plugin.json path uses, so ${CLAUDE_PLUGIN_ROOT}
+// resolution and field handling are identical. A missing file is a no-op.
+func discoverConventionMCP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
+	doc, found, err := readPluginJSON(filepath.Join(cacheDir, ".mcp.json"), readFile)
+	if err != nil || !found {
+		return err
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	for name, raw := range servers {
+		pr.MCPServers = append(pr.MCPServers, source.MCPServer{ID: name, Server: parseMCPSpec(raw, cacheDir)})
+	}
+	return nil
+}
+
+// discoverConventionLSP reads a plugin's conventional .lsp.json. Unlike the
+// inline `lspServers` object, the .lsp.json file is a BARE map of language-server
+// name → config (no wrapper), per the plugin spec — so the whole document is the
+// server map. A missing file is a no-op.
+func discoverConventionLSP(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
+	doc, found, err := readPluginJSON(filepath.Join(cacheDir, ".lsp.json"), readFile)
+	if err != nil || !found {
+		return err
+	}
+	for name, raw := range doc {
+		pr.LSPServers = append(pr.LSPServers, source.LSPServer{ID: name, Spec: parseLSPSpec(raw, cacheDir)})
+	}
+	return nil
+}
+
+// discoverConventionHooks reads a plugin's conventional hooks/hooks.json (the
+// `{"hooks": {…}}` document) and projects its event map through the same
+// applyHooks the inline plugin.json path uses. A missing file is a no-op.
+func discoverConventionHooks(cacheDir string, readFile func(string) ([]byte, error), pr *ProjectionResult) error {
+	doc, found, err := readPluginJSON(filepath.Join(cacheDir, "hooks", "hooks.json"), readFile)
+	if err != nil || !found {
+		return err
+	}
+	if hooks, ok := doc["hooks"]; ok {
+		applyHooks(hooks, pr, cacheDir)
+	}
+	return nil
+}
+
+// readPluginJSON reads and unmarshals one of a plugin's conventional JSON config
+// files (.mcp.json, .lsp.json, hooks/hooks.json) for convention-based discovery.
+// A missing file is not an error (found=false): a plugin need not ship every
+// conventional config.
+func readPluginJSON(path string, readFile func(string) ([]byte, error)) (doc map[string]any, found bool, err error) {
+	data, err := readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, false, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	return doc, true, nil
 }
 
 // maxSkillDepth caps how many directories below skillsDir a SKILL.md may live.
@@ -434,6 +574,42 @@ func discoverSkillDirs(skillsDir string, listDir func(string) ([]os.DirEntry, er
 	if err := walk(skillsDir, 0); err != nil {
 		return nil, err
 	}
+	return paths, nil
+}
+
+// discoverFlatMarkdown returns the absolute path of every regular *.md file
+// directly inside dir, sorted for determinism. It backs the convention-based
+// discovery of a plugin's commands/ and agents/ directories — the default
+// locations Claude Code auto-loads when plugin.json lists no `commands`/`agents`
+// (the common case: a plugin ships those components in the conventional
+// directory and omits the manifest field). A missing dir yields no paths and no
+// error — a plugin need not ship every component kind.
+//
+// The scan is deliberately NOT recursive: plugin commands and agents are flat
+// markdown files per the plugin spec, so descending would sweep in unrelated or
+// nested files. Non-regular entries are skipped — subdirectories, and (because a
+// fetched plugin repo is untrusted) symlinks, which IsRegular() reports false for
+// — so a symlink can never pull foreign content into the projection, matching the
+// symlink guard in collectSkillFiles.
+func discoverFlatMarkdown(dir string, listDir func(string) ([]os.DirEntry, error)) ([]string, error) {
+	entries, err := listDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var paths []string
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(paths)
 	return paths, nil
 }
 
@@ -684,74 +860,91 @@ func validateProjectedName(kind, name string) error {
 }
 
 // applyHooks interprets the hooks field (string | []string | map) and appends
-// Hook entries. Hook format from plugin.json can be:
+// Hook entries. Hook format from plugin.json — and the conventional
+// hooks/hooks.json — can be:
 //   - a plain command string → PreToolUse catch-all
 //   - []string → each a PreToolUse catch-all
-//   - map[event]command or map[event][]hookObj
+//   - map[event] → a command string, a group object, or a []group, where a
+//     group is the canonical Claude shape {matcher, hooks:[{type,command},…]}
+//     or a simplified flat {matcher, command}.
 func applyHooks(hooks any, pr *ProjectionResult, cacheDir string) {
 	if hooks == nil {
 		return
 	}
 	switch v := hooks.(type) {
 	case string:
-		pr.Hooks = append(pr.Hooks, source.Hook{
-			Event:   "PreToolUse",
-			Matcher: "*",
-			Type:    "command",
-			Command: resolvePluginRoot(v, cacheDir),
-		})
+		appendCommandHook(pr, "PreToolUse", "*", "command", v, cacheDir)
 	case []any:
 		for _, item := range v {
 			if s, ok := item.(string); ok {
-				pr.Hooks = append(pr.Hooks, source.Hook{
-					Event:   "PreToolUse",
-					Matcher: "*",
-					Type:    "command",
-					Command: resolvePluginRoot(s, cacheDir),
-				})
+				appendCommandHook(pr, "PreToolUse", "*", "command", s, cacheDir)
 			}
 		}
 	case map[string]any:
 		for event, val := range v {
 			switch ev := val.(type) {
 			case string:
-				pr.Hooks = append(pr.Hooks, source.Hook{
-					Event:   event,
-					Matcher: "*",
-					Type:    "command",
-					Command: resolvePluginRoot(ev, cacheDir),
-				})
+				appendCommandHook(pr, event, "*", "command", ev, cacheDir)
 			case map[string]any:
-				cmd, _ := ev["command"].(string)
-				matcher, _ := ev["matcher"].(string)
-				if matcher == "" {
-					matcher = "*"
-				}
-				pr.Hooks = append(pr.Hooks, source.Hook{
-					Event:   event,
-					Matcher: matcher,
-					Type:    "command",
-					Command: resolvePluginRoot(cmd, cacheDir),
-				})
+				appendHookGroup(pr, event, ev, cacheDir)
 			case []any:
 				for _, item := range ev {
 					if m, ok := item.(map[string]any); ok {
-						cmd, _ := m["command"].(string)
-						matcher, _ := m["matcher"].(string)
-						if matcher == "" {
-							matcher = "*"
-						}
-						pr.Hooks = append(pr.Hooks, source.Hook{
-							Event:   event,
-							Matcher: matcher,
-							Type:    "command",
-							Command: resolvePluginRoot(cmd, cacheDir),
-						})
+						appendHookGroup(pr, event, m, cacheDir)
 					}
 				}
 			}
 		}
 	}
+}
+
+// appendHookGroup appends the hook(s) one event-group object describes. It
+// handles the canonical Claude shape {matcher, hooks:[{type,command},…]} (one
+// Hook per nested entry, all carrying the group's matcher) and the simplified
+// flat {matcher, command} shape, distinguished by whether a nested "hooks" array
+// is present.
+func appendHookGroup(pr *ProjectionResult, event string, group map[string]any, cacheDir string) {
+	matcher, _ := group["matcher"].(string)
+	if matcher == "" {
+		matcher = "*"
+	}
+	if nested, ok := group["hooks"].([]any); ok {
+		for _, h := range nested {
+			m, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, _ := m["type"].(string)
+			if typ == "" {
+				typ = "command"
+			}
+			cmd, _ := m["command"].(string)
+			appendCommandHook(pr, event, matcher, typ, cmd, cacheDir)
+		}
+		return
+	}
+	typ, _ := group["type"].(string)
+	if typ == "" {
+		typ = "command"
+	}
+	cmd, _ := group["command"].(string)
+	appendCommandHook(pr, event, matcher, typ, cmd, cacheDir)
+}
+
+// appendCommandHook appends a single hook, resolving ${CLAUDE_PLUGIN_ROOT} in the
+// command. An entry with no command is skipped rather than projected as an empty,
+// no-op hook — this also drops the hook types agentsync's command-only Hook model
+// does not represent (http/mcp_tool/prompt/agent), which carry no shell command.
+func appendCommandHook(pr *ProjectionResult, event, matcher, typ, command, cacheDir string) {
+	if command == "" {
+		return
+	}
+	pr.Hooks = append(pr.Hooks, source.Hook{
+		Event:   event,
+		Matcher: matcher,
+		Type:    typ,
+		Command: resolvePluginRoot(command, cacheDir),
+	})
 }
 
 // parseMCPSpec converts a raw map (from JSON) into a source.MCPServerSpec,

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -686,7 +686,11 @@ type markdownEntry struct {
 // loadSkillEntry reads a skill path which may be either a directory containing
 // SKILL.md or a SKILL.md file directly. Returns nil (no error) if the file is
 // simply missing — the caller should skip that entry with a warning.
-// Returns an error only for real I/O problems or malformed frontmatter.
+// Returns an error only for real I/O problems or frontmatter neither the strict
+// nor the lenient YAML parser can read. Frontmatter is parsed the way Claude Code
+// reads it (source.ParseFrontmatterWithReport): a `description` with bare colons —
+// valid to Claude, invalid to strict YAML — is recovered leniently with a warning
+// rather than failing the projection.
 //
 // A skill is a DIRECTORY, not just SKILL.md: when listDir is non-nil, every
 // other file under the skill directory (scripts/, references/, assets/, nested
@@ -723,9 +727,12 @@ func loadSkillEntry(path string, readFile func(string) ([]byte, error), listDir 
 		skillPath = path
 	}
 
-	fm, body, err := source.ParseFrontmatter(data)
+	fm, body, lenient, err := source.ParseFrontmatterWithReport(data)
 	if err != nil {
 		return nil, fmt.Errorf("parse frontmatter in %s: %w", skillPath, err)
+	}
+	if lenient {
+		slog.Warn("plugin skill frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')", "path", skillPath)
 	}
 
 	// Derive name: prefer frontmatter "name" key, fall back to basename of the resolved path.
@@ -810,9 +817,13 @@ func collectSkillFiles(skillDir string, readFile func(string) ([]byte, error), l
 	return files, nil
 }
 
-// loadMarkdownEntry reads a markdown file at path. Returns nil (no error) if
-// the file is simply missing — the caller should skip that entry with a
-// warning. Returns an error for I/O failures or malformed frontmatter.
+// loadMarkdownEntry reads a markdown file at path (a command or subagent).
+// Returns nil (no error) if the file is simply missing — the caller should skip
+// that entry with a warning. Returns an error for I/O failures or frontmatter
+// neither the strict nor the lenient YAML parser can read. Like Claude Code (and
+// the adapter Ingest paths), it parses via source.ParseFrontmatterWithReport, so
+// a `description` containing bare colons — which strict YAML rejects but Claude
+// accepts — is recovered leniently with a warning instead of failing.
 func loadMarkdownEntry(path string, readFile func(string) ([]byte, error)) (*markdownEntry, error) {
 	data, err := readFile(path)
 	if err != nil {
@@ -823,9 +834,12 @@ func loadMarkdownEntry(path string, readFile func(string) ([]byte, error)) (*mar
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
-	fm, body, err := source.ParseFrontmatter(data)
+	fm, body, lenient, err := source.ParseFrontmatterWithReport(data)
 	if err != nil {
 		return nil, fmt.Errorf("parse frontmatter in %s: %w", path, err)
+	}
+	if lenient {
+		slog.Warn("plugin component frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')", "path", path)
 	}
 
 	// Derive name: prefer frontmatter "name" key, fall back to basename without .md.

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -137,6 +137,354 @@ func TestProject_StrictPluginJSON_MultipleComponents(t *testing.T) {
 	}
 }
 
+// TestProject_ConventionCommands is the regression for the reported bug:
+// `explain code-review@…` showed "no components" because a plugin whose
+// plugin.json omits the `commands` field — the common case — was never scanned
+// for the conventional commands/ directory. Claude Code auto-discovers
+// commands/*.md; agentsync must too, or it silently drops the command the plugin
+// plainly ships.
+func TestProject_ConventionCommands(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// plugin.json lists NO commands — exactly like the official code-review plugin.
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"code-review","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "code-review.md"),
+		[]byte("---\ndescription: Review the diff\n---\nDo the review.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "code-review"}, cache)
+	if err != nil {
+		t.Fatalf("Project should convention-discover commands/, not fail: %v", err)
+	}
+	if len(pr.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1 (commands/code-review.md must be discovered)", len(pr.Commands))
+	}
+	// No frontmatter name → derives from the filename.
+	if pr.Commands[0].Name != "code-review" {
+		t.Errorf("command name = %q, want code-review", pr.Commands[0].Name)
+	}
+	if pr.Commands[0].Body == "" {
+		t.Error("discovered command has empty body")
+	}
+}
+
+// TestProject_ConventionAgents is the sibling of the commands case: the official
+// code-simplifier plugin ships agents/code-simplifier.md with a plugin.json that
+// lists no `agents` field, so `explain code-simplifier@…` reported "no
+// components". The conventional agents/ directory must be scanned too.
+func TestProject_ConventionAgents(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"code-simplifier","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "agents", "code-simplifier.md"),
+		[]byte("---\nname: code-simplifier\ndescription: Simplifies code\n---\nSimplify.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "code-simplifier"}, cache)
+	if err != nil {
+		t.Fatalf("Project should convention-discover agents/, not fail: %v", err)
+	}
+	if len(pr.Subagents) != 1 {
+		t.Fatalf("subagents = %d, want 1 (agents/code-simplifier.md must be discovered)", len(pr.Subagents))
+	}
+	if pr.Subagents[0].Name != "code-simplifier" {
+		t.Errorf("subagent name = %q, want code-simplifier", pr.Subagents[0].Name)
+	}
+}
+
+// TestProject_ManifestCommandsReplaceConvention verifies Claude Code's "replace"
+// semantics: when plugin.json DOES list `commands`, the default commands/ scan is
+// suppressed, so a command sitting in commands/ that the manifest deliberately
+// omits is NOT projected. (Skills, by contrast, ADD to the default scan; commands
+// and agents replace it.)
+func TestProject_ManifestCommandsReplaceConvention(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Manifest lists only custom/explicit.md; commands/excluded.md must be ignored.
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p","commands":["./custom/explicit.md"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "custom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "custom", "explicit.md"),
+		[]byte("---\nname: explicit\n---\nExplicit.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "excluded.md"),
+		[]byte("---\nname: excluded\n---\nExcluded.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1 (manifest list replaces the default scan)", len(pr.Commands))
+	}
+	if pr.Commands[0].Name != "explicit" {
+		t.Errorf("command name = %q, want explicit (commands/excluded.md must NOT be scanned)", pr.Commands[0].Name)
+	}
+}
+
+// TestProject_ConventionDiscovery_NoPluginJSON proves the manifest is optional:
+// a plugin with NO plugin.json but a conventional commands/ or agents/ directory
+// is still discovered (Claude Code auto-discovers default locations whether or
+// not a manifest is present).
+func TestProject_ConventionDiscovery_NoPluginJSON(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "bare.md"),
+		[]byte("---\nname: bare\n---\nBare command.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "agents", "helper.md"),
+		[]byte("---\nname: helper\n---\nHelper agent.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "bare-plugin"}, cache)
+	if err != nil {
+		t.Fatalf("Project with no plugin.json should still discover conventional dirs: %v", err)
+	}
+	if len(pr.Commands) != 1 {
+		t.Errorf("commands = %d, want 1 (no plugin.json must not disable discovery)", len(pr.Commands))
+	}
+	if len(pr.Subagents) != 1 {
+		t.Errorf("subagents = %d, want 1 (no plugin.json must not disable discovery)", len(pr.Subagents))
+	}
+}
+
+// TestProject_ConventionCommands_IgnoresNonMarkdown confirms the flat scan picks
+// up only *.md files and skips subdirectories, so a stray README or a nested
+// directory in commands/ does not get mis-projected as a command.
+func TestProject_ConventionCommands_IgnoresNonMarkdown(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmds := filepath.Join(cache, "commands")
+	if err := os.MkdirAll(filepath.Join(cmds, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmds, "real.md"),
+		[]byte("---\nname: real\n---\nReal.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmds, "notes.txt"), []byte("not a command\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmds, "nested", "deep.md"),
+		[]byte("---\nname: deep\n---\nDeep.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1 (only top-level real.md; .txt and nested/ skipped)", len(pr.Commands))
+	}
+	if pr.Commands[0].Name != "real" {
+		t.Errorf("command name = %q, want real", pr.Commands[0].Name)
+	}
+}
+
+// TestProject_ConventionMCP discovers a plugin's conventional .mcp.json when
+// plugin.json lists no mcpServers (the default-location auto-discovery Claude
+// Code performs for the standard `{"mcpServers":{…}}` file).
+func TestProject_ConventionMCP(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".mcp.json"),
+		[]byte(`{"mcpServers":{"db":{"command":"${CLAUDE_PLUGIN_ROOT}/db","args":["--serve"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.MCPServers) != 1 {
+		t.Fatalf("mcp = %d, want 1 (.mcp.json must be discovered)", len(pr.MCPServers))
+	}
+	if pr.MCPServers[0].ID != "db" {
+		t.Errorf("mcp id = %q, want db", pr.MCPServers[0].ID)
+	}
+	if !strings.HasPrefix(pr.MCPServers[0].Server.Command, cache) {
+		t.Errorf("CLAUDE_PLUGIN_ROOT not resolved in .mcp.json: %s", pr.MCPServers[0].Server.Command)
+	}
+}
+
+// TestProject_ManifestMCPReplacesConvention verifies the inline mcpServers
+// suppress the .mcp.json scan, so a server present only in .mcp.json is ignored
+// when plugin.json declares its own — replace, not union-with-the-file.
+func TestProject_ManifestMCPReplacesConvention(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p","mcpServers":{"inline":{"command":"x"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".mcp.json"),
+		[]byte(`{"mcpServers":{"fromfile":{"command":"y"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.MCPServers) != 1 || pr.MCPServers[0].ID != "inline" {
+		t.Fatalf("mcp = %+v, want only the inline server (.mcp.json must be suppressed)", pr.MCPServers)
+	}
+}
+
+// TestProject_ConventionLSP discovers a plugin's conventional .lsp.json. The file
+// is a BARE name→config map (no `lspServers` wrapper, unlike the inline form).
+func TestProject_ConventionLSP(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Bare map: language-server name → config, NO wrapper.
+	if err := os.WriteFile(filepath.Join(cache, ".lsp.json"),
+		[]byte(`{"go":{"command":"gopls","args":["serve"]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.LSPServers) != 1 {
+		t.Fatalf("lsp = %d, want 1 (.lsp.json must be discovered)", len(pr.LSPServers))
+	}
+	if pr.LSPServers[0].ID != "go" {
+		t.Errorf("lsp id = %q, want go", pr.LSPServers[0].ID)
+	}
+	if pr.LSPServers[0].Spec.Command != "gopls" {
+		t.Errorf("lsp command = %q, want gopls", pr.LSPServers[0].Spec.Command)
+	}
+}
+
+// TestProject_ConventionHooks discovers a plugin's conventional hooks/hooks.json
+// in the canonical `{"hooks":{event:[{matcher,hooks:[{type,command}]}]}}` shape.
+func TestProject_ConventionHooks(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hooksJSON := `{"hooks":{"PostToolUse":[{"matcher":"Write|Edit","hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/fmt.sh"}]}]}}`
+	if err := os.WriteFile(filepath.Join(cache, "hooks", "hooks.json"), []byte(hooksJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Hooks) != 1 {
+		t.Fatalf("hooks = %d, want 1 (hooks/hooks.json must be discovered)", len(pr.Hooks))
+	}
+	h := pr.Hooks[0]
+	if h.Event != "PostToolUse" || h.Matcher != "Write|Edit" {
+		t.Errorf("hook event/matcher = %q/%q, want PostToolUse/Write|Edit", h.Event, h.Matcher)
+	}
+	if !strings.HasPrefix(h.Command, cache) {
+		t.Errorf("CLAUDE_PLUGIN_ROOT not resolved in hooks.json: %s", h.Command)
+	}
+}
+
+// TestProject_Hooks_NestedFormat covers the canonical nested hooks shape arriving
+// inline via plugin.json — {event:[{matcher,hooks:[{type,command},…]}]} — with
+// two nested entries under one matcher group both projected, each carrying the
+// group's matcher. A non-command hook entry (no command) is dropped, not
+// projected as an empty hook.
+func TestProject_Hooks_NestedFormat(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"p","hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[` +
+		`{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/a.sh"},` +
+		`{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/b.sh"},` +
+		`{"type":"http","url":"https://example.com"}]}]}}`
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Hooks) != 2 {
+		t.Fatalf("hooks = %d, want 2 (two command entries; the http entry has no command and is dropped)", len(pr.Hooks))
+	}
+	for _, h := range pr.Hooks {
+		if h.Event != "PreToolUse" || h.Matcher != "Bash" {
+			t.Errorf("hook event/matcher = %q/%q, want PreToolUse/Bash", h.Event, h.Matcher)
+		}
+		if !strings.HasPrefix(h.Command, cache) {
+			t.Errorf("command not resolved: %s", h.Command)
+		}
+	}
+}
+
 // TestProject_SkillBundledFiles proves a plugin-bundled skill is projected as a
 // DIRECTORY: scripts/, references/, and nested files come along (with the
 // script's executable bit preserved), not just SKILL.md. This is the plugin/

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -741,6 +741,56 @@ func TestProject_ConventionMarkdown_MalformedSkipped(t *testing.T) {
 	}
 }
 
+// TestProject_ConventionSkill_MalformedSkipped is the skills-path twin of
+// TestProject_ConventionMarkdown_MalformedSkipped. Skills load through a separate
+// helper (appendSkillEntries, not appendMarkdownComponents), so its
+// discovered-skip branch needs its own coverage — and the CHANGELOG explicitly
+// names skills/*/SKILL.md in the "one bad file can't brick every plugin" claim.
+// A convention-discovered SKILL.md that can't be parsed (unterminated frontmatter)
+// or has a traversal name is skipped; a valid sibling skill still projects.
+func TestProject_ConventionSkill_MalformedSkipped(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Valid skill.
+	if err := os.MkdirAll(filepath.Join(cache, "skills", "good"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "skills", "good", "SKILL.md"),
+		[]byte("---\nname: good-skill\ndescription: d\n---\nFine.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Unterminated frontmatter — not recovered by the lenient parser.
+	if err := os.MkdirAll(filepath.Join(cache, "skills", "broken"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "skills", "broken", "SKILL.md"),
+		[]byte("---\nname: broken\ndescription: oops\nno closing fence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Hostile traversal name.
+	if err := os.MkdirAll(filepath.Join(cache, "skills", "evil"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "skills", "evil", "SKILL.md"),
+		[]byte("---\nname: ../../evil\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatalf("a malformed DISCOVERED skill must be skipped, not abort the projection: %v", err)
+	}
+	if len(pr.Skills) != 1 || pr.Skills[0].Name != "good-skill" {
+		t.Fatalf("expected only the good skill to survive the broken siblings; got %+v", pr.Skills)
+	}
+}
+
 // TestProject_ListedCommand_MalformedErrors pins the other half of the contract:
 // a manifest-LISTED command (the author named it explicitly) with malformed
 // frontmatter is still a HARD error — only convention-discovered files are

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -531,6 +531,173 @@ func TestProject_Hooks_NestedFormat(t *testing.T) {
 	}
 }
 
+// TestProject_SkillsAddToConventionScan pins the upstream "skills ADD" exception:
+// a manifest that lists a skill does NOT suppress the default skills/ scan (unlike
+// commands/agents, where a listed field replaces the scan). Both the listed skill
+// and the conventional one must be projected.
+func TestProject_SkillsAddToConventionScan(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Manifest lists a skill in a custom dir; a second skill lives in the
+	// conventional skills/ directory and is NOT listed.
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p","skills":["./custom/listed"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "custom", "listed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "custom", "listed", "SKILL.md"),
+		[]byte("---\nname: listed-skill\ndescription: d\n---\nListed.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "skills", "conventional"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "skills", "conventional", "SKILL.md"),
+		[]byte("---\nname: conventional-skill\ndescription: d\n---\nConventional.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, s := range pr.Skills {
+		got[s.Name] = true
+	}
+	if !got["listed-skill"] {
+		t.Errorf("listed skill missing: %v", got)
+	}
+	if !got["conventional-skill"] {
+		t.Errorf("conventional skills/ skill dropped — skills must ADD to the default scan, not replace it: %v", got)
+	}
+}
+
+// TestProject_ConventionConfig_MalformedSkipped is the regression for the
+// "one bad file bricks every plugin" hole: a malformed .mcp.json / .lsp.json /
+// hooks.json must drop only that file's components (with a warning), never abort
+// the whole projection — which runs for every installed plugin, so an error would
+// break `explain`/`apply`/`status` for ALL of them. A valid command discovered
+// alongside the broken config files must still project.
+func TestProject_ConventionConfig_MalformedSkipped(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Three differently-broken JSON configs: truncated object, a JSON array
+	// (not an object), and a bare scalar.
+	if err := os.WriteFile(filepath.Join(cache, ".mcp.json"), []byte(`{"mcpServers": {`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".lsp.json"), []byte(`["not","an","object"]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "hooks", "hooks.json"), []byte(`"garbage"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A perfectly good command in the conventional dir alongside the broken files.
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "ok.md"),
+		[]byte("---\nname: ok\n---\nFine.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatalf("malformed config files must be skipped, not abort the projection: %v", err)
+	}
+	if len(pr.MCPServers) != 0 || len(pr.LSPServers) != 0 || len(pr.Hooks) != 0 {
+		t.Errorf("malformed configs must contribute nothing; mcp=%d lsp=%d hooks=%d",
+			len(pr.MCPServers), len(pr.LSPServers), len(pr.Hooks))
+	}
+	if len(pr.Commands) != 1 || pr.Commands[0].Name != "ok" {
+		t.Errorf("the valid command must still project past the broken configs; commands=%+v", pr.Commands)
+	}
+}
+
+// TestProject_ConventionHooks_NoHooksKey verifies a hooks.json that parses but
+// lacks the "hooks" wrapper key is a clean no-op (not an error, not a panic).
+func TestProject_ConventionHooks_NoHooksKey(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "hooks", "hooks.json"), []byte(`{"notHooks": {}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Hooks) != 0 {
+		t.Errorf("hooks.json without a \"hooks\" key must contribute no hooks; got %d", len(pr.Hooks))
+	}
+}
+
+// TestProject_ConventionCommands_SkipsSymlink proves discoverFlatMarkdown does not
+// follow a symlink: a fetched plugin repo is untrusted, so a symlinked command
+// pointing at a file OUTSIDE the plugin cache must never pull that foreign content
+// into the projection.
+func TestProject_ConventionCommands_SkipsSymlink(t *testing.T) {
+	cache := t.TempDir()
+	// Foreign target lives outside the plugin cache.
+	foreign := filepath.Join(t.TempDir(), "foreign.md")
+	if err := os.WriteFile(foreign, []byte("---\nname: leaked-via-symlink\n---\nLeaked.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "real.md"),
+		[]byte("---\nname: real\n---\nReal.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(foreign, filepath.Join(cache, "commands", "sneaky.md")); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range pr.Commands {
+		if c.Name == "leaked-via-symlink" {
+			t.Fatalf("symlinked command pulled foreign content into the projection: %+v", pr.Commands)
+		}
+	}
+	if len(pr.Commands) != 1 || pr.Commands[0].Name != "real" {
+		t.Errorf("expected only the real command; got %+v", pr.Commands)
+	}
+}
+
 // TestProject_SkillBundledFiles proves a plugin-bundled skill is projected as a
 // DIRECTORY: scripts/, references/, and nested files come along (with the
 // script's executable bit preserved), not just SKILL.md. This is the plugin/

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -698,6 +698,117 @@ func TestProject_ConventionCommands_SkipsSymlink(t *testing.T) {
 	}
 }
 
+// TestProject_ConventionMarkdown_MalformedSkipped is the round-2 regression: a
+// convention-DISCOVERED command/agent that can't be loaded (unterminated
+// frontmatter the lenient parser can't recover, or a hostile traversal name) must
+// be skipped with a warning, never abort the whole projection — the same "one bad
+// file bricks every plugin" class the config-file and frontmatter fixes closed.
+// A valid sibling command must still project past the broken ones.
+func TestProject_ConventionMarkdown_MalformedSkipped(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "good.md"),
+		[]byte("---\nname: good\n---\nFine.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Unterminated frontmatter: opens "---" with no closing fence — the lenient
+	// YAML fallback does NOT recover this (it errors before the fallback).
+	if err := os.WriteFile(filepath.Join(cache, "commands", "unterminated.md"),
+		[]byte("---\nname: broken\ndescription: oops\nno closing fence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Hostile traversal name in otherwise-valid frontmatter.
+	if err := os.WriteFile(filepath.Join(cache, "commands", "evil.md"),
+		[]byte("---\nname: ../../evil\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err != nil {
+		t.Fatalf("a malformed DISCOVERED command must be skipped, not abort the projection: %v", err)
+	}
+	if len(pr.Commands) != 1 || pr.Commands[0].Name != "good" {
+		t.Fatalf("expected only the good command to survive the broken siblings; got %+v", pr.Commands)
+	}
+}
+
+// TestProject_ListedCommand_MalformedErrors pins the other half of the contract:
+// a manifest-LISTED command (the author named it explicitly) with malformed
+// frontmatter is still a HARD error — only convention-discovered files are
+// skipped. This is the contrast that keeps the discovered-vs-listed policy honest.
+func TestProject_ListedCommand_MalformedErrors(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p","commands":["./commands/bad.md"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "commands", "bad.md"),
+		[]byte("---\nname: bad\ndescription: oops\nno closing fence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err == nil {
+		t.Fatal("a LISTED command with malformed frontmatter must error, not be silently skipped")
+	}
+	if !strings.Contains(err.Error(), "frontmatter") && !strings.Contains(err.Error(), "load command") {
+		t.Errorf("error should name the malformed command load; got: %v", err)
+	}
+}
+
+// TestProject_SkillsUnion_SameNameConflict verifies the ADD union meets the
+// strict same-name conflict guard: a manifest-listed skill and a conventional
+// skills/ skill that share a frontmatter `name` but differ in content are a
+// genuine packaging conflict and must error under the default strict/fatal path —
+// the always-scan can now surface a collision the old replace-gate hid.
+func TestProject_SkillsUnion_SameNameConflict(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"p","skills":["./custom/a"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "custom", "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "custom", "a", "SKILL.md"),
+		[]byte("---\nname: shared\n---\nFROM LISTED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "skills", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "skills", "b", "SKILL.md"),
+		[]byte("---\nname: shared\n---\nFROM SCAN\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := marketplace.Project(marketplace.PluginEntry{Name: "p"}, cache)
+	if err == nil {
+		t.Fatal("a same-name skill from the manifest list and the conventional scan with different content must conflict")
+	}
+	if !strings.Contains(err.Error(), "defined twice with different content") {
+		t.Errorf("error should explain the skill conflict; got: %v", err)
+	}
+}
+
 // TestProject_SkillBundledFiles proves a plugin-bundled skill is projected as a
 // DIRECTORY: scripts/, references/, and nested files come along (with the
 // script's executable bit preserved), not just SKILL.md. This is the plugin/

--- a/internal/marketplace/projection_test.go
+++ b/internal/marketplace/projection_test.go
@@ -210,6 +210,52 @@ func TestProject_ConventionAgents(t *testing.T) {
 	}
 }
 
+// TestProject_ConventionAgents_LenientFrontmatter is the regression for the
+// pr-review-toolkit crash: an official plugin ships an agent whose `description`
+// is an unquoted scalar with bare colon-space sequences (`Context: …`, `Daisy:
+// "…"`) — valid to Claude Code, rejected by strict YAML ("mapping values are not
+// allowed in this context"). Once agents/ is convention-discovered, that file is
+// loaded, and a strict parse aborted the WHOLE projection (so `explain --all`
+// died on one plugin). Projection must parse it the way Claude does (lenient
+// fallback), recovering the agent instead of crashing.
+func TestProject_ConventionAgents_LenientFrontmatter(t *testing.T) {
+	cache := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cache, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, ".claude-plugin", "plugin.json"),
+		[]byte(`{"name":"pr-review-toolkit","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cache, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Mirrors the real silent-failure-hunter.md: a single-line description with
+	// multiple bare ": " sequences that strict YAML cannot parse.
+	body := "---\n" +
+		"name: silent-failure-hunter\n" +
+		`description: Use this agent when reviewing code. Examples: Context: Daisy did X. Daisy: "review it?" Assistant: "on it"` + "\n" +
+		"---\n" +
+		"Hunt silent failures.\n"
+	if err := os.WriteFile(filepath.Join(cache, "agents", "silent-failure-hunter.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pr, err := marketplace.Project(marketplace.PluginEntry{Name: "pr-review-toolkit"}, cache)
+	if err != nil {
+		t.Fatalf("Project must parse Claude-valid (strict-YAML-invalid) frontmatter leniently, not fail: %v", err)
+	}
+	if len(pr.Subagents) != 1 {
+		t.Fatalf("subagents = %d, want 1 (lenient-parsed agent must be recovered)", len(pr.Subagents))
+	}
+	if pr.Subagents[0].Name != "silent-failure-hunter" {
+		t.Errorf("subagent name = %q, want silent-failure-hunter", pr.Subagents[0].Name)
+	}
+	if d, _ := pr.Subagents[0].Frontmatter["description"].(string); !strings.Contains(d, "Context: Daisy") {
+		t.Errorf("description not preserved verbatim through lenient parse: %q", d)
+	}
+}
+
 // TestProject_ManifestCommandsReplaceConvention verifies Claude Code's "replace"
 // semantics: when plugin.json DOES list `commands`, the default commands/ scan is
 // suppressed, so a command sitting in commands/ that the manifest deliberately


### PR DESCRIPTION
## The bug

`agentsync explain code-review@claude-plugins-official` reported `no components` for a plugin that plainly ships `commands/code-review.md`. Same for `code-simplifier`, which ships `agents/code-simplifier.md`.

**Root cause:** plugin projection only convention-scanned the `skills/` directory. Every other component kind was read *only* from an explicit list in `plugin.json`. But Claude Code **auto-discovers** components from their default locations whether or not the manifest lists them — and most plugins (including the official ones) omit those fields entirely. So anything shipped only in a conventional location was silently dropped — the silent-drop class `CLAUDE.md` warns about.

Cross-referenced the [Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference#file-locations-reference) (file-locations table + path-behavior rules).

## The fix

Projection now discovers **every** component kind agentsync models from its conventional default location, matching Claude Code's path-behavior rules:

| Component | Default location | was discovered? | now? |
|---|---|---|---|
| Skills | `skills/*/SKILL.md` | ✓ | ✓ |
| Commands | `commands/*.md` | ✗ | ✓ |
| Agents | `agents/*.md` | ✗ | ✓ |
| MCP | `.mcp.json` | ✗ | ✓ |
| LSP | `.lsp.json` (bare map, no wrapper) | ✗ | ✓ |
| Hooks | `hooks/hooks.json` | ✗ | ✓ |

- **Replace vs. add (per upstream):** a listed `commands`/`agents`/`mcp`/`lsp`/`hooks` field **replaces** its default scan, while a listed `skills` field **adds** to the always-scanned `skills/` directory. (The prior code treated skills as "replace" too — now the code, the docs, and Claude's documented behavior agree.)
- **The manifest is truly optional** — discovery runs even when `plugin.json` is absent, so a plugin that declares nothing is still picked up.
- **Hooks** now parse the canonical nested `{matcher, hooks:[{type, command}]}` shape (used by both `hooks/hooks.json` and inline `plugin.json` hooks), emitting one hook per command entry and dropping non-command hook types the command-only `Hook` model can't represent rather than projecting an empty hook.
- The manifest-SHA pin already hashes the whole plugin cache tree, so existing installs are unaffected.

## Robustness — one bad file can't brick every plugin

Projection runs for **every** installed plugin inside `explain`/`apply`/`status`/`diff`, so a single unparseable file used to abort the command for all of them. Two real cases hit this (the second reported live; the official `pr-review-toolkit` ships an agent whose `description` is strict-YAML-invalid):

- **Frontmatter Claude accepts but strict YAML rejects** (a `description` with bare `: `) is now parsed the way Claude Code reads it (`ParseFrontmatterWithReport`, as the adapter Ingest paths already do) — recovered with a warning, not a crash.
- **A malformed/unreadable `.mcp.json`/`.lsp.json`/`hooks.json`, or a convention-discovered component whose frontmatter can't be parsed even leniently (unterminated block) or whose name is a traversal attempt**, now drops only that one component with a warning instead of aborting the projection.
- **Discovered vs. listed:** only *proactively-discovered* files are skipped. A component the author *explicitly listed* in `plugin.json` still fails loudly — a named-but-broken component is a hard error.

## Verified end-to-end (real binary)

```
▸ code-review  v1.0.0
  → claude      ✓ full        1 command
▸ code-simplifier  v1.0.0
  → claude      ✓ full        1 subagent
▸ toolkit  v2.0.0          (ships .mcp.json + .lsp.json + hooks/hooks.json only)
  → claude      ✓ full        1 mcp · 1 hook · 1 lsp
```

## Review

Ran a 3-round, four-lens adversarial review (correctness / adversarial / API-design / test-rigor) before finalizing. It caught and drove fixes for: the skills `ADD`-vs-`REPLACE` doc/code contradiction, and two "one bad file bricks every plugin" residuals (malformed JSON configs, then malformed discovered markdown). Converged at round 3 (3× `CLEAN`, last test gap closed). Deliberately deferred (reviewers concurred, not ship-blocking): DoS entry-caps on config files (the fetch layer already size-bounds input) and the `listDir`-as-"full-FS-mode" overload (documented in-code).

## Tests / checks

- 13 new projection tests, each non-vacuous — the resilience and skills-`ADD` ones are **break-verified** (they fail cleanly when their fix is reverted).
- Full suite green; `golangci-lint` 0 issues; `go.mod`/`go.sum` untouched.
- Docs updated in the same change: `CHANGELOG` (`[Unreleased]`) + projection package/contract doc comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hUsHtZ4PP9847Fq3SMogL