### PR TITLE
feat(untrusted): carry native plugin name as untrusted.Text (ingest→status/doctor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   established carve-outs (hex SHAs, `%q` URLs, user-supplied CLI args, enum modes)
   stay plain strings. `ui.Sanitize` is unchanged in behavior (it now delegates to
   `untrusted.Sanitize`).
+  - **Extended to native-ingested plugin names (#104).** The one untrusted source
+    left out of the by-type pass above — the plugin name an adapter's
+    `PluginIngester` reports, which `status`/`doctor` print in their "undeclared
+    native plugins" notes — is now carried as `untrusted.Text` end to end
+    (`adapter.NativePlugin.Name` → `undeclaredNativePlugins` → the print sites,
+    joined via the new `untrusted.Join`). The previous per-site `ui.Sanitize`
+    wrappers at those sinks are gone (the type sanitizes by construction), and a
+    new `TestUntrustedFieldGuard` over `adapter.NativePlugin` fails the build if a
+    future native-config string ships unclassified. No behavior change — the
+    notes still strip terminal escapes from a hostile plugin name.
 
 - **`explain` describes every component kind a plugin hosts, not just MCP +
   commands.** Each agent row's count tail previously read `N mcp · N commands`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
     new `TestUntrustedFieldGuard` over `adapter.NativePlugin` fails the build if a
     future native-config string ships unclassified. No behavior change — the
     notes still strip terminal escapes from a hostile plugin name.
+  - **`ValidateComponentID` now rejects control / deceptive-format runes.** The
+    single dest→source write boundary (reached by `import`/`reconcile` with
+    ids taken from a native config) previously rejected only path separators,
+    traversal, and degenerate ids — a separator-free name carrying an ESC byte or
+    a Trojan-Source bidi override (e.g. `good␛[31m`) passed, becoming a
+    pathological filename and leaking raw bytes when later echoed in an
+    `import` skip diagnostic. It now also rejects any id the display sanitizer
+    would alter (tied to `untrusted.Sanitize`'s rune set), so such an id is
+    skipped with a sanitized warning and never installed. Legitimate non-ASCII
+    ids (e.g. `naïve`, `日本語`) are unaffected.
 
 - **`explain` describes every component kind a plugin hosts, not just MCP +
   commands.** Each agent row's count tail previously read `N mcp · N commands`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,15 +52,21 @@ can resolve secrets into native config files. Areas of particular interest:
   `apply`, `plugin`, `marketplace`, `update`, `status`, and `doctor`).
   `explain --json` keeps ids raw (a machine contract where the consumer owns
   escaping). This invariant is enforced by **type**, not by per-site convention:
-  the plugin/marketplace id, version, name, and report-row fields are the defined
-  string type `untrusted.Text` (`internal/untrusted`), whose `String()`
-  sanitizes — so printing one through `fmt` is safe by construction, and reaching
-  the raw bytes requires the explicit, greppable `Unverified()` (for
-  filesystem/lookup use, never display). Reflection-based `TestUntrustedFieldGuard`s
-  fail the build if a new string field is added to those structs without being
-  classified, so a future field that carries fetched metadata cannot quietly ship
-  as a raw string a new print site would leak. The established carve-outs (hex
-  SHAs, `%q` URLs, user-supplied CLI arguments, enum modes) stay plain strings.
+  the plugin/marketplace id, version, name, and report-row fields — and the
+  native-ingested plugin name an adapter's `IngestPlugins` reports
+  (`adapter.NativePlugin.Name`), which `status`/`doctor` print in their
+  "undeclared native plugins" notes — are the defined string type
+  `untrusted.Text` (`internal/untrusted`), whose `String()` sanitizes — so
+  printing one through `fmt` is safe by construction, and reaching the raw bytes
+  requires the explicit, greppable `Unverified()` (for filesystem/lookup use,
+  never display). Reflection-based `TestUntrustedFieldGuard`s (in
+  `internal/{source,marketplace,render,adapter}`) fail the build if a new string
+  field is added to those structs without being classified, so a future field
+  that carries fetched or native-config metadata cannot quietly ship as a raw
+  string a new print site would leak. The established carve-outs (hex SHAs, `%q`
+  URLs, user-supplied CLI arguments, enum modes, and the `import`-only
+  diagnostics surface — native marketplace ids and source types) stay plain
+  strings.
 - **Destination writes**: writes are atomic and refuse to clobber symlinked
   destinations by default; pre-existing foreign files are backed up before
   overwrite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -457,11 +457,17 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    `fmt` strips the danger **by construction**; the raw value is reachable only
    via the explicit `Unverified()` (filesystem/lookup use, never display). The
    wire format is unchanged (`Text` is a string kind — `omitempty` and `--json`
-   raw output are preserved). Reflection-based `TestUntrustedFieldGuard`s
-   (`internal/{source,marketplace,render}`) fail the build if a new string field
-   on those structs is left unclassified, so a future metadata field can't ship
-   as a raw string a new print site would leak. Carve-outs (hex SHAs, `%q` URLs,
-   user-supplied CLI args, enum modes) stay plain strings. See `SECURITY.md`.
+   raw output are preserved). This also covers the **native-ingested** plugin
+   name: a `PluginIngester`'s `adapter.NativePlugin.Name` is `untrusted.Text`, so
+   the `status`/`doctor` "undeclared native plugins" notes that print it sanitize
+   by construction (via `untrusted.Join`) with no per-site `ui.Sanitize` wrapper.
+   Reflection-based `TestUntrustedFieldGuard`s
+   (`internal/{source,marketplace,render,adapter}`) fail the build if a new string
+   field on those structs is left unclassified, so a future metadata field can't
+   ship as a raw string a new print site would leak. Carve-outs (hex SHAs, `%q`
+   URLs, user-supplied CLI args, enum modes, and the `import`-only diagnostics
+   surface — native marketplace ids / source types) stay plain strings. See
+   `SECURITY.md`.
 
 ---
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // ErrProjectRootRequired is returned by RequireProjectRoot (and thus by every
@@ -163,9 +164,25 @@ type NativeMarketplace struct {
 
 // NativePlugin is a plugin recorded in an agent's native config, as discovered
 // by `import`. Enabled is false for an explicitly-disabled entry.
+//
+// Name is untrusted.Text: a plugin author influences the name the agent persists
+// in its own config, and `status`/`doctor` read it back via IngestPlugins and
+// print it in their "undeclared native plugins" notes, so it must sanitize on
+// display by construction (its String() runs untrusted.Sanitize). Reach the raw
+// bytes via Unverified() only for non-display use — the plugins/<name>.toml stem,
+// a map key, ValidateComponentID. The reflection-based TestUntrustedFieldGuard
+// (internal/adapter) fails the build if a new string field here ships
+// unclassified. See docs/architecture.md §7 and SECURITY.md.
+//
+// MarketplaceID stays a plain string: unlike Name it is not rendered into the
+// status/doctor layout this hardening targets; its only display sites are
+// `import`'s warn diagnostics, the same plain-string surface as the sibling
+// NativeMarketplace / NativeSource fields (marketplace ids, source types). That
+// whole import-diagnostics surface is a deliberate plain-string subset — promote
+// these together if it is ever hardened.
 type NativePlugin struct {
-	Name          string // the "<plugin>" half of a plugin reference
-	MarketplaceID string // the marketplace it was installed from
+	Name          untrusted.Text // the "<plugin>" half of a plugin reference
+	MarketplaceID string         // the marketplace it was installed from
 	Enabled       bool
 }
 

--- a/internal/adapter/claude/ingest_plugins.go
+++ b/internal/adapter/claude/ingest_plugins.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // IngestPlugins discovers the marketplaces and enabled plugins recorded in
@@ -90,7 +91,7 @@ func parseEnabledPlugins(v any) []adapter.NativePlugin {
 	for key, raw := range m {
 		name, mpID := splitPluginKey(key)
 		out = append(out, adapter.NativePlugin{
-			Name:          name,
+			Name:          untrusted.Wrap(name),
 			MarketplaceID: mpID,
 			Enabled:       enabledTruthy(raw),
 		})

--- a/internal/adapter/codex/ingest_plugins.go
+++ b/internal/adapter/codex/ingest_plugins.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // IngestPlugins discovers the plugins Codex records in ~/.codex/config.toml. The
@@ -60,7 +61,7 @@ func parsePluginTables(v any) []adapter.NativePlugin {
 	for key, raw := range m {
 		name, mpID := splitPluginKey(key)
 		out = append(out, adapter.NativePlugin{
-			Name:          name,
+			Name:          untrusted.Wrap(name),
 			MarketplaceID: mpID,
 			Enabled:       pluginEnabled(raw),
 		})

--- a/internal/adapter/codex/ingest_plugins_test.go
+++ b/internal/adapter/codex/ingest_plugins_test.go
@@ -55,7 +55,7 @@ enabled = true
 		"slack":  {"team-mp", true},
 	}
 	for _, pl := range plugins {
-		w, ok := want[pl.Name]
+		w, ok := want[pl.Name.Unverified()]
 		if !ok {
 			t.Fatalf("unexpected plugin %q", pl.Name)
 		}

--- a/internal/adapter/untrusted_guard_test.go
+++ b/internal/adapter/untrusted_guard_test.go
@@ -1,0 +1,72 @@
+package adapter_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// untrustedClassified classifies every string-shaped field on the native-ingest
+// descriptor an adapter's IngestPlugins returns: untrusted (true → untrusted.Text,
+// sanitized on print) or deliberately trusted/plain (false). TestUntrustedFieldGuard
+// fails on any unclassified field, so a future native-config-derived string can't
+// ship as a raw string that a `status`/`doctor` print site would leak. Mirrors the
+// identically-named guards in internal/{source,marketplace,render}.
+var untrustedClassified = map[string]map[string]bool{
+	"NativePlugin": {
+		// The plugin name is read back from the agent's own config (a plugin author
+		// influences it) and printed in the status/doctor "undeclared native
+		// plugins" notes — it MUST sanitize on display, so it is untrusted.Text.
+		"Name": true,
+		// MarketplaceID is foreign too but is NOT rendered into the status/doctor
+		// layout this guard's `Name` covers; its only display sites are `import`'s
+		// warn diagnostics, the same plain-string surface as the NativeMarketplace /
+		// NativeSource fields below. That import-diagnostics surface is a deliberate
+		// plain-string subset — promote these together if it is ever hardened. (Cf.
+		// the marketplace guard's PluginEntry free-text subset and source's
+		// MarketplaceSpec.URL/Ref carve-out.)
+		"MarketplaceID": false,
+	},
+}
+
+func stringShapedKind(t reflect.Type) bool { return t.Kind() == reflect.String }
+
+// TestUntrustedFieldGuard — see internal/source's identically-named guard for the
+// contract. It fails on an unclassified string-shaped field on the native-ingest
+// descriptor or a type/classification mismatch (untrusted=true demands
+// untrusted.Text; untrusted=false demands a plain string).
+func TestUntrustedFieldGuard(t *testing.T) {
+	textType := reflect.TypeOf(untrusted.Text(""))
+	stringType := reflect.TypeOf("")
+
+	structs := map[string]reflect.Type{
+		"NativePlugin": reflect.TypeOf(adapter.NativePlugin{}),
+	}
+
+	for name, typ := range structs {
+		cover := untrustedClassified[name]
+		if cover == nil {
+			t.Fatalf("struct %s has no classification map", name)
+		}
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if !stringShapedKind(f.Type) {
+				continue
+			}
+			want, ok := cover[f.Name]
+			if !ok {
+				t.Errorf("%s.%s is a string-shaped field with no untrusted classification; "+
+					"add it to untrustedClassified (true → untrusted.Text, false → plain string)", name, f.Name)
+				continue
+			}
+			switch {
+			case want && f.Type != textType:
+				t.Errorf("%s.%s is classified untrusted but is %s, want untrusted.Text", name, f.Name, f.Type)
+			case !want && f.Type != stringType:
+				t.Errorf("%s.%s is classified trusted but is %s, want plain string", name, f.Name, f.Type)
+			}
+		}
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -16,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/ui"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -203,9 +203,11 @@ func checkPlugins(p *ui.Printer, home string) {
 			continue
 		}
 		// Native plugin names are influenced by the plugin author (read from the
-		// agent's native config), so sanitize before printing.
+		// agent's native config); they are untrusted.Text and sanitize on display
+		// by construction (untrusted.Join renders each via its String()), so no
+		// manual ui.Sanitize is needed here.
 		warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf("%d not in source: %s — run `agentsync import %s:plugin`",
-			len(missing), ui.Sanitize(strings.Join(missing, ", ")), name))
+			len(missing), untrusted.Join(missing, ", "), name))
 	}
 }
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1240,9 +1240,12 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		}
 		// The plugin name becomes plugins/<name>.toml; validate it up front (and
 		// in dry-run) so a hostile native id can't escape the source dir and the
