### PR TITLE
fix(codex): carry subagent `name`; clarify `explain` skip reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **Codex subagents no longer report a spurious "dropped name".** The Codex
+  adapter writes the canonical `name` straight into the agent TOML's `name`
+  field (Codex *requires* it), but `name` was omitted from the adapter's set of
+  known frontmatter keys — so any subagent whose frontmatter carried `name`
+  (every Claude-format agent does) was reported as dropping it. For an agent
+  whose only otherwise-unmapped key was `name`, this surfaced a misleading `◐
+  partial` / `(N skipped)` in `explain` even though the agent translated
+  cleanly. `name` is now recognized as a carried-over key (and the frontmatter
+  `name` is preferred over the filename, matching Codex's "name is the source of
+  truth" rule); `tools` and `color`, which genuinely have no Codex target, are
+  still reported as dropped.
+
 - **Plugins now project the components they ship in their conventional default
   locations, not just the ones plugin.json lists.** Claude Code auto-discovers a
   plugin's components from default locations — `commands/*.md`, `agents/*.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,25 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   (rather than from `mcp`/`commands` alone), fixing a latent case where a plugin
   whose skills rendered but whose hook was skipped was mislabeled `none`.
 
-- **`explain` itemizes skipped components.** A `◐ partial` row that reports
-  `(N skipped)` is no longer a dead end: each skipped component is now listed
-  beneath the agent row as an itemized `<component> <name>  <reason>` line (the
-  reason rendered faint) — what the agent could not translate, and why (e.g. `lsp
-  atlassian-lsp  Codex has no LSP configuration concept`). The structured surface
-  gains a `skipDetails` array
-  (`{component, name, reason}`) on every `explain --json` row. The translation
-  report carries the detail end-to-end (`render.PluginRow.SkipDetails`) rather
-  than collapsing skips to a bare count, and the counts/skips are scoped to the
-  named plugin (see the `explain` fix below).
+- **`explain` itemizes what each agent couldn't fully translate, split into
+  "reduced" vs "dropped".** A `◐ partial` row is no longer a dead-end `(N
+  skipped)` tally that reads as if N whole components were discarded. The
+  trailing note now breaks down by kind — `(N reduced · M dropped)` — and each
+  part is listed beneath the agent row under a framing header
+  (`→ <agent> couldn't fully translate — reduced = rendered without some fields;
+  dropped = not emitted:`), tagged `reduced` (the component still rendered, just
+  without fields the agent has no home for — e.g. a subagent's Claude-only
+  `tools`/`color`) or `dropped` (the whole component had no native target and was
+  not emitted — e.g. an LSP server on an agent with no LSP concept), with the
+  reason. The distinction is derived from the adapter's `-frontmatter` skip
+  suffix, which is no longer shown raw — the label names the component kind
+  plainly (`subagent reviewer`, not `subagent-frontmatter reviewer`). The
+  structured surface gains a `skipDetails` array (`{component, name, reason}`) on
+  every `explain --json` row (the raw `component` there retains its
+  `-frontmatter` suffix). The translation report carries the detail end-to-end
+  (`render.PluginRow.SkipDetails`) rather than collapsing skips to a bare count,
+  and the counts/skips are scoped to the named plugin (see the `explain` fix
+  below).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`explain` sanitizes untrusted plugin/component names before rendering them
+  to the terminal.** A fetched marketplace plugin's id, version, or a component
+  name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
+  escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
+  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`.
+  The new `ui.Sanitize` strips C0/C1 control characters (incl. ESC, CR, LF, TAB,
+  DEL) at the display boundary — applied to the skip itemization
+  (`emitSkipDetails`), the plugin header, and the `--list` text rows, before
+  width/`Pad` so a stripped byte can't skew column alignment. Printable text
+  (incl. non-ASCII) is untouched, and `explain --json` keeps ids/components raw
+  (the machine contract, where the consumer owns escaping). The rendered Codex
+  agent TOML was already safe (the marshaller escapes control bytes and the
+  filename uses the canonical name).
+
 - **Codex subagents no longer report a spurious "dropped name".** The Codex
   adapter writes the canonical `name` straight into the agent TOML's `name`
   field (Codex *requires* it), but `name` was omitted from the adapter's set of

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -207,10 +207,12 @@ literally, never resolved.)
 **Codex**
 
 - **Subagent** — Codex custom agents are TOML, not markdown: the prose body
-  becomes `developer_instructions`, the `description` + `model` frontmatter carry
-  over, and there is no per-agent `tools` allowlist (tool scoping is only
-  expressible via `[mcp_servers]` / skill toggles), so `tools` (and `color`) are
-  dropped with a reported skip.
+  becomes `developer_instructions`, and the `name` (required by Codex),
+  `description`, and `model` frontmatter carry over. There is no per-agent
+  `tools` allowlist (tool scoping is only expressible via `[mcp_servers]` / skill
+  toggles), so `tools` (and `color`) are dropped with a reported skip. Codex-only
+  agent keys agentsync has no canonical source for (`model_reasoning_effort`,
+  `sandbox_mode`, `nickname_candidates`, …) are simply not emitted.
 - **Slash command** — maps to Codex *custom prompts* (`~/.codex/prompts/*.md`),
   which do preserve `description` + `argument-hint`, but they're global-only, so a
   **project-scope** command has no target and is skipped; they also can't be

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -404,9 +404,12 @@ and that none of it landed.
 A `◐ partial` row is never a dead end: every part the agent could not fully
 translate is itemized beneath a framing header, each tagged `reduced` or
 `dropped` with the reason, so you can see exactly what loss `apply` would incur.
-`--json` carries the same breakdown — the per-kind counts (`mcp`, `commands`,
-`skills`, `subagents`, `hooks`, `lsp`) plus the `skipDetails` array (each with its
-`component`/`name`/`reason`) — on every row.
+`--json` carries the per-kind counts (`mcp`, `commands`, `skills`, `subagents`,
+`hooks`, `lsp`) and the `skipDetails` array (each entry `{component, name,
+reason}`) on every row. The `reduced` vs `dropped` split is a text-rendering
+distinction only: JSON exposes the raw `component` (a field-level reduction keeps
+its `-frontmatter` suffix, e.g. `subagent-frontmatter`), so a machine consumer
+derives the split from that suffix rather than a dedicated field.
 
 Inspect any plugin's coverage without applying:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -378,25 +378,35 @@ skipped — and the report tells you exactly which:
 
 ```
 ▸ atlassian@anthropic
-  → claude    ✓ full        1 mcp · 5 commands · 1 lsp
-  → codex     ◐ partial     1 mcp · 5 commands · 1 lsp  (1 skipped)
-      • lsp atlassian-lsp  Codex has no LSP configuration concept
+  → claude    ✓ full        1 mcp · 5 commands · 3 subagents · 1 lsp
+  → codex     ◐ partial     1 mcp · 5 commands · 3 subagents · 1 lsp  (3 reduced · 1 dropped)
+      → codex couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:
+        • subagent ai-architect   reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • subagent deploy-expert  reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • subagent perf-optimizer reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • lsp atlassian-lsp       dropped  Codex has no LSP configuration concept
 ```
 
 Each row's count tail lists every component kind the plugin hosts for that agent
 — MCP servers, commands, skills, subagents, hooks, and LSP servers (only the
 non-zero kinds are shown) — so the inventory is fully descriptive, not just `mcp`
 + `commands`. The counts describe what the plugin *hosts*; the coverage glyph and
-any `(N skipped)` note describe what the agent could *do* with it. So above,
-Codex still shows `1 lsp` (the plugin hosts one) but `✗`-skips it — an LSP-only
-plugin on Codex reads `✗ none  1 lsp`, telling you both what is there and that
-none of it landed.
+the trailing note describe what the agent could *do* with it.
 
-A `◐ partial` row is never a dead end: every skipped component is itemized
-beneath it (what it is, and why that agent could not translate it), so you can
-see exactly what loss `apply` would incur. `--json` carries the same breakdown —
-the per-kind counts (`mcp`, `commands`, `skills`, `subagents`, `hooks`, `lsp`)
-plus the `skipDetails` array — on every row.
+That trailing note is split by kind so it never reads as "N whole components
+discarded": a **reduced** part still rendered, just without some fields the agent
+has no home for (here each subagent landed as Codex TOML, only its Claude-only
+`tools`/`color` frontmatter dropped); a **dropped** part had no native target at
+all and was not emitted (the LSP server — Codex has no LSP concept). An LSP-only
+plugin on Codex reads `✗ none  1 lsp  (1 dropped)`, telling you both what is there
+and that none of it landed.
+
+A `◐ partial` row is never a dead end: every part the agent could not fully
+translate is itemized beneath a framing header, each tagged `reduced` or
+`dropped` with the reason, so you can see exactly what loss `apply` would incur.
+`--json` carries the same breakdown — the per-kind counts (`mcp`, `commands`,
+`skills`, `subagents`, `hooks`, `lsp`) plus the `skipDetails` array (each with its
+`component`/`name`/`reason`) — on every row.
 
 Inspect any plugin's coverage without applying:
 

--- a/internal/adapter/codex/render_test.go
+++ b/internal/adapter/codex/render_test.go
@@ -185,6 +185,10 @@ func TestRender_Subagent_ToTOML(t *testing.T) {
 	c := source.Canonical{Subagents: []source.Subagent{{
 		Name: "review",
 		Frontmatter: map[string]any{
+			// `name` is a real Claude subagent frontmatter key (it lives in
+			// both the Claude and Codex agent schemas); it must carry over to
+			// the TOML `name` field, never be reported as a dropped key.
+			"name":        "review",
 			"description": "Code review",
 			"model":       "gpt-5.5",
 			"tools":       []string{"Read", "Grep"},
@@ -205,18 +209,54 @@ func TestRender_Subagent_ToTOML(t *testing.T) {
 	if !strings.Contains(content, "Code review") || !strings.Contains(content, "gpt-5.5") {
 		t.Fatalf("description/model missing: %s", content)
 	}
+	if !strings.Contains(content, `name = 'review'`) {
+		t.Fatalf("required name field missing from TOML: %s", content)
+	}
 	if strings.Contains(content, "tools") || strings.Contains(content, "color") {
 		t.Fatalf("tools/color should be dropped from TOML: %s", content)
 	}
 	var sawSkip bool
 	for _, s := range skips {
-		if s.Component == "subagent-frontmatter" && s.Name == "review" &&
-			strings.Contains(s.Reason, "tools") && strings.Contains(s.Reason, "color") {
-			sawSkip = true
+		if s.Component == "subagent-frontmatter" && s.Name == "review" {
+			if strings.Contains(s.Reason, "name") {
+				t.Fatalf("name carries over to the Codex TOML; it must not be reported dropped: %q", s.Reason)
+			}
+			if strings.Contains(s.Reason, "tools") && strings.Contains(s.Reason, "color") {
+				sawSkip = true
+			}
 		}
 	}
 	if !sawSkip {
 		t.Fatalf("expected a subagent-frontmatter skip listing tools+color, got %+v", skips)
+	}
+}
+
+// A subagent whose only "extra" frontmatter key is `name` (which carries over to
+// the Codex TOML) must render with NO skip at all — regression guard for the
+// spurious "dropped name" partial that hid clean agents behind a ◐ in `explain`.
+func TestRender_Subagent_NameOnly_NoSkip(t *testing.T) {
+	c := source.Canonical{Subagents: []source.Subagent{{
+		Name: "ai-architect",
+		Frontmatter: map[string]any{
+			"name":        "ai-architect",
+			"description": "Designs the system",
+			"model":       "gpt-5.5",
+		},
+		Body: "Architect the thing.\n",
+	}}}
+	a := codex.New(codex.Options{TargetRoot: t.TempDir()})
+	ops, skips, _ := a.Render(secrets.ForRender(c), adapter.ScopeUser, "")
+	op := findOp(ops, "/agents/ai-architect.toml")
+	if op == nil {
+		t.Fatal("ai-architect.toml op missing")
+	}
+	if !strings.Contains(string(op.Content), `name = 'ai-architect'`) {
+		t.Fatalf("name field missing: %s", op.Content)
+	}
+	for _, s := range skips {
+		if s.Component == "subagent-frontmatter" && s.Name == "ai-architect" {
+			t.Fatalf("no skip expected for a name/description/model-only agent, got %q", s.Reason)
+		}
 	}
 }
 

--- a/internal/adapter/codex/subagent.go
+++ b/internal/adapter/codex/subagent.go
@@ -14,9 +14,13 @@ import (
 
 // codexAgentFile is the TOML shape of a Codex custom agent (~/.codex/agents/<name>.toml).
 // Codex defines subagents as standalone TOML, where the prose lives under
-// `developer_instructions` rather than a markdown body. agentsync projects the
-// canonical markdown body onto developer_instructions and carries the
-// `description` + `model` frontmatter; there is no per-agent tools allowlist.
+// `developer_instructions` rather than a markdown body (per
+// developers.openai.com/codex/subagents). agentsync projects the canonical
+// markdown body onto developer_instructions and carries the `name` (required by
+// Codex), `description`, and `model` frontmatter; there is no per-agent tools
+// allowlist. Codex-only agent keys agentsync has no canonical source for
+// (model_reasoning_effort, sandbox_mode, mcp_servers, skills.config,
+// nickname_candidates) are simply not emitted.
 type codexAgentFile struct {
 	Name                  string `toml:"name"`
 	Description           string `toml:"description,omitempty"`
@@ -25,19 +29,30 @@ type codexAgentFile struct {
 }
 
 // codexAgentKnownKeys are the canonical frontmatter keys with a Codex TOML home.
-// Anything else (tools, color, …) has no target and is dropped with a Skip.
-var codexAgentKnownKeys = map[string]bool{"description": true, "model": true}
+// `name` is required by Codex and is written to the TOML `name` field — it is a
+// known key, NOT a dropped one (omitting it here once caused `explain` to report
+// a spurious "dropped name" against agents whose name in fact carried over).
+// Anything else (notably `tools` and `color`) has no target and is dropped with
+// a Skip.
+var codexAgentKnownKeys = map[string]bool{"name": true, "description": true, "model": true}
 
 // renderSubagents projects canonical subagents into Codex agent TOML files.
-// markdown body → developer_instructions; description + model carry over; any
-// other frontmatter key (notably `tools` and `color`) has no Codex equivalent
-// and is dropped with a reported Skip.
+// markdown body → developer_instructions; name + description + model carry over;
+// any other frontmatter key (notably `tools` and `color`) has no Codex
+// equivalent and is dropped with a reported Skip.
 func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp, []adapter.Skip, error) {
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 	for _, s := range c.Subagents {
+		// Codex treats the `name` field as the source of truth; prefer the
+		// frontmatter name when present, falling back to the filename-derived
+		// canonical name (which is what Claude subagents use).
+		name := s.Name
+		if fmName := fmString(s.Frontmatter, "name"); fmName != "" {
+			name = fmName
+		}
 		af := codexAgentFile{
-			Name:                  s.Name,
+			Name:                  name,
 			Description:           fmString(s.Frontmatter, "description"),
 			Model:                 fmString(s.Frontmatter, "model"),
 			DeveloperInstructions: s.Body,

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -351,17 +351,18 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 		// faint count tail with an optional skip note.
 		mark := color(ui.Pad(glyph+" "+row.Coverage, 12))
 		tail := p.Faint(componentInventory(row))
-		if row.Skips > 0 {
-			tail += "  " + p.Yellow(fmt.Sprintf("(%d skipped)", row.Skips))
+		if note := skipTailNote(p, row.SkipDetails); note != "" {
+			tail += "  " + note
 		}
 		fmt.Fprintf(w, "  %s %s  %s  %s\n",
 			p.Faint(ui.GlyphArrow),
 			p.Bold(ui.Pad(row.Agent, 10)),
 			mark,
 			tail)
-		// "(N skipped)" is a dead end on its own — list each skipped component
-		// (what it is, and why the agent could not translate it) beneath the row.
-		emitSkipDetails(w, p, row.SkipDetails)
+		// The tally is a dead end on its own — list each part the agent could
+		// not fully translate (what it is, whether it was reduced or dropped,
+		// and why) beneath the row.
+		emitSkipDetails(w, p, row.Agent, row.SkipDetails)
 	}
 }
 
@@ -370,8 +371,8 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 // plugin that ships (say) only an LSP server or only skills is no longer reported
 // as a bare "0 mcp · 0 commands". Only non-zero kinds are listed, in a stable
 // order, joined by " · "; a plugin that contributes nothing to this agent reads
-// "no components". The counts describe the inventory; the coverage glyph and any
-// "(N skipped)" note describe what the agent could do with it.
+// "no components". The counts describe the inventory; the coverage glyph and the
+// "(N reduced · M dropped)" note describe what the agent could do with it.
 func componentInventory(row render.PluginRow) string {
 	parts := make([]string, 0, 6)
 	// one/many give per-count labels; the abbreviations mcp/lsp are invariant.
@@ -401,14 +402,19 @@ func componentInventory(row render.PluginRow) string {
 	return strings.Join(parts, " · ")
 }
 
-// emitSkipDetails lists each skipped component under its agent row as a faint,
-// indented "<component> <name>  <reason>" line so the "(N skipped)" tally is
-// explained rather than opaque. Reasons are aligned by padding the
-// component+name column to its widest entry.
-func emitSkipDetails(w io.Writer, p *ui.Printer, skips []render.SkipDetail) {
+// emitSkipDetails lists the parts the agent could not fully translate beneath
+// its row. A bare "(N skipped)" tally reads as if N whole components were thrown
+// away — so each line is tagged with WHAT happened: "reduced" (the component
+// still rendered, just without some fields the agent has no home for) or
+// "dropped" (the whole component had no native target and was not emitted at
+// all). A one-line header frames the list and defines the two verbs.
+func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.SkipDetail) {
 	if len(skips) == 0 {
 		return
 	}
+	fmt.Fprintf(w, "      %s\n", p.Faint(fmt.Sprintf(
+		"%s %s couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:",
+		ui.GlyphArrow, agent)))
 	width := 0
 	for _, s := range skips {
 		if n := visibleLen(skipLabel(s)); n > width {
@@ -416,20 +422,65 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, skips []render.SkipDetail) {
 		}
 	}
 	for _, s := range skips {
-		fmt.Fprintf(w, "      %s %s  %s\n",
-			p.Yellow(ui.GlyphInfo),
+		// "reduced" and "dropped" are the same width, so the reason column stays
+		// aligned without padding the (color-wrapped) status word.
+		status := p.Yellow("dropped")
+		if isReducedSkip(s.Component) {
+			status = p.Cyan("reduced")
+		}
+		fmt.Fprintf(w, "        %s %s  %s  %s\n",
+			p.Faint(ui.GlyphInfo),
 			ui.Pad(skipLabel(s), width),
+			status,
 			p.Faint(s.Reason))
 	}
 }
 
-// skipLabel renders "<component> <name>" for a skipped item, or just the
-// component when the skip has no name (e.g. an unrecognized hook event).
-func skipLabel(s render.SkipDetail) string {
-	if s.Name == "" {
-		return s.Component
+// skipTailNote summarizes a row's skips as a compact "(R reduced · D dropped)"
+// note (omitting a zero side), or "" when there are no skips. Splitting the
+// count by kind keeps the inline tally from reading as "N whole components
+// discarded" — most "skips" on a partial row are reductions, not drops.
+func skipTailNote(p *ui.Printer, skips []render.SkipDetail) string {
+	var reduced, dropped int
+	for _, s := range skips {
+		if isReducedSkip(s.Component) {
+			reduced++
+		} else {
+			dropped++
+		}
 	}
-	return s.Component + " " + s.Name
+	if reduced == 0 && dropped == 0 {
+		return ""
+	}
+	var parts []string
+	if reduced > 0 {
+		parts = append(parts, fmt.Sprintf("%d reduced", reduced))
+	}
+	if dropped > 0 {
+		parts = append(parts, fmt.Sprintf("%d dropped", dropped))
+	}
+	return p.Yellow("(" + strings.Join(parts, " · ") + ")")
+}
+
+// isReducedSkip reports whether a skip is a field-level reduction (the component
+// still rendered) rather than a whole-component drop. The adapters mark the
+// former with a "-frontmatter" component suffix (subagent-frontmatter,
+// command-frontmatter); everything else (a dropped hook event, an LSP server
+// with no native concept, a project-scope command with no target) is a true drop.
+func isReducedSkip(component string) bool {
+	return strings.HasSuffix(component, "-frontmatter")
+}
+
+// skipLabel renders "<kind> <name>" for a skipped item, or just the kind when
+// the skip has no name (e.g. an unrecognized hook event). The internal
+// "-frontmatter" suffix is stripped — the "reduced" status tag now conveys that
+// the loss was field-level, so the label names the component kind plainly.
+func skipLabel(s render.SkipDetail) string {
+	kind := strings.TrimSuffix(s.Component, "-frontmatter")
+	if s.Name == "" {
+		return kind
+	}
+	return kind + " " + s.Name
 }
 
 // coverageGlyphAndColor maps a coverage string to a glyph + semantic color

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -158,14 +158,18 @@ func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
 
 	fmt.Fprintf(p.Out, "%s %s\n", p.Bold("Installed plugins"),
 		p.Faint(fmt.Sprintf("(%d)", len(plugins))))
+	// Plugin id + version come from fetched marketplace metadata (untrusted), so
+	// sanitize before width/Pad and display to keep terminal escapes out of the
+	// text listing. (The --json branch above leaves them raw — that's the machine
+	// contract, where the consumer owns escaping.)
 	maxLabel := 0
 	for _, pl := range plugins {
-		if n := visibleLen(explainLabel(pl)); n > maxLabel {
+		if n := visibleLen(ui.Sanitize(explainLabel(pl))); n > maxLabel {
 			maxLabel = n
 		}
 	}
 	for _, pl := range plugins {
-		label := explainLabel(pl)
+		label := ui.Sanitize(explainLabel(pl))
 		hasTrail := pl.Plugin.Version != "" || pl.Plugin.Disabled
 		// Only pad the label when something follows it — a bare row with
 		// trailing spaces just leaves visible whitespace at end-of-line.
@@ -175,7 +179,7 @@ func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
 		}
 		line := fmt.Sprintf("  %s %s", p.Cyan(ui.GlyphInfo), shown)
 		if pl.Plugin.Version != "" {
-			line += "  " + p.Faint("v"+pl.Plugin.Version)
+			line += "  " + p.Faint("v"+ui.Sanitize(pl.Plugin.Version))
 		}
 		if pl.Plugin.Disabled {
 			line += "  " + p.Yellow("(disabled)")
@@ -313,12 +317,14 @@ func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agen
 	return render.BuildReport(scoped, plan, agents), nil
 }
 
-// emitPluginHeader prints a styled "▸ <id>  v<version>  (disabled)" line.
+// emitPluginHeader prints a styled "▸ <id>  v<version>  (disabled)" line. The
+// id and version come from fetched marketplace metadata (untrusted), so they are
+// sanitized before styling to keep terminal escapes out of the header.
 func emitPluginHeader(w io.Writer, p *ui.Printer, pl source.Plugin) {
-	label := explainLabel(pl)
+	label := ui.Sanitize(explainLabel(pl))
 	parts := []string{p.Bold(p.Cyan("▸") + " " + label)}
 	if pl.Plugin.Version != "" {
-		parts = append(parts, p.Faint("v"+pl.Plugin.Version))
+		parts = append(parts, p.Faint("v"+ui.Sanitize(pl.Plugin.Version)))
 	}
 	if pl.Plugin.Disabled {
 		parts = append(parts, p.Yellow("(disabled)"))
@@ -415,13 +421,20 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 	fmt.Fprintf(w, "      %s\n", p.Faint(fmt.Sprintf(
 		"%s %s couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:",
 		ui.GlyphArrow, agent)))
+	// A skip's Name comes from a fetched marketplace plugin (untrusted) and its
+	// Reason from an adapter (trusted) — sanitize both at this display boundary
+	// so neither can smuggle terminal escapes, and do it BEFORE width/Pad so a
+	// stripped byte can't skew the column. The component kind is adapter-fixed,
+	// so the whole label is safe to sanitize as one unit.
+	labels := make([]string, len(skips))
 	width := 0
-	for _, s := range skips {
-		if n := visibleLen(skipLabel(s)); n > width {
+	for i, s := range skips {
+		labels[i] = ui.Sanitize(skipLabel(s))
+		if n := visibleLen(labels[i]); n > width {
 			width = n
 		}
 	}
-	for _, s := range skips {
+	for i, s := range skips {
 		// "reduced" and "dropped" are the same width, so the reason column stays
 		// aligned without padding the (color-wrapped) status word.
 		status := p.Yellow("dropped")
@@ -430,9 +443,9 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 		}
 		fmt.Fprintf(w, "        %s %s  %s  %s\n",
 			p.Faint(ui.GlyphInfo),
-			ui.Pad(skipLabel(s), width),
+			ui.Pad(labels[i], width),
 			status,
-			p.Faint(s.Reason))
+			p.Faint(ui.Sanitize(s.Reason)))
 	}
 }
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -420,7 +420,8 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 	}
 	fmt.Fprintf(w, "      %s\n", p.Faint(fmt.Sprintf(
 		"%s %s couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:",
-		ui.GlyphArrow, agent)))
+		ui.GlyphArrow, agent,
+	)))
 	// A skip's Name comes from a fetched marketplace plugin (untrusted) and its
 	// Reason from an adapter (trusted) — sanitize both at this display boundary
 	// so neither can smuggle terminal escapes, and do it BEFORE width/Pad so a

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -77,7 +77,7 @@ func TestComponentInventory(t *testing.T) {
 // no stray bullet, no blank line.
 func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 	var buf bytes.Buffer
-	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), nil)
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", nil)
 	if buf.Len() != 0 {
 		t.Errorf("emitSkipDetails(nil) wrote %q, want nothing", buf.String())
 	}
@@ -85,15 +85,17 @@ func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 
 // TestEmitSkipDetails_UnnamedComponentOnly exercises the empty-Name skip
 // through the full emitSkipDetails formatting path (not just skipLabel): a skip
-// with no name must render as a bare "<bullet> <component>  <reason>" line with
-// no dangling separator. ColorNever lets us pin the exact bytes.
+// with no name must render as a "<bullet> <kind>  <status>  <reason>" line with
+// no dangling separator, beneath the framing header. A bare hook event with no
+// native target is a "dropped", not a "reduced", skip. ColorNever pins the bytes.
 func TestEmitSkipDetails_UnnamedComponentOnly(t *testing.T) {
 	var buf bytes.Buffer
-	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), []render.SkipDetail{
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", []render.SkipDetail{
 		{Component: "hook", Reason: "unknown event"},
 	})
 	got := buf.String()
-	want := "      " + ui.GlyphInfo + " hook  unknown event\n"
+	want := "      " + ui.GlyphArrow + " codex couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:\n" +
+		"        " + ui.GlyphInfo + " hook  dropped  unknown event\n"
 	if got != want {
 		t.Errorf("emitSkipDetails(unnamed) = %q, want %q", got, want)
 	}
@@ -112,17 +114,21 @@ func TestEmitSkipDetails_ColumnsAlignUnderColor(t *testing.T) {
 		{Component: "subagent-frontmatter", Name: "reviewer", Reason: "dropped tools allowlist"},
 	}
 	var buf bytes.Buffer
-	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorAlways), skips)
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorAlways), "codex", skips)
 
 	raw := buf.String()
 	if !strings.Contains(raw, "\x1b[") {
 		t.Fatalf("ColorAlways produced no ANSI; the colored path is untested:\n%q", raw)
 	}
 
-	lines := strings.Split(strings.TrimRight(raw, "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 skip lines, got %d:\n%q", len(lines), raw)
+	// Drop the framing header line; only the itemized skip lines are alignment-
+	// sensitive. The "reduced"/"dropped" status words are equal width, so the
+	// reason column must still land at the same offset on every item line.
+	allLines := strings.Split(strings.TrimRight(raw, "\n"), "\n")
+	if len(allLines) != 3 {
+		t.Fatalf("expected a header + 2 skip lines, got %d:\n%q", len(allLines), raw)
 	}
+	lines := allLines[1:]
 	offsets := make([]int, len(lines))
 	for i, line := range lines {
 		plain := stripANSI(line)

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -13,8 +13,12 @@ import (
 
 // untrustedControl is a plugin-supplied string carrying a screen-clear CSI, a
 // color CSI, and a carriage return — the injection payload the display-boundary
-// sanitization must neutralize.
-const untrustedControl = "evil\x1b[2J\x1b[31m\rname"
+// sanitization must neutralize. untrustedControlSanitized is what survives: the
+// ESC + CR bytes gone, the inert parameter residue left as plain text.
+const (
+	untrustedControl          = "evil\x1b[2J\x1b[31m\rname"
+	untrustedControlSanitized = "evil[2J[31mname"
+)
 
 // assertNoTerminalControl fails if out carries an ESC or CR byte (real newlines
 // emitted by the renderer are fine).
@@ -169,7 +173,7 @@ func TestEmitSkipDetails_SanitizesUntrustedName(t *testing.T) {
 	})
 	out := buf.String()
 	assertNoTerminalControl(t, "emitSkipDetails", out)
-	if !strings.Contains(out, "subagent evil[2J[31mname") {
+	if !strings.Contains(out, "subagent "+untrustedControlSanitized) {
 		t.Errorf("sanitized label not present in output: %q", out)
 	}
 }
@@ -182,7 +186,16 @@ func TestEmitPluginHeader_SanitizesUntrusted(t *testing.T) {
 	var buf bytes.Buffer
 	pl := source.Plugin{Plugin: source.PluginSpec{ID: untrustedControl, Version: "1.0\r0"}}
 	emitPluginHeader(&buf, ui.New(&buf, &buf, ui.ColorNever), pl)
-	assertNoTerminalControl(t, "emitPluginHeader", buf.String())
+	out := buf.String()
+	assertNoTerminalControl(t, "emitPluginHeader", out)
+	// Positively prove the untrusted id+version were rendered (just cleaned), so
+	// the test can't pass vacuously if a refactor dropped the value entirely.
+	if !strings.Contains(out, untrustedControlSanitized) {
+		t.Errorf("emitPluginHeader: sanitized id not rendered: %q", out)
+	}
+	if !strings.Contains(out, "v1.00") { // "1.0\r0" with the CR stripped
+		t.Errorf("emitPluginHeader: sanitized version not rendered: %q", out)
+	}
 }
 
 func TestRunExplainList_SanitizesUntrusted(t *testing.T) {
@@ -194,7 +207,14 @@ func TestRunExplainList_SanitizesUntrusted(t *testing.T) {
 	if err := runExplainList(p, c, false); err != nil {
 		t.Fatalf("runExplainList: %v", err)
 	}
-	assertNoTerminalControl(t, "runExplainList", buf.String())
+	out := buf.String()
+	assertNoTerminalControl(t, "runExplainList", out)
+	if !strings.Contains(out, untrustedControlSanitized) {
+		t.Errorf("runExplainList: sanitized id not rendered: %q", out)
+	}
+	if !strings.Contains(out, "v99") { // "9\r9" with the CR stripped
+		t.Errorf("runExplainList: sanitized version not rendered: %q", out)
+	}
 }
 
 // TestEmitSkipDetails_UnnamedComponentOnly exercises the empty-Name skip

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -139,6 +139,28 @@ func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 	}
 }
 
+// TestEmitSkipDetails_SanitizesUntrustedName proves the display boundary strips
+// terminal control bytes from a plugin-supplied (untrusted) skip name, so a
+// malicious marketplace plugin cannot smuggle ANSI/escape sequences into the
+// rendered `explain` output. No injected control byte may survive; the inert
+// parameter residue ("[31m") is allowed through as plain text.
+func TestEmitSkipDetails_SanitizesUntrustedName(t *testing.T) {
+	var buf bytes.Buffer
+	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", []render.SkipDetail{
+		{Component: "subagent-frontmatter", Name: "evil\x1b[31m\rname", Reason: "a reason"},
+	})
+	out := buf.String()
+	if strings.ContainsRune(out, '\x1b') {
+		t.Errorf("ESC byte leaked into output: %q", out)
+	}
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("CR byte leaked into output: %q", out)
+	}
+	if !strings.Contains(out, "subagent evil[31mname") {
+		t.Errorf("sanitized label not present in output: %q", out)
+	}
+}
+
 // TestEmitSkipDetails_UnnamedComponentOnly exercises the empty-Name skip
 // through the full emitSkipDetails formatting path (not just skipLabel): a skip
 // with no name must render as a "<bullet> <kind>  <status>  <reason>" line with

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -16,9 +16,10 @@ var ansiSeq = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 func stripANSI(s string) string { return ansiSeq.ReplaceAllString(s, "") }
 
-// TestSkipLabel covers both arms of skipLabel: a named skip renders
-// "<component> <name>", and an unnamed one (e.g. an unrecognized hook event
-// with no name) falls back to the bare component.
+// TestSkipLabel covers all arms of skipLabel: a named skip renders
+// "<kind> <name>", an unnamed one (e.g. an unrecognized hook event with no
+// name) falls back to the bare kind, and the internal "-frontmatter" suffix is
+// stripped so the user-facing label names the component kind plainly.
 func TestSkipLabel(t *testing.T) {
 	tests := []struct {
 		name string
@@ -27,11 +28,66 @@ func TestSkipLabel(t *testing.T) {
 	}{
 		{"named", render.SkipDetail{Component: "lsp", Name: "gopls"}, "lsp gopls"},
 		{"unnamed", render.SkipDetail{Component: "hook"}, "hook"},
+		{"frontmatter suffix stripped", render.SkipDetail{Component: "subagent-frontmatter", Name: "reviewer"}, "subagent reviewer"},
+		{"command-frontmatter stripped", render.SkipDetail{Component: "command-frontmatter", Name: "deploy"}, "command deploy"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := skipLabel(tc.in); got != tc.want {
 				t.Errorf("skipLabel(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsReducedSkip pins the classifier that splits a skip into a field-level
+// "reduced" (the component still rendered) vs a whole-component "dropped": only
+// the adapter "-frontmatter" component strings are reductions; every other
+// component kind — and an empty/unknown one — is a drop.
+func TestIsReducedSkip(t *testing.T) {
+	cases := map[string]bool{
+		"subagent-frontmatter": true,
+		"command-frontmatter":  true,
+		"subagent":             false,
+		"command":              false,
+		"hook":                 false,
+		"lsp":                  false,
+		"mcp":                  false,
+		"skill":                false,
+		"memory":               false,
+		"":                     false,
+	}
+	for component, want := range cases {
+		if got := isReducedSkip(component); got != want {
+			t.Errorf("isReducedSkip(%q) = %v, want %v", component, got, want)
+		}
+	}
+}
+
+// TestSkipTailNote pins the inline tally wording end-to-end: the empty case
+// yields no note; a single kind omits the zero side; the mixed case joins
+// "reduced" THEN "dropped" with " · " regardless of input order and wraps the
+// whole thing in parens. ColorNever makes the yellow wrap a no-op so the bytes
+// are exact.
+func TestSkipTailNote(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.New(&buf, &buf, ui.ColorNever)
+	reduced := render.SkipDetail{Component: "subagent-frontmatter", Name: "a"}
+	dropped := render.SkipDetail{Component: "lsp", Name: "x"}
+	tests := []struct {
+		name  string
+		skips []render.SkipDetail
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"reduced only", []render.SkipDetail{reduced, reduced}, "(2 reduced)"},
+		{"dropped only", []render.SkipDetail{dropped}, "(1 dropped)"},
+		{"mixed, input order does not matter", []render.SkipDetail{dropped, reduced}, "(1 reduced · 1 dropped)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := skipTailNote(p, tc.skips); got != tc.want {
+				t.Errorf("skipTailNote(%+v) = %q, want %q", tc.skips, got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -7,8 +7,26 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
+
+// untrustedControl is a plugin-supplied string carrying a screen-clear CSI, a
+// color CSI, and a carriage return — the injection payload the display-boundary
+// sanitization must neutralize.
+const untrustedControl = "evil\x1b[2J\x1b[31m\rname"
+
+// assertNoTerminalControl fails if out carries an ESC or CR byte (real newlines
+// emitted by the renderer are fine).
+func assertNoTerminalControl(t *testing.T, where, out string) {
+	t.Helper()
+	if strings.ContainsRune(out, '\x1b') {
+		t.Errorf("%s: ESC byte leaked into output: %q", where, out)
+	}
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("%s: CR byte leaked into output: %q", where, out)
+	}
+}
 
 // ansiSeq matches an SGR escape (color/bold/faint reset) so a test can measure
 // the *visible* layout of styled output independent of the color codes.
@@ -143,22 +161,40 @@ func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 // terminal control bytes from a plugin-supplied (untrusted) skip name, so a
 // malicious marketplace plugin cannot smuggle ANSI/escape sequences into the
 // rendered `explain` output. No injected control byte may survive; the inert
-// parameter residue ("[31m") is allowed through as plain text.
+// parameter residue ("[2J[31m") is allowed through as plain text.
 func TestEmitSkipDetails_SanitizesUntrustedName(t *testing.T) {
 	var buf bytes.Buffer
 	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", []render.SkipDetail{
-		{Component: "subagent-frontmatter", Name: "evil\x1b[31m\rname", Reason: "a reason"},
+		{Component: "subagent-frontmatter", Name: untrustedControl, Reason: "a reason"},
 	})
 	out := buf.String()
-	if strings.ContainsRune(out, '\x1b') {
-		t.Errorf("ESC byte leaked into output: %q", out)
-	}
-	if strings.ContainsRune(out, '\r') {
-		t.Errorf("CR byte leaked into output: %q", out)
-	}
-	if !strings.Contains(out, "subagent evil[31mname") {
+	assertNoTerminalControl(t, "emitSkipDetails", out)
+	if !strings.Contains(out, "subagent evil[2J[31mname") {
 		t.Errorf("sanitized label not present in output: %q", out)
 	}
+}
+
+// TestEmitPluginHeader_SanitizesUntrusted and TestRunExplainList_SanitizesUntrusted
+// guard the other two Sanitize call sites (the plugin header id+version, and the
+// `--list` text rows): both render fetched-marketplace metadata, so a refactor
+// that dropped the Sanitize wrap there must fail a test, not slip through.
+func TestEmitPluginHeader_SanitizesUntrusted(t *testing.T) {
+	var buf bytes.Buffer
+	pl := source.Plugin{Plugin: source.PluginSpec{ID: untrustedControl, Version: "1.0\r0"}}
+	emitPluginHeader(&buf, ui.New(&buf, &buf, ui.ColorNever), pl)
+	assertNoTerminalControl(t, "emitPluginHeader", buf.String())
+}
+
+func TestRunExplainList_SanitizesUntrusted(t *testing.T) {
+	var buf bytes.Buffer
+	p := ui.New(&buf, &buf, ui.ColorNever)
+	c := source.Canonical{Plugins: []source.Plugin{{
+		Plugin: source.PluginSpec{ID: untrustedControl, Version: "9\r9"},
+	}}}
+	if err := runExplainList(p, c, false); err != nil {
+		t.Fatalf("runExplainList: %v", err)
+	}
+	assertNoTerminalControl(t, "runExplainList", buf.String())
 }
 
 // TestEmitSkipDetails_UnnamedComponentOnly exercises the empty-Name skip

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -749,10 +749,11 @@ func setupExplainLSPOnlyFixture(t *testing.T, tmp string) string {
 // plugins used by the cross-plugin scoping regression: "clean" ships a single
 // MCP server (Codex renders it fully), "noisy" ships an MCP plus two components
 // Codex cannot fully translate — an LSP server (no LSP concept) and a subagent
-// (Codex agents are TOML; the markdown `name` frontmatter is dropped). Both of
-// noisy's skips mirror the real-world report (leaked subagents *and* LSPs). With
-// both plugins installed, explaining one must not surface the other's components
-// or skips.
+// whose `tools`/`color` frontmatter has no Codex home (Codex agents are TOML
+// with no per-agent tools allowlist; the agent's `name` itself DOES carry over).
+// Both of noisy's skips mirror the real-world report (leaked subagents *and*
+// LSPs). With both plugins installed, explaining one must not surface the
+// other's components or skips.
 func setupExplainCrossPluginFixture(t *testing.T, tmp string) string {
 	t.Helper()
 	fixture := filepath.Join(tmp, "fixture-marketplace-explain-cross")
@@ -792,7 +793,7 @@ func setupExplainCrossPluginFixture(t *testing.T, tmp string) string {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(agentsDir, "reviewer.md"),
-		[]byte("---\nname: reviewer\ndescription: reviews code\n---\nReview carefully.\n"),
+		[]byte("---\nname: reviewer\ndescription: reviews code\ntools: [Read, Grep]\ncolor: blue\n---\nReview carefully.\n"),
 		0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -401,12 +401,18 @@ func TestExplain_ListsSkips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("explain: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "skipped") {
-		t.Fatalf("expected a skipped tally; got:\n%s", out)
+	// Both the LSP server and the unknown hook are whole-component drops (no
+	// native target), so the tally counts them as "dropped", and the framing
+	// header explains the list rather than leaving a bare count.
+	if !strings.Contains(out, "dropped") {
+		t.Fatalf("expected a 'dropped' tally; got:\n%s", out)
+	}
+	if !strings.Contains(out, "couldn't fully translate") {
+		t.Fatalf("expected the framing header explaining the skip list; got:\n%s", out)
 	}
 	// The skip must be itemized, not just counted: the component and its reason.
 	if !strings.Contains(out, "lsp") {
-		t.Errorf("explain should name the skipped lsp component; got:\n%s", out)
+		t.Errorf("explain should name the dropped lsp component; got:\n%s", out)
 	}
 	if !strings.Contains(out, "Codex has no LSP configuration concept") {
 		t.Errorf("explain should print the skip reason; got:\n%s", out)
@@ -484,7 +490,7 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("explain clean: %v\n%s", err, out)
 	}
-	for _, leak := range []string{"skipped", "lsp", "subagent", "reviewer"} {
+	for _, leak := range []string{"reduced", "dropped", "couldn't fully translate", "lsp", "subagent", "reviewer"} {
 		if strings.Contains(out, leak) {
 			t.Errorf("explain clean@cross-mp leaked the noisy plugin's %q; got:\n%s", leak, out)
 		}
@@ -540,8 +546,14 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 	if !strings.Contains(outNoisy, "lsp") || !strings.Contains(outNoisy, "Codex has no LSP configuration concept") {
 		t.Errorf("explain noisy@cross-mp should surface its own lsp skip; got:\n%s", outNoisy)
 	}
-	if !strings.Contains(outNoisy, "subagent-frontmatter") || !strings.Contains(outNoisy, "reviewer") {
-		t.Errorf("explain noisy@cross-mp should surface its own subagent skip; got:\n%s", outNoisy)
+	// The reviewer subagent renders but loses its tools/color frontmatter, so it
+	// surfaces as a "reduced" subagent skip (the label is humanized — no internal
+	// "-frontmatter" suffix leaks to the user).
+	if !strings.Contains(outNoisy, "subagent reviewer") || !strings.Contains(outNoisy, "reduced") {
+		t.Errorf("explain noisy@cross-mp should surface its own reduced subagent skip; got:\n%s", outNoisy)
+	}
+	if strings.Contains(outNoisy, "subagent-frontmatter") {
+		t.Errorf("explain should not leak the internal -frontmatter component name; got:\n%s", outNoisy)
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 
 	"golang.org/x/term"
 )
@@ -173,24 +174,35 @@ func Pad(s string, width int) string {
 // letters and ordinary spaces) passes through unchanged. Apply it at the display
 // boundary, before width/Pad calculation, so a stripped byte never throws off
 // column alignment.
+//
+// Scanning is rune-level (not byte-level): byte-level stripping of the 0x80–0x9F
+// range would corrupt legitimate multibyte UTF-8 (a CJK rune's continuation
+// bytes live there). Invalid UTF-8 is normalized rather than passed verbatim — a
+// malformed byte decodes to U+FFFD and is re-emitted as U+FFFD, so a raw
+// 0x80–0x9F byte (a C1 CSI introducer on an 8-bit terminal) can never survive.
+// Sanitize does NOT touch bidi-override or zero-width runes (U+202E, U+200B, …):
+// those are a cosmetic spoofing concern, not a terminal-control one.
 func Sanitize(s string) string {
 	// Fast path: the overwhelmingly common case is clean text, so scan once and
-	// only allocate when there is something to remove.
-	hasControl := false
+	// only allocate when there is something to change. We also rebuild on invalid
+	// UTF-8 (RuneError) — `range` yields RuneError for a malformed byte, and the
+	// rebuild's WriteRune normalizes it to U+FFFD, so a raw 0x80–0x9F byte (a C1
+	// CSI introducer on an 8-bit terminal) can never pass through verbatim.
+	clean := true
 	for _, r := range s {
-		if isControl(r) {
-			hasControl = true
+		if isControl(r) || r == utf8.RuneError {
+			clean = false
 			break
 		}
 	}
-	if !hasControl {
+	if clean {
 		return s
 	}
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
 		if !isControl(r) {
-			b.WriteRune(r)
+			b.WriteRune(r) // WriteRune(RuneError) emits U+FFFD, normalizing bad bytes
 		}
 	}
 	return b.String()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strings"
 
 	"golang.org/x/term"
 )
@@ -159,6 +160,46 @@ func Pad(s string, width int) string {
 		return s
 	}
 	return s + spaces(width-n)
+}
+
+// Sanitize strips control characters from a string so untrusted text — a fetched
+// marketplace plugin's id, a plugin-supplied component name — can be rendered to
+// a terminal without smuggling escape sequences through it. It removes C0
+// controls (0x00–0x1F, which includes ESC 0x1B, CR, LF, TAB, BEL, and
+// backspace), DEL (0x7F), and C1 controls (0x80–0x9F). Neutralizing the ESC/CSI
+// introducer is the security-relevant part: a name like "\x1b[31mX" renders as
+// the inert literal "[31mX" rather than recoloring the terminal, clearing the
+// screen, or spoofing subsequent rows. Printable text (including non-ASCII
+// letters and ordinary spaces) passes through unchanged. Apply it at the display
+// boundary, before width/Pad calculation, so a stripped byte never throws off
+// column alignment.
+func Sanitize(s string) string {
+	// Fast path: the overwhelmingly common case is clean text, so scan once and
+	// only allocate when there is something to remove.
+	hasControl := false
+	for _, r := range s {
+		if isControl(r) {
+			hasControl = true
+			break
+		}
+	}
+	if !hasControl {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if !isControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// isControl reports whether r is a C0 control (incl. ESC/CR/LF/TAB), DEL, or a
+// C1 control — the runes that can carry terminal escape semantics.
+func isControl(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
 }
 
 // WarnWriter wraps a destination writer and styles "warning: " line prefixes

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -124,6 +124,8 @@ func TestSanitize(t *testing.T) {
 		{"DEL stripped", "a\x7fb", "ab"},
 		{"C1 control (U+009B CSI) stripped", "a\u009bb", "ab"},
 		{"OSC title-set neutralized (ESC and BEL gone)", "\x1b]0;pwned\x07", "]0;pwned"},
+		{"pure control string collapses to empty", "\x1b\r\n\t", ""},
+		{"invalid UTF-8 byte normalized to U+FFFD", "a\xffb", "a\ufffdb"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -126,6 +126,7 @@ func TestSanitize(t *testing.T) {
 		{"OSC title-set neutralized (ESC and BEL gone)", "\x1b]0;pwned\x07", "]0;pwned"},
 		{"pure control string collapses to empty", "\x1b\r\n\t", ""},
 		{"invalid UTF-8 byte normalized to U+FFFD", "a\xffb", "a\ufffdb"},
+		{"pre-existing U+FFFD preserved (rebuild is idempotent)", "a\ufffdb", "a\ufffdb"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -106,3 +106,30 @@ func TestPad(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean ascii passes through", "atlassian@anthropic", "atlassian@anthropic"},
+		{"empty", "", ""},
+		{"non-ascii letters preserved", "café-名前", "café-名前"},
+		{"ordinary spaces preserved", "a b  c", "a b  c"},
+		{"ESC + CSI introducer stripped, params left inert", "\x1b[31mRED\x1b[0m", "[31mRED[0m"},
+		{"carriage return stripped", "before\rafter", "beforeafter"},
+		{"newline and tab stripped", "a\nb\tc", "abc"},
+		{"BEL and backspace stripped", "x\x07\x08y", "xy"},
+		{"DEL stripped", "a\x7fb", "ab"},
+		{"C1 control (U+009B CSI) stripped", "a\u009bb", "ab"},
+		{"OSC title-set neutralized (ESC and BEL gone)", "\x1b]0;pwned\x07", "]0;pwned"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Sanitize(tc.in); got != tc.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -202,11 +202,14 @@ agentsync update --apply --auto-safe
 Prints per-agent translation coverage for one or more installed plugins, without
 applying. Pass space-separated plugin ids to explain just those, `--all` to
 explain every installed plugin, or `--list` to print just the set of installed
-ids (a quick reminder of what you can pass). A `◐ partial` row that reports
-`(N skipped)` itemizes each skipped component beneath it (its label and the
-reason that agent could not translate it), so the tally is never a dead end. Add
-`--json` for machine-readable output (rows for plugin/agent coverage — each with
-a `skipDetails` array of `{component, name, reason}` — or a `plugins` array under
+ids (a quick reminder of what you can pass). A `◐ partial` row's trailing note is
+split by kind — `(N reduced · M dropped)` — so it never reads as "N whole
+components discarded": a **reduced** part still rendered, just without some fields
+the agent has no home for, while a **dropped** part had no native target and was
+not emitted. Each part is itemized beneath a framing header, tagged `reduced` or
+`dropped` with its reason, so the tally is never a dead end. Add `--json` for
+machine-readable output (rows for plugin/agent coverage — each with a
+`skipDetails` array of `{component, name, reason}` — or a `plugins` array under
 `--list`).
 
 ```bash


### PR DESCRIPTION
## Why

Triggered by the `explain` output for the vercel plugin, which read:

```
  → codex       ◐ partial     1 mcp · 5 commands · 26 skills · 3 subagents · 4 hooks  (4 skipped)
      • subagent-frontmatter ai-architect           Codex agents are TOML with no per-agent tools allowlist; dropped name
      • subagent-frontmatter deployment-expert      ...
      • subagent-frontmatter performance-optimizer  ...
      • hook SessionEnd                             Codex does not recognize this lifecycle event
```

Two problems behind that line: a real logic bug ("dropped name" when `name` in fact carries over), and messaging that made a `◐ partial` row read as if whole agent definitions were being thrown away.

## What changed

### 1. `fix(codex)` — stop reporting subagent `name` as a dropped frontmatter key

Codex custom agents are TOML and **require** a `name` field, which the adapter already wrote straight into the agent TOML (`Name: s.Name`). But `name` was missing from the adapter's known-keys set, so `droppedKeys` flagged it as having no Codex home — and every Claude-format subagent carries `name` in frontmatter, so each one produced a spurious "dropped name" skip. For an agent whose only otherwise-unmapped key was `name`, this surfaced a misleading `◐ partial` even though it translated cleanly (verified against [Codex's subagents docs](https://developers.openai.com/codex/subagents): `name` is required; there is *no* per-agent tools allowlist, so dropping `tools`/`color` is correct). `cursor` and `gemini` already listed `name` in their known keys — codex was the lone omission.

- `name` is now a carried-over key (and the frontmatter `name` is preferred over the filename, matching Codex's "name is the source of truth" rule).
- `tools`/`color`, which genuinely have no Codex target, are still reported as dropped.

### 2. `fix(explain)` — split the skip tally into "reduced" vs "dropped"

`(N skipped)` conflated two genuinely different outcomes. Skips are now classified by the adapter's `-frontmatter` suffix:

- **reduced** — the component still rendered, just without some fields the agent has no home for (a subagent's Claude-only `tools`/`color`).
- **dropped** — the whole component had no native target and was not emitted at all (an LSP server, a `SessionEnd` hook).

The trailing note becomes `(N reduced · M dropped)`, each part is itemized under a framing header that defines the two verbs, and the internal `subagent-frontmatter` name no longer leaks to the user (the label reads `subagent reviewer`). `explain --json`'s `skipDetails` keeps the raw `component` for machines.

New output:

```
  → codex       ◐ partial     1 mcp · 5 commands · 26 skills · 3 subagents · 4 hooks  (1 dropped)
      → codex couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:
        • hook SessionEnd  dropped  Codex does not recognize this lifecycle event
```

(With fix #1, the three subagents' spurious skip is gone, so codex collapses from `(4 skipped)` to a clear `(1 dropped)` for the one genuine gap.)

## Docs

Kept in sync in the same commits per the repo's doc-sync contract: `docs/capability-matrix.md`, `docs/user-guide.md` (worked example), `website/src/content/docs/reference/cli.mdx`, and `CHANGELOG.md`.

## Testing

- New/updated unit tests: `name` carries over and is never reported dropped; a name/description/model-only agent renders with **zero** skips; exact-byte coverage of the new `explain` format; a guard that the internal `-frontmatter` name never reaches the user.
- `internal/adapter/codex`, `internal/cli`, `internal/render` all pass; `golangci-lint` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApxCUhhCfxYpwDzpqoK8do

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApxCUhhCfxYpwDzpqoK8do)_