### PR TITLE
fix(render): sanitize untrusted plugin label in the apply/verify report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,17 +54,19 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
   escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
   terminal, clear the screen, or spoof rows when a user ran `agentsync explain`,
-  `apply`, or `plugin install`. The new `ui.Sanitize` strips C0/C1 control
-  characters (incl. ESC, CR, LF, TAB, DEL) at the display boundary — applied to
+  `apply`, `plugin`, `marketplace`, or `update`. The new `ui.Sanitize` strips
+  C0/C1 control characters (incl. ESC, CR, LF, TAB, DEL) at the display boundary
+  — applied to every site that renders fetched plugin/marketplace metadata:
   `explain`'s skip itemization (`emitSkipDetails`), plugin header, and `--list`
-  text rows, to the shared translation report's plugin label that `apply` prints
-  (`render` `printText`), and to the fetched version on the `plugin install`
-  status line — before width/`Pad` so a stripped byte can't skew column
-  alignment (and the `LF` strip stops an id forging an extra report line).
-  Printable text (incl. non-ASCII) is untouched, and `explain --json` keeps
-  ids/components raw (the machine contract, where the consumer owns escaping).
-  The rendered Codex agent TOML was already safe (the marshaller
-  escapes control bytes and the filename uses the canonical name).
+  rows; the shared translation report's plugin label that `apply` prints
+  (`render` `printText`); and the `plugin` (install/list), `marketplace`
+  (add/list), and `update` (pending-bump/upgrade) status lines — before
+  width/`Pad` so a stripped byte can't skew column alignment (and the `LF` strip
+  stops an id forging an extra report line). Printable text (incl. non-ASCII) is
+  untouched, and `explain --json` keeps ids/components raw (the machine contract,
+  where the consumer owns escaping). The rendered Codex agent TOML was already
+  safe (the marshaller escapes control bytes and the filename uses the canonical
+  name).
 
 - **Codex subagents no longer report a spurious "dropped name".** The Codex
   adapter writes the canonical `name` straight into the agent TOML's `name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,15 +54,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
   escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
   terminal, clear the screen, or spoof rows when a user ran `agentsync explain`,