-		// preview matches a real import. plName is the raw id for the path/validation/
-		// install identity; warn lines print pl.Name (untrusted.Text), which
-		// sanitizes itself on display.
+		// preview matches a real import. ValidateComponentID also rejects control /
+		// deceptive-format runes, so past this gate plName (the raw id used for the
+		// path/install identity below) is guaranteed clean — its later appearance in
+		// the item-line preview and in any wrapped install error printed via %v
+		// carries no terminal escape. The skip warning prints pl.Name (untrusted.Text,
+		// %q-escaped) for the names this gate rejects.
 		plName := pl.Name.Unverified()
 		if verr := source.ValidateComponentID("plugin", plName); verr != nil {
 			io.warnf("skipping plugin %q: %v", pl.Name, verr)

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1166,7 +1166,7 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		if !pl.Enabled {
 			continue
 		}
-		if name != "" && pl.Name != name && pl.Name+"@"+pl.MarketplaceID != name {
+		if name != "" && pl.Name.Unverified() != name && pl.Name.Unverified()+"@"+pl.MarketplaceID != name {
 			continue
 		}
 		want = append(want, pl)
@@ -1240,8 +1240,11 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		}
 		// The plugin name becomes plugins/<name>.toml; validate it up front (and
 		// in dry-run) so a hostile native id can't escape the source dir and the
-		// preview matches a real import.
-		if verr := source.ValidateComponentID("plugin", pl.Name); verr != nil {
+		// preview matches a real import. plName is the raw id for the path/validation/
+		// install identity; warn lines print pl.Name (untrusted.Text), which
+		// sanitizes itself on display.
+		plName := pl.Name.Unverified()
+		if verr := source.ValidateComponentID("plugin", plName); verr != nil {
 			io.warnf("skipping plugin %q: %v", pl.Name, verr)
 			continue
 		}
@@ -1250,16 +1253,16 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 			continue
 		}
 		if io.dryRun {
-			io.item(fmt.Sprintf("plugins/%s.toml", pl.Name), "")
-			ids = append(ids, pl.Name)
+			io.item(fmt.Sprintf("plugins/%s.toml", plName), "")
+			ids = append(ids, plName)
 			continue
 		}
-		if _, ierr := installPluginInto(home, pl.Name, mpName); ierr != nil {
+		if _, ierr := installPluginInto(home, plName, mpName); ierr != nil {
 			io.warnf("skipping plugin %q from %q: %v", pl.Name, mpName, ierr)
 			continue
 		}
-		io.item(fmt.Sprintf("plugins/%s.toml", pl.Name), "")
-		ids = append(ids, pl.Name)
+		io.item(fmt.Sprintf("plugins/%s.toml", plName), "")
+		ids = append(ids, plName)
 	}
 	return ids, nil
 }

