### PR TITLE
refactor(adapter): model skip severity as a typed Kind field (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,15 +75,29 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   without fields the agent has no home for — e.g. a subagent's Claude-only
   `tools`/`color`) or `dropped` (the whole component had no native target and was
   not emitted — e.g. an LSP server on an agent with no LSP concept), with the
-  reason. The distinction is derived from the adapter's `-frontmatter` skip
-  suffix, which is no longer shown raw — the label names the component kind
-  plainly (`subagent reviewer`, not `subagent-frontmatter reviewer`). The
-  structured surface gains a `skipDetails` array (`{component, name, reason}`) on
-  every `explain --json` row (the raw `component` there retains its
-  `-frontmatter` suffix). The translation report carries the detail end-to-end
-  (`render.PluginRow.SkipDetails`) rather than collapsing skips to a bare count,
-  and the counts/skips are scoped to the named plugin (see the `explain` fix
-  below).
+  reason. The label names the component kind plainly (`subagent reviewer`). The
+  structured surface gains a `skipDetails` array (`{component, name, reason,
+  kind}`) on every `explain --json` row. The translation report carries the
+  detail end-to-end (`render.PluginRow.SkipDetails`) rather than collapsing skips
+  to a bare count, and the counts/skips are scoped to the named plugin (see the
+  `explain` fix below).
+
+- **Skip severity is a typed field, not a `-frontmatter` string convention
+  (#98).** The reduced-vs-dropped distinction `explain` shows was previously
+  derived at the presentation layer by string-matching a `-frontmatter` suffix on
+  the skip's `component` (e.g. `subagent-frontmatter`) — load-bearing for
+  user-facing output yet enforced only by an undocumented naming convention with
+  no compile-time guard. It is now a typed `adapter.Skip.Kind`
+  (`SkipDropped`/`SkipReduced`) the adapter sets at each skip site, carried
+  through `render.SkipDetail` to `explain`. `internal/cli/explain.go` reads
+  `Kind` directly (the `isReducedSkip`/`HasSuffix` heuristic is gone), and a new
+  reflective exhaustiveness guard (`TestEveryAdapterClassifiesSkips`) renders
+  every registered adapter at both scopes and fails if any skip ships with `Kind`
+  unset — so a new adapter or skip site can no longer silently misclassify.
+  - **Breaking change to `explain --json`.** Each `skipDetails` entry gains an
+    explicit `kind` field (`"reduced"`/`"dropped"`), and `component` is now the
+    plain kind (`subagent`, `command`, …) — it no longer carries the
+    `-frontmatter` suffix machine consumers had to parse. Read `kind` instead.
 
 ### Fixed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,18 @@ Two design points worth internalizing:
 `CapLSP` (and the Codex and Cursor adapters omit `CapLSP` — neither has an LSP
 concept) and the pipeline reports those components as skipped.
 
+**Skips are typed, not stringly-classified.** A `Skip` carries a `Kind`
+(`adapter.SkipKind`): `SkipDropped` when the whole component had no native target
+and was not emitted, `SkipReduced` when it rendered but lost fields the agent has
+no home for (a subagent's Claude-only `tools`/`color`, a command's frontmatter).
+The adapter that builds the `Skip` sets `Kind` — the CLI's `explain` reads it
+directly and `explain --json` surfaces it as `kind` (`"reduced"`/`"dropped"`).
+The zero value `SkipKindUnset` is invalid: `Component` is the plain kind (`mcp`,
+`subagent`, …) and no longer encodes the distinction via a `-frontmatter` suffix.
+`TestEveryAdapterClassifiesSkips` (`internal/cli`) renders every registered
+adapter at both scopes and fails if any emitted skip leaves `Kind` unset, so a
+new adapter or skip site cannot silently ship unclassified.
+
 **Key-merge strategies and on-disk format.** `KeyMergeStrategy` /
 `FileOp.MergeStrategy` name how an adapter co-owns keys inside a shared config
 file: `merge-json-keys` (Claude's `.claude.json`/`settings.json`, a project's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,9 +140,14 @@ The adapter that builds the `Skip` sets `Kind` — the CLI's `explain` reads it
 directly and `explain --json` surfaces it as `kind` (`"reduced"`/`"dropped"`).
 The zero value `SkipKindUnset` is invalid: `Component` is the plain kind (`mcp`,
 `subagent`, …) and no longer encodes the distinction via a `-frontmatter` suffix.
-`TestEveryAdapterClassifiesSkips` (`internal/cli`) renders every registered
-adapter at both scopes and fails if any emitted skip leaves `Kind` unset, so a
-new adapter or skip site cannot silently ship unclassified.
+Two complementary guards make an unclassified skip impossible to ship.
+`TestEverySkipLiteralSetsKind` (`internal/adapter`) statically parses every
+production `adapter.Skip` literal under `internal/` and fails if one omits `Kind`
+— reachability-independent, so a skip site gated on a path that is never empty at
+runtime (e.g. a scope-gap branch) cannot hide from it. `TestEveryAdapterClassifiesSkips`
+(`internal/cli`) is the behavioral complement: it renders every registered
+adapter at both scopes, fails on any unset `Kind`, and pins that both kind values
+are exercised.
 
 **Key-merge strategies and on-disk format.** `KeyMergeStrategy` /
 `FileOp.MergeStrategy` name how an adapter co-owns keys inside a shared config

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -406,10 +406,10 @@ translate is itemized beneath a framing header, each tagged `reduced` or
 `dropped` with the reason, so you can see exactly what loss `apply` would incur.
 `--json` carries the per-kind counts (`mcp`, `commands`, `skills`, `subagents`,
 `hooks`, `lsp`) and the `skipDetails` array (each entry `{component, name,
-reason}`) on every row. The `reduced` vs `dropped` split is a text-rendering
-distinction only: JSON exposes the raw `component` (a field-level reduction keeps
-its `-frontmatter` suffix, e.g. `subagent-frontmatter`), so a machine consumer
-derives the split from that suffix rather than a dedicated field.
+reason, kind}`) on every row. `kind` is `"reduced"` or `"dropped"` — the explicit
+machine surface for the split, so a consumer never re-derives it from the
+component string. `component` is the plain component kind (`subagent`, `command`,
+`lsp`, …); it carries no `-frontmatter` suffix.
 
 Inspect any plugin's coverage without applying:
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -4,6 +4,7 @@
 package adapter
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 
@@ -95,12 +96,56 @@ type FileOp struct {
 	OwnedKeys     []string // JSON pointers owned by agentsync; populated by Apply from state, not Render
 }
 
-// Skip describes a component the adapter chose not to render. Surfaces in the
-// translation report and in `apply --strict`'s exit logic.
+// SkipKind classifies how much of a component was lost, so consumers never have
+// to re-derive the distinction from a component-name convention. The adapter that
+// constructs the Skip sets it — it is the only layer that knows whether the whole
+// component was dropped or merely reduced. (It replaces the former "-frontmatter"
+// component-suffix convention, which encoded the same fact in a string only the
+// CLI knew how to parse.)
+type SkipKind int
+
+const (
+	// SkipKindUnset is the zero value and is INVALID: every constructed Skip MUST
+	// set Kind to one of the classifications below. Leaving it unset is a bug —
+	// the exhaustiveness guard TestEveryAdapterClassifiesSkips (internal/cli)
+	// renders every registered adapter over a component-complete fixture at both
+	// scopes and fails if any emitted skip carries SkipKindUnset, closing the
+	// "no compile-time guard" gap a silent string suffix left open.
+	SkipKindUnset SkipKind = iota
+	// SkipDropped — the whole component had no native target on this agent and was
+	// not emitted at all (e.g. an LSP server on an agent with no LSP concept, a
+	// SessionEnd hook on Codex).
+	SkipDropped
+	// SkipReduced — the component still rendered, minus fields the target agent has
+	// no home for (e.g. a subagent's Claude-only tools/color frontmatter).
+	SkipReduced
+)
+
+// String renders the kind for human notes and the report's machine surface.
+func (k SkipKind) String() string {
+	switch k {
+	case SkipReduced:
+		return "reduced"
+	case SkipDropped:
+		return "dropped"
+	default:
+		return "unset"
+	}
+}
+
+// MarshalJSON emits the lowercase string form so `explain --json` carries an
+// explicit "kind":"reduced"|"dropped" rather than an opaque integer.
+func (k SkipKind) MarshalJSON() ([]byte, error) { return json.Marshal(k.String()) }
+
+// Skip describes a component the adapter could not fully render. Surfaces in the
+// translation report and in `apply --strict`'s exit logic. Kind distinguishes a
+// whole-component drop from a field-level reduction (the component still
+// rendered) and MUST be set explicitly at every construction site.
 type Skip struct {
-	Component string // "skill" | "subagent" | etc.
+	Component string // "skill" | "subagent" | "command" | etc.
 	Name      string
 	Reason    string
+	Kind      SkipKind
 }
 
 // Adapter is the per-agent contract.

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -106,11 +106,16 @@ type SkipKind int
 
 const (
 	// SkipKindUnset is the zero value and is INVALID: every constructed Skip MUST
-	// set Kind to one of the classifications below. Leaving it unset is a bug —
-	// the exhaustiveness guard TestEveryAdapterClassifiesSkips (internal/cli)
-	// renders every registered adapter over a component-complete fixture at both
-	// scopes and fails if any emitted skip carries SkipKindUnset, closing the
-	// "no compile-time guard" gap a silent string suffix left open.
+	// set Kind to one of the classifications below. Leaving it unset is a bug,
+	// caught by two complementary guards. TestEverySkipLiteralSetsKind
+	// (internal/adapter) statically parses every production adapter.Skip literal
+	// under internal/ and fails if one omits Kind — reachability-independent, so a
+	// skip site gated on a path that is never empty at runtime cannot hide from it.
+	// TestEveryAdapterClassifiesSkips (internal/cli) is the behavioral complement:
+	// it renders every registered adapter at both scopes and fails if any emitted
+	// skip carries SkipKindUnset, while also pinning that both kind values are
+	// exercised. Together they close the "no compile-time guard" gap a silent
+	// string suffix left open.
 	SkipKindUnset SkipKind = iota
 	// SkipDropped — the whole component had no native target on this agent and was
 	// not emitted at all (e.g. an LSP server on an agent with no LSP concept, a

--- a/internal/adapter/cline/command.go
+++ b/internal/adapter/cline/command.go
@@ -23,6 +23,7 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Cline's global workflows live in the non-XDG ~/Documents/Cline/Workflows path agentsync does not target; workflows project at project scope only (.clinerules/workflows/)",
+				Kind:      adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil
@@ -32,9 +33,10 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 	for _, cmd := range c.Commands {
 		if len(cmd.Frontmatter) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Cline workflows are plain markdown (no frontmatter); dropped " + strings.Join(sortedKeys(cmd.Frontmatter), ", "),
+				Kind:      adapter.SkipReduced,
 			})
 		}
 		ops = append(ops, adapter.FileOp{

--- a/internal/adapter/cline/mcp.go
+++ b/internal/adapter/cline/mcp.go
@@ -32,6 +32,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, []ad
 			skips = append(skips, adapter.Skip{
 				Component: "mcp", Name: m.ID,
 				Reason: "Cline has no project-level MCP file; agentsync targets the Cline CLI's ~/.cline/mcp.json at user scope",
+				Kind:   adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil

--- a/internal/adapter/cline/memory.go
+++ b/internal/adapter/cline/memory.go
@@ -22,6 +22,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, [
 			Component: "memory",
 			Name:      "rules",
 			Reason:    "Cline global rules live in ~/Documents/Cline/ (a non-XDG app path agentsync does not target); memory projects at project scope only (.clinerules/)",
+			Kind:      adapter.SkipDropped,
 		}}, nil
 	}
 	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, memoryRuleFile, c.Config.MemoryBannerEnabled())

--- a/internal/adapter/cline/render.go
+++ b/internal/adapter/cline/render.go
@@ -51,16 +51,16 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 
 	// Components Cline has no faithful target for — skipped with a report.
 	for _, s := range renderC.Skills {
-		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Cline has no Agent Skills concept"})
+		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Cline has no Agent Skills concept", Kind: adapter.SkipDropped})
 	}
 	for _, s := range renderC.Subagents {
-		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Cline has no subagent concept"})
+		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Cline has no subagent concept", Kind: adapter.SkipDropped})
 	}
 	for _, h := range renderC.Hooks {
-		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Cline has no declarative hook concept"})
+		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Cline has no declarative hook concept", Kind: adapter.SkipDropped})
 	}
 	for _, l := range renderC.LSPServers {
-		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Cline has no LSP configuration concept"})
+		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Cline has no LSP configuration concept", Kind: adapter.SkipDropped})
 	}
 	return ops, skips, nil
 }

--- a/internal/adapter/cline/render_test.go
+++ b/internal/adapter/cline/render_test.go
@@ -21,9 +21,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) bool {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) bool {
 	for _, s := range skips {
-		if s.Component == component && s.Name == name {
+		if s.Component == component && s.Name == name && s.Kind == kind {
 			return true
 		}
 	}
@@ -67,7 +67,7 @@ func TestRender_UserScope_MCPOnly(t *testing.T) {
 	if _, hasType := srv["type"]; hasType {
 		t.Fatalf("Cline infers transport; must not write a type key: %v", srv)
 	}
-	if !hasSkip(skips, "memory", "rules") || !hasSkip(skips, "command", "deploy") {
+	if !hasSkip(skips, "memory", "rules", adapter.SkipDropped) || !hasSkip(skips, "command", "deploy", adapter.SkipDropped) {
 		t.Errorf("expected user-scope memory + command skips, got %+v", skips)
 	}
 	if findOp(ops, "agentsync.md") != nil || findOp(ops, "deploy.md") != nil {
@@ -125,13 +125,13 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	if cmdOp == nil || string(cmdOp.Content) != "Run deploy.\n" {
 		t.Fatalf("workflow should be plain body: %+v", cmdOp)
 	}
-	if !hasSkip(skips, "command-frontmatter", "deploy") {
-		t.Errorf("expected command-frontmatter skip, got %+v", skips)
+	if !hasSkip(skips, "command", "deploy", adapter.SkipReduced) {
+		t.Errorf("expected reduced command skip, got %+v", skips)
 	}
 	if findOp(ops, "mcp.json") != nil {
 		t.Fatalf("MCP must not render at project scope: %+v", ops)
 	}
-	if !hasSkip(skips, "mcp", "github") {
+	if !hasSkip(skips, "mcp", "github", adapter.SkipDropped) {
 		t.Errorf("expected project-scope MCP skip, got %+v", skips)
 	}
 }
@@ -148,7 +148,7 @@ func TestRender_UnsupportedComponentsSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, w := range []struct{ comp, name string }{{"skill", "demo"}, {"subagent", "rev"}, {"hook", "PreToolUse"}, {"lsp", "gopls"}} {
-		if !hasSkip(skips, w.comp, w.name) {
+		if !hasSkip(skips, w.comp, w.name, adapter.SkipDropped) {
 			t.Errorf("expected %s skip for %q, got %+v", w.comp, w.name, skips)
 		}
 	}

--- a/internal/adapter/codex/command.go
+++ b/internal/adapter/codex/command.go
@@ -23,6 +23,7 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths, scope adapter.Scop
 				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Codex custom prompts are global-only; no project-scope target",
+				Kind:      adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil

--- a/internal/adapter/codex/hook.go
+++ b/internal/adapter/codex/hook.go
@@ -49,6 +49,7 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []
 				Component: "hook",
 				Name:      h.Event,
 				Reason:    "Codex does not recognize this lifecycle event",
+				Kind:      adapter.SkipDropped,
 			})
 			continue
 		}

--- a/internal/adapter/codex/render.go
+++ b/internal/adapter/codex/render.go
@@ -72,6 +72,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "Codex has no LSP configuration concept",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	return ops, skips, nil

--- a/internal/adapter/codex/render_test.go
+++ b/internal/adapter/codex/render_test.go
@@ -217,7 +217,7 @@ func TestRender_Subagent_ToTOML(t *testing.T) {
 	}
 	var sawSkip bool
 	for _, s := range skips {
-		if s.Component == "subagent-frontmatter" && s.Name == "review" {
+		if s.Component == "subagent" && s.Name == "review" && s.Kind == adapter.SkipReduced {
 			if strings.Contains(s.Reason, "name") {
 				t.Fatalf("name carries over to the Codex TOML; it must not be reported dropped: %q", s.Reason)
 			}
@@ -227,7 +227,7 @@ func TestRender_Subagent_ToTOML(t *testing.T) {
 		}
 	}
 	if !sawSkip {
-		t.Fatalf("expected a subagent-frontmatter skip listing tools+color, got %+v", skips)
+		t.Fatalf("expected a reduced subagent skip listing tools+color, got %+v", skips)
 	}
 }
 
@@ -254,7 +254,7 @@ func TestRender_Subagent_NameOnly_NoSkip(t *testing.T) {
 		t.Fatalf("name field missing: %s", op.Content)
 	}
 	for _, s := range skips {
-		if s.Component == "subagent-frontmatter" && s.Name == "ai-architect" {
+		if s.Component == "subagent" && s.Name == "ai-architect" && s.Kind == adapter.SkipReduced {
 			t.Fatalf("no skip expected for a name/description/model-only agent, got %q", s.Reason)
 		}
 	}
@@ -300,7 +300,7 @@ func TestRender_Command_ProjectScope_Skipped(t *testing.T) {
 	}
 	var sawSkip bool
 	for _, s := range skips {
-		if s.Component == "command" && s.Name == "summarize" {
+		if s.Component == "command" && s.Name == "summarize" && s.Kind == adapter.SkipDropped {
 			sawSkip = true
 		}
 	}
@@ -341,7 +341,7 @@ func TestRender_Hooks_KnownAndUnknownEvents(t *testing.T) {
 	}
 	var sawSkip bool
 	for _, s := range skips {
-		if s.Component == "hook" && s.Name == "SessionEnd" {
+		if s.Component == "hook" && s.Name == "SessionEnd" && s.Kind == adapter.SkipDropped {
 			sawSkip = true
 		}
 	}
@@ -406,7 +406,7 @@ func TestRender_LSP_Skipped(t *testing.T) {
 	}
 	var sawLSP bool
 	for _, s := range skips {
-		if s.Component == "lsp" && s.Name == "gopls" {
+		if s.Component == "lsp" && s.Name == "gopls" && s.Kind == adapter.SkipDropped {
 			sawLSP = true
 		}
 	}

--- a/internal/adapter/codex/subagent.go
+++ b/internal/adapter/codex/subagent.go
@@ -59,10 +59,11 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		}
 		if dropped := droppedKeys(s.Frontmatter); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "subagent-frontmatter",
+				Component: "subagent",
 				Name:      s.Name,
 				Reason: fmt.Sprintf("Codex agents are TOML with no per-agent tools allowlist; dropped %s",
 					strings.Join(dropped, ", ")),
+				Kind: adapter.SkipReduced,
 			})
 		}
 		body, err := toml.Marshal(af)

--- a/internal/adapter/continuedev/command.go
+++ b/internal/adapter/continuedev/command.go
@@ -31,9 +31,10 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 		}
 		if dropped := droppedKeys(cmd.Frontmatter, continueCommandKnownKeys); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Continue prompt blocks carry only name/description; dropped " + strings.Join(dropped, ", "),
+				Kind:      adapter.SkipReduced,
 			})
 		}
 		body, err := claude.EncodeFrontmatter(fm, cmd.Body)

--- a/internal/adapter/continuedev/render.go
+++ b/internal/adapter/continuedev/render.go
@@ -48,16 +48,16 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 
 	// Components Continue has no faithful target for — skipped with a report.
 	for _, s := range renderC.Skills {
-		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Continue has no Agent Skills concept"})
+		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Continue has no Agent Skills concept", Kind: adapter.SkipDropped})
 	}
 	for _, s := range renderC.Subagents {
-		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Continue agents are top-level assistants, not per-file subagents"})
+		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Continue agents are top-level assistants, not per-file subagents", Kind: adapter.SkipDropped})
 	}
 	for _, h := range renderC.Hooks {
-		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Continue has no declarative hook concept"})
+		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Continue has no declarative hook concept", Kind: adapter.SkipDropped})
 	}
 	for _, l := range renderC.LSPServers {
-		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Continue has no LSP configuration concept"})
+		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Continue has no LSP configuration concept", Kind: adapter.SkipDropped})
 	}
 	return ops, skips, nil
 }

--- a/internal/adapter/continuedev/render_test.go
+++ b/internal/adapter/continuedev/render_test.go
@@ -22,9 +22,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) bool {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) bool {
 	for _, s := range skips {
-		if s.Component == component && s.Name == name {
+		if s.Component == component && s.Name == name && s.Kind == kind {
 			return true
 		}
 	}
@@ -161,8 +161,8 @@ func TestRender_Command_PromptBlock(t *testing.T) {
 	if strings.Contains(content, "argument-hint") {
 		t.Fatalf("argument-hint must be dropped: %s", content)
 	}
-	if !hasSkip(skips, "command-frontmatter", "summarize") {
-		t.Fatalf("expected a command-frontmatter skip, got %+v", skips)
+	if !hasSkip(skips, "command", "summarize", adapter.SkipReduced) {
+		t.Fatalf("expected a reduced command skip, got %+v", skips)
 	}
 }
 
@@ -187,7 +187,7 @@ func TestRender_UnsupportedComponentsSkipped(t *testing.T) {
 	for _, want := range []struct{ comp, name string }{
 		{"skill", "demo"}, {"subagent", "rev"}, {"hook", "PreToolUse"}, {"lsp", "gopls"},
 	} {
-		if !hasSkip(skips, want.comp, want.name) {
+		if !hasSkip(skips, want.comp, want.name, adapter.SkipDropped) {
 			t.Errorf("expected %s skip for %q, got %+v", want.comp, want.name, skips)
 		}
 	}

--- a/internal/adapter/cursor/command.go
+++ b/internal/adapter/cursor/command.go
@@ -21,10 +21,11 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 	for _, cmd := range c.Commands {
 		if len(cmd.Frontmatter) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason: "Cursor commands are plain markdown (no frontmatter); dropped " +
 					strings.Join(sortedKeys(cmd.Frontmatter), ", "),
+				Kind: adapter.SkipReduced,
 			})
 		}
 		ops = append(ops, adapter.FileOp{

--- a/internal/adapter/cursor/hook.go
+++ b/internal/adapter/cursor/hook.go
@@ -74,6 +74,7 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []
 				Component: "hook",
 				Name:      h.Event,
 				Reason:    "Cursor has no equivalent hook event",
+				Kind:      adapter.SkipDropped,
 			})
 			continue
 		}
@@ -86,6 +87,7 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []
 				Component: "hook",
 				Name:      h.Event,
 				Reason:    fmt.Sprintf("agentsync models only command hooks; type %q is not projected", h.Type),
+				Kind:      adapter.SkipDropped,
 			})
 			continue
 		}

--- a/internal/adapter/cursor/memory.go
+++ b/internal/adapter/cursor/memory.go
@@ -20,6 +20,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths, scope adapter.Scope)
 			Component: "memory",
 			Name:      "AGENTS.md",
 			Reason:    "Cursor stores user-level rules in app-local storage; no filesystem projection target (use project scope for AGENTS.md)",
+			Kind:      adapter.SkipDropped,
 		}}, nil
 	}
 	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.Memory), c.Config.MemoryBannerEnabled())

--- a/internal/adapter/cursor/render.go
+++ b/internal/adapter/cursor/render.go
@@ -70,6 +70,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "Cursor has no LSP configuration concept",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	return ops, skips, nil

--- a/internal/adapter/cursor/render_test.go
+++ b/internal/adapter/cursor/render_test.go
@@ -22,9 +22,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) *adapter.Skip {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) *adapter.Skip {
 	for i := range skips {
-		if skips[i].Component == component && skips[i].Name == name {
+		if skips[i].Component == component && skips[i].Name == name && skips[i].Kind == kind {
 			return &skips[i]
 		}
 	}
@@ -155,7 +155,7 @@ func TestRender_Memory_UserScope_Skipped(t *testing.T) {
 	if op := findOp(ops, "AGENTS.md"); op != nil {
 		t.Fatalf("user-scope memory must not be written (app-local storage): %s", op.Path)
 	}
-	if hasSkip(skips, "memory", "AGENTS.md") == nil {
+	if hasSkip(skips, "memory", "AGENTS.md", adapter.SkipDropped) == nil {
 		t.Fatalf("expected a user-scope memory skip, got %+v", skips)
 	}
 }
@@ -224,9 +224,9 @@ func TestRender_Subagent_DropsToolsAndColor(t *testing.T) {
 	if strings.Contains(content, "tools") || strings.Contains(content, "color") {
 		t.Fatalf("tools/color must be dropped: %s", content)
 	}
-	sk := hasSkip(skips, "subagent-frontmatter", "review")
+	sk := hasSkip(skips, "subagent", "review", adapter.SkipReduced)
 	if sk == nil || !strings.Contains(sk.Reason, "tools") || !strings.Contains(sk.Reason, "color") {
-		t.Fatalf("expected a subagent-frontmatter skip listing tools+color, got %+v", skips)
+		t.Fatalf("expected a reduced subagent skip listing tools+color, got %+v", skips)
 	}
 }
 
@@ -256,9 +256,9 @@ func TestRender_Command_BodyOnly(t *testing.T) {
 	if content != "Summarize $ARGUMENTS.\n" {
 		t.Fatalf("body should be written verbatim, got: %q", content)
 	}
-	sk := hasSkip(skips, "command-frontmatter", "summarize")
+	sk := hasSkip(skips, "command", "summarize", adapter.SkipReduced)
 	if sk == nil || !strings.Contains(sk.Reason, "argument-hint") || !strings.Contains(sk.Reason, "description") {
-		t.Fatalf("expected a command-frontmatter skip listing dropped keys, got %+v", skips)
+		t.Fatalf("expected a reduced command skip listing dropped keys, got %+v", skips)
 	}
 }
 
@@ -326,7 +326,7 @@ func TestRender_Hooks_MapsEventsAndShape(t *testing.T) {
 			t.Fatalf("/version must never be an owned key: %v", op.OwnedKeys)
 		}
 	}
-	if hasSkip(skips, "hook", "Notification") == nil {
+	if hasSkip(skips, "hook", "Notification", adapter.SkipDropped) == nil {
 		t.Fatalf("expected a skip for unmapped event Notification, got %+v", skips)
 	}
 }
@@ -351,7 +351,7 @@ func TestRender_Hooks_SkipsNonCommandType(t *testing.T) {
 	if strings.Contains(string(op.Content), "preToolUse") {
 		t.Fatalf("prompt-type hook must not render: %s", op.Content)
 	}
-	sk := hasSkip(skips, "hook", "PreToolUse")
+	sk := hasSkip(skips, "hook", "PreToolUse", adapter.SkipDropped)
 	if sk == nil || !strings.Contains(sk.Reason, `type "prompt"`) {
 		t.Fatalf("expected a typed skip for the prompt hook, got %+v", skips)
 	}
@@ -368,7 +368,7 @@ func TestRender_LSP_Skipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hasSkip(skips, "lsp", "gopls") == nil {
+	if hasSkip(skips, "lsp", "gopls", adapter.SkipDropped) == nil {
 		t.Fatalf("expected an lsp skip, got %+v", skips)
 	}
 }

--- a/internal/adapter/cursor/subagent.go
+++ b/internal/adapter/cursor/subagent.go
@@ -40,10 +40,11 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		}
 		if dropped := droppedKeys(s.Frontmatter, cursorAgentKnownKeys); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "subagent-frontmatter",
+				Component: "subagent",
 				Name:      s.Name,
 				Reason: fmt.Sprintf("Cursor subagents support only name/description/model/readonly/is_background; dropped %s",
 					strings.Join(dropped, ", ")),
+				Kind: adapter.SkipReduced,
 			})
 		}
 		body, err := claude.EncodeFrontmatter(fm, s.Body)

--- a/internal/adapter/gemini/command.go
+++ b/internal/adapter/gemini/command.go
@@ -37,9 +37,10 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 		}
 		if dropped := droppedKeys(cmd.Frontmatter, geminiCommandKnownKeys); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Gemini commands are TOML (description + prompt); dropped " + strings.Join(dropped, ", "),
+				Kind:      adapter.SkipReduced,
 			})
 		}
 		body, err := toml.Marshal(cf)

--- a/internal/adapter/gemini/hook.go
+++ b/internal/adapter/gemini/hook.go
@@ -60,6 +60,7 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []
 				Component: "hook",
 				Name:      h.Event,
 				Reason:    "Gemini CLI has no equivalent hook event",
+				Kind:      adapter.SkipDropped,
 			})
 			continue
 		}
@@ -72,6 +73,7 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []
 				Component: "hook",
 				Name:      h.Event,
 				Reason:    fmt.Sprintf("agentsync models only command hooks; type %q is not projected", h.Type),
+				Kind:      adapter.SkipDropped,
 			})
 			continue
 		}

--- a/internal/adapter/gemini/render.go
+++ b/internal/adapter/gemini/render.go
@@ -62,6 +62,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "skill", Name: s.Name,
 			Reason: "Gemini CLI has no Agent Skills concept (use a Gemini extension)",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	// LSP: Gemini CLI has no LSP configuration concept — skip.
@@ -69,6 +70,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "Gemini CLI has no LSP configuration concept",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	return ops, skips, nil

--- a/internal/adapter/gemini/render_test.go
+++ b/internal/adapter/gemini/render_test.go
@@ -23,9 +23,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) *adapter.Skip {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) *adapter.Skip {
 	for i := range skips {
-		if skips[i].Component == component && skips[i].Name == name {
+		if skips[i].Component == component && skips[i].Name == name && skips[i].Kind == kind {
 			return &skips[i]
 		}
 	}
@@ -186,9 +186,9 @@ func TestRender_Command_TOML(t *testing.T) {
 	if cf.Description != "Summarize code" || cf.Prompt != "Summarize {{args}}.\n" {
 		t.Fatalf("command TOML wrong: %+v", cf)
 	}
-	sk := hasSkip(skips, "command-frontmatter", "summarize")
+	sk := hasSkip(skips, "command", "summarize", adapter.SkipReduced)
 	if sk == nil || !strings.Contains(sk.Reason, "argument-hint") {
-		t.Fatalf("expected dropped-frontmatter skip listing argument-hint, got %+v", skips)
+		t.Fatalf("expected reduced command skip listing argument-hint, got %+v", skips)
 	}
 }
 
@@ -220,9 +220,9 @@ func TestRender_Subagent_DropsToolsKeepsCore(t *testing.T) {
 	if strings.Contains(content, "tools") || strings.Contains(content, "color") {
 		t.Fatalf("tools/color must be dropped: %s", content)
 	}
-	sk := hasSkip(skips, "subagent-frontmatter", "review")
+	sk := hasSkip(skips, "subagent", "review", adapter.SkipReduced)
 	if sk == nil || !strings.Contains(sk.Reason, "tools") || !strings.Contains(sk.Reason, "color") {
-		t.Fatalf("expected subagent-frontmatter skip listing tools+color, got %+v", skips)
+		t.Fatalf("expected reduced subagent skip listing tools+color, got %+v", skips)
 	}
 }
 
@@ -259,7 +259,7 @@ func TestRender_Hooks_MapsEventsNestedShape(t *testing.T) {
 	if _, ok := hooks["AfterAgent"]; !ok {
 		t.Fatalf("Stop should map to AfterAgent: %s", op.Content)
 	}
-	if hasSkip(skips, "hook", "SubagentStop") == nil {
+	if hasSkip(skips, "hook", "SubagentStop", adapter.SkipDropped) == nil {
 		t.Fatalf("expected a skip for unmapped event SubagentStop, got %+v", skips)
 	}
 }
@@ -280,10 +280,10 @@ func TestRender_SkillAndLSP_Skipped(t *testing.T) {
 	if op := findOp(ops, "SKILL.md"); op != nil {
 		t.Fatalf("Gemini has no skills; none should be written: %s", op.Path)
 	}
-	if hasSkip(skips, "skill", "demo") == nil {
+	if hasSkip(skips, "skill", "demo", adapter.SkipDropped) == nil {
 		t.Fatalf("expected a skill skip, got %+v", skips)
 	}
-	if hasSkip(skips, "lsp", "gopls") == nil {
+	if hasSkip(skips, "lsp", "gopls", adapter.SkipDropped) == nil {
 		t.Fatalf("expected an lsp skip, got %+v", skips)
 	}
 }

--- a/internal/adapter/gemini/subagent.go
+++ b/internal/adapter/gemini/subagent.go
@@ -45,10 +45,11 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		}
 		if dropped := droppedKeys(s.Frontmatter, geminiAgentKnownKeys); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "subagent-frontmatter",
+				Component: "subagent",
 				Name:      s.Name,
 				Reason: fmt.Sprintf("Gemini agents support name/description/model (its `tools` vocabulary differs from Claude's); dropped %s",
 					strings.Join(dropped, ", ")),
+				Kind: adapter.SkipReduced,
 			})
 		}
 		body, err := claude.EncodeFrontmatter(fm, s.Body)

--- a/internal/adapter/generic/generic_test.go
+++ b/internal/adapter/generic/generic_test.go
@@ -26,9 +26,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) bool {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) bool {
 	for _, s := range skips {
-		if s.Component == component && s.Name == name {
+		if s.Component == component && s.Name == name && s.Kind == kind {
 			return true
 		}
 	}
@@ -127,7 +127,7 @@ func TestRender_Memory_ScopeGapReported(t *testing.T) {
 	if findOp(ops, ".goosehints") != nil {
 		t.Fatal("project-only memory must not render at user scope")
 	}
-	if !hasSkip(skips, "memory", "goose") {
+	if !hasSkip(skips, "memory", "goose", adapter.SkipDropped) {
 		t.Fatalf("expected memory scope-gap skip, got %+v", skips)
 	}
 }
@@ -213,7 +213,7 @@ func TestRender_MCP_SkipWhenUnsupported(t *testing.T) {
 	if findOp(ops, "mcp") != nil {
 		t.Fatal("memory-only spec must not write MCP")
 	}
-	if !hasSkip(skips, "mcp", "g") {
+	if !hasSkip(skips, "mcp", "g", adapter.SkipDropped) {
 		t.Fatalf("expected mcp skip, got %+v", skips)
 	}
 }
@@ -235,7 +235,7 @@ func TestRender_UnsupportedComponentsSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, w := range []struct{ comp, name string }{{"skill", "sk"}, {"subagent", "sa"}, {"command", "cmd"}, {"hook", "PreToolUse"}, {"lsp", "gopls"}} {
-		if !hasSkip(skips, w.comp, w.name) {
+		if !hasSkip(skips, w.comp, w.name, adapter.SkipDropped) {
 			t.Errorf("expected %s skip for %q, got %+v", w.comp, w.name, skips)
 		}
 	}
@@ -554,7 +554,7 @@ func TestSkills_RoundTrip_Fidelity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hasSkip(skips, "skill", "pdf") {
+	if hasSkip(skips, "skill", "pdf", adapter.SkipDropped) {
 		t.Fatalf("a supported skills spec must not skip the skill: %+v", skips)
 	}
 	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
@@ -632,7 +632,7 @@ func TestSkills_ScopeGapSkip(t *testing.T) {
 	if findOp(ops, "SKILL.md") != nil {
 		t.Fatal("project-only skills spec must not write at user scope")
 	}
-	if !hasSkip(skips, "skill", "sk") {
+	if !hasSkip(skips, "skill", "sk", adapter.SkipDropped) {
 		t.Fatalf("expected user-scope skill skip, got %+v", skips)
 	}
 }
@@ -652,7 +652,7 @@ func TestSkills_UnsupportedSpecStillSkips(t *testing.T) {
 	if findOp(ops, "SKILL.md") != nil {
 		t.Fatal("a spec with no Skills target must not write skills")
 	}
-	if !hasSkip(skips, "skill", "sk") {
+	if !hasSkip(skips, "skill", "sk", adapter.SkipDropped) {
 		t.Fatalf("expected skill skip for a skills-less spec, got %+v", skips)
 	}
 }
@@ -856,7 +856,7 @@ func TestSkills_SkippedAgentsEmitNothing(t *testing.T) {
 			if op := findOp(ops, "SKILL.md"); op != nil {
 				t.Fatalf("skills-less agent %q wrote a skill op: %s", s.Name, op.Path)
 			}
-			if !hasSkip(skips, "skill", "sk") {
+			if !hasSkip(skips, "skill", "sk", adapter.SkipDropped) {
 				t.Fatalf("skills-less agent %q did not report a skill skip", s.Name)
 			}
 		})

--- a/internal/adapter/generic/render.go
+++ b/internal/adapter/generic/render.go
@@ -49,6 +49,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 			skips = append(skips, adapter.Skip{
 				Component: "memory", Name: a.spec.Name,
 				Reason: fmt.Sprintf("%s memory has no %s-scope target", a.spec.Name, scope.String()),
+				Kind:   adapter.SkipDropped,
 			})
 		}
 	}
@@ -96,6 +97,7 @@ func (a *Adapter) renderSkills(c source.Canonical, scope adapter.Scope, project 
 			skips = append(skips, adapter.Skip{
 				Component: "skill", Name: s.Name,
 				Reason: fmt.Sprintf("%s skills have no %s-scope target", a.spec.Name, scope.String()),
+				Kind:   adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil
@@ -124,6 +126,7 @@ func (a *Adapter) renderMCP(c source.Canonical, scope adapter.Scope, project str
 			skips = append(skips, adapter.Skip{
 				Component: "mcp", Name: m.ID,
 				Reason: a.mcpSkipReason(scope),
+				Kind:   adapter.SkipDropped,
 			})
 			continue
 		}
@@ -171,20 +174,21 @@ func (a *Adapter) unsupportedSkips(c source.Canonical) []adapter.Skip {
 			skips = append(skips, adapter.Skip{
 				Component: "skill", Name: s.Name,
 				Reason: fmt.Sprintf("%s does not natively scan an Agent-Skills (SKILL.md) directory", a.spec.Name),
+				Kind:   adapter.SkipDropped,
 			})
 		}
 	}
 	for _, s := range c.Subagents {
-		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: reason("subagents")})
+		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: reason("subagents"), Kind: adapter.SkipDropped})
 	}
 	for _, cmd := range c.Commands {
-		skips = append(skips, adapter.Skip{Component: "command", Name: cmd.Name, Reason: reason("commands")})
+		skips = append(skips, adapter.Skip{Component: "command", Name: cmd.Name, Reason: reason("commands"), Kind: adapter.SkipDropped})
 	}
 	for _, h := range c.Hooks {
-		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: reason("hooks")})
+		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: reason("hooks"), Kind: adapter.SkipDropped})
 	}
 	for _, l := range c.LSPServers {
-		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: reason("LSP")})
+		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: reason("LSP"), Kind: adapter.SkipDropped})
 	}
 	return skips
 }

--- a/internal/adapter/opencode/command.go
+++ b/internal/adapter/opencode/command.go
@@ -35,8 +35,9 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 		// Drop unmappable fields, emit Skip notes.
 		if _, ok := cmd.Frontmatter["argument-hint"]; ok {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter", Name: cmd.Name,
+				Component: "command", Name: cmd.Name,
 				Reason: "Claude `argument-hint` has no OpenCode equivalent",
+				Kind:   adapter.SkipReduced,
 			})
 		}
 

--- a/internal/adapter/opencode/render.go
+++ b/internal/adapter/opencode/render.go
@@ -60,6 +60,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "hook", Name: h.Event,
 			Reason: "OpenCode hooks are JS/TS plugins; shim generation deferred to post-v1",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	// LSP: skip with explanation.
@@ -67,6 +68,7 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 		skips = append(skips, adapter.Skip{
 			Component: "lsp", Name: l.ID,
 			Reason: "OpenCode LSP projection deferred to v1.x",
+			Kind:   adapter.SkipDropped,
 		})
 	}
 	return ops, skips, nil

--- a/internal/adapter/opencode/render_test.go
+++ b/internal/adapter/opencode/render_test.go
@@ -329,7 +329,7 @@ func TestRender_Subagent_FrontmatterMunge(t *testing.T) {
 	// verify skip log
 	var sawToolsSkip bool
 	for _, s := range skips {
-		if s.Component == "subagent-frontmatter" && s.Name == "review" {
+		if s.Component == "subagent" && s.Name == "review" && s.Kind == adapter.SkipReduced {
 			if strings.Contains(s.Reason, "tools") {
 				sawToolsSkip = true
 			}
@@ -407,7 +407,7 @@ func TestRender_Command_FrontmatterMunge(t *testing.T) {
 	// verify skip for argument-hint
 	var sawHintSkip bool
 	for _, s := range skips {
-		if s.Component == "command-frontmatter" && s.Name == "summarize" {
+		if s.Component == "command" && s.Name == "summarize" && s.Kind == adapter.SkipReduced {
 			if strings.Contains(s.Reason, "argument-hint") {
 				sawHintSkip = true
 			}
@@ -503,10 +503,10 @@ func TestRender_HooksAndLSP_Skipped(t *testing.T) {
 	}
 	var hookSkip, lspSkip bool
 	for _, s := range skips {
-		if s.Component == "hook" {
+		if s.Component == "hook" && s.Kind == adapter.SkipDropped {
 			hookSkip = true
 		}
-		if s.Component == "lsp" {
+		if s.Component == "lsp" && s.Kind == adapter.SkipDropped {
 			lspSkip = true
 		}
 	}

--- a/internal/adapter/opencode/subagent.go
+++ b/internal/adapter/opencode/subagent.go
@@ -35,14 +35,16 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		// Drop unmappable fields, emit Skip notes so the user knows what was lost.
 		if _, ok := s.Frontmatter["tools"]; ok {
 			skips = append(skips, adapter.Skip{
-				Component: "subagent-frontmatter", Name: s.Name,
+				Component: "subagent", Name: s.Name,
 				Reason: "Claude `tools` allowlist not projected to OpenCode `permission` (manual rule design needed)",
+				Kind:   adapter.SkipReduced,
 			})
 		}
 		if _, ok := s.Frontmatter["color"]; ok {
 			skips = append(skips, adapter.Skip{
-				Component: "subagent-frontmatter", Name: s.Name,
+				Component: "subagent", Name: s.Name,
 				Reason: "Claude `color` has no OpenCode equivalent",
+				Kind:   adapter.SkipReduced,
 			})
 		}
 

--- a/internal/adapter/roo/command.go
+++ b/internal/adapter/roo/command.go
@@ -35,9 +35,10 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 		}
 		if dropped := droppedKeys(cmd.Frontmatter, rooCommandKnownKeys); len(dropped) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Roo commands support description + argument-hint; dropped " + strings.Join(dropped, ", "),
+				Kind:      adapter.SkipReduced,
 			})
 		}
 		body, err := claude.EncodeFrontmatter(fm, cmd.Body)

--- a/internal/adapter/roo/mcp.go
+++ b/internal/adapter/roo/mcp.go
@@ -29,6 +29,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, []ad
 			skips = append(skips, adapter.Skip{
 				Component: "mcp", Name: m.ID,
 				Reason: "Roo global MCP lives in VS Code globalStorage (OS/editor-specific); agentsync targets the project-level .roo/mcp.json (use project scope)",
+				Kind:   adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil

--- a/internal/adapter/roo/render.go
+++ b/internal/adapter/roo/render.go
@@ -50,16 +50,16 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 
 	// Components Roo has no faithful target for — skipped with a report.
 	for _, s := range renderC.Skills {
-		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Roo has no Agent Skills concept"})
+		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Roo has no Agent Skills concept", Kind: adapter.SkipDropped})
 	}
 	for _, s := range renderC.Subagents {
-		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Roo uses custom modes, not per-file subagents"})
+		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Roo uses custom modes, not per-file subagents", Kind: adapter.SkipDropped})
 	}
 	for _, h := range renderC.Hooks {
-		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Roo has no declarative hook concept"})
+		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Roo has no declarative hook concept", Kind: adapter.SkipDropped})
 	}
 	for _, l := range renderC.LSPServers {
-		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Roo has no LSP configuration concept"})
+		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Roo has no LSP configuration concept", Kind: adapter.SkipDropped})
 	}
 	return ops, skips, nil
 }

--- a/internal/adapter/roo/render_test.go
+++ b/internal/adapter/roo/render_test.go
@@ -21,9 +21,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) bool {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) bool {
 	for _, s := range skips {
-		if s.Component == component && s.Name == name {
+		if s.Component == component && s.Name == name && s.Kind == kind {
 			return true
 		}
 	}
@@ -94,8 +94,8 @@ func TestRender_ProjectScope_All(t *testing.T) {
 	if strings.Contains(content, "allowed-tools") {
 		t.Fatalf("allowed-tools must be dropped: %s", content)
 	}
-	if !hasSkip(skips, "command-frontmatter", "review") {
-		t.Errorf("expected command-frontmatter skip listing allowed-tools, got %+v", skips)
+	if !hasSkip(skips, "command", "review", adapter.SkipReduced) {
+		t.Errorf("expected reduced command skip listing allowed-tools, got %+v", skips)
 	}
 }
 
@@ -144,7 +144,7 @@ func TestRender_UserScope_NoMCP(t *testing.T) {
 	if findOp(ops, "mcp.json") != nil {
 		t.Fatalf("MCP must not render at user scope: %+v", ops)
 	}
-	if !hasSkip(skips, "mcp", "github") {
+	if !hasSkip(skips, "mcp", "github", adapter.SkipDropped) {
 		t.Errorf("expected user-scope MCP skip, got %+v", skips)
 	}
 }
@@ -161,7 +161,7 @@ func TestRender_UnsupportedComponentsSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, w := range []struct{ comp, name string }{{"skill", "demo"}, {"subagent", "rev"}, {"hook", "PreToolUse"}, {"lsp", "gopls"}} {
-		if !hasSkip(skips, w.comp, w.name) {
+		if !hasSkip(skips, w.comp, w.name, adapter.SkipDropped) {
 			t.Errorf("expected %s skip for %q, got %+v", w.comp, w.name, skips)
 		}
 	}

--- a/internal/adapter/skipkind_test.go
+++ b/internal/adapter/skipkind_test.go
@@ -1,0 +1,177 @@
+package adapter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// TestSkipKind_StringAndJSON pins the wire contract SkipKind promises: the human
+// String() form and, crucially, the explain --json surface (MarshalJSON). It
+// covers the invalid zero value too — an unset Kind that somehow escaped the
+// guards must serialize to a visible "unset" (surfacing the bug) rather than a
+// silent real kind. Without this, nothing proved SkipReduced→"reduced" or the
+// zero-value behavior the doc comments promise.
+func TestSkipKind_StringAndJSON(t *testing.T) {
+	cases := []struct {
+		k    adapter.SkipKind
+		str  string
+		json string
+	}{
+		{adapter.SkipReduced, "reduced", `"reduced"`},
+		{adapter.SkipDropped, "dropped", `"dropped"`},
+		{adapter.SkipKindUnset, "unset", `"unset"`},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.str {
+			t.Errorf("SkipKind(%d).String() = %q, want %q", int(c.k), got, c.str)
+		}
+		b, err := json.Marshal(c.k)
+		if err != nil {
+			t.Fatalf("json.Marshal(%s): %v", c.str, err)
+		}
+		if string(b) != c.json {
+			t.Errorf("json.Marshal(%s) = %s, want %s", c.str, b, c.json)
+		}
+	}
+}
+
+// TestEverySkipLiteralSetsKind is the reachability-INDEPENDENT guard that a skip
+// site cannot omit adapter.Skip.Kind. Its sibling TestEveryAdapterClassifiesSkips
+// (internal/cli) renders every registered adapter and checks no emitted skip is
+// unset — but a render-based check only covers skip sites the fixture actually
+// reaches. A site gated on a path that ResolvePaths never leaves empty (e.g.
+// windsurf's scope-gap command branch) lives in defensive code the fixture can't
+// trigger, so an unset Kind there would slip past unnoticed. This test instead
+// parses every production .go file under internal/ and fails if any adapter.Skip
+// composite literal omits the Kind field — caught whether or not the site is
+// reachable at runtime. The two guards are complementary: this one proves the
+// field is always SET; the runtime one proves both kind VALUES are exercised and
+// the classification flows through the report.
+func TestEverySkipLiteralSetsKind(t *testing.T) {
+	root := moduleInternalDir(t)
+	fset := token.NewFileSet()
+	var (
+		offenders []string
+		total     int
+	)
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Production Go only: test files may construct partial Skip literals on
+		// purpose (e.g. to exercise the unset/default path).
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
+		}
+		inPkgAdapter := f.Name.Name == "adapter"
+		ast.Inspect(f, func(n ast.Node) bool {
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			// Direct `adapter.Skip{...}` (and bare `Skip{...}` only inside package
+			// adapter, where Skip is the local type).
+			if isSkipType(cl.Type, inPkgAdapter) {
+				total++
+				if !hasKindField(cl) {
+					offenders = append(offenders, posOf(fset, cl))
+				}
+				return true
+			}
+			// `[]adapter.Skip{ {...}, {...} }`: the element literals have an elided
+			// type, so reach them through the slice's element type here.
+			if at, ok := cl.Type.(*ast.ArrayType); ok && isSkipType(at.Elt, inPkgAdapter) {
+				for _, el := range cl.Elts {
+					ecl, ok := el.(*ast.CompositeLit)
+					if !ok {
+						continue
+					}
+					total++
+					if !hasKindField(ecl) {
+						offenders = append(offenders, posOf(fset, ecl))
+					}
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanning internal/ for adapter.Skip literals: %v", err)
+	}
+
+	// Anti-vacuity: if the matcher silently stopped matching (e.g. the type was
+	// renamed), the "no offenders" pass would be meaningless. The tree holds ~54
+	// real skip sites; assert a healthy floor rather than an exact count so adding
+	// or removing one site doesn't churn this test.
+	if total < 40 {
+		t.Fatalf("only matched %d adapter.Skip literals — the matcher likely broke; expected ~54", total)
+	}
+	for _, o := range offenders {
+		t.Errorf("adapter.Skip literal omits Kind (set adapter.SkipReduced or adapter.SkipDropped): %s", o)
+	}
+}
+
+// isSkipType reports whether e is the type of an adapter.Skip composite literal:
+// the qualified `adapter.Skip` everywhere, or the bare `Skip` only within package
+// adapter itself.
+func isSkipType(e ast.Expr, inPkgAdapter bool) bool {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		x, ok := t.X.(*ast.Ident)
+		return ok && x.Name == "adapter" && t.Sel.Name == "Skip"
+	case *ast.Ident:
+		return inPkgAdapter && t.Name == "Skip"
+	}
+	return false
+}
+
+// hasKindField reports whether a composite literal sets the Kind field by name.
+func hasKindField(cl *ast.CompositeLit) bool {
+	for _, el := range cl.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if id, ok := kv.Key.(*ast.Ident); ok && id.Name == "Kind" {
+			return true
+		}
+	}
+	return false
+}
+
+func posOf(fset *token.FileSet, n ast.Node) string {
+	p := fset.Position(n.Pos())
+	return fmt.Sprintf("%s:%d", filepath.Base(filepath.Dir(p.Filename))+"/"+filepath.Base(p.Filename), p.Line)
+}
+
+// moduleInternalDir locates the repo's internal/ directory from this test file's
+// own path, so the scan is independent of the test's working directory.
+func moduleInternalDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate the source tree")
+	}
+	// thisFile = <root>/internal/adapter/skipkind_test.go → <root>/internal
+	internalDir := filepath.Dir(filepath.Dir(thisFile))
+	if filepath.Base(internalDir) != "internal" {
+		t.Fatalf("expected to resolve internal/, got %q", internalDir)
+	}
+	return internalDir
+}

--- a/internal/adapter/skipkind_test.go
+++ b/internal/adapter/skipkind_test.go
@@ -88,7 +88,7 @@ func TestEverySkipLiteralSetsKind(t *testing.T) {
 			// adapter, where Skip is the local type).
 			if isSkipType(cl.Type, inPkgAdapter) {
 				total++
-				if !hasKindField(cl) {
+				if !hasValidKind(cl) {
 					offenders = append(offenders, posOf(fset, cl))
 				}
 				return true
@@ -102,7 +102,7 @@ func TestEverySkipLiteralSetsKind(t *testing.T) {
 						continue
 					}
 					total++
-					if !hasKindField(ecl) {
+					if !hasValidKind(ecl) {
 						offenders = append(offenders, posOf(fset, ecl))
 					}
 				}
@@ -127,6 +127,65 @@ func TestEverySkipLiteralSetsKind(t *testing.T) {
 	}
 }
 
+// TestSkipKindStaticGuardMatchers is the standing self-test for the static guard's
+// own logic, so TestEverySkipLiteralSetsKind cannot silently rot into a vacuous
+// pass (e.g. a refactor that makes hasValidKind match any field, or isSkipType
+// match nothing). It exercises the matchers against synthetic literals — both the
+// shapes that MUST be accepted and the ones that MUST be flagged, including the
+// explicit-unset case the round-2 review surfaced. This bakes in the
+// break-verification CLAUDE.md asks of a guard.
+func TestSkipKindStaticGuardMatchers(t *testing.T) {
+	lit := func(expr string) *ast.CompositeLit {
+		t.Helper()
+		e, err := parser.ParseExpr(expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", expr, err)
+		}
+		cl, ok := e.(*ast.CompositeLit)
+		if !ok {
+			t.Fatalf("%q is not a composite literal", expr)
+		}
+		return cl
+	}
+
+	// hasValidKind: a keyed, non-unset Kind is the only accepted form.
+	valid := []string{
+		`adapter.Skip{Component: "c", Kind: adapter.SkipReduced}`,
+		`adapter.Skip{Component: "c", Kind: adapter.SkipDropped}`,
+	}
+	flagged := []string{
+		`adapter.Skip{Component: "c"}`,                              // Kind omitted
+		`adapter.Skip{Component: "c", Kind: adapter.SkipKindUnset}`, // explicit unset
+		`adapter.Skip{Component: "c", Kind: 0}`,                     // zero literal
+		`adapter.Skip{"c", "n", "r", adapter.SkipDropped}`,          // positional → over-report (safe)
+	}
+	for _, s := range valid {
+		if !hasValidKind(lit(s)) {
+			t.Errorf("hasValidKind(%s) = false, want true", s)
+		}
+	}
+	for _, s := range flagged {
+		if hasValidKind(lit(s)) {
+			t.Errorf("hasValidKind(%s) = true, want false (must be flagged)", s)
+		}
+	}
+
+	// isSkipType: qualified adapter.Skip always; bare Skip only inside package adapter.
+	if !isSkipType(lit(`adapter.Skip{Kind: adapter.SkipDropped}`).Type, false) {
+		t.Error("isSkipType(adapter.Skip) = false, want true")
+	}
+	if isSkipType(lit(`adapter.FileOp{Action: "write"}`).Type, false) {
+		t.Error("isSkipType(adapter.FileOp) = true, want false")
+	}
+	bare := lit(`Skip{Kind: SkipDropped}`).Type
+	if !isSkipType(bare, true) {
+		t.Error("isSkipType(bare Skip, inPkgAdapter=true) = false, want true")
+	}
+	if isSkipType(bare, false) {
+		t.Error("isSkipType(bare Skip, inPkgAdapter=false) = true, want false")
+	}
+}
+
 // isSkipType reports whether e is the type of an adapter.Skip composite literal:
 // the qualified `adapter.Skip` everywhere, or the bare `Skip` only within package
 // adapter itself.
@@ -141,16 +200,39 @@ func isSkipType(e ast.Expr, inPkgAdapter bool) bool {
 	return false
 }
 
-// hasKindField reports whether a composite literal sets the Kind field by name.
-func hasKindField(cl *ast.CompositeLit) bool {
+// hasValidKind reports whether a composite literal sets the Kind field by name to
+// a value that is NOT the invalid zero (SkipKindUnset / 0). Checking only that the
+// field name appears would let an explicit `Kind: adapter.SkipKindUnset` (or
+// `Kind: 0`) pass while being exactly the invalid state the guard forbids — and a
+// site like that in unreachable defensive code would slip past the runtime guard
+// too. A positional literal (no keyed Kind) returns false and is flagged; the
+// codebase convention is keyed fields, so this only ever over-reports, never
+// under-reports.
+func hasValidKind(cl *ast.CompositeLit) bool {
 	for _, el := range cl.Elts {
 		kv, ok := el.(*ast.KeyValueExpr)
 		if !ok {
 			continue
 		}
 		if id, ok := kv.Key.(*ast.Ident); ok && id.Name == "Kind" {
-			return true
+			return !isUnsetKindValue(kv.Value)
 		}
+	}
+	return false
+}
+
+// isUnsetKindValue reports whether an expression denotes the invalid zero value:
+// `adapter.SkipKindUnset`, bare `SkipKindUnset` (inside package adapter), or the
+// integer literal `0`.
+func isUnsetKindValue(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.SelectorExpr:
+		x, ok := v.X.(*ast.Ident)
+		return ok && x.Name == "adapter" && v.Sel.Name == "SkipKindUnset"
+	case *ast.Ident:
+		return v.Name == "SkipKindUnset"
+	case *ast.BasicLit:
+		return v.Kind == token.INT && v.Value == "0"
 	}
 	return false
 }

--- a/internal/adapter/windsurf/command.go
+++ b/internal/adapter/windsurf/command.go
@@ -33,9 +33,10 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 	for _, cmd := range c.Commands {
 		if len(cmd.Frontmatter) > 0 {
 			skips = append(skips, adapter.Skip{
-				Component: "command-frontmatter",
+				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "Windsurf workflows are plain markdown (no frontmatter); dropped " + strings.Join(sortedKeys(cmd.Frontmatter), ", "),
+				Kind:      adapter.SkipReduced,
 			})
 		}
 		ops = append(ops, adapter.FileOp{

--- a/internal/adapter/windsurf/command.go
+++ b/internal/adapter/windsurf/command.go
@@ -24,6 +24,7 @@ func (a *Adapter) renderCommands(c source.Canonical, p Paths) ([]adapter.FileOp,
 				Component: "command",
 				Name:      cmd.Name,
 				Reason:    "no Windsurf workflows target at this scope",
+				Kind:      adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil

--- a/internal/adapter/windsurf/mcp.go
+++ b/internal/adapter/windsurf/mcp.go
@@ -29,6 +29,7 @@ func (a *Adapter) renderMCP(c source.Canonical, p Paths) ([]adapter.FileOp, []ad
 			skips = append(skips, adapter.Skip{
 				Component: "mcp", Name: m.ID,
 				Reason: "Windsurf MCP config is global-only (~/.codeium/windsurf/mcp_config.json); no project-scope target",
+				Kind:   adapter.SkipDropped,
 			})
 		}
 		return nil, skips, nil

--- a/internal/adapter/windsurf/memory.go
+++ b/internal/adapter/windsurf/memory.go
@@ -53,6 +53,7 @@ func (a *Adapter) renderMemory(c source.Canonical, p Paths) ([]adapter.FileOp, [
 			Component: "memory",
 			Name:      "rules",
 			Reason:    "no Windsurf rules target at this scope",
+			Kind:      adapter.SkipDropped,
 		}}, nil
 	}
 	body := source.RenderManagedMemory(c.Memory.Body, c.Memory.Fragments, filepath.Base(p.GlobalRules), banner)

--- a/internal/adapter/windsurf/render.go
+++ b/internal/adapter/windsurf/render.go
@@ -52,16 +52,16 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 
 	// Components Windsurf has no faithful target for — skipped with a report.
 	for _, s := range renderC.Skills {
-		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Windsurf has no Agent Skills concept"})
+		skips = append(skips, adapter.Skip{Component: "skill", Name: s.Name, Reason: "Windsurf has no Agent Skills concept", Kind: adapter.SkipDropped})
 	}
 	for _, s := range renderC.Subagents {
-		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Windsurf has no subagent concept"})
+		skips = append(skips, adapter.Skip{Component: "subagent", Name: s.Name, Reason: "Windsurf has no subagent concept", Kind: adapter.SkipDropped})
 	}
 	for _, h := range renderC.Hooks {
-		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Windsurf has no declarative hook concept"})
+		skips = append(skips, adapter.Skip{Component: "hook", Name: h.Event, Reason: "Windsurf has no declarative hook concept", Kind: adapter.SkipDropped})
 	}
 	for _, l := range renderC.LSPServers {
-		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Windsurf has no LSP configuration concept"})
+		skips = append(skips, adapter.Skip{Component: "lsp", Name: l.ID, Reason: "Windsurf has no LSP configuration concept", Kind: adapter.SkipDropped})
 	}
 	return ops, skips, nil
 }

--- a/internal/adapter/windsurf/render_test.go
+++ b/internal/adapter/windsurf/render_test.go
@@ -21,9 +21,9 @@ func findOp(ops []adapter.FileOp, suffix string) *adapter.FileOp {
 	return nil
 }
 
-func hasSkip(skips []adapter.Skip, component, name string) bool {
+func hasSkip(skips []adapter.Skip, component, name string, kind adapter.SkipKind) bool {
 	for _, s := range skips {
-		if s.Component == component && s.Name == name {
+		if s.Component == component && s.Name == name && s.Kind == kind {
 			return true
 		}
 	}
@@ -142,14 +142,14 @@ func TestRender_ProjectScope_RulesAndWorkflows(t *testing.T) {
 	if string(cmdOp.Content) != "Run deploy.\n" {
 		t.Fatalf("workflow should be plain body: %q", cmdOp.Content)
 	}
-	if !hasSkip(skips, "command-frontmatter", "deploy") {
-		t.Errorf("expected command-frontmatter skip, got %+v", skips)
+	if !hasSkip(skips, "command", "deploy", adapter.SkipReduced) {
+		t.Errorf("expected reduced command skip, got %+v", skips)
 	}
 	// MCP has no project target → reported skip, no op.
 	if findOp(ops, "mcp_config.json") != nil {
 		t.Fatalf("MCP must not render at project scope: %+v", ops)
 	}
-	if !hasSkip(skips, "mcp", "github") {
+	if !hasSkip(skips, "mcp", "github", adapter.SkipDropped) {
 		t.Errorf("expected project-scope MCP skip, got %+v", skips)
 	}
 }
@@ -170,7 +170,7 @@ func TestRender_UnsupportedComponentsSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, w := range []struct{ comp, name string }{{"skill", "demo"}, {"subagent", "rev"}, {"hook", "PreToolUse"}, {"lsp", "gopls"}} {
-		if !hasSkip(skips, w.comp, w.name) {
+		if !hasSkip(skips, w.comp, w.name, adapter.SkipDropped) {
 			t.Errorf("expected %s skip for %q, got %+v", w.comp, w.name, skips)
 		}
 	}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -440,35 +440,51 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 		}
 	}
 	for i, s := range skips {
-		// "reduced" and "dropped" are the same width, so the reason column stays
-		// aligned without padding the (color-wrapped) status word.
-		status := p.Yellow("dropped")
-		if s.Kind == adapter.SkipReduced {
-			status = p.Cyan("reduced")
-		}
+		// Pad the status word (plain) to the widest real kind BEFORE coloring, so
+		// the reason column holds even for the guard-impossible "unset" fallback and
+		// ANSI never shifts it.
+		word, color := skipStatus(p, s.Kind)
 		fmt.Fprintf(w, "        %s %s  %s  %s\n",
 			p.Faint(ui.GlyphInfo),
 			ui.Pad(labels[i], width),
-			status,
+			color(ui.Pad(word, len("dropped"))),
 			p.Faint(ui.Sanitize(s.Reason)))
+	}
+}
+
+// skipStatus maps a skip's Kind to its display word + semantic color. An unset
+// Kind — which the static (TestEverySkipLiteralSetsKind) and runtime
+// (TestEveryAdapterClassifiesSkips) guards make unconstructable from real
+// adapters — renders as a red "unset" (its String()), a bug made VISIBLE rather
+// than silently mislabeled "dropped".
+func skipStatus(p *ui.Printer, k adapter.SkipKind) (string, func(string) string) {
+	switch k {
+	case adapter.SkipReduced:
+		return "reduced", p.Cyan
+	case adapter.SkipDropped:
+		return "dropped", p.Yellow
+	default:
+		return k.String(), p.Red
 	}
 }
 
 // skipTailNote summarizes a row's skips as a compact "(R reduced · D dropped)"
 // note (omitting a zero side), or "" when there are no skips. Splitting the
 // count by kind keeps the inline tally from reading as "N whole components
-// discarded" — most "skips" on a partial row are reductions, not drops.
+// discarded" — most "skips" on a partial row are reductions, not drops. A skip
+// that is neither (an unset Kind the guards forbid) is counted under its own
+// "unset" bucket rather than silently folded into "dropped".
 func skipTailNote(p *ui.Printer, skips []render.SkipDetail) string {
-	var reduced, dropped int
+	var reduced, dropped, unset int
 	for _, s := range skips {
-		if s.Kind == adapter.SkipReduced {
+		switch s.Kind {
+		case adapter.SkipReduced:
 			reduced++
-		} else {
+		case adapter.SkipDropped:
 			dropped++
+		default:
+			unset++
 		}
-	}
-	if reduced == 0 && dropped == 0 {
-		return ""
 	}
 	var parts []string
 	if reduced > 0 {
@@ -476,6 +492,12 @@ func skipTailNote(p *ui.Printer, skips []render.SkipDetail) string {
 	}
 	if dropped > 0 {
 		parts = append(parts, fmt.Sprintf("%d dropped", dropped))
+	}
+	if unset > 0 {
+		parts = append(parts, fmt.Sprintf("%d unset", unset))
+	}
+	if len(parts) == 0 {
+		return ""
 	}
 	return p.Yellow("(" + strings.Join(parts, " · ") + ")")
 }

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -443,7 +443,7 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 		// "reduced" and "dropped" are the same width, so the reason column stays
 		// aligned without padding the (color-wrapped) status word.
 		status := p.Yellow("dropped")
-		if isReducedSkip(s.Component) {
+		if s.Kind == adapter.SkipReduced {
 			status = p.Cyan("reduced")
 		}
 		fmt.Fprintf(w, "        %s %s  %s  %s\n",
@@ -461,7 +461,7 @@ func emitSkipDetails(w io.Writer, p *ui.Printer, agent string, skips []render.Sk
 func skipTailNote(p *ui.Printer, skips []render.SkipDetail) string {
 	var reduced, dropped int
 	for _, s := range skips {
-		if isReducedSkip(s.Component) {
+		if s.Kind == adapter.SkipReduced {
 			reduced++
 		} else {
 			dropped++
@@ -480,26 +480,17 @@ func skipTailNote(p *ui.Printer, skips []render.SkipDetail) string {
 	return p.Yellow("(" + strings.Join(parts, " · ") + ")")
 }
 
-// isReducedSkip reports whether a skip is a field-level reduction (the component
-// still rendered) rather than a whole-component drop. The adapters mark the
-// former with a "-frontmatter" component suffix (subagent-frontmatter,
-// command-frontmatter); everything else (a dropped hook event, an LSP server
-// with no native concept, a project-scope command with no target) is a true drop.
-func isReducedSkip(component string) bool {
-	return strings.HasSuffix(component, "-frontmatter")
-}
-
-// skipLabel renders "<kind> <name>" for a skipped item, or just the kind when
-// the skip has no name (e.g. an unrecognized hook event). The internal
-// "-frontmatter" suffix is stripped — the "reduced" status tag now conveys that
-// the loss was field-level, so the label names the component kind plainly.
+// skipLabel renders "<component> <name>" for a skipped item, or just the
+// component kind when the skip has no name (e.g. an unrecognized hook event).
+// Component is now the plain kind (mcp, subagent, command, …); the reduced-vs-
+// dropped distinction is carried by SkipDetail.Kind and shown as the status tag,
+// not encoded in the component string.
 func skipLabel(s render.SkipDetail) string {
-	kind := strings.TrimSuffix(s.Component, "-frontmatter")
 	if s.Name.Empty() {
-		return kind
+		return s.Component
 	}
 	// s.Name is untrusted.Text; String() sanitizes it for the display label.
-	return kind + " " + s.Name.String()
+	return s.Component + " " + s.Name.String()
 }
 
 // coverageGlyphAndColor maps a coverage string to a glyph + semantic color

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
@@ -39,19 +40,20 @@ var ansiSeq = regexp.MustCompile("\x1b\\[[0-9;]*m")
 func stripANSI(s string) string { return ansiSeq.ReplaceAllString(s, "") }
 
 // TestSkipLabel covers all arms of skipLabel: a named skip renders
-// "<kind> <name>", an unnamed one (e.g. an unrecognized hook event with no
-// name) falls back to the bare kind, and the internal "-frontmatter" suffix is
-// stripped so the user-facing label names the component kind plainly.
+// "<component> <name>", and an unnamed one (e.g. an unrecognized hook event with
+// no name) falls back to the bare component kind. Component is now the plain kind
+// for every skip — reduced and dropped alike label identically; the reduced/
+// dropped distinction is carried by Kind (shown as a status tag), not the label.
 func TestSkipLabel(t *testing.T) {
 	tests := []struct {
 		name string
 		in   render.SkipDetail
 		want string
 	}{
-		{"named", render.SkipDetail{Component: "lsp", Name: "gopls"}, "lsp gopls"},
-		{"unnamed", render.SkipDetail{Component: "hook"}, "hook"},
-		{"frontmatter suffix stripped", render.SkipDetail{Component: "subagent-frontmatter", Name: "reviewer"}, "subagent reviewer"},
-		{"command-frontmatter stripped", render.SkipDetail{Component: "command-frontmatter", Name: "deploy"}, "command deploy"},
+		{"named dropped", render.SkipDetail{Component: "lsp", Name: "gopls", Kind: adapter.SkipDropped}, "lsp gopls"},
+		{"unnamed", render.SkipDetail{Component: "hook", Kind: adapter.SkipDropped}, "hook"},
+		{"reduced subagent labels plainly", render.SkipDetail{Component: "subagent", Name: "reviewer", Kind: adapter.SkipReduced}, "subagent reviewer"},
+		{"reduced command labels plainly", render.SkipDetail{Component: "command", Name: "deploy", Kind: adapter.SkipReduced}, "command deploy"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -59,30 +61,6 @@ func TestSkipLabel(t *testing.T) {
 				t.Errorf("skipLabel(%+v) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
-	}
-}
-
-// TestIsReducedSkip pins the classifier that splits a skip into a field-level
-// "reduced" (the component still rendered) vs a whole-component "dropped": only
-// the adapter "-frontmatter" component strings are reductions; every other
-// component kind — and an empty/unknown one — is a drop.
-func TestIsReducedSkip(t *testing.T) {
-	cases := map[string]bool{
-		"subagent-frontmatter": true,
-		"command-frontmatter":  true,
-		"subagent":             false,
-		"command":              false,
-		"hook":                 false,
-		"lsp":                  false,
-		"mcp":                  false,
-		"skill":                false,
-		"memory":               false,
-		"":                     false,
-	}
-	for component, want := range cases {
-		if got := isReducedSkip(component); got != want {
-			t.Errorf("isReducedSkip(%q) = %v, want %v", component, got, want)
-		}
 	}
 }
 
@@ -94,8 +72,8 @@ func TestIsReducedSkip(t *testing.T) {
 func TestSkipTailNote(t *testing.T) {
 	var buf bytes.Buffer
 	p := ui.New(&buf, &buf, ui.ColorNever)
-	reduced := render.SkipDetail{Component: "subagent-frontmatter", Name: "a"}
-	dropped := render.SkipDetail{Component: "lsp", Name: "x"}
+	reduced := render.SkipDetail{Component: "subagent", Name: "a", Kind: adapter.SkipReduced}
+	dropped := render.SkipDetail{Component: "lsp", Name: "x", Kind: adapter.SkipDropped}
 	tests := []struct {
 		name  string
 		skips []render.SkipDetail
@@ -169,7 +147,7 @@ func TestEmitSkipDetails_EmptyIsNoOp(t *testing.T) {
 func TestEmitSkipDetails_SanitizesUntrustedName(t *testing.T) {
 	var buf bytes.Buffer
 	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", []render.SkipDetail{
-		{Component: "subagent-frontmatter", Name: untrustedControl, Reason: "a reason"},
+		{Component: "subagent", Name: untrustedControl, Reason: "a reason", Kind: adapter.SkipReduced},
 	})
 	out := buf.String()
 	assertNoTerminalControl(t, "emitSkipDetails", out)
@@ -225,7 +203,7 @@ func TestRunExplainList_SanitizesUntrusted(t *testing.T) {
 func TestEmitSkipDetails_UnnamedComponentOnly(t *testing.T) {
 	var buf bytes.Buffer
 	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorNever), "codex", []render.SkipDetail{
-		{Component: "hook", Reason: "unknown event"},
+		{Component: "hook", Reason: "unknown event", Kind: adapter.SkipDropped},
 	})
 	got := buf.String()
 	want := "      " + ui.GlyphArrow + " codex couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:\n" +
@@ -244,8 +222,8 @@ func TestEmitSkipDetails_UnnamedComponentOnly(t *testing.T) {
 // offsets catches that.
 func TestEmitSkipDetails_ColumnsAlignUnderColor(t *testing.T) {
 	skips := []render.SkipDetail{
-		{Component: "lsp", Name: "x", Reason: "no LSP concept"},
-		{Component: "subagent-frontmatter", Name: "reviewer", Reason: "dropped tools allowlist"},
+		{Component: "lsp", Name: "x", Reason: "no LSP concept", Kind: adapter.SkipDropped},
+		{Component: "subagent", Name: "reviewer", Reason: "dropped tools allowlist", Kind: adapter.SkipReduced},
 	}
 	var buf bytes.Buffer
 	emitSkipDetails(&buf, ui.New(&buf, &buf, ui.ColorAlways), "codex", skips)

--- a/internal/cli/explain_internal_test.go
+++ b/internal/cli/explain_internal_test.go
@@ -93,6 +93,42 @@ func TestSkipTailNote(t *testing.T) {
 	}
 }
 
+// TestExplain_UnsetKindShownNotMaskedAsDropped pins the defensive display
+// contract: a skip whose Kind is the invalid zero value (which the static +
+// runtime guards forbid from real adapters) must surface VISIBLY as "unset" in
+// both the per-skip line and the inline tally — never silently mislabeled
+// "dropped", which would hide exactly the bug the typed field exists to prevent.
+// This matches the JSON surface (SkipKind.MarshalJSON → "unset") so the human and
+// machine outputs agree.
+func TestExplain_UnsetKindShownNotMaskedAsDropped(t *testing.T) {
+	unset := render.SkipDetail{Component: "mystery", Name: "x", Reason: "no kind set", Kind: adapter.SkipKindUnset}
+
+	var buf bytes.Buffer
+	p := ui.New(&buf, &buf, ui.ColorNever)
+	emitSkipDetails(&buf, p, "codex", []render.SkipDetail{unset})
+	// Inspect the per-skip line, not the framing header (which legitimately spells
+	// out "reduced = …; dropped = …").
+	var skipLine string
+	for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if strings.Contains(ln, "mystery") {
+			skipLine = ln
+		}
+	}
+	if skipLine == "" {
+		t.Fatalf("no skip line emitted:\n%s", buf.String())
+	}
+	if !strings.Contains(skipLine, "unset") {
+		t.Errorf("skip line must show 'unset' for an unset Kind; got: %q", skipLine)
+	}
+	if strings.Contains(skipLine, "dropped") {
+		t.Errorf("skip line must NOT mislabel an unset Kind as 'dropped'; got: %q", skipLine)
+	}
+
+	if got := skipTailNote(p, []render.SkipDetail{unset}); got != "(1 unset)" {
+		t.Errorf("skipTailNote(unset) = %q, want %q", got, "(1 unset)")
+	}
+}
+
 // TestComponentInventory pins the descriptive count tail: every non-zero kind is
 // listed in a stable order, with correct singular/plural (the mcp/lsp
 // abbreviations stay invariant), and a row that hosts nothing for the agent reads

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -611,7 +611,7 @@ func TestExplain_AllAttributesPerRow(t *testing.T) {
 			}
 		case "noisy@cross-mp":
 			sawNoisy = true
-			// noisy owns exactly its two skips (lsp + subagent-frontmatter).
+			// noisy owns exactly its two skips (dropped lsp + reduced subagent).
 			if r.MCP != 1 || r.Skips != 2 {
 				t.Errorf("noisy row in --all has wrong own counts: mcp=%d skips=%d (want mcp=1 skips=2)",
 					r.MCP, r.Skips)

--- a/internal/cli/skipkind_guard_test.go
+++ b/internal/cli/skipkind_guard_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestEveryAdapterClassifiesSkips is the exhaustiveness guard the typed-Kind
+// refactor (issue #98) installs in place of the old "-frontmatter" string
+// convention. The reduced-vs-dropped distinction is now a typed field every skip
+// site MUST set explicitly (adapter.SkipKind); its zero value, SkipKindUnset, is
+// invalid. A new adapter or a new skip site that forgets to classify its Kind
+// leaves it SkipKindUnset, which compiles fine and no other test would catch — so
+// here we render every REGISTERED adapter (the same set apply uses, via
+// registryFactory) over a component-complete fixture at both scopes and fail if
+// any emitted skip is unclassified.
+//
+// The fixture deliberately carries reduced-triggering frontmatter (a subagent
+// with tools/color, a command with argument-hint/allowed-tools) AND
+// whole-component drops (skill/hook/lsp on agents with no such concept), so the
+// run also asserts both Kinds are actually exercised — the guard can't pass
+// vacuously by triggering no skips.
+func TestEveryAdapterClassifiesSkips(t *testing.T) {
+	// Component-complete canonical. The frontmatter keys are the ones the deep
+	// adapters drop with a field-level reduction (so reduced sites fire); the
+	// skill/hook/lsp components have no native home on several agents (so dropped
+	// sites fire). SessionEnd is an event no adapter maps.
+	base := source.Canonical{
+		Memory:     source.Memory{Body: "remember this\n"},
+		MCPServers: []source.MCPServer{{ID: "github", Server: source.MCPServerSpec{Type: "stdio", Command: "npx"}}},
+		Skills:     []source.Skill{{Name: "demo", Frontmatter: map[string]any{"name": "demo"}, Body: "x\n"}},
+		Subagents: []source.Subagent{{
+			Name:        "review",
+			Frontmatter: map[string]any{"description": "Code review", "tools": []any{"Read", "Grep"}, "color": "blue"},
+			Body:        "Review.\n",
+		}},
+		Commands: []source.Command{{
+			Name:        "summarize",
+			Frontmatter: map[string]any{"description": "Summarize", "argument-hint": "<text>", "allowed-tools": "Read"},
+			Body:        "Summarize.\n",
+		}},
+		Hooks: []source.Hook{
+			{Event: "PreToolUse", Matcher: "*", Type: "command", Command: "echo hi"},
+			{Event: "SessionEnd", Matcher: "*", Type: "command", Command: "echo bye"},
+		},
+		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
+	}
+
+	// At project scope the scope-aware adapters render the Project overlay rather
+	// than the merged canonical — populate it with the same components so their
+	// project-scope skip sites fire too.
+	proj := base
+	proj.Project = nil
+	withProject := base
+	withProject.Project = &proj
+
+	reg := registryFactory()
+
+	var (
+		offenders   []string
+		sawReduced  bool
+		sawDropped  bool
+		totalSkips  int
+		renderCases = []struct {
+			scope   adapter.Scope
+			project string
+			model   source.Canonical
+		}{
+			{adapter.ScopeUser, "", base},
+			{adapter.ScopeProject, t.TempDir(), withProject},
+		}
+	)
+
+	for _, name := range reg.Names() {
+		a := reg.Lookup(name)
+		for _, rc := range renderCases {
+			_, skips, err := a.Render(secrets.ForRender(rc.model), rc.scope, rc.project)
+			if err != nil {
+				t.Fatalf("%s.Render(scope=%s): %v", name, rc.scope, err)
+			}
+			for _, s := range skips {
+				totalSkips++
+				switch s.Kind {
+				case adapter.SkipReduced:
+					sawReduced = true
+				case adapter.SkipDropped:
+					sawDropped = true
+				default:
+					offenders = append(offenders, name+" ["+rc.scope.String()+"]: "+
+						s.Component+" "+s.Name+" — Kind is unset (set adapter.SkipReduced or adapter.SkipDropped at the skip site)")
+				}
+			}
+		}
+	}
+
+	for _, o := range offenders {
+		t.Errorf("unclassified skip: %s", o)
+	}
+	// Guard against a vacuous pass: if the fixture stopped triggering skips, the
+	// "no unclassified skip" assertion above would be meaningless.
+	if totalSkips == 0 {
+		t.Fatal("no skips emitted by any adapter — the fixture no longer exercises skip sites")
+	}
+	if !sawReduced {
+		t.Error("no SkipReduced observed — the reduced (field-level) sites are not exercised by the fixture")
+	}
+	if !sawDropped {
+		t.Error("no SkipDropped observed — the dropped (whole-component) sites are not exercised by the fixture")
+	}
+}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -67,6 +67,12 @@ type SkipDetail struct {
 	// site sanitizes it by construction. Reason is adapter-authored (trusted).
 	Name   untrusted.Text `json:"name,omitempty"`
 	Reason string         `json:"reason"`
+	// Kind classifies the loss as "reduced" (the component still rendered, minus
+	// some fields) or "dropped" (the whole component was not emitted). It is set by
+	// the adapter and carried verbatim from adapter.Skip; explain reads it directly
+	// instead of re-deriving the split from the component name, and --json surfaces
+	// it as an explicit "kind" field (adapter.SkipKind marshals to the string form).
+	Kind adapter.SkipKind `json:"kind"`
 }
 
 // skipDetails converts an adapter's []Skip into the report's JSON-tagged form.
@@ -77,8 +83,9 @@ func skipDetails(skips []adapter.Skip) []SkipDetail {
 	out := make([]SkipDetail, len(skips))
 	for i, s := range skips {
 		// s.Name is the plugin component's name (untrusted upstream); tag it as
-		// untrusted.Text at this boundary so every display site sanitizes it.
-		out[i] = SkipDetail{Component: s.Component, Name: untrusted.Wrap(s.Name), Reason: s.Reason}
+		// untrusted.Text at this boundary so every display site sanitizes it. Kind
+		// carries the adapter's reduced/dropped classification through verbatim.
+		out[i] = SkipDetail{Component: s.Component, Name: untrusted.Wrap(s.Name), Reason: s.Reason, Kind: s.Kind}
 	}
 	return out
 }

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -119,7 +119,7 @@ func TestBuildReport_PartialCoverage(t *testing.T) {
 					{Action: "write", MergeStrategy: "merge-json-keys"},
 				},
 				Skips: []adapter.Skip{
-					{Component: "hook", Name: "pre-run", Reason: "unsupported"},
+					{Component: "hook", Name: "pre-run", Reason: "unsupported", Kind: adapter.SkipDropped},
 				},
 			},
 		},
@@ -146,8 +146,8 @@ func TestBuildReport_SkipDetails(t *testing.T) {
 		},
 	}
 	skips := []adapter.Skip{
-		{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"},
-		{Component: "hook", Name: "SessionEnd", Reason: "Codex does not recognize this lifecycle event"},
+		{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept", Kind: adapter.SkipDropped},
+		{Component: "hook", Name: "SessionEnd", Reason: "Codex does not recognize this lifecycle event", Kind: adapter.SkipDropped},
 	}
 	plan := render.RenderPlan{
 		PerAgent: map[string]render.AgentResult{
@@ -168,11 +168,11 @@ func TestBuildReport_SkipDetails(t *testing.T) {
 	if len(row.SkipDetails) != 2 {
 		t.Fatalf("SkipDetails len = %d, want 2: %+v", len(row.SkipDetails), row.SkipDetails)
 	}
-	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}) {
+	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept", Kind: adapter.SkipDropped}) {
 		t.Errorf("SkipDetails[0] = %+v, want the gopls lsp skip", row.SkipDetails[0])
 	}
 
-	// JSON surface: lowercase component/name/reason keys under skipDetails.
+	// JSON surface: lowercase component/name/reason/kind keys under skipDetails.
 	var buf bytes.Buffer
 	if err := report.PrintJSON(&buf); err != nil {
 		t.Fatalf("PrintJSON: %v", err)
@@ -183,6 +183,7 @@ func TestBuildReport_SkipDetails(t *testing.T) {
 				Component string `json:"component"`
 				Name      string `json:"name"`
 				Reason    string `json:"reason"`
+				Kind      string `json:"kind"`
 			} `json:"skipDetails"`
 		} `json:"rows"`
 	}
@@ -194,6 +195,11 @@ func TestBuildReport_SkipDetails(t *testing.T) {
 	}
 	if parsed.Rows[0].SkipDetails[1].Reason != "Codex does not recognize this lifecycle event" {
 		t.Errorf("JSON skipDetails[1].reason = %q", parsed.Rows[0].SkipDetails[1].Reason)
+	}
+	// kind is the explicit machine surface for the reduced/dropped split — no more
+	// re-deriving it from a component-name suffix.
+	if parsed.Rows[0].SkipDetails[0].Kind != "dropped" {
+		t.Errorf("JSON skipDetails[0].kind = %q, want dropped", parsed.Rows[0].SkipDetails[0].Kind)
 	}
 }
 
@@ -209,7 +215,7 @@ func TestBuildReport_SkipDetails_BaseBranch(t *testing.T) {
 		PerAgent: map[string]render.AgentResult{
 			"codex": {
 				Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "merge-toml-keys"}},
-				Skips: []adapter.Skip{{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}},
+				Skips: []adapter.Skip{{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept", Kind: adapter.SkipDropped}},
 			},
 		},
 	}
@@ -224,7 +230,7 @@ func TestBuildReport_SkipDetails_BaseBranch(t *testing.T) {
 	if row.Skips != 1 || len(row.SkipDetails) != 1 {
 		t.Fatalf("base-branch skips not carried: Skips=%d SkipDetails=%+v", row.Skips, row.SkipDetails)
 	}
-	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept"}) {
+	if row.SkipDetails[0] != (render.SkipDetail{Component: "lsp", Name: "gopls", Reason: "Codex has no LSP configuration concept", Kind: adapter.SkipDropped}) {
 		t.Errorf("SkipDetails[0] = %+v, want the gopls lsp skip", row.SkipDetails[0])
 	}
 }
@@ -554,7 +560,7 @@ func TestBuildReport_CoverageNoneWhenNothingRendered(t *testing.T) {
 	}
 	plan := render.RenderPlan{
 		PerAgent: map[string]render.AgentResult{
-			"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Name: "l", Reason: "no LSP concept"}}},
+			"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Name: "l", Reason: "no LSP concept", Kind: adapter.SkipDropped}}},
 		},
 	}
 	row := render.BuildReport(c, plan, []string{"codex"}).Rows[0]
@@ -580,7 +586,7 @@ func TestBuildReport_CoveragePartialWhenSomethingRendered(t *testing.T) {
 		PerAgent: map[string]render.AgentResult{
 			"codex": {
 				Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "replace"}}, // the skill rendered
-				Skips: []adapter.Skip{{Component: "hook", Name: "x", Reason: "unknown event"}},
+				Skips: []adapter.Skip{{Component: "hook", Name: "x", Reason: "unknown event", Kind: adapter.SkipDropped}},
 			},
 		},
 	}
@@ -603,14 +609,14 @@ func TestBuildReport_BaseCoverageFromRendered(t *testing.T) {
 	rendered := render.RenderPlan{PerAgent: map[string]render.AgentResult{
 		"codex": {
 			Ops:   []adapter.FileOp{{Action: "write", MergeStrategy: "replace"}},
-			Skips: []adapter.Skip{{Component: "hook", Reason: "unknown event"}},
+			Skips: []adapter.Skip{{Component: "hook", Reason: "unknown event", Kind: adapter.SkipDropped}},
 		},
 	}}
 	if row := render.BuildReport(c, rendered, []string{"codex"}).Rows[0]; row.Plugin != "(base)" || row.Coverage != "partial" {
 		t.Errorf("base row = {plugin:%q coverage:%q}, want {(base) partial}", row.Plugin, row.Coverage)
 	}
 	nothing := render.RenderPlan{PerAgent: map[string]render.AgentResult{
-		"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Reason: "no LSP concept"}}},
+		"codex": {Ops: nil, Skips: []adapter.Skip{{Component: "lsp", Reason: "no LSP concept", Kind: adapter.SkipDropped}}},
 	}}
 	if row := render.BuildReport(c, nothing, []string{"codex"}).Rows[0]; row.Coverage != "none" {
 		t.Errorf("base row coverage = %q, want none (nothing rendered)", row.Coverage)

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -209,8 +209,9 @@ the agent has no home for, while a **dropped** part had no native target and was
 not emitted. Each part is itemized beneath a framing header, tagged `reduced` or
 `dropped` with its reason, so the tally is never a dead end. Add `--json` for
 machine-readable output (rows for plugin/agent coverage — each with a
-`skipDetails` array of `{component, name, reason}` — or a `plugins` array under
-`--list`).
+`skipDetails` array of `{component, name, reason, kind}`, where `kind` is
+`"reduced"` or `"dropped"` and `component` is the plain kind — or a `plugins`
+array under `--list`).
 
 ```bash
 agentsync explain atlassian@anthropic


### PR DESCRIPTION
Fixes #98.

## What & why

The reduced-vs-dropped split `explain` shows was derived at the **presentation layer** by string-matching a `-frontmatter` suffix on each skip's `Component` (e.g. `subagent-frontmatter`):

```go
func isReducedSkip(component string) bool {
	return strings.HasSuffix(component, "-frontmatter")
}
```

That made a user-facing classification depend on an undocumented adapter naming convention with **no compile-time guard** — a new adapter that forgot the suffix would silently misclassify a field-level reduction as a hard drop, and `explain --json` consumers had to re-derive the split from the suffix.

This promotes it to a typed `adapter.Skip.Kind` the adapter sets at every construction site, carried through `render.SkipDetail` to `explain`.

## Changes

- **`adapter.SkipKind`** — `SkipDropped` / `SkipReduced`, with an *invalid* zero value `SkipKindUnset`. `String()` + `MarshalJSON()` render the lowercase form. (The zero-value sentinel is a deliberate deviation from the issue's literal `SkipDropped = iota` — it's what makes the exhaustiveness guard meaningful; a forgotten `Kind` is caught rather than silently defaulting to "dropped".)
- **All 54 skip sites** across the 8 reducing deep adapters + `generic` set `Kind` explicitly (12 reduced, 42 dropped). `Component` is now the plain kind everywhere (`subagent`, `command`, …).
- **`internal/cli/explain.go`** reads `s.Kind` directly; `isReducedSkip` + its `strings.HasSuffix` heuristic are deleted, and `skipLabel` no longer strips a suffix.
- **Exhaustiveness guard** `TestEveryAdapterClassifiesSkips` (`internal/cli`) renders **every registered adapter at both scopes** over a component-complete fixture and fails if any emitted skip leaves `Kind` unset (and asserts both kinds are actually exercised, so it can't pass vacuously). It caught a windsurf project-scope MCP site I'd initially missed.
- **Per-adapter render tests** now assert `Kind`, not just the component string.

## Breaking change — `explain --json`

Each `skipDetails` entry gains an explicit `kind` field (`"reduced"`/`"dropped"`), and `component` is now the plain kind — it **no longer carries the `-frontmatter` suffix** machine consumers had to parse. Read `kind` instead. Decided deliberately per the issue (the suffix existed only to encode this distinction).

## Docs (same commit, per the repo's doc-sync contract)

`docs/user-guide.md`, website `reference/cli.mdx`, `docs/architecture.md` (new "Skips are typed" note), and `CHANGELOG.md` (corrected the now-superseded #97 entry + added a dedicated `[Unreleased]` entry).

## Acceptance criteria

- [x] `adapter.Skip` carries a typed `Kind`; every adapter sets it at each skip site
- [x] `explain.go` no longer string-matches `-frontmatter`; `isReducedSkip` is gone
- [x] Reflective/exhaustiveness guard closes the "no compile-time guard" gap
- [x] `explain --json` exposes `kind`; user-guide + cli.mdx updated (suffix note removed)
- [x] Per-adapter render tests assert `Kind`
- [x] `docs/architecture.md` updated for the new `Skip` contract
- [x] `CHANGELOG.md` under `[Unreleased]`

## Verification

- `go test ./...` — all pass (incl. the new guard)
- `golangci-lint` (forced `GOTOOLCHAIN=go1.26.2`) — **0 issues**
- gofmt / gofumpt / `go mod tidy` clean (go.mod/go.sum unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6FubhMjzGyUGqCnCuZ2Kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6FubhMjzGyUGqCnCuZ2Kg)_