### PR TITLE
ci(release): deploy docs site on every published release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,16 @@ name: release
 # `--snapshot --skip publish` mode to prove the cross-build stays viable; this
 # workflow is the one that actually cuts a GitHub Release and updates the
 # Homebrew tap. Push an annotated `vX.Y.Z` tag on a green `main` commit and
-# GoReleaser takes it from there.
+# GoReleaser takes it from there. Once the release publishes, the `docs` job
+# rebuilds and redeploys the agentsync.cc site so the live docs always track the
+# just-shipped CLI version.
 on:
   push:
     tags: ["v*"]
 
-# goreleaser needs to create the GitHub Release + upload assets in THIS repo.
+# goreleaser needs to create the GitHub Release + upload assets in THIS repo,
+# and the `docs` job force-pushes the rebuilt site to the gh-pages branch — both
+# need contents:write here.
 permissions:
   contents: write
 
@@ -36,3 +40,28 @@ jobs:
           # with contents:write on the tap. If this secret is unset the brew step
           # fails; everything else (GitHub Release, deb/rpm) still publishes.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  # Redeploy agentsync.cc after a successful publish so the live docs always
+  # track the just-released CLI. This is exactly `just docs-publish` (rebuild
+  # website/ and force-push dist/ to the gh-pages branch); GitHub Pages serves
+  # gh-pages via "deploy from a branch", so no extra Actions minutes are spent
+  # rendering the site. Gated on `goreleaser` so a failed publish never ships
+  # docs claiming a version that isn't out.
+  docs:
+    name: docs-publish (agentsync.cc)
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: extractions/setup-just@v3
+      # `just docs-publish` runs `git push` from a throwaway repo it inits inside
+      # website/dist, which inherits none of actions/checkout's auth. Inject the
+      # workflow token for github.com transports so that force-push to gh-pages
+      # authenticates (contents:write, granted above).
+      - name: Authenticate git pushes to GitHub
+        run: |
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "https://github.com/"
+      - run: just docs-publish

--- a/website/README.md
+++ b/website/README.md
@@ -64,11 +64,16 @@ relevant page under `reference/` (the sync table in `CLAUDE.md` lists this).
 
 ## Deploy
 
-Pushing to `main` triggers the `docs` workflow, which builds `website/` and
-publishes `dist/` to GitHub Pages. The custom domain is set via
-[`public/CNAME`](public/CNAME). Pull requests build the site for validation but
-do not deploy.
+The site is served by GitHub Pages from the `gh-pages` branch ("deploy from a
+branch"), so serving it costs no GitHub Actions minutes. Cutting a release —
+pushing a `vX.Y.Z` tag — runs the [`release` workflow](../.github/workflows/release.yml),
+whose `docs` job rebuilds `website/` and force-pushes `dist/` to `gh-pages` once
+the CLI is published. The result: the live docs always track the latest released
+CLI. The custom domain is set via [`public/CNAME`](public/CNAME).
 
-One-time setup in the GitHub repo: **Settings → Pages → Source: GitHub Actions**,
-then add `agentsync.cc` as the custom domain (the `CNAME` file enforces it on each
-deploy).
+To redeploy out of band (e.g. a docs-only fix between releases), run
+`just docs-publish` locally — it does the same rebuild + force-push to `gh-pages`.
+
+One-time setup in the GitHub repo: **Settings → Pages → Source: Deploy from a
+branch → `gh-pages` / `(root)`**, with `agentsync.cc` as the custom domain (the
+`CNAME` file re-enforces it on each deploy).


### PR DESCRIPTION
## What

Adds a `docs` job to the `release` workflow that runs `just docs-publish` after `goreleaser` publishes, so the live [agentsync.cc](https://agentsync.cc) site is rebuilt and redeployed to the `gh-pages` branch every time a new CLI version ships. The published docs now stay in lock-step with the latest released CLI.

## How

```yaml
docs:
  name: docs-publish (agentsync.cc)
  needs: goreleaser          # only deploys if the CLI actually published
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - uses: oven-sh/setup-bun@v2
    - uses: extractions/setup-just@v3
    - name: Authenticate git pushes to GitHub
      run: git config --global url."https://x-access-token:***@github.com/".insteadOf "https://github.com/"
    - run: just docs-publish
```

- **Gated on `goreleaser`** (`needs: goreleaser`) — a failed publish never ships docs advertising a version that isn't out.
- **Git auth via `url.insteadOf`.** `just docs-publish` force-pushes from a throwaway repo it `git init`s inside `website/dist`, which inherits none of `actions/checkout`'s credentials. The global token rewrite is the least-invasive fix and needs **no change to the recipe**. `contents: write` is already granted at the workflow level, so the push to `gh-pages` authenticates.

## Docs

Also corrects the website README's stale **Deploy** section, which described a non-existent push-to-`main` `docs` workflow and a "Source: GitHub Actions" Pages setup. The real mechanism is the `gh-pages` branch ("deploy from a branch"), now fed by this release job (or `just docs-publish` locally).

## Notes / assumptions

- **Assumes** GitHub Pages is configured as **Settings → Pages → Source: Deploy from a branch → `gh-pages`** (what `just docs-publish` has always targeted).
- Fires on **all `v*` tags, including pre-releases** (e.g. `v1.2.3-rc.1`), matching the existing release trigger. Easy to guard out RCs if preferred.
- No `CHANGELOG.md` entry — this is CI/release infra, not a change to the CLI/product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118ru1gGZcdkHKUvNcMXZ7j

---
_Generated by [Claude Code](https://claude.ai/code/session_0118ru1gGZcdkHKUvNcMXZ7j)_