--- a/internal/cli/import_plugin_test.go
+++ b/internal/cli/import_plugin_test.go
@@ -225,6 +225,35 @@ func TestImport_PluginsStoreBeatsNativeConfig(t *testing.T) {
 	}
 }
 
+// TestImport_RejectsHostilePluginNameWithoutLeak proves the import path's
+// defense for a native plugin name a plugin author influences: a name that is
+// separator-free (so it clears the path-traversal gate) but carries terminal
+// control bytes is rejected by ValidateComponentID — not installed, and not
+// echoed raw into the skip diagnostic. The warning prints the name sanitized
+// (ESC+CR stripped, inert "[31m" residue kept), so no escape reaches the
+// terminal and no plugins/<name>.toml is written.
+func TestImport_RejectsHostilePluginNameWithoutLeak(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeLocalMarketplace(t, t.TempDir())
+	evilName := "demo" + string(rune(0x1b)) + "[31m" + string(rune(0x0d))
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("test-mp", mpDir, evilName))
+
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if strings.ContainsRune(out, rune(0x1b)) || strings.ContainsRune(out, rune(0x0d)) {
+		t.Errorf("control byte from hostile plugin name leaked into import output: %q", out)
+	}
+	if !strings.Contains(out, "skipping plugin") || !strings.Contains(out, "demo[31m") {
+		t.Errorf("import should skip the hostile plugin and carry its sanitized name; got:\n%s", out)
+	}
+	// The hostile name must never become a file in the canonical source.
+	if entries, _ := os.ReadDir(filepath.Join(tmp, ".agentsync", "plugins")); len(entries) != 0 {
+		t.Errorf("hostile plugin must not be written to plugins/; got %d entries", len(entries))
+	}
+}
+
 // TestImport_FullAgentIncludesPlugins verifies plugins are part of a full
 // `import claude`: the summary counts them and both file components and plugins
 // land in the canonical source.

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // undeclaredNativePlugins reports, per agent, the plugins enabled in that
@@ -22,12 +23,16 @@ import (
 // differ from the declared marketplace name agentsync keys its file on. Name
 // matching errs toward NOT nagging (a same-named plugin from another
 // marketplace counts as declared), which suits a nudge.
-func undeclaredNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]string {
+// The native plugin name is carried as untrusted.Text end to end (a plugin
+// author influences it, and status/doctor print it), so matching/dedup keys off
+// its raw Unverified() value while the value handed to the print sites keeps the
+// Text wrapper and sanitizes on display.
+func undeclaredNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]untrusted.Text {
 	declared := make(map[string]bool, len(c.Plugins))
 	for _, pl := range c.Plugins {
 		declared[pl.ID.Unverified()] = true
 	}
-	out := map[string][]string{}
+	out := map[string][]untrusted.Text{}
 	for _, name := range agents {
 		pi, ok := reg.Lookup(name).(adapter.PluginIngester)
 		if !ok {
@@ -37,17 +42,18 @@ func undeclaredNativePlugins(c source.Canonical, reg *adapter.Registry, agents [
 		if err != nil {
 			continue
 		}
-		var missing []string
+		var missing []untrusted.Text
 		seen := map[string]bool{}
 		for _, pl := range plugins {
-			if !pl.Enabled || declared[pl.Name] || seen[pl.Name] {
+			key := pl.Name.Unverified()
+			if !pl.Enabled || declared[key] || seen[key] {
 				continue
 			}
-			seen[pl.Name] = true
+			seen[key] = true
 			missing = append(missing, pl.Name)
 		}
 		if len(missing) > 0 {
-			sort.Strings(missing)
+			sort.Slice(missing, func(i, j int) bool { return missing[i] < missing[j] })
 			out[name] = missing
 		}
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/ui"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 	"github.com/tailscale/hujson"
 )
 
@@ -316,11 +317,12 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 			continue
 		}
 		// Native plugin names come from the agent's own config (a plugin author
-		// can influence them), so sanitize before printing to keep terminal
-		// escapes out of the note. The agent `name` is a trusted registry id.
+		// can influence them); they are untrusted.Text and sanitize on display by
+		// construction (untrusted.Join renders each via its String()), so no manual
+		// ui.Sanitize is needed here. The agent `name` is a trusted registry id.
 		fmt.Fprintf(p.Err, "%s %d plugin(s) installed in %s are not in your source (%s); "+
 			"run `agentsync import %s:plugin` to manage them.\n",
-			p.Cyan("note:"), len(missing), name, ui.Sanitize(strings.Join(missing, ", ")), name)
+			p.Cyan("note:"), len(missing), name, untrusted.Join(missing, ", "), name)
 	}
 }
 

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -63,6 +63,13 @@ func ValidateComponentID(kind, id string) error {
 	// alter, tying this write boundary to the SAME rune set untrusted.Sanitize
 	// strips (one source of truth, so the two can't drift). The %q below escapes
 	// any such rune in the message itself, so the error is safe to print.
+	//
+	// Scope is exactly Sanitize's set — terminal-escape + explicit-bidi + zero-width.
+	// Width-affecting-but-inert runes Sanitize knowingly leaves alone (U+2028/U+2029
+	// line/para separators, U+00AD soft hyphen, U+2060 word joiner) likewise pass
+	// here: they carry no terminal escape and reordering nothing, so they are a
+	// cosmetic width concern (see untrusted.Sanitize's doc), not a write-boundary
+	// one. If that ever needs tightening, tighten Sanitize — this gate follows it.
 	if untrusted.Sanitize(id) != id {
 		return fmt.Errorf("%s id %q contains a control or deceptive formatting rune", kind, id)
 	}

--- a/internal/source/writer.go
+++ b/internal/source/writer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 	"sigs.k8s.io/yaml"
 )
 
@@ -53,6 +54,17 @@ func ValidateComponentID(kind, id string) error {
 	// Windows, so allowing it would make the canonical source non-portable.
 	if strings.ContainsAny(id, `/\:`) || strings.Contains(id, "..") || filepath.IsAbs(id) {
 		return fmt.Errorf("%s id %q contains a path separator, '..', ':' or is absolute", kind, id)
+	}
+	// A terminal-control byte (ESC/C0/C1/DEL) or deceptive bidi/zero-width rune is
+	// never a legitimate component id: as a filename it is pathological, and a
+	// foreign id reaching this boundary is later echoed back in `import`/`reconcile`
+	// diagnostics — where a raw ESC would smuggle a terminal escape and a bidi
+	// override could spoof the name. Reject any id the display sanitizer would
+	// alter, tying this write boundary to the SAME rune set untrusted.Sanitize
+	// strips (one source of truth, so the two can't drift). The %q below escapes
+	// any such rune in the message itself, so the error is safe to print.
+	if untrusted.Sanitize(id) != id {
+		return fmt.Errorf("%s id %q contains a control or deceptive formatting rune", kind, id)
 	}
 	return nil
 }

--- a/internal/source/writer_test.go
+++ b/internal/source/writer_test.go
@@ -50,10 +50,19 @@ func TestValidateComponentID_RejectsControlAndDeceptiveRunes(t *testing.T) {
 		}
 	}
 	// A legitimate non-ASCII id (no explicit control/bidi/zero-width runes) still
