### PR TITLE
feat(untrusted): enforce display-boundary sanitization by type (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **Untrusted plugin/marketplace metadata is now sanitized by type, not by
+  convention (`internal/untrusted`).** Issue #93 / PR #100 sanitized ~24 terminal
+  print sites by hand-wrapping each fetched id/version/marketplace-name in
+  `ui.Sanitize`, but nothing stopped the *next* `Fprintf` from printing one raw
+  and silently reintroducing the escape-injection class. Those fields are now the
+  defined string type `untrusted.Text`, whose `String()` sanitizes — so printing
+  one through `fmt` is safe **by construction**, and obtaining the raw bytes
+  requires the explicit, greppable `Unverified()` (filesystem/lookup use only).
+  The canonical TOML / marketplace.json wire format is unchanged (`Text` is a
+  string kind: `omitempty` still elides an empty value, and `--json` surfaces
+  still emit the raw value — the machine contract). Reflection-based
+  `TestUntrustedFieldGuard`s in `internal/{source,marketplace,render}` fail the
+  build if a new string field is added to the plugin/marketplace identity or
+  report-row structs without being classified untrusted-or-trusted, and the
+  established carve-outs (hex SHAs, `%q` URLs, user-supplied CLI args, enum modes)
+  stay plain strings. `ui.Sanitize` is unchanged in behavior (it now delegates to
+  `untrusted.Sanitize`).
+
 - **`explain` describes every component kind a plugin hosts, not just MCP +
   commands.** Each agent row's count tail previously read `N mcp · N commands`
   even for a plugin that ships only skills, subagents, hooks, or an LSP server —

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,16 @@ can resolve secrets into native config files. Areas of particular interest:
   such metadata is sanitized at the print boundary (today that spans `explain`,
   `apply`, `plugin`, `marketplace`, `update`, `status`, and `doctor`).
   `explain --json` keeps ids raw (a machine contract where the consumer owns
-  escaping).
+  escaping). This invariant is enforced by **type**, not by per-site convention:
+  the plugin/marketplace id, version, name, and report-row fields are the defined
+  string type `untrusted.Text` (`internal/untrusted`), whose `String()`
+  sanitizes — so printing one through `fmt` is safe by construction, and reaching
+  the raw bytes requires the explicit, greppable `Unverified()` (for
+  filesystem/lookup use, never display). Reflection-based `TestUntrustedFieldGuard`s
+  fail the build if a new string field is added to those structs without being
+  classified, so a future field that carries fetched metadata cannot quietly ship
+  as a raw string a new print site would leak. The established carve-outs (hex
+  SHAs, `%q` URLs, user-supplied CLI arguments, enum modes) stay plain strings.
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,6 +449,19 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    re-uploaded version *or* a tampered component body is detected as drift
    rather than silently consumed. (An entry-only plugin with no cached bodies is
    pinned over its marketplace entry.)
+6. **Display-boundary sanitization, enforced by type** (`internal/untrusted`) —
+   a fetched/native plugin or marketplace id, version, or name can carry terminal
+   escapes (a screen-clear/recolor CSI, an OSC title-set) or deceptive bidi /
+   zero-width runes ("Trojan Source"). Those fields are the defined string type
+   `untrusted.Text`, whose `String()` runs `Sanitize`, so printing one through
+   `fmt` strips the danger **by construction**; the raw value is reachable only
+   via the explicit `Unverified()` (filesystem/lookup use, never display). The
+   wire format is unchanged (`Text` is a string kind — `omitempty` and `--json`
+   raw output are preserved). Reflection-based `TestUntrustedFieldGuard`s
+   (`internal/{source,marketplace,render}`) fail the build if a new string field
+   on those structs is left unclassified, so a future metadata field can't ship
+   as a raw string a new print site would leak. Carve-outs (hex SHAs, `%q` URLs,
+   user-supplied CLI args, enum modes) stay plain strings. See `SECURITY.md`.
 
 ---
 
@@ -527,7 +540,7 @@ flowchart TD
     PRJ["internal/project — <root>/.agentsync/ tree overlay"]
     DRF["internal/drift — 3-way classifier (pure)"]
     ST["internal/state — targets.json"]
-    INFRA["internal/iox · paths · jsonkeys · log"]
+    INFRA["internal/iox · paths · jsonkeys · log · untrusted"]
 
     CLI --> REN & CAP & AD & SRC & SEC & MKT & PRJ & DRF & ST
     REN --> AD & SEC & SRC & ST & DRF & INFRA
