### PR TITLE
fix(ui): strip deceptive bidi/zero-width runes in Sanitize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`ui.Sanitize` now also strips deceptive bidi / zero-width runes, not just
+  terminal-control bytes.** Following up on the escape-injection fix below, the
+  same untrusted-name display boundary now removes the printable-but-deceptive
+  format runes: the explicit Unicode bidi controls (U+202A–U+202E, U+2066–U+2069
+  — the "Trojan Source" / CVE-2021-42574 class, where a crafted U+202E could
+  visually reorder a plugin id in `explain` output to read as a trusted name)
+  and the zero-width / invisible runes (U+200B–U+200D, U+FEFF) that can hide or
+  invisibly pad a name. Ordinary right-to-left scripts (Arabic, Hebrew) and CJK
+  are preserved byte-for-byte — only the explicit override/isolate controls are
+  removed, never the implicit direction of legitimate letters. Display *width*
+  (combining marks, wide-width runes skewing `Pad`/`visibleLen` column
+  alignment) remains an accepted, documented cosmetic limitation, not a spoofing
+  vector.
+
 - **agentsync sanitizes untrusted plugin/component names before rendering them
   to the terminal.** A fetched marketplace plugin's id, version, or a component
   name it supplies is attacker-influenced; rendered raw, a name carrying ANSI/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,11 +36,22 @@ can resolve secrets into native config files. Areas of particular interest:
   `ui.Sanitize` at every display boundary before it reaches the terminal,
   stripping C0/C1 control bytes (ESC, CR, LF, …) so a hostile plugin cannot
   smuggle terminal escape sequences (recoloring the screen, spoofing rows, or
-  setting the window title) into agentsync's own output. The invariant — not a
-  fixed list of commands — is that any terminal rendering of such metadata is
-  sanitized at the print boundary (today that spans `explain`, `apply`,
-  `plugin`, `marketplace`, `update`, `status`, and `doctor`). `explain --json`
-  keeps ids raw (a machine contract where the consumer owns escaping).
+  setting the window title) into agentsync's own output. `ui.Sanitize` also
+  strips the printable-but-deceptive format runes: the explicit Unicode bidi
+  controls (U+202A–U+202E, U+2066–U+2069 — the "Trojan Source" / CVE-2021-42574
+  class that can visually reorder a plugin id to read as a trusted name) and the
+  zero-width / invisible runes (U+200B–U+200D, U+FEFF) that can hide or pad a
+  name. Ordinary right-to-left scripts (Arabic, Hebrew) and CJK are preserved
+  byte-for-byte — only the explicit override/isolate controls an attacker would
+  inject are removed, never the implicit direction of legitimate letters.
+  Display *width* is explicitly out of scope: combining marks and wide-width
+  runes can still skew agentsync's rune-counted column alignment, a purely
+  cosmetic limitation (documented on `ui.Pad`), not a spoofing vector. The
+  invariant — not a fixed list of commands — is that any terminal rendering of
+  such metadata is sanitized at the print boundary (today that spans `explain`,
+  `apply`, `plugin`, `marketplace`, `update`, `status`, and `doctor`).
+  `explain --json` keeps ids raw (a machine contract where the consumer owns
+  escaping).
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -152,6 +152,14 @@ func (p *Printer) Section(title string) {
 // is single-width) rather than bytes, then returns the padded plain string.
 // Callers color the RESULT so that ANSI bytes never throw off the column —
 // padding is applied before any escape codes exist.
+//
+// Alignment is best-effort for non-ASCII: counting is per-rune, so wide/
+// ambiguous-width runes (CJK, emoji) and combining marks make the rune count
+// diverge from the actual display-cell width and skew the column. This is a
+// deliberate, purely cosmetic limitation — bringing in a grapheme-aware width
+// table (golang.org/x/text/width) was judged not worth the dependency for the
+// curated, mostly-ASCII output here. Sanitize removes the security-relevant
+// deceptive runes (bidi/zero-width) but does not normalize width.
 func Pad(s string, width int) string {
 	n := 0
 	for range s {
@@ -163,25 +171,44 @@ func Pad(s string, width int) string {
 	return s + spaces(width-n)
 }
 
-// Sanitize strips control characters from a string so untrusted text — a fetched
-// marketplace plugin's id, a plugin-supplied component name — can be rendered to
-// a terminal without smuggling escape sequences through it. It removes C0
-// controls (0x00–0x1F, which includes ESC 0x1B, CR, LF, TAB, BEL, and
-// backspace), DEL (0x7F), and C1 controls (0x80–0x9F). Neutralizing the ESC/CSI
-// introducer is the security-relevant part: a name like "\x1b[31mX" renders as
-// the inert literal "[31mX" rather than recoloring the terminal, clearing the
-// screen, or spoofing subsequent rows. Printable text (including non-ASCII
-// letters and ordinary spaces) passes through unchanged. Apply it at the display
-// boundary, before width/Pad calculation, so a stripped byte never throws off
-// column alignment.
+// Sanitize strips control characters and deceptive format runes from a string so
+// untrusted text — a fetched marketplace plugin's id, a plugin-supplied component
+// name — can be rendered to a terminal without smuggling escape sequences or
+// spoofed/hidden text through it. It removes:
+//
+//   - C0 controls (0x00–0x1F, which includes ESC 0x1B, CR, LF, TAB, BEL, and
+//     backspace), DEL (0x7F), and C1 controls (0x80–0x9F). Neutralizing the
+//     ESC/CSI introducer is the security-relevant part: a name like "\x1b[31mX"
+//     renders as the inert literal "[31mX" rather than recoloring the terminal,
+//     clearing the screen, or spoofing subsequent rows.
+//   - The explicit Unicode bidirectional formatting controls — the embedding/
+//     override set U+202A–U+202E (LRE/RLE/PDF/LRO/RLO) and the isolate set
+//     U+2066–U+2069 (LRI/RLI/FSI/PDI). These are the "Trojan Source"
+//     (CVE-2021-42574) class: U+202E and friends can visually reorder a plugin
+//     id so it reads as a trusted name while its bytes say otherwise.
+//   - Zero-width / invisible format runes — U+200B–U+200D (ZWSP/ZWNJ/ZWJ) and
+//     U+FEFF (zero-width no-break space / BOM) — which can hide characters or
+//     invisibly pad a name.
+//
+// Printable text passes through unchanged, including non-ASCII letters and
+// ordinary spaces. This deliberately leaves *implicit* bidi alone: ordinary
+// right-to-left scripts (Arabic, Hebrew) and CJK get their direction from the
+// letters themselves, not from the explicit override controls, so a legitimate
+// non-Latin name survives byte-for-byte — only the explicit formatting controls
+// an attacker would inject are removed. Apply Sanitize at the display boundary,
+// before width/Pad calculation, so a stripped rune never throws off column
+// alignment.
 //
 // Scanning is rune-level (not byte-level): byte-level stripping of the 0x80–0x9F
 // range would corrupt legitimate multibyte UTF-8 (a CJK rune's continuation
 // bytes live there). Invalid UTF-8 is normalized rather than passed verbatim — a
 // malformed byte decodes to U+FFFD and is re-emitted as U+FFFD, so a raw
 // 0x80–0x9F byte (a C1 CSI introducer on an 8-bit terminal) can never survive.
-// Sanitize does NOT touch bidi-override or zero-width runes (U+202E, U+200B, …):
-// those are a cosmetic spoofing concern, not a terminal-control one.
+//
+// What Sanitize does NOT do: it does not normalize display *width*. Combining
+// marks and wide/ambiguous-width runes still skew the rune-counting Pad/visibleLen
+// alignment; that is a purely cosmetic limitation, documented on Pad, not a
+// spoofing vector this function targets.
 func Sanitize(s string) string {
 	// Fast path: the overwhelmingly common case is clean text, so scan once and
 	// only allocate when there is something to change. We also rebuild on invalid
@@ -190,7 +217,7 @@ func Sanitize(s string) string {
 	// CSI introducer on an 8-bit terminal) can never pass through verbatim.
 	clean := true
 	for _, r := range s {
-		if isControl(r) || r == utf8.RuneError {
+		if shouldStrip(r) || r == utf8.RuneError {
 			clean = false
 			break
 		}
@@ -201,17 +228,44 @@ func Sanitize(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
-		if !isControl(r) {
+		if !shouldStrip(r) {
 			b.WriteRune(r) // WriteRune(RuneError) emits U+FFFD, normalizing bad bytes
 		}
 	}
 	return b.String()
 }
 
+// shouldStrip reports whether Sanitize removes r: either a terminal-control rune
+// (isControl) or a deceptive format rune (isDeceptiveFormat).
+func shouldStrip(r rune) bool {
+	return isControl(r) || isDeceptiveFormat(r)
+}
+
 // isControl reports whether r is a C0 control (incl. ESC/CR/LF/TAB), DEL, or a
 // C1 control — the runes that can carry terminal escape semantics.
 func isControl(r rune) bool {
 	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+// isDeceptiveFormat reports whether r is a printable-but-deceptive format rune
+// that Sanitize strips: an explicit Unicode bidi formatting control (the
+// embedding/override set U+202A–U+202E and the isolate set U+2066–U+2069 — the
+// "Trojan Source" class) or a zero-width / invisible rune (U+200B–U+200D, U+FEFF).
+// It deliberately excludes ordinary RTL/CJK letters and the implicit-direction
+// marks, so legitimate non-Latin names are preserved.
+func isDeceptiveFormat(r rune) bool {
+	switch {
+	case r >= 0x202a && r <= 0x202e: // LRE, RLE, PDF, LRO, RLO
+		return true
+	case r >= 0x2066 && r <= 0x2069: // LRI, RLI, FSI, PDI
+		return true
+	case r >= 0x200b && r <= 0x200d: // ZWSP, ZWNJ, ZWJ
+		return true
+	case r == 0xfeff: // zero-width no-break space / BOM
+		return true
+	default:
+		return false
+	}
 }
 
 // WarnWriter wraps a destination writer and styles "warning: " line prefixes

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -252,9 +252,10 @@ func isControl(r rune) bool {
 // that Sanitize strips: an explicit Unicode bidi formatting control (the
 // embedding/override set U+202A–U+202E and the isolate set U+2066–U+2069 — the
 // "Trojan Source" class) or a zero-width / invisible rune (U+200B–U+200D, U+FEFF).
-// It deliberately excludes ordinary RTL/CJK letters and the implicit-direction
-// marks (U+200E/U+200F LRM/RLM, U+061C ALM), so legitimate non-Latin names are
-// preserved. Scope is the explicit bidi + zero-width spoofing set, not every
+// It deliberately excludes ordinary RTL/CJK letters and the benign directional
+// marks (U+200E/U+200F LRM/RLM, U+061C ALM) — which only set the direction of
+// adjacent neutrals and cannot reorder text the way the override/isolate controls
+// can — so legitimate non-Latin names are preserved. Scope is the explicit bidi + zero-width spoofing set, not every
 // default-ignorable or width-affecting rune: e.g. U+2028/U+2029 (line/paragraph
 // separators), U+00AD (soft hyphen), and U+2060 (word joiner) are knowingly left
 // alone — terminals don't act on them the way they do on CR/LF (which isControl

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -206,9 +206,10 @@ func Pad(s string, width int) string {
 // 0x80–0x9F byte (a C1 CSI introducer on an 8-bit terminal) can never survive.
 //
 // What Sanitize does NOT do: it does not normalize display *width*. Combining
-// marks and wide/ambiguous-width runes still skew the rune-counting Pad/visibleLen
-// alignment; that is a purely cosmetic limitation, documented on Pad, not a
-// spoofing vector this function targets.
+// marks and wide/ambiguous-width runes still skew the rune-counting alignment of
+// Pad (and of the caller-side column counting in internal/cli's explain output);
+// that is a purely cosmetic limitation, documented on Pad, not a spoofing vector
+// this function targets.
 func Sanitize(s string) string {
 	// Fast path: the overwhelmingly common case is clean text, so scan once and
 	// only allocate when there is something to change. We also rebuild on invalid
@@ -252,7 +253,12 @@ func isControl(r rune) bool {
 // embedding/override set U+202A–U+202E and the isolate set U+2066–U+2069 — the
 // "Trojan Source" class) or a zero-width / invisible rune (U+200B–U+200D, U+FEFF).
 // It deliberately excludes ordinary RTL/CJK letters and the implicit-direction
-// marks, so legitimate non-Latin names are preserved.
+// marks (U+200E/U+200F LRM/RLM, U+061C ALM), so legitimate non-Latin names are
+// preserved. Scope is the explicit bidi + zero-width spoofing set, not every
+// default-ignorable or width-affecting rune: e.g. U+2028/U+2029 (line/paragraph
+// separators), U+00AD (soft hyphen), and U+2060 (word joiner) are knowingly left
+// alone — terminals don't act on them the way they do on CR/LF (which isControl
+// already strips), and width skew is an accepted cosmetic limitation (see Pad).
 func isDeceptiveFormat(r rune) bool {
 	switch {
 	case r >= 0x202a && r <= 0x202e: // LRE, RLE, PDF, LRO, RLO

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -128,7 +128,9 @@ func TestSanitize(t *testing.T) {
 		{"invalid UTF-8 byte normalized to U+FFFD", "a\xffb", "a\ufffdb"},
 		{"pre-existing U+FFFD preserved (rebuild is idempotent)", "a\ufffdb", "a\ufffdb"},
 		// Explicit bidi formatting controls (Trojan Source / CVE-2021-42574).
-		{"RLO (U+202E) bidi override stripped", "user\u202egpj.evil", "usergpj.evil"},
+		// Cover both fences of the override range: U+202A (LRE) and U+202E (RLO).
+		{"LRE (U+202A) bidi embedding stripped (range lower fence)", "a\u202ab", "ab"},
+		{"RLO (U+202E) bidi override stripped (range upper fence)", "user\u202egpj.evil", "usergpj.evil"},
 		{"LRO (U+202D) bidi override stripped", "a\u202db", "ab"},
 		{"bidi embedding pair (U+202B/U+202C) stripped", "a\u202bb\u202cc", "abc"},
 		{"bidi isolates (U+2066\u2013U+2069) stripped", "a\u2066b\u2069c\u2067d\u2068e", "abcde"},
@@ -136,12 +138,28 @@ func TestSanitize(t *testing.T) {
 		{"zero-width space (U+200B) stripped", "a\u200bb", "ab"},
 		{"ZWNJ/ZWJ (U+200C/U+200D) stripped", "a\u200cb\u200dc", "abc"},
 		{"zero-width no-break space / BOM (U+FEFF) stripped", "a\ufeffb", "ab"},
+		// Mixed strip+preserve: prove a legitimate RTL letter survives WHILE the
+		// explicit override embedded between letters is removed (non-vacuous).
+		{"RTL letters survive while embedded override stripped", "\u0645\u202e\u0631", "\u0645\u0631"},
 		// Legitimate non-Latin names survive byte-for-byte: implicit RTL/CJK is
 		// not an explicit formatting control, so it is preserved.
 		{"Arabic name preserved", "\u0645\u0631\u062d\u0628\u0627", "\u0645\u0631\u062d\u0628\u0627"},
 		{"Hebrew name preserved", "\u05e9\u05dc\u05d5\u05dd", "\u05e9\u05dc\u05d5\u05dd"},
 		{"CJK name preserved", "\u540d\u524d-\u30d7\u30e9\u30b0\u30a4\u30f3", "\u540d\u524d-\u30d7\u30e9\u30b0\u30a4\u30f3"},
 		{"ordinary RTL letters with implicit bidi preserved", "abc-\u0645\u0631\u062d\u0628\u0627", "abc-\u0645\u0631\u062d\u0628\u0627"},
+		// Boundary preservation: runes adjacent to / just outside the stripped
+		// ranges, and benign format runes, must NOT be over-stripped. These guard
+		// the exact range fences in isDeceptiveFormat against an accidental widening.
+		{"implicit marks U+200E/U+200F (LRM/RLM) preserved", "a\u200eb\u200fc", "a\u200eb\u200fc"},
+		{"U+200A (hair space, below ZW range) preserved", "a\u200ab", "a\u200ab"},
+		{"U+200E adjacent above ZW range preserved", "a\u200eb", "a\u200eb"},
+		{"U+2029 (below override range) preserved", "a\u2029b", "a\u2029b"},
+		{"U+202F (above override range) preserved", "a\u202fb", "a\u202fb"},
+		{"U+2065 (below isolate range) preserved", "a\u2065b", "a\u2065b"},
+		{"U+206A (above isolate range) preserved", "a\u206ab", "a\u206ab"},
+		{"U+2060 (word joiner) preserved", "a\u2060b", "a\u2060b"},
+		{"U+00A0 (NBSP) preserved", "a\u00a0b", "a\u00a0b"},
+		{"U+FEFE (below BOM) preserved", "a\ufefeb", "a\ufefeb"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -127,6 +127,21 @@ func TestSanitize(t *testing.T) {
 		{"pure control string collapses to empty", "\x1b\r\n\t", ""},
 		{"invalid UTF-8 byte normalized to U+FFFD", "a\xffb", "a\ufffdb"},
 		{"pre-existing U+FFFD preserved (rebuild is idempotent)", "a\ufffdb", "a\ufffdb"},
+		// Explicit bidi formatting controls (Trojan Source / CVE-2021-42574).
+		{"RLO (U+202E) bidi override stripped", "user\u202egpj.evil", "usergpj.evil"},
+		{"LRO (U+202D) bidi override stripped", "a\u202db", "ab"},
+		{"bidi embedding pair (U+202B/U+202C) stripped", "a\u202bb\u202cc", "abc"},
+		{"bidi isolates (U+2066\u2013U+2069) stripped", "a\u2066b\u2069c\u2067d\u2068e", "abcde"},
+		// Zero-width / invisible format runes.
+		{"zero-width space (U+200B) stripped", "a\u200bb", "ab"},
+		{"ZWNJ/ZWJ (U+200C/U+200D) stripped", "a\u200cb\u200dc", "abc"},
+		{"zero-width no-break space / BOM (U+FEFF) stripped", "a\ufeffb", "ab"},
+		// Legitimate non-Latin names survive byte-for-byte: implicit RTL/CJK is
+		// not an explicit formatting control, so it is preserved.
+		{"Arabic name preserved", "\u0645\u0631\u062d\u0628\u0627", "\u0645\u0631\u062d\u0628\u0627"},
+		{"Hebrew name preserved", "\u05e9\u05dc\u05d5\u05dd", "\u05e9\u05dc\u05d5\u05dd"},
+		{"CJK name preserved", "\u540d\u524d-\u30d7\u30e9\u30b0\u30a4\u30f3", "\u540d\u524d-\u30d7\u30e9\u30b0\u30a4\u30f3"},
+		{"ordinary RTL letters with implicit bidi preserved", "abc-\u0645\u0631\u062d\u0628\u0627", "abc-\u0645\u0631\u062d\u0628\u0627"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #99.

## What

Implements **Option 2** from #99: extend `ui.Sanitize` (`internal/ui/ui.go`) to strip the printable-but-deceptive format runes that #97 deliberately left out, on top of the C0/C1/DEL terminal-control bytes it already neutralizes.

Newly stripped:
- **Explicit Unicode bidi controls** — embedding/override `U+202A–U+202E` (LRE/RLE/PDF/LRO/RLO) and isolates `U+2066–U+2069` (LRI/RLI/FSI/PDI). This is the "Trojan Source" (CVE-2021-42574) class: a crafted `U+202E` could visually reorder a plugin id in `agentsync explain` output so it reads as a trusted name.
- **Zero-width / invisible runes** — `U+200B–U+200D` (ZWSP/ZWNJ/ZWJ) and `U+FEFF` (BOM / zero-width no-break space), which can hide characters or invisibly pad a name.

Crucially **not** stripped: ordinary RTL scripts (Arabic, Hebrew) and CJK, which derive their direction from the letters themselves (implicit bidi), not from the explicit override controls. Legitimate non-Latin names survive byte-for-byte.

## Display-width decision

The `visibleLen`/`Pad` skew from combining/wide runes is recorded as a **deliberate, accepted cosmetic limitation** (documented on `ui.Pad`) rather than handled — pulling in `golang.org/x/text/width` was judged not worth the dependency for the curated, mostly-ASCII output here. It's not a spoofing vector.

## Acceptance criteria

- [x] Decision recorded in the `Sanitize` doc comment and `SECURITY.md` (strip explicit bidi + zero-width; accept + document display-width).
- [x] `Sanitize` handles the chosen set via a new `isDeceptiveFormat` predicate; `TestSanitize` gains cases for `U+202E`, other bidi controls, zero-width runes, and preserved Arabic/Hebrew/CJK names.
- [x] The doc comment's old "does NOT touch bidi-override or zero-width runes" non-goal note is replaced.
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] Display-width behavior documented on `ui.Pad`.

All call sites (`emitPluginHeader`, `runExplainList`, `emitSkipDetails`, the apply/verify report) already route through `ui.Sanitize`, so they pick this up with no change.

## Testing

`go test ./internal/ui/` passes; `golangci-lint run ./internal/ui/...` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YBQJ2zwbgwPQ1QQg3eFM5

---
_Generated by [Claude Code](https://claude.ai/code/session_013YBQJ2zwbgwPQ1QQg3eFM5)_