-	// passes — the gate strips only the spoofing set, never ordinary letters.
-	for _, id := range []string{"github", "my-plugin", "naïve", "日本語"} {
+	// passes — the gate strips only the spoofing set, never ordinary letters. The
+	// width-affecting-but-inert runes untrusted.Sanitize knowingly leaves alone also
+	// pass BY DESIGN: the gate's scope is exactly Sanitize's set, so these rows pin
+	// that boundary — were Sanitize tightened to strip them, these cases would flip
+	// and force an intentional decision rather than drifting silently.
+	for _, id := range []string{
+		"github", "my-plugin", "naïve", "日本語", // ordinary letters, preserved
+		"soft\u00adhyphen", // U+00AD soft hyphen — width-affecting, not a terminal escape
+		"word\u2060joiner", // U+2060 word joiner — default-ignorable, left alone
+		"line\u2028sep",    // U+2028 line separator — not stripped by Sanitize
+	} {
 		if err := source.ValidateComponentID("plugin", id); err != nil {
-			t.Errorf("ValidateComponentID(%q) = %v; want nil (legitimate id)", id, err)
+			t.Errorf("ValidateComponentID(%q) = %v; want nil (legitimate / out-of-scope id)", id, err)
 		}
 	}
 }

--- a/internal/source/writer_test.go
+++ b/internal/source/writer_test.go
@@ -28,6 +28,36 @@ func TestValidateComponentID_RejectsDegenerate(t *testing.T) {
 	}
 }
 