-  `apply`, `plugin`, `marketplace`, or `update`. The new `ui.Sanitize` strips
-  C0/C1 control characters (incl. ESC, CR, LF, TAB, DEL) at the display boundary
-  — applied to every site that renders fetched plugin/marketplace metadata:
-  `explain`'s skip itemization (`emitSkipDetails`), plugin header, and `--list`
-  rows; the shared translation report's plugin label that `apply` prints
-  (`render` `printText`); and the `plugin` (install/list), `marketplace`
-  (add/list), and `update` (pending-bump/upgrade) status lines — before
-  width/`Pad` so a stripped byte can't skew column alignment (and the `LF` strip
-  stops an id forging an extra report line). Printable text (incl. non-ASCII) is
+  `apply`, `plugin`, `marketplace`, `update`, `status`, or `doctor`. The new
+  `ui.Sanitize` strips C0/C1 control characters (incl. ESC, CR, LF, TAB, DEL) at
+  the display boundary — applied to every site that renders fetched (or
+  native-config-derived) plugin/marketplace metadata: `explain`'s skip
+  itemization (`emitSkipDetails`), plugin header, and `--list` rows; the shared
+  translation report's plugin label that `apply` prints (`render` `printText`);
+  the `plugin` (install/list), `marketplace` (add/list), and `update`
+  (pending-bump/upgrade) status lines; and the `status`/`doctor`
+  undeclared-native-plugin note — before width/`Pad` so a stripped byte can't
+  skew column alignment (and the `LF` strip stops an id forging an extra report
+  line). Printable text (incl. non-ASCII) is
   untouched, and `explain --json` keeps ids/components raw (the machine contract,
   where the consumer owns escaping). The rendered Codex agent TOML was already
   safe (the marshaller escapes control bytes and the filename uses the canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,16 +53,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   to the terminal.** A fetched marketplace plugin's id, version, or a component
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
   escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
-  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`
-  or `apply`. The new `ui.Sanitize` strips C0/C1 control characters (incl. ESC,
-  CR, LF, TAB, DEL) at the display boundary — applied to `explain`'s skip
-  itemization (`emitSkipDetails`), plugin header, and `--list` text rows, and to
-  the shared translation report's plugin label that `apply` prints (`render`
-  `printText`) — before width/`Pad` so a stripped byte can't skew column
+  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`,
+  `apply`, or `plugin install`. The new `ui.Sanitize` strips C0/C1 control
+  characters (incl. ESC, CR, LF, TAB, DEL) at the display boundary — applied to
+  `explain`'s skip itemization (`emitSkipDetails`), plugin header, and `--list`
+  text rows, to the shared translation report's plugin label that `apply` prints
+  (`render` `printText`), and to the fetched version on the `plugin install`
+  status line — before width/`Pad` so a stripped byte can't skew column
   alignment (and the `LF` strip stops an id forging an extra report line).
-  Printable text (incl. non-ASCII) is untouched, and `explain
-  --json` keeps ids/components raw (the machine contract, where the consumer
-  owns escaping). The rendered Codex agent TOML was already safe (the marshaller
+  Printable text (incl. non-ASCII) is untouched, and `explain --json` keeps
+  ids/components raw (the machine contract, where the consumer owns escaping).
+  The rendered Codex agent TOML was already safe (the marshaller
   escapes control bytes and the filename uses the canonical name).
 
 - **Codex subagents no longer report a spurious "dropped name".** The Codex
@@ -124,7 +125,7 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   (`marketplace.ProjectInstalled`) and builds its coverage row from only that
   plugin's own components, so each row — counts, coverage glyph, and skip
   details, in both text and `--json` — reflects exactly the plugin named.
-  (`apply`/`verify`'s end-of-run report still shows the per-agent summary across
+  (`apply`'s end-of-run report still shows the per-agent summary across
   the whole model.)
 
 - **Managed-file banner on rendered memory.** Every rendered memory file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,19 +49,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
-- **`explain` sanitizes untrusted plugin/component names before rendering them
+- **agentsync sanitizes untrusted plugin/component names before rendering them
   to the terminal.** A fetched marketplace plugin's id, version, or a component
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
   escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
-  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`.
-  The new `ui.Sanitize` strips C0/C1 control characters (incl. ESC, CR, LF, TAB,
-  DEL) at the display boundary — applied to the skip itemization
-  (`emitSkipDetails`), the plugin header, and the `--list` text rows, before
-  width/`Pad` so a stripped byte can't skew column alignment. Printable text
-  (incl. non-ASCII) is untouched, and `explain --json` keeps ids/components raw
-  (the machine contract, where the consumer owns escaping). The rendered Codex
-  agent TOML was already safe (the marshaller escapes control bytes and the
-  filename uses the canonical name).
+  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`,
+  `apply`, or `verify`. The new `ui.Sanitize` strips C0/C1 control characters
+  (incl. ESC, CR, LF, TAB, DEL) at the display boundary — applied to `explain`'s
+  skip itemization (`emitSkipDetails`), plugin header, and `--list` text rows,
+  and to the shared `apply`/`verify` translation report's plugin label
+  (`render` `printText`) — before width/`Pad` so a stripped byte can't skew
+  column alignment. Printable text (incl. non-ASCII) is untouched, and `explain
+  --json` keeps ids/components raw (the machine contract, where the consumer
+  owns escaping). The rendered Codex agent TOML was already safe (the marshaller
+  escapes control bytes and the filename uses the canonical name).
 
 - **Codex subagents no longer report a spurious "dropped name".** The Codex
   adapter writes the canonical `name` straight into the agent TOML's `name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,14 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   to the terminal.** A fetched marketplace plugin's id, version, or a component
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/
   escape sequences (CSI color, OSC title-set, `\r`/`\x1b`) could recolor the
-  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`,
-  `apply`, or `verify`. The new `ui.Sanitize` strips C0/C1 control characters
-  (incl. ESC, CR, LF, TAB, DEL) at the display boundary — applied to `explain`'s
-  skip itemization (`emitSkipDetails`), plugin header, and `--list` text rows,
-  and to the shared `apply`/`verify` translation report's plugin label
-  (`render` `printText`) — before width/`Pad` so a stripped byte can't skew
-  column alignment. Printable text (incl. non-ASCII) is untouched, and `explain
+  terminal, clear the screen, or spoof rows when a user ran `agentsync explain`
+  or `apply`. The new `ui.Sanitize` strips C0/C1 control characters (incl. ESC,
+  CR, LF, TAB, DEL) at the display boundary — applied to `explain`'s skip
+  itemization (`emitSkipDetails`), plugin header, and `--list` text rows, and to
+  the shared translation report's plugin label that `apply` prints (`render`
+  `printText`) — before width/`Pad` so a stripped byte can't skew column
+  alignment (and the `LF` strip stops an id forging an extra report line).
+  Printable text (incl. non-ASCII) is untouched, and `explain
   --json` keeps ids/components raw (the machine contract, where the consumer
   owns escaping). The rendered Codex agent TOML was already safe (the marshaller
   escapes control bytes and the filename uses the canonical name).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,12 +32,13 @@ can resolve secrets into native config files. Areas of particular interest:
   hashed by its target path), so a tampered or re-uploaded body — or a swapped
   link target — is detected at apply rather than silently consumed. A plugin's
   id and the component names it supplies are also untrusted *display* input:
-  agentsync sanitizes them (`ui.Sanitize`) at every terminal surface that styles
-  them — `explain` and the translation report printed by `apply` — stripping
-  C0/C1 control bytes (ESC, CR, LF, …) so a hostile plugin cannot smuggle
-  terminal escape sequences (recoloring the screen, spoofing rows, or setting
-  the window title) into agentsync's own output. `explain --json` keeps ids raw
-  (a machine contract where the consumer owns escaping).
+  agentsync sanitizes them (`ui.Sanitize`) on the surfaces that render them to
+  the terminal — `explain`, the translation report `apply` prints, and the
+  `plugin install` status line — stripping C0/C1 control bytes (ESC, CR, LF, …)
+  so a hostile plugin cannot smuggle terminal escape sequences (recoloring the
+  screen, spoofing rows, or setting the window title) into agentsync's own
+  output. `explain --json` keeps ids raw (a machine contract where the consumer
+  owns escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,14 @@ can resolve secrets into native config files. Areas of particular interest:
   installed plugin is pinned with a content hash over its *entire* cache tree
   (every projected component body, not just `plugin.json`; a cached symlink is
   hashed by its target path), so a tampered or re-uploaded body — or a swapped
-  link target — is detected at apply rather than silently consumed.
+  link target — is detected at apply rather than silently consumed. A plugin's
+  id and the component names it supplies are also untrusted *display* input:
+  `explain` and the shared `apply`/`verify` translation report sanitize them
+  (`ui.Sanitize`) before styling, stripping C0/C1 control bytes (ESC, CR, LF,
+  …) so a hostile plugin cannot smuggle terminal escape sequences — recoloring
+  the screen, spoofing rows, or setting the window title — through agentsync's
+  own output. `explain --json` keeps ids raw (a machine contract where the
+  consumer owns escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,12 +32,12 @@ can resolve secrets into native config files. Areas of particular interest:
   hashed by its target path), so a tampered or re-uploaded body — or a swapped
   link target — is detected at apply rather than silently consumed. A plugin's
   id and the component names it supplies are also untrusted *display* input:
-  `explain` and the shared `apply`/`verify` translation report sanitize them
-  (`ui.Sanitize`) before styling, stripping C0/C1 control bytes (ESC, CR, LF,
-  …) so a hostile plugin cannot smuggle terminal escape sequences — recoloring
-  the screen, spoofing rows, or setting the window title — through agentsync's
-  own output. `explain --json` keeps ids raw (a machine contract where the
-  consumer owns escaping).
+  agentsync sanitizes them (`ui.Sanitize`) at every terminal surface that styles
+  them — `explain` and the translation report printed by `apply` — stripping
+  C0/C1 control bytes (ESC, CR, LF, …) so a hostile plugin cannot smuggle
+  terminal escape sequences (recoloring the screen, spoofing rows, or setting
+  the window title) into agentsync's own output. `explain --json` keeps ids raw
+  (a machine contract where the consumer owns escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,11 +32,12 @@ can resolve secrets into native config files. Areas of particular interest:
   hashed by its target path), so a tampered or re-uploaded body — or a swapped
   link target — is detected at apply rather than silently consumed. A plugin's
   id and the component names it supplies are also untrusted *display* input:
-  agentsync sanitizes them (`ui.Sanitize`) on the surfaces that render them to
-  the terminal — `explain`, the translation report `apply` prints, and the
-  `plugin install` status line — stripping C0/C1 control bytes (ESC, CR, LF, …)
-  so a hostile plugin cannot smuggle terminal escape sequences (recoloring the
-  screen, spoofing rows, or setting the window title) into agentsync's own
+  agentsync sanitizes that metadata (`ui.Sanitize`) wherever it renders it to
+  the terminal — `explain`, the `apply` translation report, and the status
+  output of `plugin` (install/list), `marketplace` (add/list), and `update`
+  (the pending-bump and upgrade lines) — stripping C0/C1 control bytes (ESC, CR,
+  LF, …) so a hostile plugin cannot smuggle terminal escape sequences (recoloring
+  the screen, spoofing rows, or setting the window title) into agentsync's own
   output. `explain --json` keeps ids raw (a machine contract where the consumer
   owns escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,16 +31,16 @@ can resolve secrets into native config files. Areas of particular interest:
   (every projected component body, not just `plugin.json`; a cached symlink is
   hashed by its target path), so a tampered or re-uploaded body — or a swapped
   link target — is detected at apply rather than silently consumed. A plugin's
-  id and the component names it supplies are also untrusted *display* input:
-  agentsync sanitizes that metadata (`ui.Sanitize`) wherever it renders it to
-  the terminal — `explain`, the `apply` translation report, and the status
-  output of `plugin` (install/list), `marketplace` (add/list), `update`
-  (bump/upgrade lines), and `status`/`doctor` (the undeclared-native-plugin
-  note) — stripping C0/C1 control bytes (ESC, CR,
-  LF, …) so a hostile plugin cannot smuggle terminal escape sequences (recoloring
-  the screen, spoofing rows, or setting the window title) into agentsync's own
-  output. `explain --json` keeps ids raw (a machine contract where the consumer
-  owns escaping).
+  id, version, and the component names it supplies are also untrusted *display*
+  input: agentsync sanitizes plugin- and native-config-derived metadata with
+  `ui.Sanitize` at every display boundary before it reaches the terminal,
+  stripping C0/C1 control bytes (ESC, CR, LF, …) so a hostile plugin cannot
+  smuggle terminal escape sequences (recoloring the screen, spoofing rows, or
+  setting the window title) into agentsync's own output. The invariant — not a
+  fixed list of commands — is that any terminal rendering of such metadata is
+  sanitized at the print boundary (today that spans `explain`, `apply`,
+  `plugin`, `marketplace`, `update`, `status`, and `doctor`). `explain --json`
+  keeps ids raw (a machine contract where the consumer owns escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,8 +34,9 @@ can resolve secrets into native config files. Areas of particular interest:
   id and the component names it supplies are also untrusted *display* input:
   agentsync sanitizes that metadata (`ui.Sanitize`) wherever it renders it to
   the terminal — `explain`, the `apply` translation report, and the status
-  output of `plugin` (install/list), `marketplace` (add/list), and `update`
-  (the pending-bump and upgrade lines) — stripping C0/C1 control bytes (ESC, CR,
+  output of `plugin` (install/list), `marketplace` (add/list), `update`
+  (bump/upgrade lines), and `status`/`doctor` (the undeclared-native-plugin
+  note) — stripping C0/C1 control bytes (ESC, CR,
   LF, …) so a hostile plugin cannot smuggle terminal escape sequences (recoloring
   the screen, spoofing rows, or setting the window title) into agentsync's own
   output. `explain --json` keeps ids raw (a machine contract where the consumer

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -168,8 +168,9 @@ included pending a faithful implementation. Replit/Rovo Dev are likewise deferre
 
 ## Reading the report
 
-Every `apply`, `verify`, and `explain` ends with a coverage report — per plugin,
-per agent — using the same three marks:
+Every `apply` and `explain` ends with a coverage report — per plugin, per agent
+— using the same three marks (`verify` does not print one; it only schema-lints
+the source and validates secrets):
 
 ```
 plugin: atlassian@anthropic

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -164,8 +164,9 @@ for discovery, `apply` never re-emits it. See
 for the full rationale.
 
 ### Translation report & coverage
-Every `apply`, `verify`, and `explain` ends with a report showing, per plugin
-per agent, what landed:
+Every `apply` and `explain` ends with a report showing, per plugin per agent,
+what landed (`verify` only schema-lints the source and validates secrets — it
+does not project plugins or print a coverage report):
 
 - **✓ native** — full fidelity; the agent has the concept directly.
 - **◐ projected** — lossy but defensible translation, explicitly reported.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -202,8 +202,10 @@ func checkPlugins(p *ui.Printer, home string) {
 		if len(missing) == 0 {
 			continue
 		}
+		// Native plugin names are influenced by the plugin author (read from the
+		// agent's native config), so sanitize before printing.
 		warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf("%d not in source: %s — run `agentsync import %s:plugin`",
-			len(missing), strings.Join(missing, ", "), name))
+			len(missing), ui.Sanitize(strings.Join(missing, ", ")), name))
 	}
 }
 

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/marketplace"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newMarketplaceCmd() *cobra.Command {
@@ -78,7 +79,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "added marketplace %s (sha=%s)\n",
-		mpName, truncate(headSHA, 12))
+		ui.Sanitize(mpName), truncate(headSHA, 12))
 	return nil
 }
 
@@ -261,7 +262,7 @@ func marketplaceListRun(cmd *cobra.Command, _ []string) error {
 	for _, name := range names {
 		mp := mps[name]
 		fmt.Fprintf(cmd.OutOrStdout(), "%-20s url=%-40s sha=%s\n",
-			name, mp.URL, truncate(mp.HeadSHA, 12))
+			ui.Sanitize(name), mp.URL, truncate(mp.HeadSHA, 12))
 	}
 	return nil
 }

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/marketplace"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newPluginCmd() *cobra.Command {
@@ -73,8 +74,12 @@ func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// spec.Version comes from the fetched plugin/marketplace manifest (untrusted),
+	// so sanitize it before printing — a control sequence in the version string
+	// must not smuggle terminal escapes into the status line. (id is the user's
+	// own argument and sha is hex, so neither needs it.)
 	fmt.Fprintf(cmd.OutOrStdout(), "installed plugin %s (version=%s sha=%s)\n",
-		id, spec.Version, truncate(spec.ManifestSHA, 12))
+		id, ui.Sanitize(spec.Version), truncate(spec.ManifestSHA, 12))
 	return nil
 }
 

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -374,7 +374,7 @@ func pluginListRun(cmd *cobra.Command, _ []string) error {
 			status = "disabled"
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%-20s version=%-10s sha=%-14s %s\n",
-			name, p.Version, truncate(p.ManifestSHA, 12), status)
+			ui.Sanitize(name), ui.Sanitize(p.Version), truncate(p.ManifestSHA, 12), status)
 	}
 	return nil
 }

--- a/internal/cli/plugin_drift_test.go
+++ b/internal/cli/plugin_drift_test.go
@@ -107,3 +107,24 @@ func TestStatus_SanitizesUndeclaredPluginName(t *testing.T) {
 		t.Errorf("status nudge should carry the sanitized plugin name; got:\n%s", out)
 	}
 }
+
+// TestDoctor_SanitizesUndeclaredPluginName mirrors the status guard for doctor's
+// own undeclared-native-plugin report, which shares the undeclaredNativePlugins
+// source and the same ui.Sanitize display boundary — so a refactor dropping the
+// doctor wrap fails a test too, not just the status one.
+func TestDoctor_SanitizesUndeclaredPluginName(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	evilName := "demo" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, evilName))
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("control byte from native plugin name leaked into doctor report: %q", out)
+	}
+	if !strings.Contains(out, "demo[31m") {
+		t.Errorf("doctor report should carry the sanitized plugin name; got:\n%s", out)
+	}
+}

--- a/internal/cli/plugin_drift_test.go
+++ b/internal/cli/plugin_drift_test.go
@@ -81,3 +81,27 @@ func TestDoctor_PluginsOKWhenNoneInstalled(t *testing.T) {
 		t.Fatalf("doctor should report a clean plugin state; got:\n%s", out)
 	}
 }
+
+// TestStatus_SanitizesUndeclaredPluginName proves the status (and doctor) nudge
+// strips terminal control bytes from a native plugin NAME — a plugin author can
+// influence the name the agent persists in its own config, which status reads
+// back via IngestPlugins. writeClaudeSettings json-encodes the settings, so the
+// hostile name rides in as a valid escaped JSON string and decodes to real
+// control bytes before the nudge prints it.
+func TestStatus_SanitizesUndeclaredPluginName(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	evilName := "demo" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, evilName))
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("control byte from native plugin name leaked into status note: %q", out)
+	}
+	// The nudge must still fire (sanitized residue present), proving non-vacuity.
+	if !strings.Contains(out, "import claude:plugin") {
+		t.Errorf("status should still nudge about the undeclared plugin; got:\n%s", out)
+	}
+}

--- a/internal/cli/plugin_drift_test.go
+++ b/internal/cli/plugin_drift_test.go
@@ -100,8 +100,10 @@ func TestStatus_SanitizesUndeclaredPluginName(t *testing.T) {
 	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
 		t.Errorf("control byte from native plugin name leaked into status note: %q", out)
 	}
-	// The nudge must still fire (sanitized residue present), proving non-vacuity.
-	if !strings.Contains(out, "import claude:plugin") {
-		t.Errorf("status should still nudge about the undeclared plugin; got:\n%s", out)
+	// The nudge must still fire AND carry the name in its sanitized form
+	// (ESC+CR stripped, the inert "[31m" residue kept) — proving the
+	// no-control-byte assertion ran against a line that actually embeds the name.
+	if !strings.Contains(out, "demo[31m") {
+		t.Errorf("status nudge should carry the sanitized plugin name; got:\n%s", out)
 	}
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -105,6 +105,15 @@ func makeVersionedMarketplace(t *testing.T, dir, version string) string {
 	t.Helper()
 	mpDir := filepath.Join(dir, "fixture-marketplace-v")
 
+	// JSON-encode the version so a value containing control bytes (used by the
+	// install-sanitization test) rides through the manifest as a valid escaped
+	// string; a normal version like "1.0.0" encodes to the same value as before.
+	vb, err := json.Marshal(version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verJSON := string(vb)
+
 	mpClaudePlugin := filepath.Join(mpDir, ".claude-plugin")
 	if err := os.MkdirAll(mpClaudePlugin, 0o755); err != nil {
 		t.Fatal(err)
@@ -113,7 +122,7 @@ func makeVersionedMarketplace(t *testing.T, dir, version string) string {
 		"name": "test-mp-v",
 		"owner": {"name": "tester"},
 		"plugins": [
-			{"name": "demo", "source": "./plugins/demo", "version": "` + version + `"}
+			{"name": "demo", "source": "./plugins/demo", "version": ` + verJSON + `}
 		]
 	}`
 	if err := os.WriteFile(filepath.Join(mpClaudePlugin, "marketplace.json"), []byte(mpJSON), 0o644); err != nil {
@@ -126,7 +135,7 @@ func makeVersionedMarketplace(t *testing.T, dir, version string) string {
 	}
 	pluginJSON := `{
 		"name": "demo",
-		"version": "` + version + `",
+		"version": ` + verJSON + `,
 		"mcpServers": {
 			"demo-mcp": {"command": "${CLAUDE_PLUGIN_ROOT}/run.sh"}
 		}
@@ -386,6 +395,41 @@ func TestPlugin_InstallFromLocalMarketplace(t *testing.T) {
 	pluginPath := filepath.Join(home, "plugins", "demo.toml")
 	if _, err := os.Stat(pluginPath); err != nil {
 		t.Fatalf("demo.toml not written: %v", err)
+	}
+}
+
+// TestPlugin_InstallSanitizesUntrustedVersion proves the `plugin install` status
+// line strips terminal control bytes from the fetched (untrusted) plugin
+// version, so a hostile marketplace cannot smuggle ANSI/escape sequences into
+// agentsync's install output. The version rides through the JSON manifest
+// (json-encoded by the fixture) and decodes to real control bytes in
+// spec.Version before the status line prints it.
+func TestPlugin_InstallSanitizesUntrustedVersion(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	// Built from code points so no literal control byte sits in the test source:
+	// "1.0" + ESC + "[31m" (a CSI color) + CR.
+	ver := "1.0" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	mpDir := makeVersionedMarketplace(t, t.TempDir(), ver)
+	if _, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "plugin", "install", "demo@test-mp-v")
+	if err != nil {
+		t.Fatalf("plugin install: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) {
+		t.Errorf("ESC byte from untrusted version leaked into install output: %q", out)
+	}
+	if strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("CR byte from untrusted version leaked into install output: %q", out)
+	}
+	// The inert CSI-parameter residue survives as plain text.
+	if !strings.Contains(out, "version=1.0[31m") {
+		t.Errorf("sanitized version not present in install output: %q", out)
 	}
 }
 

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -797,3 +797,26 @@ func TestMarketplace_AddNameNoReservedWarning(t *testing.T) {
 		t.Fatalf("a formerly-reserved name must no longer warn; got:\n%s", out)
 	}
 }
+
+// TestPlugin_ListSanitizesUntrustedVersion proves `plugin list` strips terminal
+// control bytes from the persisted plugin version (originally fetched from the
+// untrusted manifest, decoded back from the TOML) before printing it.
+func TestPlugin_ListSanitizesUntrustedVersion(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	ver := "1.0" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	mpDir := makeVersionedMarketplace(t, t.TempDir(), ver)
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "install", "demo@test-mp-v")
+	out, err := runCLI(t, env, "plugin", "list")
+	if err != nil {
+		t.Fatalf("plugin list: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("control byte from persisted version leaked into plugin list: %q", out)
+	}
+	if !strings.Contains(out, "version=1.0[31m") {
+		t.Errorf("sanitized version not present in plugin list: %q", out)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -315,9 +315,12 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 		if len(missing) == 0 {
 			continue
 		}
+		// Native plugin names come from the agent's own config (a plugin author
+		// can influence them), so sanitize before printing to keep terminal
+		// escapes out of the note. The agent `name` is a trusted registry id.
 		fmt.Fprintf(p.Err, "%s %d plugin(s) installed in %s are not in your source (%s); "+
 			"run `agentsync import %s:plugin` to manage them.\n",
-			p.Cyan("note:"), len(missing), name, strings.Join(missing, ", "), name)
+			p.Cyan("note:"), len(missing), name, ui.Sanitize(strings.Join(missing, ", ")), name)
 	}
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newUpdateCmd() *cobra.Command {
@@ -92,7 +93,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 
 		src, perr := parseMarketplaceSource(mp.Marketplace.URL)
 		if perr != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", mpName, mp.Marketplace.URL, perr)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", ui.Sanitize(mpName), mp.Marketplace.URL, perr)
 			continue
 		}
 		if mp.Marketplace.Ref != "" {
@@ -104,7 +105,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		result, err := fetcher.Fetch(src, cacheDir)
 		stopSpin()
 		if err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", mpName, err)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", ui.Sanitize(mpName), err)
 			continue
 		}
 
@@ -129,7 +130,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "fetched marketplace %s (sha=%s)\n",
-			mpName, truncate(result.HeadSHA, 12))
+			ui.Sanitize(mpName), truncate(result.HeadSHA, 12))
 	}
 
 	// Compute fresh manifest SHAs for installed plugins (for SHA drift detection).
@@ -142,7 +143,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	for _, w := range shaWarnings {
 		fmt.Fprintf(cmd.OutOrStdout(),
 			"warning: manifest-sha-mismatch plugin=%s version=%s recorded=%s fetched=%s (re-uploaded?)\n",
-			w.ID, w.Version, truncate(w.RecordedSHA, 12), truncate(w.FetchedSHA, 12))
+			ui.Sanitize(w.ID), ui.Sanitize(w.Version), truncate(w.RecordedSHA, 12), truncate(w.FetchedSHA, 12))
 	}
 
 	// Compute pending bumps.
@@ -159,7 +160,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		for _, b := range lossy {
 			fmt.Fprintf(cmd.OutOrStdout(),
 				"auto-safe: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)\n",
-				b.ID, b.From, b.To)
+				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To))
 		}
 		bumps = safe
 	}
@@ -169,7 +170,8 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "\npending bumps (%d):\n", len(bumps))
 		for _, b := range bumps {
-			fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %s → %s  [%s]\n", b.ID, b.From, b.To, b.UpdateMode)
+			fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %s → %s  [%s]\n",
+				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To), b.UpdateMode)
 		}
 	}
 
@@ -188,9 +190,10 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	// --apply: upgrade each plugin with a pending bump.
 	for _, b := range bumps {
 		if err := applyPluginBump(home, b, fetched); err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: upgrade %s failed: %v\n", b.ID, err)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: upgrade %s failed: %v\n", ui.Sanitize(b.ID), err)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s %s → %s\n", b.ID, b.From, b.To)
+			fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s %s → %s\n",
+				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To))
 		}
 	}
 
@@ -316,13 +319,13 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		tmp, err := os.MkdirTemp("", "agentsync-drift-")
 		if err != nil {
 			if warn != nil {
-				fmt.Fprintf(warn, "warning: drift check for %s skipped: %v\n", pl.ID, err)
+				fmt.Fprintf(warn, "warning: drift check for %s skipped: %v\n", ui.Sanitize(pl.ID), err)
 			}
 			continue
 		}
 		if _, ferr := marketplace.Dispatch(src).Fetch(src, tmp); ferr != nil {
 			if warn != nil {
-				fmt.Fprintf(warn, "warning: drift check for %s skipped (re-fetch failed): %v\n", pl.ID, ferr)
+				fmt.Fprintf(warn, "warning: drift check for %s skipped (re-fetch failed): %v\n", ui.Sanitize(pl.ID), ferr)
 			}
 			_ = os.RemoveAll(tmp)
 			continue
@@ -441,7 +444,7 @@ func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]m
 	for _, b := range bumps {
 		isLossy, err := bumpIsLossy(home, b, fetched, cfg, reg, agents, userHome)
 		if err != nil {
-			fmt.Fprintf(warn, "warning: auto-safe: cannot evaluate %s (%v); excluding to be safe\n", b.ID, err)
+			fmt.Fprintf(warn, "warning: auto-safe: cannot evaluate %s (%v); excluding to be safe\n", ui.Sanitize(b.ID), err)
 			lossy = append(lossy, b)
 			continue
 		}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -419,3 +419,32 @@ func TestUpdate_DryRunNoBump(t *testing.T) {
 		t.Errorf("dry-run update should not apply, got: %s", out)
 	}
 }
+
+// TestUpdate_SanitizesUntrustedBumpVersion proves the `update` pending-bumps
+// list strips terminal control bytes from the fetched candidate version. A
+// non-semver candidate triggers track-latest (any change bumps), so the hostile
+// version reaches the bump line and must be defanged before printing.
+func TestUpdate_SanitizesUntrustedBumpVersion(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mpDir := makeVersionedMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "install", "demo@test-mp-v")
+	mustRun(t, env, "apply")
+	// Publish a non-semver candidate carrying control bytes -> a pending bump.
+	hostile := "9.9" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	_ = makeVersionedMarketplace(t, base, hostile)
+	out, err := runCLI(t, env, "update")
+	if err != nil {
+		t.Fatalf("update: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("control byte from fetched bump version leaked into update output: %q", out)
+	}
+	if !strings.Contains(out, "pending bumps") {
+		t.Errorf("expected a pending bump to be listed; got:\n%s", out)
+	}
+}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -111,6 +111,10 @@ func (r TranslationReport) PrintTextStyled(w io.Writer, p *ui.Printer) {
 	r.printText(w, p)
 }
 
+// printText is the shared body of PrintText / PrintTextStyled. The only
+// untrusted token it renders is the plugin label (a fetched marketplace id),
+// which is passed through ui.Sanitize before reaching the terminal so a hostile
+// plugin cannot smuggle ANSI/control sequences into the report; see the loop.
 func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 	// Group rows by plugin.
 	byPlugin := map[string][]PluginRow{}
@@ -129,11 +133,19 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 		// The plugin label is the plugin id from fetched marketplace metadata
 		// (untrusted), so sanitize it before rendering to the terminal: a control
 		// sequence smuggled into a plugin id must not recolor/clear the screen or
-		// spoof rows in the apply/verify translation report. Clean labels pass
-		// through unchanged, so the byte-stable plain fixtures still hold. (The
-		// explain command sanitizes the same untrusted source at its own display
-		// sites; this covers the shared report path that apply/verify print
-		// through.)
+		// spoof rows in the translation report `apply` prints. Sanitizing strips
+		// embedded newlines too, so the id cannot forge an extra report line.
+		// Clean labels pass through unchanged, so the byte-stable plain fixtures
+		// still hold. (The explain command sanitizes the same untrusted source at
+		// its own display sites; this covers the shared report body explain
+		// reuses too.)
+		//
+		// Grouping and ordering still key on the RAW label (byPlugin,
+		// pluginOrder, sort.Strings): two distinct raw ids that sanitize to the
+		// same visible text therefore render as separate rows that merely look
+		// alike — a cosmetic spoof of the same class as the bidi/zero-width runes
+		// ui.Sanitize deliberately leaves, not a terminal-control escape, so it
+		// is an accepted residual.
 		label := ui.Sanitize(plug)
 		if p != nil {
 			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), label)

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -126,10 +126,19 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 	sort.Strings(pluginOrder)
 
 	for _, plug := range pluginOrder {
+		// The plugin label is the plugin id from fetched marketplace metadata
+		// (untrusted), so sanitize it before rendering to the terminal: a control
+		// sequence smuggled into a plugin id must not recolor/clear the screen or
+		// spoof rows in the apply/verify translation report. Clean labels pass
+		// through unchanged, so the byte-stable plain fixtures still hold. (The
+		// explain command sanitizes the same untrusted source at its own display
+		// sites; this covers the shared report path that apply/verify print
+		// through.)
+		label := ui.Sanitize(plug)
 		if p != nil {
-			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), plug)
+			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), label)
 		} else {
-			fmt.Fprintf(w, "plugin: %s\n", plug)
+			fmt.Fprintf(w, "plugin: %s\n", label)
 		}
 		rows := byPlugin[plug]
 		sort.Slice(rows, func(i, j int) bool { return rows[i].Agent < rows[j].Agent })

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -1,7 +1,8 @@
 // Package render — translation report.
 //
 // TranslationReport summarises, per plugin (or source component), how many
-// items each adapter rendered vs skipped. Emitted at the end of apply/verify.
+// items each adapter rendered vs skipped. Emitted at the end of apply (and
+// rendered per-plugin by explain); verify does not print it.
 package render
 
 import (
@@ -41,7 +42,7 @@ type PluginRow struct {
 	// SkipDetails enumerates the components behind Skips — what the adapter
 	// could not translate, and why — so a "(N skipped)" tally is never a dead
 	// end. Attribution follows the canonical+plan passed to BuildReport (see its
-	// doc): when the caller passes the whole flattened model (apply/verify), the
+	// doc): when the caller passes the whole flattened model (apply), the
 	// skips are the agent's across every component and are repeated under each
 	// plugin row; when the caller passes a per-plugin-scoped model (`explain
 	// <id>`, which re-projects one plugin in isolation), they are narrowed to
@@ -136,9 +137,8 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 		// spoof rows in the translation report `apply` prints. Sanitizing strips
 		// embedded newlines too, so the id cannot forge an extra report line.
 		// Clean labels pass through unchanged, so the byte-stable plain fixtures
-		// still hold. (The explain command sanitizes the same untrusted source at
-		// its own display sites; this covers the shared report body explain
-		// reuses too.)
+		// still hold. (This text path is the one `apply` prints; `explain` renders
+		// its own report body and sanitizes the same untrusted source there.)
 		//
 		// Grouping and ordering still key on the RAW label (byPlugin,
 		// pluginOrder, sort.Strings): two distinct raw ids that sanitize to the
@@ -212,7 +212,7 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 // BuildReport does NOT itself correlate a component to its origin plugin — the
 // projected canonical is flattened with no origin tag. Attribution is therefore
 // the caller's choice of what model+plan to pass:
-//   - apply/verify pass the whole flattened model, so every plugin row carries
+//   - apply passes the whole flattened model, so every plugin row carries
 //     the same global counts/skips (the documented summary behavior).
 //   - `explain <id>` re-projects ONE plugin in isolation
 //     (marketplace.ProjectInstalled) and passes a model+plan holding only that
@@ -221,7 +221,7 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 	var report TranslationReport
 
 	// The canonical is flattened (no origin-plugin tag), so the per-agent counts
-	// are computed over whatever model the caller scoped: apply/verify pass the
+	// are computed over whatever model the caller scoped: apply passes the
 	// whole model (one global summary repeated per plugin row), while `explain
 	// <id>` passes a model holding only one re-projected plugin's components.
 	//

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -338,6 +338,51 @@ func TestTranslationReport_PrintTextStyled(t *testing.T) {
 	}
 }
 
+// TestTranslationReport_SanitizesUntrustedPluginLabel proves the shared
+// apply/verify translation report strips terminal control bytes from a plugin
+// id (untrusted fetched-marketplace metadata) before printing it, so a hostile
+// plugin cannot smuggle ANSI/escape sequences into agentsync's apply/verify
+// output. Both the plain (PrintText) and styled (PrintTextStyled) paths are
+// covered; the inert parameter residue ("[2J[31m") may survive as plain text.
+func TestTranslationReport_SanitizesUntrustedPluginLabel(t *testing.T) {
+	// A plugin id carrying a screen-clear CSI, a color CSI, and a carriage
+	// return — the injection payload the report's display boundary must defang.
+	const evil = "evil\x1b[2J\x1b[31m\rname"
+	c := source.Canonical{
+		Plugins: []source.Plugin{
+			{ID: "evil", Plugin: source.PluginSpec{ID: evil, Version: "1.0.0"}},
+		},
+	}
+	plan := render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+		},
+	}
+	report := render.BuildReport(c, plan, []string{"claude"})
+
+	assertClean := func(t *testing.T, where, out string) {
+		t.Helper()
+		if strings.ContainsRune(out, '\x1b') {
+			t.Errorf("%s: ESC byte leaked into report output: %q", where, out)
+		}
+		if strings.ContainsRune(out, '\r') {
+			t.Errorf("%s: CR byte leaked into report output: %q", where, out)
+		}
+		// The label is neutralized but still recognizable as inert text.
+		if !strings.Contains(out, "plugin: evil[2J[31mname") {
+			t.Errorf("%s: sanitized plugin label not present: %q", where, out)
+		}
+	}
+
+	// Plain path (p == nil) and the styled path under ColorNever (p != nil, so no
+	// legitimate ANSI is emitted) — both must carry no raw ESC/CR from the id.
+	var plain, styled bytes.Buffer
+	report.PrintText(&plain)
+	report.PrintTextStyled(&styled, ui.New(&styled, &styled, ui.ColorNever))
+	assertClean(t, "PrintText", plain.String())
+	assertClean(t, "PrintTextStyled", styled.String())
+}
+
 func TestTranslationReport_PrintJSON(t *testing.T) {
 	c := source.Canonical{
 		Plugins: []source.Plugin{

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -339,28 +339,36 @@ func TestTranslationReport_PrintTextStyled(t *testing.T) {
 }
 
 // TestTranslationReport_SanitizesUntrustedPluginLabel proves the shared
-// apply/verify translation report strips terminal control bytes from a plugin
-// id (untrusted fetched-marketplace metadata) before printing it, so a hostile
-// plugin cannot smuggle ANSI/escape sequences into agentsync's apply/verify
-// output. Both the plain (PrintText) and styled (PrintTextStyled) paths are
-// covered; the inert parameter residue ("[2J[31m") may survive as plain text.
+// translation report (printed by `apply`, and whose body `explain` reuses)
+// strips terminal control bytes from a plugin id (untrusted fetched-marketplace
+// metadata) before printing it, so a hostile plugin cannot smuggle ANSI/escape
+// sequences into agentsync's output. The payload also embeds a NEWLINE that
+// forges a second "plugin:" header line — sanitizing must drop it so the id
+// stays on its own line and cannot fabricate rows. Both the plain (PrintText)
+// and styled-under-ColorNever (PrintTextStyled) paths, and the disabled-plugin
+// row, are covered; the inert CSI-parameter residue ("[2J[31m") is plain text.
 func TestTranslationReport_SanitizesUntrustedPluginLabel(t *testing.T) {
-	// A plugin id carrying a screen-clear CSI, a color CSI, and a carriage
-	// return — the injection payload the report's display boundary must defang.
-	const evil = "evil\x1b[2J\x1b[31m\rname"
-	c := source.Canonical{
-		Plugins: []source.Plugin{
-			{ID: "evil", Plugin: source.PluginSpec{ID: evil, Version: "1.0.0"}},
-		},
-	}
-	plan := render.RenderPlan{
-		PerAgent: map[string]render.AgentResult{
-			"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
-		},
-	}
-	report := render.BuildReport(c, plan, []string{"claude"})
+	// A plugin id that tries to (a) clear the screen + set a color via CSI,
+	// (b) hide a carriage return, and (c) inject a \n to forge a SECOND plugin
+	// header row. Every control byte — including the \n — must be stripped.
+	const evil = "x\x1b[2J\x1b[31m\r\nplugin: SPOOFED"
+	const wantHeader = "plugin: x[2J[31mplugin: SPOOFED" // ESC/CR/LF gone, residue inert
 
-	assertClean := func(t *testing.T, where, out string) {
+	build := func(disabled bool) render.TranslationReport {
+		c := source.Canonical{Plugins: []source.Plugin{
+			{ID: "evil", Plugin: source.PluginSpec{ID: evil, Version: "1.0.0", Disabled: disabled}},
+		}}
+		plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+			"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+		}}
+		return render.BuildReport(c, plan, []string{"claude"})
+	}
+
+	// assertNoInjection pins three things at once: no raw ESC/CR survives, the
+	// output is EXACTLY two lines (so the injected \n forged no third line), and
+	// the whole hostile id collapsed onto the one header line (wantHeader). The
+	// caller names the expected substring of the second (non-header) line.
+	assertNoInjection := func(t *testing.T, where, out, wantSecond string) {
 		t.Helper()
 		if strings.ContainsRune(out, '\x1b') {
 			t.Errorf("%s: ESC byte leaked into report output: %q", where, out)
@@ -368,19 +376,68 @@ func TestTranslationReport_SanitizesUntrustedPluginLabel(t *testing.T) {
 		if strings.ContainsRune(out, '\r') {
 			t.Errorf("%s: CR byte leaked into report output: %q", where, out)
 		}
-		// The label is neutralized but still recognizable as inert text.
-		if !strings.Contains(out, "plugin: evil[2J[31mname") {
-			t.Errorf("%s: sanitized plugin label not present: %q", where, out)
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("%s: newline injection — want exactly 2 lines (header + row), got %d: %q",
+				where, len(lines), out)
+		}
+		if lines[0] != wantHeader {
+			t.Errorf("%s: header line = %q, want %q", where, lines[0], wantHeader)
+		}
+		if !strings.Contains(lines[1], wantSecond) {
+			t.Errorf("%s: second line = %q, want it to contain %q", where, lines[1], wantSecond)
 		}
 	}
 
-	// Plain path (p == nil) and the styled path under ColorNever (p != nil, so no
-	// legitimate ANSI is emitted) — both must carry no raw ESC/CR from the id.
-	var plain, styled bytes.Buffer
-	report.PrintText(&plain)
-	report.PrintTextStyled(&styled, ui.New(&styled, &styled, ui.ColorNever))
-	assertClean(t, "PrintText", plain.String())
-	assertClean(t, "PrintTextStyled", styled.String())
+	t.Run("enabled plugin: plain and styled-ColorNever", func(t *testing.T) {
+		report := build(false)
+		var plain, styled bytes.Buffer
+		report.PrintText(&plain)
+		report.PrintTextStyled(&styled, ui.New(&styled, &styled, ui.ColorNever))
+		assertNoInjection(t, "PrintText", plain.String(), "claude")
+		assertNoInjection(t, "PrintTextStyled", styled.String(), "claude")
+	})
+
+	t.Run("disabled plugin header is sanitized too", func(t *testing.T) {
+		// A disabled plugin renders the (sanitized) header + a "(disabled…)"
+		// marker line instead of agent rows — the hostile id must be defanged on
+		// that path as well.
+		var plain bytes.Buffer
+		build(true).PrintText(&plain)
+		assertNoInjection(t, "PrintText(disabled)", plain.String(), "(disabled by project)")
+	})
+}
+
+// TestTranslationReport_JSONKeepsUntrustedLabelRaw pins the other half of the
+// contract: `--json` is a machine surface where the consumer owns escaping, so
+// PrintJSON must NOT strip control bytes from a plugin id (unlike the text
+// path). Asserting the hostile id round-trips byte-for-byte proves the sanitize
+// step is scoped to the terminal renderer and never leaks into the JSON.
+func TestTranslationReport_JSONKeepsUntrustedLabelRaw(t *testing.T) {
+	const evil = "x\x1b[2J\x1b[31m\r\nplugin: SPOOFED"
+	c := source.Canonical{Plugins: []source.Plugin{
+		{ID: "evil", Plugin: source.PluginSpec{ID: evil}},
+	}}
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{{Action: "write", MergeStrategy: "merge-json-keys"}}},
+	}}
+	report := render.BuildReport(c, plan, []string{"claude"})
+
+	var buf bytes.Buffer
+	if err := report.PrintJSON(&buf); err != nil {
+		t.Fatalf("PrintJSON: %v", err)
+	}
+	var got render.TranslationReport
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal PrintJSON output: %v", err)
+	}
+	if len(got.Rows) == 0 {
+		t.Fatal("no rows decoded from PrintJSON output")
+	}
+	if got.Rows[0].Plugin != evil {
+		t.Errorf("JSON must keep the id raw (consumer owns escaping): got %q, want %q",
+			got.Rows[0].Plugin, evil)
+	}
 }
 
 func TestTranslationReport_PrintJSON(t *testing.T) {


### PR DESCRIPTION
Completes issue #93. #97 added `ui.Sanitize` and applied it at every
`explain` display site (skip name/reason, plugin header, `--list` rows),
but the shared translation report rendered by `apply`/`verify`
(`render.printText`) still printed the plugin label raw. That label is the
plugin id from fetched marketplace metadata (untrusted), so a hostile plugin
could smuggle ANSI/escape sequences — a screen-clear CSI, a color CSI, an
OSC title-set, `\r`/`\x1b` — into agentsync's own `apply`/`verify` output to
recolor the terminal, clear the screen, or spoof report rows.

- internal/render/report.go: `printText` now runs the plugin label through
  `ui.Sanitize` before printing, in both the styled (`p != nil`) and plain
  paths. Clean labels pass through verbatim, so the byte-stable plain
  fixtures still hold; only control bytes are stripped.
- internal/render/report_test.go: TestTranslationReport_SanitizesUntrustedPluginLabel
  feeds a plugin id carrying a screen-clear/color CSI + CR and asserts no raw
  ESC/CR survives either PrintText or PrintTextStyled. Break-verified by
  printing the raw label (ESC+CR leak) and restoring.
- SECURITY.md: record the terminal-output sanitization guarantee under the
  untrusted-marketplaces threat model (the issue's acceptance criterion).
- CHANGELOG.md: broaden the existing [Unreleased] entry from "explain
  sanitizes…" to cover the apply/verify report too.

With this, every site that styles plugin-derived text — explain and the
shared apply/verify report — sanitizes before render, satisfying #93's
acceptance criteria. (The optional ingestion-time guard the issue floats as
secondary is intentionally not added; the display-layer fix is the
authoritative guarantee.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RiptBL4GbCxdZnYZN3trrV