@@ -540,6 +553,6 @@ flowchart TD
     ST --> INFRA
 ```
 
-`internal/drift`, `internal/iox`, `internal/jsonkeys`, `internal/paths`, and
-`internal/log` have no internal dependencies — they're the leaves. See the
-[component map](components.md) for what each package contains.
+`internal/drift`, `internal/iox`, `internal/jsonkeys`, `internal/paths`,
+`internal/log`, and `internal/untrusted` have no internal dependencies — they're
+the leaves. See the [component map](components.md) for what each package contains.

--- a/docs/components.md
+++ b/docs/components.md
@@ -356,6 +356,16 @@ absolute and `${HOME}`-relative forms for portable state.
 ### `internal/log`
 slog setup. **Key:** `New(w, verbose) *slog.Logger`. **Files:** `log.go`.
 
+### `internal/untrusted`
+The display trust boundary for fetched/native metadata. Owns `Sanitize` (strip
+terminal-control + deceptive bidi/zero-width runes) and the `Text` defined string
+type whose `String()` sanitizes — so a plugin/marketplace id, version, or name
+typed `untrusted.Text` is safe to print through `fmt` by construction; the raw
+value is reachable only via the explicit `Unverified()`. `ui.Sanitize` delegates
+here. See [architecture §7](architecture.md#7-safety-primitives) and `SECURITY.md`.
+- **Key:** `Text` (`.String()` / `.Unverified()` / `.Empty()`); `Wrap`; `Sanitize`.
+- **Files:** `untrusted.go`.
+
 ### `internal/testenv`
 Guards FS-touching tests so they only run in the hermetic container.
 - **Key:** `RequireContainer(t)`; `MustRunInContainer()`; `InContainer() bool`;
@@ -368,6 +378,8 @@ Guards FS-touching tests so they only run in the hermetic container.
 
 `cli` sits on top of everything. `render`, `capture`, and the adapters depend on
 `source` + `secrets`. `source`/`secrets`/`state` depend only on the leaf infra
-packages (`iox`, `jsonkeys`, `paths`). `drift`, `iox`, `jsonkeys`, `paths`, and
-`log` depend on nothing internal — they're the foundation. See the rendered
-dependency graph in [architecture §10](architecture.md#10-package-layering).
+packages (`iox`, `jsonkeys`, `paths`, and — for the canonical plugin/marketplace
+identity fields typed `untrusted.Text` — `untrusted`). `drift`, `iox`,
+`jsonkeys`, `paths`, `log`, and `untrusted` depend on nothing internal — they're
+the foundation. See the rendered dependency graph in
+[architecture §10](architecture.md#10-package-layering).

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -377,7 +377,7 @@ func projectDisabledPlugins(fs afero.Fs, projHome string) ([]string, error) {
 	var out []string
 	for _, p := range pc.Plugins {
 		if p.Plugin.Disabled {
-			out = append(out, p.ID)
+			out = append(out, p.ID.Unverified())
 		}
 	}
 	return out, nil

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 func newExplainCmd() *cobra.Command {
@@ -101,14 +102,14 @@ func resolveExplainTargets(c source.Canonical, args []string, all bool) (matched
 	// (the @marketplace form and the short id).
 	byID := map[string]source.Plugin{}
 	for _, pl := range c.Plugins {
-		if pl.Plugin.ID != "" {
-			byID[pl.Plugin.ID] = pl
+		if !pl.Plugin.ID.Empty() {
+			byID[pl.Plugin.ID.Unverified()] = pl
 		}
-		if pl.ID != "" {
-			byID[pl.ID] = pl
+		if !pl.ID.Empty() {
+			byID[pl.ID.Unverified()] = pl
 		}
 	}
-	seen := map[string]bool{}
+	seen := map[untrusted.Text]bool{}
 	for _, want := range args {
 		pl, ok := byID[want]
 		if !ok {
@@ -141,8 +142,10 @@ func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
 		rows := make([]listRow, 0, len(plugins))
 		for _, pl := range plugins {
 			rows = append(rows, listRow{
-				ID:       explainLabel(pl),
-				Version:  pl.Plugin.Version,
+				// --json is the machine contract: emit the RAW id/version, the
+				// consumer owns escaping (Unverified bypasses display sanitization).
+				ID:       explainLabel(pl).Unverified(),
+				Version:  pl.Plugin.Version.Unverified(),
 				Disabled: pl.Plugin.Disabled,
 			})
 		}
@@ -164,13 +167,14 @@ func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
 	// contract, where the consumer owns escaping.)
 	maxLabel := 0
 	for _, pl := range plugins {
-		if n := visibleLen(ui.Sanitize(explainLabel(pl))); n > maxLabel {
+		if n := visibleLen(explainLabel(pl).String()); n > maxLabel {
 			maxLabel = n
 		}
 	}
 	for _, pl := range plugins {
-		label := ui.Sanitize(explainLabel(pl))
-		hasTrail := pl.Plugin.Version != "" || pl.Plugin.Disabled
+		// explainLabel/Version are untrusted.Text; String() sanitizes for display.
+		label := explainLabel(pl).String()
+		hasTrail := !pl.Plugin.Version.Empty() || pl.Plugin.Disabled
 		// Only pad the label when something follows it — a bare row with
 		// trailing spaces just leaves visible whitespace at end-of-line.
 		shown := label
@@ -178,8 +182,8 @@ func runExplainList(p *ui.Printer, c source.Canonical, jsonOut bool) error {
 			shown = ui.Pad(label, maxLabel)
 		}
 		line := fmt.Sprintf("  %s %s", p.Cyan(ui.GlyphInfo), shown)
-		if pl.Plugin.Version != "" {
-			line += "  " + p.Faint("v"+ui.Sanitize(pl.Plugin.Version))
+		if !pl.Plugin.Version.Empty() {
+			line += "  " + p.Faint("v"+pl.Plugin.Version.String())
 		}
 		if pl.Plugin.Disabled {
 			line += "  " + p.Yellow("(disabled)")
@@ -321,10 +325,10 @@ func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agen
 // id and version come from fetched marketplace metadata (untrusted), so they are
 // sanitized before styling to keep terminal escapes out of the header.
 func emitPluginHeader(w io.Writer, p *ui.Printer, pl source.Plugin) {
-	label := ui.Sanitize(explainLabel(pl))
+	label := explainLabel(pl).String()
 	parts := []string{p.Bold(p.Cyan("▸") + " " + label)}
-	if pl.Plugin.Version != "" {
-		parts = append(parts, p.Faint("v"+ui.Sanitize(pl.Plugin.Version)))
+	if !pl.Plugin.Version.Empty() {
+		parts = append(parts, p.Faint("v"+pl.Plugin.Version.String()))
 	}
 	if pl.Plugin.Disabled {
 		parts = append(parts, p.Yellow("(disabled)"))
@@ -422,15 +426,15 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 		"%s %s couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:",
 		ui.GlyphArrow, agent,
 	)))
-	// A skip's Name comes from a fetched marketplace plugin (untrusted) and its
-	// Reason from an adapter (trusted) — sanitize both at this display boundary
-	// so neither can smuggle terminal escapes, and do it BEFORE width/Pad so a
-	// stripped byte can't skew the column. The component kind is adapter-fixed,
-	// so the whole label is safe to sanitize as one unit.
+	// A skip's Name is untrusted.Text and skipLabel sanitizes it (via String())
+	// while joining it to the adapter-fixed component kind, so labels are already
+	// terminal-safe here — and sanitized BEFORE width/Pad so a stripped byte can't
+	// skew the column. Reason (below) is adapter-authored (trusted) but still run
+	// through ui.Sanitize defensively.
 	labels := make([]string, len(skips))
 	width := 0
 	for i, s := range skips {
-		labels[i] = ui.Sanitize(skipLabel(s))
+		labels[i] = skipLabel(s)
 		if n := visibleLen(labels[i]); n > width {
 			width = n
 		}
@@ -491,10 +495,11 @@ func isReducedSkip(component string) bool {
 // the loss was field-level, so the label names the component kind plainly.
 func skipLabel(s render.SkipDetail) string {
 	kind := strings.TrimSuffix(s.Component, "-frontmatter")
-	if s.Name == "" {
+	if s.Name.Empty() {
 		return kind
 	}
-	return kind + " " + s.Name
+	// s.Name is untrusted.Text; String() sanitizes it for the display label.
+	return kind + " " + s.Name.String()
 }
 
 // coverageGlyphAndColor maps a coverage string to a glyph + semantic color
@@ -511,9 +516,10 @@ func coverageGlyphAndColor(p *ui.Printer, cov string) (string, func(string) stri
 }
 
 // explainLabel returns the human label for a plugin (the @marketplace form,
-// falling back to the short id).
-func explainLabel(pl source.Plugin) string {
-	if pl.Plugin.ID != "" {
+// falling back to the short id). Both candidates are untrusted.Text, so the
+// label stays untrusted: printed via %s / String() it sanitizes itself.
+func explainLabel(pl source.Plugin) untrusted.Text {
+	if !pl.Plugin.ID.Empty() {
 		return pl.Plugin.ID
 	}
 	return pl.ID

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/marketplace"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/ui"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 func newPluginCmd() *cobra.Command {
@@ -39,12 +40,15 @@ type pluginTOML struct {
 }
 
 type pluginTOMLSpec struct {
-	ID          string   `toml:"id"`
-	Version     string   `toml:"version,omitempty"`
-	ManifestSHA string   `toml:"manifest_sha,omitempty"`
-	Update      string   `toml:"update,omitempty"`
-	Agents      []string `toml:"agents,omitempty"`
-	Disabled    bool     `toml:"disabled,omitempty"`
+	// ID/Version mirror source.PluginSpec and originate from fetched marketplace
+	// metadata, so they are untrusted.Text (sanitize-on-print). The SHA/update
+	// fields are agentsync-controlled and stay plain strings.
+	ID          untrusted.Text `toml:"id"`
+	Version     untrusted.Text `toml:"version,omitempty"`
+	ManifestSHA string         `toml:"manifest_sha,omitempty"`
+	Update      string         `toml:"update,omitempty"`
+	Agents      []string       `toml:"agents,omitempty"`
+	Disabled    bool           `toml:"disabled,omitempty"`
 }
 
 // ---- install ----------------------------------------------------------------
@@ -74,12 +78,12 @@ func pluginInstallRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// spec.Version comes from the fetched plugin/marketplace manifest (untrusted),
-	// so sanitize it before printing — a control sequence in the version string
-	// must not smuggle terminal escapes into the status line. (id is the user's
-	// own argument and sha is hex, so neither needs it.)
+	// spec.Version is untrusted.Text from the fetched manifest, so printing it via
+	// %s sanitizes it by construction — a control sequence in the version string
+	// cannot smuggle terminal escapes into the status line. (id is the user's own
+	// argument and sha is hex, so neither needs it.)
 	fmt.Fprintf(cmd.OutOrStdout(), "installed plugin %s (version=%s sha=%s)\n",
-		id, ui.Sanitize(spec.Version), truncate(spec.ManifestSHA, 12))
+		id, spec.Version, truncate(spec.ManifestSHA, 12))
 	return nil
 }
 
@@ -122,14 +126,16 @@ func installPluginInto(home, id, mpName string) (pluginTOMLSpec, error) {
 	// Write plugins/<id>.toml.
 	pluginPath := filepath.Join(home, "plugins", id+".toml")
 	spec := pluginTOMLSpec{
-		ID:          id + "@" + resolveMarketplaceName(mpName),
+		// id/marketplace are validated cache keys; wrap the composed id as Text to
+		// match the canonical model (the ManifestSHA below stays a plain string).
+		ID:          untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
 		Version:     mpEntry.Version,
 		ManifestSHA: manifestSHA,
 		Update:      "track",
 		Agents:      []string{"*"},
 	}
 	if result.Version != "" {
-		spec.Version = result.Version
+		spec.Version = untrusted.Wrap(result.Version)
 	}
 	data, err := toml.Marshal(pluginTOML{Plugin: spec})
 	if err != nil {
@@ -167,7 +173,7 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse marketplace name from the stored id "name@marketplace".
-	_, mpName := splitPluginRef(existing.Plugin.ID)
+	_, mpName := splitPluginRef(existing.Plugin.ID.Unverified())
 
 	// Re-resolve marketplace entry.
 	mpData, mpEntry, err := resolveMarketplaceEntry(home, mpName, id)
@@ -197,11 +203,11 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string) error {
 	}
 
 	existing.Plugin.ManifestSHA = manifestSHA
-	if mpEntry.Version != "" {
+	if !mpEntry.Version.Empty() {
 		existing.Plugin.Version = mpEntry.Version
 	}
 	if result.Version != "" {
-		existing.Plugin.Version = result.Version
+		existing.Plugin.Version = untrusted.Wrap(result.Version)
 	}
 
 	data, err := toml.Marshal(existing)
@@ -374,7 +380,7 @@ func pluginListRun(cmd *cobra.Command, _ []string) error {
 			status = "disabled"
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "%-20s version=%-10s sha=%-14s %s\n",
-			ui.Sanitize(name), ui.Sanitize(p.Version), truncate(p.ManifestSHA, 12), status)
+			ui.Sanitize(name), p.Version, truncate(p.ManifestSHA, 12), status)
 	}
 	return nil
 }
@@ -474,7 +480,7 @@ func resolveMarketplaceEntry(home, mpName, pluginID string) ([]byte, marketplace
 	}
 
 	for _, entry := range mp.Plugins {
-		if entry.Name == pluginID {
+		if entry.Name.Unverified() == pluginID {
 			return data, entry, nil
 		}
 	}
@@ -508,7 +514,7 @@ func searchAllMarketplaces(home, pluginID string) ([]byte, marketplace.PluginEnt
 			continue
 		}
 		for _, entry := range mp.Plugins {
-			if entry.Name == pluginID {
+			if entry.Name.Unverified() == pluginID {
 				return data, entry, nil
 			}
 		}

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -25,7 +25,7 @@ import (
 func undeclaredNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]string {
 	declared := make(map[string]bool, len(c.Plugins))
 	for _, pl := range c.Plugins {
-		declared[pl.ID] = true
+		declared[pl.ID.Unverified()] = true
 	}
 	out := map[string][]string{}
 	for _, name := range agents {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
-	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func newUpdateCmd() *cobra.Command {
@@ -88,12 +87,15 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	fetched := map[string]map[string]marketplace.PluginEntry{} // mpName → pluginName → entry
 
 	for _, mp := range c.Marketplaces {
+		// mpName is untrusted.Text: printed via %s it sanitizes itself, so the
+		// warnings/notices below need no explicit ui.Sanitize; Unverified() is the
+		// raw value for filesystem/map use.
 		mpName := mp.Name
-		cacheDir := marketplaceCacheDir(home, mpName)
+		cacheDir := marketplaceCacheDir(home, mpName.Unverified())
 
 		src, perr := parseMarketplaceSource(mp.Marketplace.URL)
 		if perr != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", ui.Sanitize(mpName), mp.Marketplace.URL, perr)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", mpName, mp.Marketplace.URL, perr)
 			continue
 		}
 		if mp.Marketplace.Ref != "" {
@@ -105,12 +107,12 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		result, err := fetcher.Fetch(src, cacheDir)
 		stopSpin()
 		if err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", ui.Sanitize(mpName), err)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", mpName, err)
 			continue
 		}
 
 		// Update state with new fetch time and SHA.
-		st.Marketplaces[mpName] = state.Marketplace{
+		st.Marketplaces[mpName.Unverified()] = state.Marketplace{
 			URL:       mp.Marketplace.URL,
 			HeadSHA:   result.HeadSHA,
 			FetchedAt: time.Now().UTC(),
@@ -123,14 +125,14 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 			if json.Unmarshal(data, &mpDoc) == nil {
 				entries := make(map[string]marketplace.PluginEntry, len(mpDoc.Plugins))
 				for _, pe := range mpDoc.Plugins {
-					entries[pe.Name] = pe
+					entries[pe.Name.Unverified()] = pe
 				}
-				fetched[mpName] = entries
+				fetched[mpName.Unverified()] = entries
 			}
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "fetched marketplace %s (sha=%s)\n",
-			ui.Sanitize(mpName), truncate(result.HeadSHA, 12))
+			mpName, truncate(result.HeadSHA, 12))
 	}
 
 	// Compute fresh manifest SHAs for installed plugins (for SHA drift detection).
@@ -143,7 +145,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	for _, w := range shaWarnings {
 		fmt.Fprintf(cmd.OutOrStdout(),
 			"warning: manifest-sha-mismatch plugin=%s version=%s recorded=%s fetched=%s (re-uploaded?)\n",
-			ui.Sanitize(w.ID), ui.Sanitize(w.Version), truncate(w.RecordedSHA, 12), truncate(w.FetchedSHA, 12))
+			w.ID, w.Version, truncate(w.RecordedSHA, 12), truncate(w.FetchedSHA, 12))
 	}
 
 	// Compute pending bumps.
@@ -160,7 +162,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		for _, b := range lossy {
 			fmt.Fprintf(cmd.OutOrStdout(),
 				"auto-safe: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)\n",
-				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To))
+				b.ID, b.From, b.To)
 		}
 		bumps = safe
 	}
@@ -171,7 +173,7 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 		fmt.Fprintf(cmd.OutOrStdout(), "\npending bumps (%d):\n", len(bumps))
 		for _, b := range bumps {
 			fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %s → %s  [%s]\n",
-				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To), b.UpdateMode)
+				b.ID, b.From, b.To, b.UpdateMode)
 		}
 	}
 
@@ -190,10 +192,10 @@ func updateRun(cmd *cobra.Command, doApply, autoSafe bool, scopeFlag, projectFla
 	// --apply: upgrade each plugin with a pending bump.
 	for _, b := range bumps {
 		if err := applyPluginBump(home, b, fetched); err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: upgrade %s failed: %v\n", ui.Sanitize(b.ID), err)
+			fmt.Fprintf(cmd.OutOrStdout(), "warning: upgrade %s failed: %v\n", b.ID, err)
 		} else {
 			fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s %s → %s\n",
-				ui.Sanitize(b.ID), ui.Sanitize(b.From), ui.Sanitize(b.To))
+				b.ID, b.From, b.To)
 		}
 	}
 
@@ -283,7 +285,10 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		if pl.Plugin.ManifestSHA == "" {
 			continue
 		}
-		_, mpName := splitPluginRef(pl.Plugin.ID)
+		// plID is the raw plugin id for filesystem/map use; pl.ID prints itself
+		// sanitized when used directly in the warnings below.
+		plID := pl.ID.Unverified()
+		_, mpName := splitPluginRef(pl.Plugin.ID.Unverified())
 		if mpName == "" {
 			mpName = "default"
 		}
@@ -291,7 +296,7 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		if !ok {
 			continue
 		}
-		mpEntry, ok := entries[pl.ID]
+		mpEntry, ok := entries[plID]
 		if !ok {
 			continue
 		}
@@ -299,7 +304,7 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		// advertises a DIFFERENT version, that's a pending bump (handled by
 		// ComputePendingBumps), not a re-upload — comparing the recorded SHA
 		// against a different version's manifest would be a false positive.
-		if mpEntry.Version != "" && mpEntry.Version != pl.Plugin.Version {
+		if !mpEntry.Version.Empty() && mpEntry.Version != pl.Plugin.Version {
 			continue
 		}
 		mpCacheRoot := marketplaceCacheDir(home, mpName)
@@ -309,8 +314,8 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		// place — the plugin.json lives at <mpCacheRoot>/<relative>/.claude-plugin/.
 		if src.Relative != "" {
 			relCacheDir := filepath.Join(mpCacheRoot, src.Relative)
-			if sha := computeManifestSHA(home, pl.ID, mpEntry, nil, relCacheDir); sha != "" {
-				out[pl.ID] = sha
+			if sha := computeManifestSHA(home, plID, mpEntry, nil, relCacheDir); sha != "" {
+				out[plID] = sha
 			}
 			continue
 		}
@@ -319,19 +324,19 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 		tmp, err := os.MkdirTemp("", "agentsync-drift-")
 		if err != nil {
 			if warn != nil {
-				fmt.Fprintf(warn, "warning: drift check for %s skipped: %v\n", ui.Sanitize(pl.ID), err)
+				fmt.Fprintf(warn, "warning: drift check for %s skipped: %v\n", pl.ID, err)
 			}
 			continue
 		}
 		if _, ferr := marketplace.Dispatch(src).Fetch(src, tmp); ferr != nil {
 			if warn != nil {
-				fmt.Fprintf(warn, "warning: drift check for %s skipped (re-fetch failed): %v\n", ui.Sanitize(pl.ID), ferr)
+				fmt.Fprintf(warn, "warning: drift check for %s skipped (re-fetch failed): %v\n", pl.ID, ferr)
 			}
 			_ = os.RemoveAll(tmp)
 			continue
 		}
-		if sha := computeManifestSHA(home, pl.ID, mpEntry, nil, tmp); sha != "" {
-			out[pl.ID] = sha
+		if sha := computeManifestSHA(home, plID, mpEntry, nil, tmp); sha != "" {
+			out[plID] = sha
 		}
 		_ = os.RemoveAll(tmp)
 	}
@@ -340,14 +345,16 @@ func computeFreshPluginSHAs(home string, plugins []source.Plugin, fetched map[st
 
 // applyPluginBump re-fetches a single plugin and updates its plugins/<id>.toml.
 func applyPluginBump(home string, b marketplace.Bump, fetched map[string]map[string]marketplace.PluginEntry) error {
-	pluginPath := filepath.Join(home, "plugins", b.ID+".toml")
+	// bID is the raw id for path/map use; b.ID prints itself sanitized in errors.
+	bID := b.ID.Unverified()
+	pluginPath := filepath.Join(home, "plugins", bID+".toml")
 	existing, err := readPluginTOML(pluginPath)
 	if err != nil {
 		return err
 	}
 
 	// Find the marketplace entry for re-fetch.
-	_, mpName := splitPluginRef(existing.Plugin.ID)
+	_, mpName := splitPluginRef(existing.Plugin.ID.Unverified())
 	if mpName == "" {
 		mpName = "default"
 	}
@@ -356,12 +363,12 @@ func applyPluginBump(home string, b marketplace.Bump, fetched map[string]map[str
 	if !ok {
 		return fmt.Errorf("marketplace %q not in fetched index", mpName)
 	}
-	mpEntry, ok := entries[b.ID]
+	mpEntry, ok := entries[bID]
 	if !ok {
 		return fmt.Errorf("plugin %q not found in marketplace %q", b.ID, mpName)
 	}
 
-	cacheDir := pluginCacheDir(home, b.ID)
+	cacheDir := pluginCacheDir(home, bID)
 	mpCacheRoot := marketplaceCacheDir(home, mpName)
 	src := mpEntry.Source
 	if src.Relative != "" {
@@ -380,7 +387,7 @@ func applyPluginBump(home string, b marketplace.Bump, fetched map[string]map[str
 	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
 		return fmt.Errorf("prepare cache dir for %s: %w", b.ID, err)
 	}
-	tmpCache, err := os.MkdirTemp(filepath.Dir(cacheDir), ".bump-"+b.ID+"-")
+	tmpCache, err := os.MkdirTemp(filepath.Dir(cacheDir), ".bump-"+bID+"-")
 	if err != nil {
 		return fmt.Errorf("temp cache for %s: %w", b.ID, err)
 	}
@@ -396,7 +403,7 @@ func applyPluginBump(home string, b marketplace.Bump, fetched map[string]map[str
 	// the recorded SHA matches the new plugin.json the re-apply will project.
 	prevTOML, _ := os.ReadFile(pluginPath) // for rollback if the cache swap fails
 	existing.Plugin.Version = b.To
-	if sha := computeManifestSHA(home, b.ID, mpEntry, nil, tmpCache); sha != "" {
+	if sha := computeManifestSHA(home, bID, mpEntry, nil, tmpCache); sha != "" {
 		existing.Plugin.ManifestSHA = sha
 	}
 	data, err := toml.Marshal(existing)
@@ -444,7 +451,7 @@ func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]m
 	for _, b := range bumps {
 		isLossy, err := bumpIsLossy(home, b, fetched, cfg, reg, agents, userHome)
 		if err != nil {
-			fmt.Fprintf(warn, "warning: auto-safe: cannot evaluate %s (%v); excluding to be safe\n", ui.Sanitize(b.ID), err)
+			fmt.Fprintf(warn, "warning: auto-safe: cannot evaluate %s (%v); excluding to be safe\n", b.ID, err)
 			lossy = append(lossy, b)
 			continue
 		}
@@ -464,11 +471,12 @@ func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]m
 // Rendering both under identical conditions cancels any pipeline quirk, so the
 // delta is exactly the bump's effect.
 func bumpIsLossy(home string, b marketplace.Bump, fetched map[string]map[string]marketplace.PluginEntry, cfg source.Config, reg *adapter.Registry, agents []string, userHome string) (bool, error) {
-	existing, err := readPluginTOML(filepath.Join(home, "plugins", b.ID+".toml"))
+	bID := b.ID.Unverified()
+	existing, err := readPluginTOML(filepath.Join(home, "plugins", bID+".toml"))
 	if err != nil {
 		return false, err
 	}
-	_, mpName := splitPluginRef(existing.Plugin.ID)
+	_, mpName := splitPluginRef(existing.Plugin.ID.Unverified())
 	if mpName == "" {
 		mpName = "default"
 	}
@@ -476,12 +484,12 @@ func bumpIsLossy(home string, b marketplace.Bump, fetched map[string]map[string]
 	if !ok {
 		return false, fmt.Errorf("marketplace %q not in fetched index", mpName)
 	}
-	mpEntry, ok := entries[b.ID]
+	mpEntry, ok := entries[bID]
 	if !ok {
 		return false, fmt.Errorf("plugin %q not found in marketplace %q", b.ID, mpName)
 	}
 
-	oldSkips, err := projectedSkips(mpEntry, pluginCacheDir(home, b.ID), cfg, reg, agents, userHome)
+	oldSkips, err := projectedSkips(mpEntry, pluginCacheDir(home, bID), cfg, reg, agents, userHome)
 	if err != nil {
 		return false, err
 	}

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // LoadProjected loads the canonical model and expands each installed plugin's
@@ -124,12 +125,12 @@ func ProjectInstalled(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 // (pl.Plugin.Disabled), or disabled by the active project tree
 // (disabledByProject[pl.ID], the plugins/<id>.toml `disabled = true` flag).
 func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugin, disabledByProject map[string]bool, lenient bool) (ProjectionResult, bool, error) {
-	if pl.Plugin.Disabled || disabledByProject[pl.ID] {
+	if pl.Plugin.Disabled || disabledByProject[pl.ID.Unverified()] {
 		return ProjectionResult{}, false, nil
 	}
-	id, mpName := splitPluginRefPkg(pl.Plugin.ID)
+	id, mpName := splitPluginRefPkg(pl.Plugin.ID.Unverified())
 	if id == "" {
-		id = pl.ID
+		id = pl.ID.Unverified()
 	}
 	// Defense-in-depth: a hand-edited plugins/<id>.toml whose id contains
 	// "../" must not let plugin.json reads escape the cache root.
@@ -255,12 +256,12 @@ func lspRenderFields(s source.LSPServerSpec) source.LSPServerSpec {
 // components; at worst a stale entry adds a slightly-ahead override.
 func resolveInstalledEntry(home, id, mpName string) PluginEntry {
 	if mpName == "" {
-		return PluginEntry{Name: id}
+		return PluginEntry{Name: untrusted.Wrap(id)}
 	}
 	cacheRoot := filepath.Join(home, ".state", "cache", "marketplaces")
 	dirs, err := os.ReadDir(cacheRoot)
 	if err != nil {
-		return PluginEntry{Name: id}
+		return PluginEntry{Name: untrusted.Wrap(id)}
 	}
 	for _, d := range dirs {
 		if !d.IsDir() {
@@ -278,12 +279,12 @@ func resolveInstalledEntry(home, id, mpName string) PluginEntry {
 			continue
 		}
 		for _, e := range mp.Plugins {
-			if e.Name == id {
+			if e.Name.Unverified() == id {
 				return e
 			}
 		}
 	}
-	return PluginEntry{Name: id}
+	return PluginEntry{Name: untrusted.Wrap(id)}
 }
 
 // verifyPluginManifestSHA checks the on-disk plugin cache against the SHA

--- a/internal/marketplace/manifest.go
+++ b/internal/marketplace/manifest.go
@@ -3,7 +3,11 @@
 // that decomposes plugin manifests into canonical source model entries.
 package marketplace
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
 
 // Marketplace is the .claude-plugin/marketplace.json document.
 type Marketplace struct {
@@ -28,20 +32,23 @@ type MarketplaceMetadata struct {
 	PluginRoot string `json:"pluginRoot,omitempty"`
 }
 
-// PluginEntry is one plugin listed in a marketplace.
+// PluginEntry is one plugin listed in a marketplace. Name/Version come straight
+// from fetched marketplace.json (untrusted), so they are untrusted.Text: they
+// sanitize themselves when printed and marshal RAW back to JSON (the machine
+// contract). Reach the raw value via Unverified() for lookup/path use.
 type PluginEntry struct {
-	Name        string   `json:"name"`
-	Source      Source   `json:"source"`
-	Description string   `json:"description,omitempty"`
-	Version     string   `json:"version,omitempty"`
-	Author      *Author  `json:"author,omitempty"`
-	Homepage    string   `json:"homepage,omitempty"`
-	Repository  string   `json:"repository,omitempty"`
-	License     string   `json:"license,omitempty"`
-	Keywords    []string `json:"keywords,omitempty"`
-	Category    string   `json:"category,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	Strict      *bool    `json:"strict,omitempty"` // conflict policy on the plugin.json+entry union (default true): strict errors on a same-name conflict, non-strict lets the entry override. See marketplace.resolveConflicts.
+	Name        untrusted.Text `json:"name"`
+	Source      Source         `json:"source"`
+	Description string         `json:"description,omitempty"`
+	Version     untrusted.Text `json:"version,omitempty"`
+	Author      *Author        `json:"author,omitempty"`
+	Homepage    string         `json:"homepage,omitempty"`
+	Repository  string         `json:"repository,omitempty"`
+	License     string         `json:"license,omitempty"`
+	Keywords    []string       `json:"keywords,omitempty"`
+	Category    string         `json:"category,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	Strict      *bool          `json:"strict,omitempty"` // conflict policy on the plugin.json+entry union (default true): strict errors on a same-name conflict, non-strict lets the entry override. See marketplace.resolveConflicts.
 
 	// Component config can be inlined here (overlaid on plugin.json):
 	Skills     any            `json:"skills,omitempty"`   // string | []string

--- a/internal/marketplace/untrusted_guard_test.go
+++ b/internal/marketplace/untrusted_guard_test.go
@@ -1,0 +1,85 @@
+package marketplace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// untrustedClassified classifies every string-shaped field on the
+// fetched-metadata structs: untrusted (true → untrusted.Text, sanitized on
+// print) or deliberately trusted/plain (false). TestUntrustedFieldGuard fails on
+// any unclassified field, so a new field carrying marketplace.json / report data
+// can't slip in as a raw string that a print site would leak. Mirrors
+// internal/source's guard and secrets.TestNewSecretFieldGuard.
+var untrustedClassified = map[string]map[string]bool{
+	"Bump": {
+		"ID":         true,  // plugin id (fetched/installed)
+		"From":       true,  // installed version
+		"To":         true,  // candidate version (fetched)
+		"UpdateMode": false, // enum: pinned | track | manual
+	},
+	"SHAWarning": {
+		"ID":          true,  // plugin id
+		"Version":     true,  // re-uploaded version
+		"RecordedSHA": false, // agentsync-computed hash
+		"FetchedSHA":  false, // agentsync-computed hash
+	},
+	"PluginEntry": {
+		"Name":    true, // marketplace.json plugin name (printed)
+		"Version": true, // marketplace.json plugin version (printed)
+		// The remaining strings come from marketplace.json too but are free-text
+		// metadata NOT rendered into any terminal layout today. They are a
+		// deliberate plain-string subset: promote one to untrusted.Text BEFORE
+		// adding a print site for it (the guard cannot catch a leak of a plain
+		// string). Kept plain to bound the refactor to the printed fields #102
+		// scopes (ids/versions/names).
+		"Description": false,
+		"Homepage":    false,
+		"Repository":  false,
+		"License":     false,
+		"Category":    false,
+	},
+}
+
+func stringShapedKind(t reflect.Type) bool { return t.Kind() == reflect.String }
+
+// TestUntrustedFieldGuard — see internal/source's identically-named guard for
+// the contract. It fails on an unclassified string-shaped field or a
+// type/classification mismatch.
+func TestUntrustedFieldGuard(t *testing.T) {
+	textType := reflect.TypeOf(untrusted.Text(""))
+	stringType := reflect.TypeOf("")
+
+	structs := map[string]reflect.Type{
+		"Bump":        reflect.TypeOf(Bump{}),
+		"SHAWarning":  reflect.TypeOf(SHAWarning{}),
+		"PluginEntry": reflect.TypeOf(PluginEntry{}),
+	}
+
+	for name, typ := range structs {
+		cover := untrustedClassified[name]
+		if cover == nil {
+			t.Fatalf("struct %s has no classification map", name)
+		}
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !stringShapedKind(f.Type) {
+				continue
+			}
+			want, ok := cover[f.Name]
+			if !ok {
+				t.Errorf("%s.%s is a string-shaped field with no untrusted classification; "+
+					"add it to untrustedClassified (true → untrusted.Text, false → plain string)", name, f.Name)
+				continue
+			}
+			switch {
+			case want && f.Type != textType:
+				t.Errorf("%s.%s is classified untrusted but is %s, want untrusted.Text", name, f.Name, f.Type)
+			case !want && f.Type != stringType:
+				t.Errorf("%s.%s is classified trusted but is %s, want plain string", name, f.Name, f.Type)
+			}
+		}
+	}
+}

--- a/internal/marketplace/update.go
+++ b/internal/marketplace/update.go
@@ -6,28 +6,34 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // Bump describes a pending plugin version change discovered by the update scan.
+// ID/From/To derive from fetched marketplace metadata, so they are
+// untrusted.Text — printed directly they sanitize themselves; reach the raw
+// value via Unverified() for filesystem/lookup use.
 type Bump struct {
 	// ID is the plugin's filesystem ID (e.g. "demo").
-	ID string
+	ID untrusted.Text
 	// From is the currently pinned version (from plugins/<id>.toml).
-	From string
+	From untrusted.Text
 	// To is the latest version available in the fetched marketplace.
-	To string
+	To untrusted.Text
 	// UpdateMode is the plugin's configured update mode ("pinned", "track", "manual").
 	UpdateMode string
 }
 
 // SHAWarning is emitted when a plugin's recorded manifest_sha differs from
 // the freshly-fetched SHA for the same version — a signal that the marketplace
-// publisher re-uploaded the same version with different content.
+// publisher re-uploaded the same version with different content. ID/Version come
+// from fetched/installed plugin metadata and are untrusted.Text; the two SHA
+// fields are agentsync-computed hex and stay plain strings.
 type SHAWarning struct {
 	// ID is the plugin's filesystem ID.
-	ID string
+	ID untrusted.Text
 	// Version is the version that was re-uploaded.
-	Version string
+	Version untrusted.Text
 	// RecordedSHA is what was stored in plugins/<id>.toml at install time.
 	RecordedSHA string
 	// FetchedSHA is the SHA of the freshly-fetched plugin.json.
@@ -42,7 +48,7 @@ type SHAWarning struct {
 func DetectSHADrift(plugins []source.Plugin, freshSHAs map[string]string) []SHAWarning {
 	var out []SHAWarning
 	for _, pl := range plugins {
-		freshSHA, ok := freshSHAs[pl.ID]
+		freshSHA, ok := freshSHAs[pl.ID.Unverified()]
 		if !ok || freshSHA == "" {
 			continue
 		}
@@ -105,11 +111,11 @@ func ComputePendingBumps(
 
 		// Find this plugin in one of the fetched marketplaces.
 		// The spec.ID format is "<name>@<marketplace>".
-		_, mpName := splitPluginRefPkg(spec.ID)
+		_, mpName := splitPluginRefPkg(spec.ID.Unverified())
 		if mpName == "" {
 			// No marketplace hint — search all fetched.
 			for _, entries := range fetched {
-				if entry, ok := entries[pl.ID]; ok {
+				if entry, ok := entries[pl.ID.Unverified()]; ok {
 					if newer := computeBump(pl, spec, entry, mode); newer != nil {
 						out = append(out, *newer)
 					}
@@ -123,7 +129,7 @@ func ComputePendingBumps(
 		if !ok {
 			continue
 		}
-		entry, ok := entries[pl.ID]
+		entry, ok := entries[pl.ID.Unverified()]
 		if !ok {
 			continue
 		}
@@ -147,7 +153,7 @@ func computeBump(pl source.Plugin, spec source.PluginSpec, entry PluginEntry, mo
 	// version is strictly OLDER. If the cores are equal (e.g. a prerelease
 	// suffix differs) or either version is non-semver, fall back to
 	// track-latest (any change bumps) so an exotic scheme isn't stranded.
-	if cmp, ok := compareSemver(spec.Version, latestVersion); ok && cmp > 0 {
+	if cmp, ok := compareSemver(spec.Version.Unverified(), latestVersion.Unverified()); ok && cmp > 0 {
 		return nil
 	}
 	return &Bump{

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -14,12 +14,16 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // PluginRow is one row in the translation report — one plugin × one agent.
 type PluginRow struct {
-	Plugin string `json:"plugin"`
-	Agent  string `json:"agent"`
+	// Plugin is the plugin id from fetched marketplace metadata (untrusted), so
+	// it is untrusted.Text: it sanitizes itself when printed to the terminal and
+	// marshals RAW to JSON (the --json machine contract owns its own escaping).
+	Plugin untrusted.Text `json:"plugin"`
+	Agent  string         `json:"agent"`
 	// Coverage is "full", "partial", or "none".
 	Coverage string `json:"coverage"`
 	// MCP, Commands, Skills, Subagents, Hooks, and LSP count the components the
@@ -58,8 +62,11 @@ type PluginRow struct {
 // for the report's machine-readable surface.
 type SkipDetail struct {
 	Component string `json:"component"`
-	Name      string `json:"name,omitempty"`
-	Reason    string `json:"reason"`
+	// Name is the skipped component's name, which for a plugin component derives
+	// from fetched marketplace metadata (untrusted) — untrusted.Text so a display
+	// site sanitizes it by construction. Reason is adapter-authored (trusted).
+	Name   untrusted.Text `json:"name,omitempty"`
+	Reason string         `json:"reason"`
 }
 
 // skipDetails converts an adapter's []Skip into the report's JSON-tagged form.
@@ -69,7 +76,9 @@ func skipDetails(skips []adapter.Skip) []SkipDetail {
 	}
 	out := make([]SkipDetail, len(skips))
 	for i, s := range skips {
-		out[i] = SkipDetail{Component: s.Component, Name: s.Name, Reason: s.Reason}
+		// s.Name is the plugin component's name (untrusted upstream); tag it as
+		// untrusted.Text at this boundary so every display site sanitizes it.
+		out[i] = SkipDetail{Component: s.Component, Name: untrusted.Wrap(s.Name), Reason: s.Reason}
 	}
 	return out
 }
@@ -113,14 +122,16 @@ func (r TranslationReport) PrintTextStyled(w io.Writer, p *ui.Printer) {
 }
 
 // printText is the shared body of PrintText / PrintTextStyled. The only
-// untrusted token it renders is the plugin label (a fetched marketplace id),
-// which is passed through ui.Sanitize before reaching the terminal so a hostile
-// plugin cannot smuggle ANSI/control sequences into the report; see the loop.
+// untrusted token it renders is the plugin label (a fetched marketplace id);
+// it is an untrusted.Text, whose String() sanitizes when it is printed via %s,
+// so a hostile plugin cannot smuggle ANSI/control sequences into the report
+// (safe by construction — see the loop).
 func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
-	// Group rows by plugin.
-	byPlugin := map[string][]PluginRow{}
-	pluginOrder := []string{}
-	seen := map[string]bool{}
+	// Group rows by plugin. The keys stay untrusted.Text (raw): grouping/ordering
+	// key on the RAW id, while the label printed below sanitizes via Text.String().
+	byPlugin := map[untrusted.Text][]PluginRow{}
+	pluginOrder := []untrusted.Text{}
+	seen := map[untrusted.Text]bool{}
 	for _, row := range r.Rows {
 		if !seen[row.Plugin] {
 			pluginOrder = append(pluginOrder, row.Plugin)
@@ -128,29 +139,30 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 		}
 		byPlugin[row.Plugin] = append(byPlugin[row.Plugin], row)
 	}
-	sort.Strings(pluginOrder)
+	// untrusted.Text is a defined string type, so ordering on it compares the raw
+	// bytes (sort.Strings can't take []Text directly).
+	sort.Slice(pluginOrder, func(i, j int) bool { return pluginOrder[i] < pluginOrder[j] })
 
 	for _, plug := range pluginOrder {
 		// The plugin label is the plugin id from fetched marketplace metadata
-		// (untrusted), so sanitize it before rendering to the terminal: a control
-		// sequence smuggled into a plugin id must not recolor/clear the screen or
-		// spoof rows in the translation report `apply` prints. Sanitizing strips
-		// embedded newlines too, so the id cannot forge an extra report line.
-		// Clean labels pass through unchanged, so the byte-stable plain fixtures
-		// still hold. (This text path is the one `apply` prints; `explain` renders
-		// its own report body and sanitizes the same untrusted source there.)
+		// (untrusted.Text). Printing it via %s invokes Text.String(), which
+		// sanitizes — a control sequence smuggled into a plugin id cannot
+		// recolor/clear the screen or spoof rows in the translation report `apply`
+		// prints, and embedded newlines are stripped so the id cannot forge an
+		// extra report line. Clean labels pass through unchanged, so the
+		// byte-stable plain fixtures still hold. (This text path is the one `apply`
+		// prints; `explain` renders its own report body over the same Text source.)
 		//
-		// Grouping and ordering still key on the RAW label (byPlugin,
-		// pluginOrder, sort.Strings): two distinct raw ids that sanitize to the
-		// same visible text therefore render as separate rows that merely look
-		// alike — a cosmetic spoof of the same class as the bidi/zero-width runes
-		// ui.Sanitize deliberately leaves, not a terminal-control escape, so it
-		// is an accepted residual.
-		label := ui.Sanitize(plug)
+		// Grouping and ordering above key on the RAW label (byPlugin, pluginOrder,
+		// the raw-byte sort): two distinct raw ids that sanitize to the same
+		// visible text therefore render as separate rows that merely look alike — a
+		// cosmetic spoof of the same class as the bidi/zero-width runes Sanitize
+		// deliberately leaves, not a terminal-control escape, so it is an accepted
+		// residual.
 		if p != nil {
-			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), label)
+			fmt.Fprintf(w, "%s %s\n", p.Bold("plugin:"), plug)
 		} else {
-			fmt.Fprintf(w, "plugin: %s\n", label)
+			fmt.Fprintf(w, "plugin: %s\n", plug)
 		}
 		rows := byPlugin[plug]
 		sort.Slice(rows, func(i, j int) bool { return rows[i].Agent < rows[j].Agent })
@@ -271,7 +283,7 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 // (counts of what the model hosts for agName), the skip tally + details, and the
 // derived coverage. c is whatever model the caller scoped (whole model or one
 // plugin); res is that agent's render result.
-func reportRow(label, agName string, c source.Canonical, res AgentResult) PluginRow {
+func reportRow(label untrusted.Text, agName string, c source.Canonical, res AgentResult) PluginRow {
 	row := PluginRow{
 		Plugin:      label,
 		Agent:       agName,

--- a/internal/render/untrusted_guard_test.go
+++ b/internal/render/untrusted_guard_test.go
@@ -1,0 +1,62 @@
+package render
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// untrustedClassified classifies every string-shaped field on the translation
+// report's row structs. The report is printed by apply/verify/explain, so any
+// field carrying fetched plugin metadata must be untrusted.Text. See
+// internal/source's TestUntrustedFieldGuard for the contract.
+var untrustedClassified = map[string]map[string]bool{
+	"PluginRow": {
+		"Plugin":   true,  // plugin id from fetched marketplace metadata
+		"Agent":    false, // trusted registry id (claude, opencode, …)
+		"Coverage": false, // enum: full | partial | none | disabled
+	},
+	"SkipDetail": {
+		"Component": false, // adapter-fixed component kind (mcp, command, …)
+		"Name":      true,  // component name, plugin-derived (untrusted)
+		"Reason":    false, // adapter-authored human reason (trusted)
+	},
+}
+
+func stringShapedKind(t reflect.Type) bool { return t.Kind() == reflect.String }
+
+func TestUntrustedFieldGuard(t *testing.T) {
+	textType := reflect.TypeOf(untrusted.Text(""))
+	stringType := reflect.TypeOf("")
+
+	structs := map[string]reflect.Type{
+		"PluginRow":  reflect.TypeOf(PluginRow{}),
+		"SkipDetail": reflect.TypeOf(SkipDetail{}),
+	}
+
+	for name, typ := range structs {
+		cover := untrustedClassified[name]
+		if cover == nil {
+			t.Fatalf("struct %s has no classification map", name)
+		}
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !stringShapedKind(f.Type) {
+				continue
+			}
+			want, ok := cover[f.Name]
+			if !ok {
+				t.Errorf("%s.%s is a string-shaped field with no untrusted classification; "+
+					"add it to untrustedClassified (true → untrusted.Text, false → plain string)", name, f.Name)
+				continue
+			}
+			switch {
+			case want && f.Type != textType:
+				t.Errorf("%s.%s is classified untrusted but is %s, want untrusted.Text", name, f.Name, f.Type)
+			case !want && f.Type != stringType:
+				t.Errorf("%s.%s is classified trusted but is %s, want plain string", name, f.Name, f.Type)
+			}
+		}
+	}
+}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // Load reads a canonical model from <home>. Missing home or missing
@@ -143,7 +144,7 @@ func loadPlugins(fs afero.Fs, home string) ([]Plugin, error) {
 		if err := toml.Unmarshal(data, &pl); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
-		pl.ID = strings.TrimSuffix(e.Name(), ".toml")
+		pl.ID = untrusted.Wrap(strings.TrimSuffix(e.Name(), ".toml"))
 		out = append(out, pl)
 	}
 	return out, nil
@@ -172,7 +173,7 @@ func loadMarketplaces(fs afero.Fs, home string) ([]Marketplace, error) {
 		if err := toml.Unmarshal(data, &m); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
-		m.Name = strings.TrimSuffix(e.Name(), ".toml")
+		m.Name = untrusted.Wrap(strings.TrimSuffix(e.Name(), ".toml"))
 		out = append(out, m)
 	}
 	return out, nil

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -4,6 +4,8 @@
 // types directly.
 package source
 
+import "github.com/spxrogers/agentsync/internal/untrusted"
+
 // Canonical is the in-memory image of a fully-loaded ~/.agentsync/ tree.
 type Canonical struct {
 	Config       Config
@@ -117,16 +119,22 @@ type SkillFile struct {
 // silent no-op. (Per-agent fan-out is still controllable via a component's
 // `agents` allowlist.)
 type Plugin struct {
-	ID     string     `toml:"-"`
-	Plugin PluginSpec `toml:"plugin"`
+	// ID is the plugin's filesystem id (the plugins/<id>.toml stem), originating
+	// from a marketplace install — untrusted.Text so a print site sanitizes it by
+	// construction; use Unverified() for path/lookup use.
+	ID     untrusted.Text `toml:"-"`
+	Plugin PluginSpec     `toml:"plugin"`
 }
 
 type PluginSpec struct {
-	ID          string   `toml:"id"`
-	Version     string   `toml:"version,omitempty"`
-	ManifestSHA string   `toml:"manifest_sha,omitempty"`
-	Update      string   `toml:"update,omitempty"` // pinned | track | manual
-	Agents      []string `toml:"agents,omitempty"`
+	// ID is "<name>@<marketplace>" and Version comes from the fetched manifest;
+	// both are untrusted.Text (see Plugin.ID). ManifestSHA/Update are
+	// agentsync-controlled and stay plain strings.
+	ID          untrusted.Text `toml:"id"`
+	Version     untrusted.Text `toml:"version,omitempty"`
+	ManifestSHA string         `toml:"manifest_sha,omitempty"`
+	Update      string         `toml:"update,omitempty"` // pinned | track | manual
+	Agents      []string       `toml:"agents,omitempty"`
 	// Disabled, when true, suppresses the plugin's projection during
 	// marketplace.LoadProjected. `agentsync plugin disable <id>` sets this.
 	// Without honouring it there, the CLI's TOML write would be a no-op:
@@ -137,7 +145,10 @@ type PluginSpec struct {
 
 // Marketplace mirrors marketplaces/<name>.toml.
 type Marketplace struct {
-	Name        string          `toml:"-"`
+	// Name is the declared marketplace name (from marketplace.json, falling back
+	// to a URL-derived slug) — untrusted.Text so a print site sanitizes it by
+	// construction; use Unverified() for path/lookup use.
+	Name        untrusted.Text  `toml:"-"`
 	Marketplace MarketplaceSpec `toml:"marketplace"`
 }
 

--- a/internal/source/untrusted_guard_test.go
+++ b/internal/source/untrusted_guard_test.go
@@ -1,0 +1,88 @@
+package source
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// untrustedClassified is the authoritative classification of every
+// string-shaped field on the plugin/marketplace identity structs: a field is
+// either untrusted (true → must be untrusted.Text, so a print site sanitizes it
+// by construction) or deliberately trusted/plain (false → a plain string).
+// TestUntrustedFieldGuard fails if a string-shaped field exists here that is in
+// neither column — forcing whoever adds it to decide whether it carries
+// fetched/native metadata that must be display-sanitized. This is the guard
+// that makes the issue-#102 invariant correct by construction rather than a
+// per-site convention nothing enforces.
+var untrustedClassified = map[string]map[string]bool{
+	"Plugin": {
+		"ID": true, // plugins/<id>.toml stem, from a marketplace install
+	},
+	"PluginSpec": {
+		"ID":          true,  // "<name>@<marketplace>", from the install ref
+		"Version":     true,  // from the fetched manifest
+		"ManifestSHA": false, // agentsync-computed tree/hex, not display text
+		"Update":      false, // enum: pinned | track | manual
+	},
+	"Marketplace": {
+		"Name": true, // declared marketplace name (marketplace.json) or URL slug
+	},
+	"MarketplaceSpec": {
+		// URL/Ref are USER-supplied (a `marketplace add <url>` argument), printed
+		// with %q — the documented carve-out that stays un-sanitized. Promote one
+		// to untrusted.Text only if it ever starts carrying fetched metadata.
+		"URL":               false,
+		"Ref":               false,
+		"DefaultUpdateMode": false, // enum
+	},
+}
+
+// stringShapedKind reports whether t is a single string-valued field — a plain
+// string OR a defined string type such as untrusted.Text (both reflect.String).
+// Slices/maps/bools/structs are not the guard's concern: none of the untrusted
+// display fields in scope are non-scalar.
+func stringShapedKind(t reflect.Type) bool { return t.Kind() == reflect.String }
+
+// TestUntrustedFieldGuard fails when a string-shaped field on a guarded struct
+// is unclassified, or when its concrete type disagrees with its classification
+// (untrusted=true demands untrusted.Text; untrusted=false demands a plain
+// string). Reverting a Text field to string, or adding a new id/version/name
+// field without tagging it Text, both trip here.
+func TestUntrustedFieldGuard(t *testing.T) {
+	textType := reflect.TypeOf(untrusted.Text(""))
+	stringType := reflect.TypeOf("")
+
+	structs := map[string]reflect.Type{
+		"Plugin":          reflect.TypeOf(Plugin{}),
+		"PluginSpec":      reflect.TypeOf(PluginSpec{}),
+		"Marketplace":     reflect.TypeOf(Marketplace{}),
+		"MarketplaceSpec": reflect.TypeOf(MarketplaceSpec{}),
+	}
+
+	for name, typ := range structs {
+		cover := untrustedClassified[name]
+		if cover == nil {
+			t.Fatalf("struct %s has no classification map", name)
+		}
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !stringShapedKind(f.Type) {
+				continue
+			}
+			want, ok := cover[f.Name]
+			if !ok {
+				t.Errorf("%s.%s is a string-shaped field with no untrusted classification; "+
+					"add it to untrustedClassified (true → untrusted.Text, false → plain string)", name, f.Name)
+				continue
+			}
+			switch {
+			case want && f.Type != textType:
+				t.Errorf("%s.%s is classified untrusted but is %s, want untrusted.Text", name, f.Name, f.Type)
+			case !want && f.Type != stringType:
+				t.Errorf("%s.%s is classified trusted but is %s, want plain string", name, f.Name, f.Type)
+			}
+		}
+	}
+}

--- a/internal/source/untrusted_guard_test.go
+++ b/internal/source/untrusted_guard_test.go
@@ -48,8 +48,11 @@ func stringShapedKind(t reflect.Type) bool { return t.Kind() == reflect.String }
 // TestUntrustedFieldGuard fails when a string-shaped field on a guarded struct
 // is unclassified, or when its concrete type disagrees with its classification
 // (untrusted=true demands untrusted.Text; untrusted=false demands a plain
-// string). Reverting a Text field to string, or adding a new id/version/name
-// field without tagging it Text, both trip here.
+// string). Its primary live coverage is a NEW unclassified id/version/name
+// field; the converse — silently reverting a Text field back to string — is
+// usually caught earlier by the compiler (the raw use sites that took
+// .Unverified() / Wrap() no longer build), with this guard as the backstop if
+// such a revert ever did compile.
 func TestUntrustedFieldGuard(t *testing.T) {
 	textType := reflect.TypeOf(untrusted.Text(""))
 	stringType := reflect.TypeOf("")

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -25,10 +25,10 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"strings"
-	"unicode/utf8"
 
 	"golang.org/x/term"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // ANSI SGR codes, restricted to the basic 16-color palette so any terminal
@@ -171,109 +171,15 @@ func Pad(s string, width int) string {
 	return s + spaces(width-n)
 }
 
-// Sanitize strips control characters and deceptive format runes from a string so
-// untrusted text — a fetched marketplace plugin's id, a plugin-supplied component
-// name — can be rendered to a terminal without smuggling escape sequences or
-// spoofed/hidden text through it. It removes:
-//
-//   - C0 controls (0x00–0x1F, which includes ESC 0x1B, CR, LF, TAB, BEL, and
-//     backspace), DEL (0x7F), and C1 controls (0x80–0x9F). Neutralizing the
-//     ESC/CSI introducer is the security-relevant part: a name like "\x1b[31mX"
-//     renders as the inert literal "[31mX" rather than recoloring the terminal,
-//     clearing the screen, or spoofing subsequent rows.
-//   - The explicit Unicode bidirectional formatting controls — the embedding/
-//     override set U+202A–U+202E (LRE/RLE/PDF/LRO/RLO) and the isolate set
-//     U+2066–U+2069 (LRI/RLI/FSI/PDI). These are the "Trojan Source"
-//     (CVE-2021-42574) class: U+202E and friends can visually reorder a plugin
-//     id so it reads as a trusted name while its bytes say otherwise.
-//   - Zero-width / invisible format runes — U+200B–U+200D (ZWSP/ZWNJ/ZWJ) and
-//     U+FEFF (zero-width no-break space / BOM) — which can hide characters or
-//     invisibly pad a name.
-//
-// Printable text passes through unchanged, including non-ASCII letters and
-// ordinary spaces. This deliberately leaves *implicit* bidi alone: ordinary
-// right-to-left scripts (Arabic, Hebrew) and CJK get their direction from the
-// letters themselves, not from the explicit override controls, so a legitimate
-// non-Latin name survives byte-for-byte — only the explicit formatting controls
-// an attacker would inject are removed. Apply Sanitize at the display boundary,
-// before width/Pad calculation, so a stripped rune never throws off column
-// alignment.
-//
-// Scanning is rune-level (not byte-level): byte-level stripping of the 0x80–0x9F
-// range would corrupt legitimate multibyte UTF-8 (a CJK rune's continuation
-// bytes live there). Invalid UTF-8 is normalized rather than passed verbatim — a
-// malformed byte decodes to U+FFFD and is re-emitted as U+FFFD, so a raw
-// 0x80–0x9F byte (a C1 CSI introducer on an 8-bit terminal) can never survive.
-//
-// What Sanitize does NOT do: it does not normalize display *width*. Combining
-// marks and wide/ambiguous-width runes still skew the rune-counting alignment of
-// Pad (and of the caller-side column counting in internal/cli's explain output);
-// that is a purely cosmetic limitation, documented on Pad, not a spoofing vector
-// this function targets.
-func Sanitize(s string) string {
-	// Fast path: the overwhelmingly common case is clean text, so scan once and
-	// only allocate when there is something to change. We also rebuild on invalid
-	// UTF-8 (RuneError) — `range` yields RuneError for a malformed byte, and the
-	// rebuild's WriteRune normalizes it to U+FFFD, so a raw 0x80–0x9F byte (a C1
-	// CSI introducer on an 8-bit terminal) can never pass through verbatim.
-	clean := true
-	for _, r := range s {
-		if shouldStrip(r) || r == utf8.RuneError {
-			clean = false
-			break
-		}
-	}
-	if clean {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if !shouldStrip(r) {
-			b.WriteRune(r) // WriteRune(RuneError) emits U+FFFD, normalizing bad bytes
-		}
-	}
-	return b.String()
-}
-
-// shouldStrip reports whether Sanitize removes r: either a terminal-control rune
-// (isControl) or a deceptive format rune (isDeceptiveFormat).
-func shouldStrip(r rune) bool {
-	return isControl(r) || isDeceptiveFormat(r)
-}
-
-// isControl reports whether r is a C0 control (incl. ESC/CR/LF/TAB), DEL, or a
-// C1 control — the runes that can carry terminal escape semantics.
-func isControl(r rune) bool {
-	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
-}
-
-// isDeceptiveFormat reports whether r is a printable-but-deceptive format rune
-// that Sanitize strips: an explicit Unicode bidi formatting control (the
-// embedding/override set U+202A–U+202E and the isolate set U+2066–U+2069 — the
-// "Trojan Source" class) or a zero-width / invisible rune (U+200B–U+200D, U+FEFF).
-// It deliberately excludes ordinary RTL/CJK letters and the benign directional
-// marks (U+200E/U+200F LRM/RLM, U+061C ALM) — which only set the direction of
-// adjacent neutrals and cannot reorder text the way the override/isolate controls
-// can — so legitimate non-Latin names are preserved. Scope is the explicit bidi + zero-width spoofing set, not every
-// default-ignorable or width-affecting rune: e.g. U+2028/U+2029 (line/paragraph
-// separators), U+00AD (soft hyphen), and U+2060 (word joiner) are knowingly left
-// alone — terminals don't act on them the way they do on CR/LF (which isControl
-// already strips), and width skew is an accepted cosmetic limitation (see Pad).
-func isDeceptiveFormat(r rune) bool {
-	switch {
-	case r >= 0x202a && r <= 0x202e: // LRE, RLE, PDF, LRO, RLO
-		return true
-	case r >= 0x2066 && r <= 0x2069: // LRI, RLI, FSI, PDI
-		return true
-	case r >= 0x200b && r <= 0x200d: // ZWSP, ZWNJ, ZWJ
-		return true
-	case r == 0xfeff: // zero-width no-break space / BOM
-		return true
-	default:
-		return false
-	}
-}
+// Sanitize strips control characters and deceptive format runes from a string
+// so untrusted text can be rendered to a terminal without smuggling escape
+// sequences or spoofed/hidden text. It is a thin re-export of
+// untrusted.Sanitize (which owns the implementation and its full doc) for the
+// display sites that hold a plain composite/built string rather than an
+// untrusted.Text — a Text sanitizes itself via its String() method, so prefer
+// printing a Text directly. Apply at the display boundary, before width/Pad
+// calculation, so a stripped rune never throws off column alignment.
+func Sanitize(s string) string { return untrusted.Sanitize(s) }
 
 // WarnWriter wraps a destination writer and styles "warning: " line prefixes
 // as a bold-yellow "⚠️ warning:" so every warning — whether emitted by the

--- a/internal/untrusted/untrusted.go
+++ b/internal/untrusted/untrusted.go
@@ -1,0 +1,179 @@
+// Package untrusted carries strings that originate from OUTSIDE agentsync's
+// trust boundary — fetched marketplace/plugin metadata (ids, versions,
+// marketplace names) and native-config-derived plugin names — and that must be
+// sanitized before they reach a terminal.
+//
+// # The Text type and why it is the enforcement
+//
+// A bare `string` field gives a future print site no way to know its value is
+// hostile-controlled: PR #100 / issue #93 hardened ~24 print sites by wrapping
+// each in Sanitize, but nothing stopped the *next* Fprintf from printing a
+// fetched id raw and silently reintroducing the escape-injection class. Text
+// closes that gap structurally:
+//
+//   - Text implements fmt.Stringer, and its String() returns the SANITIZED
+//     value. Because fmt's %s/%v/%q invoke String() for any value implementing
+//     fmt.Stringer, a Text printed through fmt.Fprint* / fmt.Sprintf is
+//     sanitized BY DEFAULT. A new print site of an untrusted field therefore
+//     cannot reintroduce the #93 class by accident — the type sanitizes itself.
+//   - The only way to obtain the raw, UNSANITIZED bytes is the explicit,
+//     deliberately-alarming Unverified() method. Every call is a greppable
+//     acknowledgement that the caller is bypassing display sanitization; it is
+//     for non-display logic only (filesystem paths, map keys, comparisons,
+//     re-serialization), never for building terminal output.
+//
+// Text is a defined string type (not a struct) on purpose: it serializes
+// transparently through encoding/json and go-toml/v2 (a named string kind, so
+// `omitempty` still elides an empty value and round-trip fidelity is preserved)
+// and keeps the `==`/`!=`/`<` operators and map-key usability the canonical
+// model relies on. The residual that a defined string type permits — a
+// deliberate `string(t)` conversion to defeat the Stringer, then a raw print —
+// is the same shape of *accepted residual* documented for secrets.Resolved
+// (the lint fence there is likewise defeatable by a deliberate two-step). No
+// innocent print produces it; Unverified() is the blessed, named unwrap.
+//
+// # Machine vs terminal contract
+//
+// MarshalText/JSON is NOT overridden: a Text marshals to its RAW value. That is
+// deliberate — the `--json` surfaces are a machine contract where the consumer
+// owns escaping, exactly as the per-site comments in the CLI already state. Raw
+// in JSON, sanitized on the terminal, with no extra plumbing, falls out of the
+// named-string design for free.
+package untrusted
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Text is an untrusted string: marketplace/plugin/native metadata that must be
+// sanitized before terminal display. Print it directly (its String() sanitizes)
+// or reach Sanitize-applied text via String(); use Unverified() only for
+// non-display logic. See the package doc for the full contract.
+type Text string
+
+// Wrap tags s as untrusted. Use it at the boundary where a plain string crossing
+// in from outside the trust boundary (a fetched manifest field decoded into a
+// plain string, an adapter-reported component name) first becomes Text.
+func Wrap(s string) Text { return Text(s) }
+
+// String returns the value sanitized for terminal display (control + deceptive
+// format runes stripped). It satisfies fmt.Stringer, so fmt's %s/%v/%q sanitize
+// a Text automatically — the safe-by-default property the type exists for.
+func (t Text) String() string { return Sanitize(string(t)) }
+
+// Unverified returns the RAW, UNSANITIZED bytes. The name is intentionally
+// alarming: every call is an explicit acknowledgement that display sanitization
+// is being bypassed. Use it ONLY for non-display logic (filesystem paths, map
+// keys, comparisons, re-serialization) — never to build terminal output. To
+// render a Text, print it directly or call String().
+func (t Text) Unverified() string { return string(t) }
+
+// Empty reports whether the underlying value is the empty string. Provided so
+// callers read `t.Empty()` instead of comparing against a Text("") literal.
+func (t Text) Empty() bool { return t == "" }
+
+// Sanitize strips control characters and deceptive format runes from a string so
+// untrusted text — a fetched marketplace plugin's id, a plugin-supplied component
+// name — can be rendered to a terminal without smuggling escape sequences or
+// spoofed/hidden text through it. It removes:
+//
+//   - C0 controls (0x00–0x1F, which includes ESC 0x1B, CR, LF, TAB, BEL, and
+//     backspace), DEL (0x7F), and C1 controls (0x80–0x9F). Neutralizing the
+//     ESC/CSI introducer is the security-relevant part: a name like "\x1b[31mX"
+//     renders as the inert literal "[31mX" rather than recoloring the terminal,
+//     clearing the screen, or spoofing subsequent rows.
+//   - The explicit Unicode bidirectional formatting controls — the embedding/
+//     override set U+202A–U+202E (LRE/RLE/PDF/LRO/RLO) and the isolate set
+//     U+2066–U+2069 (LRI/RLI/FSI/PDI). These are the "Trojan Source"
+//     (CVE-2021-42574) class: U+202E and friends can visually reorder a plugin
+//     id so it reads as a trusted name while its bytes say otherwise.
+//   - Zero-width / invisible format runes — U+200B–U+200D (ZWSP/ZWNJ/ZWJ) and
+//     U+FEFF (zero-width no-break space / BOM) — which can hide characters or
+//     invisibly pad a name.
+//
+// Printable text passes through unchanged, including non-ASCII letters and
+// ordinary spaces. This deliberately leaves *implicit* bidi alone: ordinary
+// right-to-left scripts (Arabic, Hebrew) and CJK get their direction from the
+// letters themselves, not from the explicit override controls, so a legitimate
+// non-Latin name survives byte-for-byte — only the explicit formatting controls
+// an attacker would inject are removed. Apply Sanitize at the display boundary,
+// before width/Pad calculation, so a stripped rune never throws off column
+// alignment. (Text.String() applies it; ui.Sanitize delegates here for the
+// composite/string-built display sites that don't hold a Text.)
+//
+// Scanning is rune-level (not byte-level): byte-level stripping of the 0x80–0x9F
+// range would corrupt legitimate multibyte UTF-8 (a CJK rune's continuation
+// bytes live there). Invalid UTF-8 is normalized rather than passed verbatim — a
+// malformed byte decodes to U+FFFD and is re-emitted as U+FFFD, so a raw
+// 0x80–0x9F byte (a C1 CSI introducer on an 8-bit terminal) can never survive.
+//
+// What Sanitize does NOT do: it does not normalize display *width*. Combining
+// marks and wide/ambiguous-width runes still skew rune-counting alignment (see
+// ui.Pad); that is a purely cosmetic limitation, not a spoofing vector this
+// function targets.
+func Sanitize(s string) string {
+	// Fast path: the overwhelmingly common case is clean text, so scan once and
+	// only allocate when there is something to change. We also rebuild on invalid
+	// UTF-8 (RuneError) — `range` yields RuneError for a malformed byte, and the
+	// rebuild's WriteRune normalizes it to U+FFFD, so a raw 0x80–0x9F byte (a C1
+	// CSI introducer on an 8-bit terminal) can never pass through verbatim.
+	clean := true
+	for _, r := range s {
+		if shouldStrip(r) || r == utf8.RuneError {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if !shouldStrip(r) {
+			b.WriteRune(r) // WriteRune(RuneError) emits U+FFFD, normalizing bad bytes
+		}
+	}
+	return b.String()
+}
+
+// shouldStrip reports whether Sanitize removes r: either a terminal-control rune
+// (isControl) or a deceptive format rune (isDeceptiveFormat).
+func shouldStrip(r rune) bool {
+	return isControl(r) || isDeceptiveFormat(r)
+}
+
+// isControl reports whether r is a C0 control (incl. ESC/CR/LF/TAB), DEL, or a
+// C1 control — the runes that can carry terminal escape semantics.
+func isControl(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+// isDeceptiveFormat reports whether r is a printable-but-deceptive format rune
+// that Sanitize strips: an explicit Unicode bidi formatting control (the
+// embedding/override set U+202A–U+202E and the isolate set U+2066–U+2069 — the
+// "Trojan Source" class) or a zero-width / invisible rune (U+200B–U+200D, U+FEFF).
+// It deliberately excludes ordinary RTL/CJK letters and the benign directional
+// marks (U+200E/U+200F LRM/RLM, U+061C ALM) — which only set the direction of
+// adjacent neutrals and cannot reorder text the way the override/isolate controls
+// can — so legitimate non-Latin names are preserved. Scope is the explicit bidi +
+// zero-width spoofing set, not every default-ignorable or width-affecting rune:
+// e.g. U+2028/U+2029 (line/paragraph separators), U+00AD (soft hyphen), and
+// U+2060 (word joiner) are knowingly left alone — terminals don't act on them the
+// way they do on CR/LF (which isControl already strips), and width skew is an
+// accepted cosmetic limitation (see ui.Pad).
+func isDeceptiveFormat(r rune) bool {
+	switch {
+	case r >= 0x202a && r <= 0x202e: // LRE, RLE, PDF, LRO, RLO
+		return true
+	case r >= 0x2066 && r <= 0x2069: // LRI, RLI, FSI, PDI
+		return true
+	case r >= 0x200b && r <= 0x200d: // ZWSP, ZWNJ, ZWJ
+		return true
+	case r == 0xfeff: // zero-width no-break space / BOM
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/untrusted/untrusted_test.go
+++ b/internal/untrusted/untrusted_test.go
@@ -47,6 +47,33 @@ func TestText_Empty(t *testing.T) {
 	}
 }
 
+// TestText_Wrap pins the boundary constructor: Wrap stores the bytes verbatim
+// (Unverified round-trips them) without sanitizing at construction — sanitization
+// happens at the display boundary (String), not at ingestion, so the raw value
+// stays available for path/lookup use.
+func TestText_Wrap(t *testing.T) {
+	raw := "demo\x1b[0m@mp"
+	w := Wrap(raw)
+	if got := w.Unverified(); got != raw {
+		t.Errorf("Wrap(%q).Unverified() = %q, want raw round-trip", raw, got)
+	}
+	if got := w.String(); got != "demo[0m@mp" {
+		t.Errorf("Wrap(%q).String() = %q, want sanitized", raw, got)
+	}
+}
+
+// TestText_WidthVerb guards the alignment property the CLI relies on: a width
+// verb (%-Ns, used for padded list columns) applies its padding to the SANITIZED
+// String() output, so a stripped rune never throws off the column. The input is
+// the 5-rune "ev<ZWSP>il"; the ZWSP is stripped, leaving the 4-rune "evil",
+// which is then padded to width 8 → four trailing spaces. Were padding applied
+// to the raw value, the 5-rune input would yield only three spaces.
+func TestText_WidthVerb(t *testing.T) {
+	if got := fmt.Sprintf("%-8s|", Text("ev\u200bil")); got != "evil    |" {
+		t.Errorf("%%-8s on Text = %q, want padding applied to sanitized output", got)
+	}
+}
+
 // TestText_Serialization guards the named-string design's load-bearing
 // serialization properties (the reason Text is a defined string type, not a
 // struct): TOML/JSON treat it transparently, `omitempty` still elides an empty

--- a/internal/untrusted/untrusted_test.go
+++ b/internal/untrusted/untrusted_test.go
@@ -1,0 +1,114 @@
+package untrusted
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// TestText_StringSanitizes pins the safe-by-default property: printing a Text
+// through fmt (which invokes String() for a fmt.Stringer) strips terminal
+// escapes, so a new print site cannot reintroduce the #93 escape-injection
+// class. Break-verified by returning string(t) from String() (the ESC leaks).
+func TestText_StringSanitizes(t *testing.T) {
+	hostile := Text("plug\x1b[31m\rid\u202egnp")
+	if got := hostile.String(); got != "plug[31midgnp" {
+		t.Errorf("String() = %q, want sanitized %q", got, "plug[31midgnp")
+	}
+	// Every fmt verb that consults Stringer must see the sanitized form.
+	for _, verb := range []string{"%s", "%v"} {
+		if got := fmt.Sprintf(verb, hostile); got != "plug[31midgnp" {
+			t.Errorf("fmt.Sprintf(%q) = %q, want sanitized", verb, got)
+		}
+	}
+	// %q quotes the sanitized String() output (no raw ESC survives the quoting).
+	if got := fmt.Sprintf("%q", hostile); got != `"plug[31midgnp"` {
+		t.Errorf("fmt %%q = %q, want quoted-sanitized", got)
+	}
+}
+
+// TestText_Unverified is the explicit raw escape hatch: it returns the bytes
+// verbatim (no sanitization), for non-display use only.
+func TestText_Unverified(t *testing.T) {
+	raw := "ev\x1b[31mil"
+	if got := Text(raw).Unverified(); got != raw {
+		t.Errorf("Unverified() = %q, want raw %q", got, raw)
+	}
+}
+
+func TestText_Empty(t *testing.T) {
+	if !Text("").Empty() {
+		t.Error("Text(\"\").Empty() = false, want true")
+	}
+	if Text("x").Empty() {
+		t.Error("Text(\"x\").Empty() = true, want false")
+	}
+}
+
+// TestText_Serialization guards the named-string design's load-bearing
+// serialization properties (the reason Text is a defined string type, not a
+// struct): TOML/JSON treat it transparently, `omitempty` still elides an empty
+// value (no `version = ""` round-trip regression), and the machine surfaces emit
+// the RAW value — the --json/-file consumer owns escaping, exactly as the CLI's
+// per-site comments state.
+func TestText_Serialization(t *testing.T) {
+	type spec struct {
+		ID      Text `toml:"id" json:"id"`
+		Version Text `toml:"version,omitempty" json:"version,omitempty"`
+	}
+
+	t.Run("toml omitempty elides empty", func(t *testing.T) {
+		out, err := toml.Marshal(spec{ID: "demo@mp"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := string(out); got != "id = 'demo@mp'\n" {
+			t.Errorf("TOML = %q, want only id (empty version omitted)", got)
+		}
+	})
+
+	t.Run("toml round-trip", func(t *testing.T) {
+		in := spec{ID: "demo@mp", Version: "1.2.3"}
+		out, err := toml.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got spec
+		if err := toml.Unmarshal(out, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got != in {
+			t.Errorf("round-trip = %+v, want %+v", got, in)
+		}
+	})
+
+	t.Run("json marshals RAW (machine contract)", func(t *testing.T) {
+		out, err := json.Marshal(spec{ID: "ev\x1b[31mil", Version: "1.0"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// encoding/json renders the ESC as a \u001b unicode escape: the byte is
+		// PRESERVED (not stripped, as String() would) — raw fidelity for the machine consumer.
+		want := `{"id":"ev\u001b[31mil","version":"1.0"}`
+		if got := string(out); got != want {
+			t.Errorf("JSON = %q, want raw-preserving %q", got, want)
+		}
+	})
+
+	t.Run("json round-trip", func(t *testing.T) {
+		in := spec{ID: "demo@mp", Version: "9"}
+		out, err := json.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got spec
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got != in {
+			t.Errorf("round-trip = %+v, want %+v", got, in)
+		}
+	})
+}


### PR DESCRIPTION
Closes #102.

## Problem

Issue #93 / PR #100 hardened terminal output by hand-wrapping ~24 print sites in
`ui.Sanitize` — but there was **no enforcement**. A future `Fprintf`/`Pad` that
printed a fetched plugin/marketplace string without wrapping it would silently
reintroduce the escape-injection class, and nothing failed CI. The review loop
proved this was live: adversarial review found a *new* unsanitized sink in three
consecutive rounds before convergence.

A plain `forbidigo` rule can't solve it — the untrusted fields are plain
`string`s a static matcher can't type-distinguish from trusted ones.

## Approach — option 1 (typed wrapper)

Replace the per-site convention with a **compile-level invariant**. The
plugin/marketplace identity, version, name, and report-row fields are now the
defined string type **`untrusted.Text`** (new leaf package `internal/untrusted`),
whose `String()` runs `Sanitize`:

- Printing a `Text` through `fmt` (`%s`/`%v`/`%q`) is sanitized **by
  construction** — a new print site cannot reintroduce the #93 class by accident.
- Obtaining the raw bytes requires the explicit, greppable **`Unverified()`**
  (filesystem paths, map keys, comparisons — never display).

### Why a defined string type, not a struct

`Text` stays a string kind so the **canonical wire format is unchanged**: TOML
`omitempty` still elides an empty value (no `version = ""` round-trip
regression), and `--json` surfaces still emit the raw value (the machine
contract, where the consumer owns escaping). A struct wrapper would have broken
`omitempty` and lost the `==`/`<`/map-key operators the canonical model relies
on. New `internal/untrusted/untrusted_test.go` pins these serialization
properties.

### Enforcement: reflection guards

`TestUntrustedFieldGuard` in `internal/{source,marketplace,render}` fails the
build if a new string field is added to the plugin/marketplace identity or
report-row structs without being classified untrusted-or-trusted (mirrors
`secrets.TestNewSecretFieldGuard`). Break-verified: adding an unclassified
string field trips the guard with a remediation message. The established
**carve-outs** (hex SHAs, `%q` URLs, user-supplied CLI args, enum modes) stay
plain strings and are recorded in the classification maps.

## Scope of converted fields

- `marketplace.{Bump.ID/From/To, SHAWarning.ID/Version, PluginEntry.Name/Version}`
- `source.{Plugin.ID, PluginSpec.ID/Version, Marketplace.Name}`
- `render.{PluginRow.Plugin, SkipDetail.Name}`
- the CLI's `pluginTOMLSpec.ID/Version` write mirror

The pure `Sanitize` implementation moved into the new leaf package; `ui.Sanitize`
delegates, so its public API and all existing call sites/tests hold. The
remaining `ui.Sanitize` sites take genuine plain strings (native-ingested
plugin-name lists, filename stems, adapter reasons).

## Acceptance criteria

- ✅ A new print site that renders untrusted metadata is sanitized by
  construction; a new *field* that ships it as a raw string fails the guard test.
- ✅ Existing carve-outs (hex SHAs, `%q` URLs, CLI args, enum modes) remain
  un-sanitized without tripping the check.

## Docs

`SECURITY.md` and `docs/architecture.md` §7 record the type-level enforcement;
`docs/components.md` adds `internal/untrusted` and fixes the dependency-direction
note; `CHANGELOG` `[Unreleased]`.

## Testing

- `go test ./...` green (run with `AGENTSYNC_TEST_IN_CONTAINER=1`).
- `gofmt -s`, `gofumpt`, and `golangci-lint v2.12.2` clean; `go mod tidy` is a
  no-op (no new deps — `untrusted` is stdlib-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm1rYXaSgnLNr4LAWdDX4z)_