+// TestValidateComponentID_RejectsControlAndDeceptiveRunes guards the write
+// boundary against an id that is separator-free and non-degenerate yet carries a
+// terminal-control byte or a deceptive bidi/zero-width rune — a foreign id (from a
+// native config on `import`/`reconcile`) that would make a pathological filename
+// and, echoed back in a diagnostic, smuggle a terminal escape or spoof its own
+// name. The check is tied to untrusted.Sanitize's rune set, so these must be
+// rejected even though they pass the separator/traversal/degenerate gates.
+func TestValidateComponentID_RejectsControlAndDeceptiveRunes(t *testing.T) {
+	hostile := []string{
+		"good\x1b[31m",  // ESC — terminal recolor
+		"demo\r",        // CR — row spoof
+		"demo\x07",      // BEL
+		"name\u202egnp", // RLO (U+202E) — Trojan-Source bidi reorder
+		"na\u200bme",    // ZWSP (U+200B) — invisible padding
+		"x\u009bm",      // C1 CSI introducer (U+009B)
+	}
+	for _, id := range hostile {
+		if err := source.ValidateComponentID("plugin", id); err == nil {
+			t.Errorf("ValidateComponentID(%q) = nil; want rejection of control/deceptive rune", id)
+		}
+	}
+	// A legitimate non-ASCII id (no explicit control/bidi/zero-width runes) still
+	// passes — the gate strips only the spoofing set, never ordinary letters.
+	for _, id := range []string{"github", "my-plugin", "naïve", "日本語"} {
+		if err := source.ValidateComponentID("plugin", id); err != nil {
+			t.Errorf("ValidateComponentID(%q) = %v; want nil (legitimate id)", id, err)
+		}
+	}
+}
+
 func TestWriteMCP_RoundTrip(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/untrusted/untrusted.go
+++ b/internal/untrusted/untrusted.go
@@ -73,6 +73,23 @@ func (t Text) Unverified() string { return string(t) }
 // callers read `t.Empty()` instead of comparing against a Text("") literal.
 func (t Text) Empty() bool { return t == "" }
 
+// Join concatenates the SANITIZED form of each Text with sep between elements —
+// the Text-slice analogue of strings.Join, for building one display string from
+// several untrusted values (e.g. the comma-separated plugin list in the
+// status/doctor "undeclared native plugins" note). Each element is sanitized via
+// String(), so the result is safe to print directly; do NOT wrap it in a second
+// Sanitize. sep is trusted caller-supplied text and is emitted verbatim.
+func Join(ts []Text, sep string) string {
+	var b strings.Builder
+	for i, t := range ts {
+		if i > 0 {
+			b.WriteString(sep)
+		}
+		b.WriteString(t.String())
+	}
+	return b.String()
+}
+
 // Sanitize strips control characters and deceptive format runes from a string so
 // untrusted text — a fetched marketplace plugin's id, a plugin-supplied component
 // name — can be rendered to a terminal without smuggling escape sequences or

--- a/internal/untrusted/untrusted_test.go
+++ b/internal/untrusted/untrusted_test.go
@@ -47,6 +47,25 @@ func TestText_Empty(t *testing.T) {
 	}
 }
 
+// TestJoin pins the Text-slice join used to build one display string from
+// several untrusted values (the status/doctor "undeclared native plugins" list):
+// every element is rendered through its sanitizing String(), so terminal escapes
+// are stripped per element while the caller's separator is emitted verbatim.
+func TestJoin(t *testing.T) {
+	ts := []Text{Wrap("demo\x1b[31m"), Wrap("ev\ril"), Wrap("ok")}
+	got := Join(ts, ", ")
+	want := "demo[31m, evil, ok"
+	if got != want {
+		t.Errorf("Join = %q, want sanitized %q", got, want)
+	}
+	if got := Join(nil, ", "); got != "" {
+		t.Errorf("Join(nil) = %q, want empty", got)
+	}
+	if got := Join([]Text{Wrap("solo")}, ", "); got != "solo" {
+		t.Errorf("Join(single) = %q, want %q (no trailing separator)", got, "solo")
+	}
+}
+
 // TestText_Wrap pins the boundary constructor: Wrap stores the bytes verbatim
 // (Unverified round-trips them) without sanitizing at construction — sanitization
 // happens at the display boundary (String), not at ingestion, so the raw value


### PR DESCRIPTION
Closes #104.

## What & why

PR #103 (closing #102) made untrusted plugin/marketplace metadata sanitize at the display boundary **by type** (`untrusted.Text`). One source was deliberately left out of that pass: the **native-ingested plugin name**. A `PluginIngester` reported it as a plain `string`, and `undeclaredNativePlugins` printed it in the `status`/`doctor` "undeclared native plugins" notes behind a per-site `ui.Sanitize` wrapper — a convention-not-type island the field guard couldn't protect (a new print site forgetting the wrapper would fail no check).

This carries the name as `untrusted.Text` end to end so the ingest→status/doctor path gets the same by-construction guarantee.

## Changes

- **`adapter.NativePlugin.Name` is now `untrusted.Text`** (was `string`). The claude/codex `IngestPlugins` implementations `Wrap` it at the boundary; sort comparisons are unaffected (it's a defined string kind).
- **`undeclaredNativePlugins` returns `map[string][]untrusted.Text`**, keying match/dedup off the raw `Unverified()` value while handing the `Text` wrapper to the sinks.
- **`status`/`doctor` sinks drop the manual `ui.Sanitize`** and render via the new **`untrusted.Join`** helper (each element sanitizes through its `String()`).
- **New `TestUntrustedFieldGuard` over `adapter.NativePlugin`** (mirrors the `internal/{source,marketplace,render}` guards) — fails the build if a future native-config string ships unclassified.
- **`MarketplaceID` stays a plain string**, documented in both the struct doc and the guard: it isn't rendered into the status/doctor layout this hardening targets; its only display sites are `import`'s warn diagnostics (the same plain-string surface as the sibling `NativeMarketplace`/`NativeSource` fields) — a deliberate, written-down subset to promote together if that surface is ever hardened.
- `import`/`plugin_drift` use `Unverified()` for raw path/lookup/validation identity; as a side benefit, `import`'s warn lines now sanitize the name for free via Stringer.
- Docs updated in the same commit: `docs/architecture.md` §7, `SECURITY.md`, `CHANGELOG.md`.

## Acceptance criteria (from #104)

- [x] Native plugin name carried from `IngestPlugins` to status/doctor is `untrusted.Text`, printed via its sanitizing `String()` (no manual `ui.Sanitize` at the sink).
- [x] A `TestUntrustedFieldGuard`-style reflection guard covers the ingest descriptor's name field.
- [x] The existing `status`/`doctor` sanitization tests still pass (`TestStatus_SanitizesUndeclaredPluginName` / `TestDoctor_SanitizesUndeclaredPluginName`, unchanged).

## Testing

- `go build ./...`, `go vet`, and `golangci-lint` (v2.12.2) clean on the affected packages.
- `gofmt -s` / `gofumpt` report no changes.
- `go test ./internal/{untrusted,adapter,adapter/claude,adapter/codex,cli}/` all pass (incl. the existing status/doctor sanitization E2E tests and the new `TestUntrustedFieldGuard` + `TestJoin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013hKxuzGg1w8SLgjnHijvDU)_