### PR TITLE
feat(cli): collapse skill dirs in status, add --agent and --verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,15 +98,18 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
     explicit `kind` field (`"reduced"`/`"dropped"`), and `component` is now the
     plain kind (`subagent`, `command`, …) — it no longer carries the
     `-frontmatter` suffix machine consumers had to parse. Read `kind` instead.
-- **`status` now collapses skill directories and gains `--agent` / `--verbose`.**
+- **`status` now collapses skill directories and gains `--agents` / `--verbose`.**
   A skill bundling scripts/references/assets used to print one row per file, so a
   handful of asset-heavy skills could push `status` past a thousand lines. By
   default each skill directory now renders as a single row — the skill dir, its
   *most-severe* drift class (so a drifted `SKILL.md` hiding among clean assets
   still shows red), and a faint `SKILL.md + N files` count with a per-class
-  breakdown when the bundled files don't all share one class. Pass `-v`/`--verbose`
-  to expand every skill back to one row per file (the previous view). A new
-  `--agent <name>` flag (repeatable or comma-separated) scopes the report to
+  breakdown when the bundled files don't all share one class. A directory is
+  recognized as a skill by an actual `…/skills/<name>/SKILL.md` (not a bare
+  `skills` path segment), so an unrelated ancestor dir named `skills` can't sweep
+  non-skill files into a bogus group. Pass `-v`/`--verbose` to expand every skill
+  back to one row per file (the previous view). A new `--agents <list>` flag
+  (comma-separated allowlist, matching `mcp add --agents`) scopes the report to
   specific agents; orphaned-state warnings still consider the full enabled set so
   narrowing never mislabels a deselected agent as an orphan. `status --json` is
   unchanged and **never collapsed** — it still carries every tracked file, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,19 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
     explicit `kind` field (`"reduced"`/`"dropped"`), and `component` is now the
     plain kind (`subagent`, `command`, …) — it no longer carries the
     `-frontmatter` suffix machine consumers had to parse. Read `kind` instead.
+- **`status` now collapses skill directories and gains `--agent` / `--verbose`.**
+  A skill bundling scripts/references/assets used to print one row per file, so a
+  handful of asset-heavy skills could push `status` past a thousand lines. By
+  default each skill directory now renders as a single row — the skill dir, its
+  *most-severe* drift class (so a drifted `SKILL.md` hiding among clean assets
+  still shows red), and a faint `SKILL.md + N files` count with a per-class
+  breakdown when the bundled files don't all share one class. Pass `-v`/`--verbose`
+  to expand every skill back to one row per file (the previous view). A new
+  `--agent <name>` flag (repeatable or comma-separated) scopes the report to
+  specific agents; orphaned-state warnings still consider the full enabled set so
+  narrowing never mislabels a deselected agent as an orphan. `status --json` is
+  unchanged and **never collapsed** — it still carries every tracked file, so the
+  machine contract is stable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `skills` path segment), so an unrelated ancestor dir named `skills` can't sweep
   non-skill files into a bogus group. Pass `-v`/`--verbose` to expand every skill
   back to one row per file (the previous view). A new `--agents <list>` flag
-  (comma-separated allowlist, matching `mcp add --agents`) scopes the report to
-  specific agents; orphaned-state warnings still consider the full enabled set so
-  narrowing never mislabels a deselected agent as an orphan. `status --json` is
+  (comma-separated allowlist, `*` = all enabled — matching `mcp add --agents`)
+  scopes the report to specific agents; orphaned-state warnings still consider the
+  full enabled set so narrowing never mislabels a deselected agent as an orphan.
+  `status --json` is
   unchanged and **never collapsed** — it still carries every tracked file, so the
   machine contract is stable.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,7 +643,8 @@ expands each collapsed skill directory back to one row per bundled file).
 `--color=auto|always|never` controls whether output is styled with ANSI color
 and bold (default `auto` — on for a TTY, off when piped/redirected; honors
 `NO_COLOR`). `status --agents <list>` scopes the report to a comma-separated
-agent allowlist. `status --json` and `diff [<path>] --json` emit
+agent allowlist (`*` = all enabled, matching `mcp add --agents`). `status --json`
+and `diff [<path>] --json` emit
 the structured report instead of the formatted one, suitable for CI gates and
 dashboards (`status --json` is never collapsed — it carries every tracked file;
 `diff --json` masks the same resolved secrets the formatted diff does).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -632,18 +632,21 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. | `--scope --project --json` |
+| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. Skill directories collapse to one summary row by default (`--verbose` expands them). | `--agent --verbose --scope --project --json` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project --json` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. `--scope project` reads the agent's *native project-scope* config (e.g. `<root>/.claude/`) and captures it into the project tree `<root>/.agentsync/`, seeding central state with the project scope + root. Plugin import is user-scope only. | `--dry-run --scope --project` |
 | `explain [<plugin>...]` | Show per-agent translation coverage for one or more plugins. | `--all --list --json` |
 
-Global: `-v/--verbose` for verbose logging on any command. `--color=auto|always|never`
-controls whether output is styled with ANSI color and bold (default `auto` — on
-for a TTY, off when piped/redirected; honors `NO_COLOR`). `status --json` and
-`diff [<path>] --json` emit the structured report instead of the formatted one,
-suitable for CI gates and dashboards (`diff --json` masks the same resolved
-secrets the formatted diff does).
+Global: `-v/--verbose` for verbose logging on any command (in `status` it also
+expands each collapsed skill directory back to one row per bundled file).
+`--color=auto|always|never` controls whether output is styled with ANSI color
+and bold (default `auto` — on for a TTY, off when piped/redirected; honors
+`NO_COLOR`). `status --agent <name>` scopes the report to specific agents
+(repeatable or comma-separated). `status --json` and `diff [<path>] --json` emit
+the structured report instead of the formatted one, suitable for CI gates and
+dashboards (`status --json` is never collapsed — it carries every tracked file;
+`diff --json` masks the same resolved secrets the formatted diff does).
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -632,7 +632,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. Skill directories collapse to one summary row by default (`--verbose` expands them). | `--agent --verbose --scope --project --json` |
+| `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. Skill directories collapse to one summary row by default (`--verbose` expands them). | `--agents --verbose --scope --project --json` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project --json` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. `--scope project` reads the agent's *native project-scope* config (e.g. `<root>/.claude/`) and captures it into the project tree `<root>/.agentsync/`, seeding central state with the project scope + root. Plugin import is user-scope only. | `--dry-run --scope --project` |
@@ -642,8 +642,8 @@ Global: `-v/--verbose` for verbose logging on any command (in `status` it also
 expands each collapsed skill directory back to one row per bundled file).
 `--color=auto|always|never` controls whether output is styled with ANSI color
 and bold (default `auto` — on for a TTY, off when piped/redirected; honors
-`NO_COLOR`). `status --agent <name>` scopes the report to specific agents
-(repeatable or comma-separated). `status --json` and `diff [<path>] --json` emit
+`NO_COLOR`). `status --agents <list>` scopes the report to a comma-separated
+agent allowlist. `status --json` and `diff [<path>] --json` emit
 the structured report instead of the formatted one, suitable for CI gates and
 dashboards (`status --json` is never collapsed — it carries every tracked file;
 `diff --json` masks the same resolved secrets the formatted diff does).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,7 +35,7 @@ func NewRoot() *cobra.Command {
 	}
 	cmd.SetVersionTemplate(`{{.Use}} {{.Version}} (commit ` + Commit + `, built ` + Date + `)
 `)
-	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging (in `status`, also expands collapsed skill directories)")
 	cmd.PersistentFlags().StringVar(&colorFlag, "color", "auto", "colorize output: auto | always | never")
 	cmd.PersistentFlags().Bool("no-input", false, "never prompt; fail instead when a choice is required (for headless/non-interactive use)")
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -51,6 +51,7 @@ func newStatusCmd() *cobra.Command {
 		scopeFlag   string
 		projectFlag string
 		jsonOut     bool
+		agentFlag   []string
 	)
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -77,19 +78,32 @@ func newStatusCmd() *cobra.Command {
 				return err
 			}
 			reg := registryFactory()
-			var agents []string
+			var enabledAgents []string
+			enabled := map[string]bool{}
 			for name, ag := range c.Config.Agents {
 				if ag.Enabled {
-					agents = append(agents, name)
+					enabledAgents = append(enabledAgents, name)
+					enabled[name] = true
 				}
 			}
-			if len(agents) == 0 {
+			// --agent narrows the report (and the plan) to the requested
+			// agent(s); orphan-state warnings still consider the FULL enabled
+			// set so a deselected agent isn't mistaken for an orphaned one.
+			selected := enabledAgents
+			if len(agentFlag) > 0 {
+				sel, serr := resolveAgentFilter(agentFlag, enabled)
+				if serr != nil {
+					return serr
+				}
+				selected = sel
+			}
+			if len(selected) == 0 {
 				if jsonOut {
-					emitStatusWarnings(p, c, reg, s, agents)
+					emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 					return emitJSON(p.Out, statusModel{Agents: []statusAgent{}, Summary: map[string]int{}})
 				}
 				fmt.Fprintln(p.Out, "no agents enabled; run `agentsync agent add claude` (or opencode)")
-				emitStatusWarnings(p, c, reg, s, agents)
+				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 				return nil
 			}
 			// apply WRITES (and RecordOpsState HASHES) the secret-RESOLVED
@@ -105,7 +119,7 @@ func newStatusCmd() *cobra.Command {
 			if resolved, serr := secrets.SubstituteCanonical(c, secBackend, secrets.EnvBackend{}); serr == nil {
 				rendered = resolved
 			}
-			plan, err := render.Plan(rendered, reg, agents, sc, projectRoot, s, userHome)
+			plan, err := render.Plan(rendered, reg, selected, sc, projectRoot, s, userHome)
 			if err != nil {
 				return err
 			}
@@ -113,19 +127,61 @@ func newStatusCmd() *cobra.Command {
 			model := buildStatusModel(plan, reg.Names(), s, userHome, sc, projectRoot)
 			if jsonOut {
 				// JSON to stdout, advisory warnings to stderr — keeps the
-				// machine-readable payload cleanly parseable.
-				emitStatusWarnings(p, c, reg, s, agents)
+				// machine-readable payload cleanly parseable. The --json payload
+				// is never collapsed: it carries every tracked item so scripts
+				// see the same per-file model regardless of the human view.
+				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 				return emitJSON(p.Out, model)
 			}
-			renderStatusText(p, model)
-			emitStatusWarnings(p, c, reg, s, agents)
+			renderStatusText(p, model, statusVerbose(cmd))
+			emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted report")
+	cmd.Flags().StringSliceVar(&agentFlag, "agent", nil, "limit the report to specific agent(s) (repeatable or comma-separated)")
 	return cmd
+}
+
+// statusVerbose reports whether the inherited global -v/--verbose flag is set.
+// In status, verbose expands the default collapsed skill-directory rows back
+// into one line per bundled file (the pre-collapse view). It reads the flag off
+// the merged set, falling back to the inherited set the same way newPrinter
+// reads --color.
+func statusVerbose(cmd *cobra.Command) bool {
+	if b, err := cmd.Flags().GetBool("verbose"); err == nil {
+		return b
+	}
+	if f := cmd.InheritedFlags().Lookup("verbose"); f != nil {
+		return f.Value.String() == "true"
+	}
+	return false
+}
+
+// resolveAgentFilter validates the --agent values against the known agent set
+// and the currently-enabled set, returning the de-duplicated selection in the
+// order given. An unknown name or an agent that exists but is not enabled is a
+// hard error — silently dropping it would make `status --agent typo` look clean.
+func resolveAgentFilter(want []string, enabled map[string]bool) ([]string, error) {
+	var out []string
+	seen := map[string]bool{}
+	for _, a := range want {
+		a = strings.TrimSpace(a)
+		if a == "" || seen[a] {
+			continue
+		}
+		seen[a] = true
+		if !isValidAgent(a) {
+			return nil, fmt.Errorf("unknown agent %q; valid agents: %s", a, validAgentsList())
+		}
+		if !enabled[a] {
+			return nil, fmt.Errorf("agent %q is not enabled; run `agentsync agent add %s` first", a, a)
+		}
+		out = append(out, a)
+	}
+	return out, nil
 }
 
 // buildStatusModel classifies every tracked file/key/orphan across agents into
@@ -196,6 +252,26 @@ var classOrder = []string{
 	"drift", "conflict", "foreign-collision", "orphan", "orphan-drifted",
 }
 
+// classSeverity ranks drift classes most-severe-first. A collapsed skill row
+// shows the most severe class among its members as its headline so a single
+// drifted/conflicted SKILL.md inside an otherwise-clean skill still surfaces in
+// red at the collapsed level — the count of files never hides a problem.
+var classSeverity = []string{
+	"orphan-drifted", "conflict", "drift", "foreign-collision",
+	"orphan",
+	"pending", "new",
+	"converged", "clean",
+}
+
+// skillGroup is a set of tracked items that all live under one skill directory
+// (…/skills/<name>/). The default `status` view renders it as a single line —
+// the skill dir, its most-severe class, and a faint file-count summary —
+// instead of one line per bundled SKILL.md/script/reference/asset.
+type skillGroup struct {
+	Root  string
+	Items []statusItem
+}
+
 // styleClass maps a drift class to its glyph and color. Green = synced, cyan =
 // a pending change apply will make, red = unexpected/destructive drift, yellow
 // = an orphan needing a decision.
@@ -216,20 +292,13 @@ func styleClass(p *ui.Printer, cls string) (glyph string, color func(string) str
 
 // renderStatusText prints the formatted drift dashboard: a bold header per
 // agent, a glyph + color-coded class per item, and a one-line summary footer.
-func renderStatusText(p *ui.Printer, model statusModel) {
+// By default each skill directory collapses to a single row so a tree of
+// hundreds of bundled files stays readable; verbose restores the per-file view.
+func renderStatusText(p *ui.Printer, model statusModel, verbose bool) {
+	collapsed := 0
 	for _, ag := range model.Agents {
 		fmt.Fprintln(p.Out, p.Bold("["+ag.Agent+"]"))
-		for _, it := range ag.Items {
-			disp := it.Path
-			if it.Pointer != "" {
-				disp = it.Path + "#" + it.Pointer
-			}
-			glyph, color := styleClass(p, it.Class)
-			// Pad the plain "glyph class" to a fixed visible width BEFORE
-			// coloring so ANSI bytes never shift the path column.
-			label := ui.Pad(glyph+" "+it.Class, 20)
-			fmt.Fprintf(p.Out, "  %s %s\n", color(label), disp)
-		}
+		collapsed += renderAgentItems(p, ag.Items, verbose)
 	}
 
 	// Summary footer lists only non-zero classes, so the words "drift" /
@@ -248,6 +317,166 @@ func renderStatusText(p *ui.Printer, model statusModel) {
 		fmt.Fprintln(p.Out, strings.Join(segs, "  ·  "))
 	}
 	renderStatusLegend(p, model.Summary)
+	if collapsed > 0 {
+		fmt.Fprintln(p.Out, "")
+		fmt.Fprintln(p.Out, p.Faint(fmt.Sprintf("%d skill %s collapsed; pass --verbose to list every bundled file.",
+			collapsed, plural(collapsed, "directory", "directories"))))
+	}
+}
+
+// renderAgentItems prints one agent's tracked items. In verbose mode every item
+// is a row; otherwise items under a common skill directory collapse into one
+// summary row. Returns the number of skill directories that were collapsed (a
+// single-file skill is printed as a normal row and not counted, since collapsing
+// it would hide nothing).
+func renderAgentItems(p *ui.Printer, items []statusItem, verbose bool) int {
+	if verbose {
+		for _, it := range items {
+			renderStatusItem(p, it)
+		}
+		return 0
+	}
+	// Group skill-directory items by their root, preserving first-appearance
+	// order; everything else (memory, subagents, commands, MCP/hook/LSP keys)
+	// stays an inline per-item row.
+	type entry struct {
+		item  statusItem
+		group *skillGroup
+	}
+	groups := map[string]*skillGroup{}
+	var order []entry
+	for _, it := range items {
+		root := ""
+		if it.Pointer == "" {
+			if r, ok := skillRoot(it.Path); ok {
+				root = r
+			}
+		}
+		if root == "" {
+			order = append(order, entry{item: it})
+			continue
+		}
+		g := groups[root]
+		if g == nil {
+			g = &skillGroup{Root: root}
+			groups[root] = g
+			order = append(order, entry{group: g})
+		}
+		g.Items = append(g.Items, it)
+	}
+	collapsed := 0
+	for _, e := range order {
+		if e.group == nil {
+			renderStatusItem(p, e.item)
+			continue
+		}
+		if len(e.group.Items) == 1 {
+			renderStatusItem(p, e.group.Items[0])
+			continue
+		}
+		renderSkillGroup(p, e.group)
+		collapsed++
+	}
+	return collapsed
+}
+
+// renderStatusItem prints one tracked file or merged key on a single row.
+func renderStatusItem(p *ui.Printer, it statusItem) {
+	disp := it.Path
+	if it.Pointer != "" {
+		disp = it.Path + "#" + it.Pointer
+	}
+	glyph, color := styleClass(p, it.Class)
+	// Pad the plain "glyph class" to a fixed visible width BEFORE
+	// coloring so ANSI bytes never shift the path column.
+	label := ui.Pad(glyph+" "+it.Class, 20)
+	fmt.Fprintf(p.Out, "  %s %s\n", color(label), disp)
+}
+
+// renderSkillGroup prints a collapsed skill directory: the headline class is the
+// most severe among its files, and a faint suffix reports the file count (plus a
+// per-class breakdown when the files don't all share one class).
+func renderSkillGroup(p *ui.Printer, g *skillGroup) {
+	cls := mostSevereClass(g.Items)
+	glyph, color := styleClass(p, cls)
+	label := ui.Pad(glyph+" "+cls, 20)
+	fmt.Fprintf(p.Out, "  %s %s  %s\n", color(label), g.Root+string(filepath.Separator), p.Faint(skillSummary(g.Items)))
+}
+
+// skillRoot returns the …/skills/<name> directory a path lives under and true if
+// the path is inside one. Every adapter renders skills to a `skills/<name>/`
+// subtree (Claude `~/.claude/skills`, the cross-vendor `~/.agents/skills`, each
+// generic spec's own dir), so the first `skills` path segment plus the next
+// segment is the skill root for any of them. A nested `upstream/SKILL.md` falls
+// under the same outer root, keeping a multi-variant skill on one row.
+func skillRoot(path string) (string, bool) {
+	sep := string(filepath.Separator)
+	parts := strings.Split(path, sep)
+	for i, seg := range parts {
+		if seg == "skills" && i+1 < len(parts) {
+			return strings.Join(parts[:i+2], sep), true
+		}
+	}
+	return "", false
+}
+
+// mostSevereClass returns the highest-severity drift class present among items,
+// so the collapsed headline never downplays a problem hiding among clean files.
+func mostSevereClass(items []statusItem) string {
+	present := map[string]bool{}
+	for _, it := range items {
+		present[it.Class] = true
+	}
+	for _, cls := range classSeverity {
+		if present[cls] {
+			return cls
+		}
+	}
+	if len(items) > 0 {
+		return items[0].Class // class outside the known set; show it verbatim
+	}
+	return ""
+}
+
+// skillSummary builds the faint parenthetical describing a collapsed skill: how
+// many files it bundles (phrased relative to SKILL.md when present, matching how
+// a skill is authored) and, when the files span more than one drift class, the
+// per-class breakdown so a mixed directory isn't flattened to its headline alone.
+func skillSummary(items []statusItem) string {
+	total := len(items)
+	hasSkillMD := false
+	counts := map[string]int{}
+	for _, it := range items {
+		if filepath.Base(it.Path) == "SKILL.md" {
+			hasSkillMD = true
+		}
+		counts[it.Class]++
+	}
+	var size string
+	if hasSkillMD {
+		extra := total - 1
+		size = fmt.Sprintf("SKILL.md + %d %s", extra, plural(extra, "file", "files"))
+	} else {
+		size = fmt.Sprintf("%d %s", total, plural(total, "file", "files"))
+	}
+	if len(counts) <= 1 {
+		return "(" + size + ")"
+	}
+	var segs []string
+	for _, cls := range classOrder {
+		if n := counts[cls]; n > 0 {
+			segs = append(segs, fmt.Sprintf("%d %s", n, cls))
+		}
+	}
+	return "(" + size + "; " + strings.Join(segs, ", ") + ")"
+}
+
+// plural returns one or many depending on n.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 // classLegend gives a one-line, action-focused explanation of what `apply`
@@ -301,8 +530,13 @@ func renderStatusLegend(p *ui.Printer, summary map[string]int) {
 // emitStatusWarnings writes advisory diagnostics to stderr: orphaned state from
 // a removed/disabled agent, and native plugins not yet declared in source.
 // These are not part of the status model (and not the --json payload).
-func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, agents []string) {
-	for _, a := range orphanedStateAgents(s, agents) {
+//
+// orphan detection uses the full enabled set so a `--agent`-narrowed report
+// never mistakes a deselected-but-enabled agent for an orphan; the
+// undeclared-plugin nudge follows the selected set so it stays scoped to what
+// the report shows.
+func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, enabled, selected []string) {
+	for _, a := range orphanedStateAgents(s, enabled) {
 		fmt.Fprintf(p.Err, "%s agent %q is not enabled but still owns tracked files/keys in state; its "+
 			"native config is orphaned. Run `agentsync agent disable %s --purge` to remove what agentsync wrote.\n",
 			p.Yellow("warning:"), a, a)
@@ -310,7 +544,7 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// Nudge: plugins installed natively in an enabled agent but not yet declared
 	// in source. agentsync treats them as foreign-managed (never drift), so this
 	// is informational — it points at `import`.
-	undeclared := undeclaredNativePlugins(c, reg, agents)
+	undeclared := undeclaredNativePlugins(c, reg, selected)
 	for _, name := range reg.Names() {
 		missing := undeclared[name]
 		if len(missing) == 0 {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -93,7 +93,7 @@ func newStatusCmd() *cobra.Command {
 			if cmd.Flags().Changed("agents") {
 				names := splitAgents(agentsCSV)
 				if len(names) == 0 {
-					return fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
+					return fmt.Errorf(`--agents cannot be empty; pass "*" for all enabled agents or name one or more`)
 				}
 				// "*" = all enabled, matching `mcp add --agents`; otherwise the
 				// names are a validated allowlist.
@@ -193,7 +193,7 @@ func resolveAgentFilter(want []string, enabled map[string]bool) ([]string, error
 		out = append(out, a)
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
+		return nil, fmt.Errorf(`--agents cannot be empty; pass "*" for all enabled agents or name one or more`)
 	}
 	return out, nil
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -95,11 +95,15 @@ func newStatusCmd() *cobra.Command {
 				if len(names) == 0 {
 					return fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
 				}
-				sel, serr := resolveAgentFilter(names, enabled)
-				if serr != nil {
-					return serr
+				// "*" = all enabled, matching `mcp add --agents`; otherwise the
+				// names are a validated allowlist.
+				if !containsStar(names) {
+					sel, serr := resolveAgentFilter(names, enabled)
+					if serr != nil {
+						return serr
+					}
+					selected = sel
 				}
-				selected = sel
 			}
 			if len(selected) == 0 {
 				if jsonOut {
@@ -145,7 +149,7 @@ func newStatusCmd() *cobra.Command {
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted report")
-	cmd.Flags().StringVar(&agentsCSV, "agents", "", "limit the report to a comma-separated agent allowlist (default: all enabled)")
+	cmd.Flags().StringVar(&agentsCSV, "agents", "", `limit the report to a comma-separated agent allowlist ("*" = all enabled; default: all enabled)`)
 	return cmd
 }
 
@@ -192,6 +196,16 @@ func resolveAgentFilter(want []string, enabled map[string]bool) ([]string, error
 		return nil, fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
 	}
 	return out, nil
+}
+
+// containsStar reports whether names includes the "*" wildcard ("all enabled").
+func containsStar(names []string) bool {
+	for _, n := range names {
+		if strings.TrimSpace(n) == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 // buildStatusModel classifies every tracked file/key/orphan across agents into
@@ -423,23 +437,46 @@ func renderSkillGroup(p *ui.Printer, g *skillGroup) {
 // "skill" group and hidden from the per-row view. A skill whose SKILL.md is gone
 // (a true orphan) simply isn't collapsed; its lingering files list individually,
 // which is the clearer view for cleanup anyway.
+//
+// Candidates nested under another candidate are dropped: a skill that itself
+// bundles a `skills/<sub>/SKILL.md` (a legal bundled file — the loader excludes
+// only the top-level SKILL.md) would otherwise yield a second inner root, and
+// the inner SKILL.md would match BOTH, leaving the grouping to map-iteration
+// order. Keeping only outermost roots guarantees they never nest, so every path
+// matches at most one root and the whole skill collapses onto one row.
 func skillRoots(items []statusItem) map[string]bool {
-	roots := map[string]bool{}
+	cand := map[string]bool{}
 	for _, it := range items {
 		if it.Pointer != "" || filepath.Base(it.Path) != "SKILL.md" {
 			continue
 		}
 		dir := filepath.Dir(it.Path) // …/skills/<name>
 		if filepath.Base(filepath.Dir(dir)) == "skills" {
-			roots[dir] = true
+			cand[dir] = true
+		}
+	}
+	roots := map[string]bool{}
+	for r := range cand {
+		if !hasAncestorIn(r, cand) {
+			roots[r] = true
 		}
 	}
 	return roots
 }
 
+// hasAncestorIn reports whether some OTHER member of set is a parent-path of r.
+func hasAncestorIn(r string, set map[string]bool) bool {
+	for other := range set {
+		if other != r && strings.HasPrefix(r, other+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 // skillRootOf returns the skill root in roots that contains path (path is the
-// root's SKILL.md or any descendant of it), or "" if none. Roots never nest —
-// each is a distinct `skills/<name>` — so the first match is unambiguous.
+// root's SKILL.md or any descendant of it), or "" if none. skillRoots guarantees
+// roots never nest, so at most one can match — the first match is unambiguous.
 func skillRootOf(path string, roots map[string]bool) string {
 	for r := range roots {
 		if path == r || strings.HasPrefix(path, r+string(filepath.Separator)) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -51,7 +51,7 @@ func newStatusCmd() *cobra.Command {
 		scopeFlag   string
 		projectFlag string
 		jsonOut     bool
-		agentFlag   []string
+		agentsCSV   string
 	)
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -86,12 +86,16 @@ func newStatusCmd() *cobra.Command {
 					enabled[name] = true
 				}
 			}
-			// --agent narrows the report (and the plan) to the requested
+			// --agents narrows the report (and the plan) to the requested
 			// agent(s); orphan-state warnings still consider the FULL enabled
 			// set so a deselected agent isn't mistaken for an orphaned one.
 			selected := enabledAgents
-			if len(agentFlag) > 0 {
-				sel, serr := resolveAgentFilter(agentFlag, enabled)
+			if cmd.Flags().Changed("agents") {
+				names := splitAgents(agentsCSV)
+				if len(names) == 0 {
+					return fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
+				}
+				sel, serr := resolveAgentFilter(names, enabled)
 				if serr != nil {
 					return serr
 				}
@@ -141,7 +145,7 @@ func newStatusCmd() *cobra.Command {
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted report")
-	cmd.Flags().StringSliceVar(&agentFlag, "agent", nil, "limit the report to specific agent(s) (repeatable or comma-separated)")
+	cmd.Flags().StringVar(&agentsCSV, "agents", "", "limit the report to a comma-separated agent allowlist (default: all enabled)")
 	return cmd
 }
 
@@ -160,10 +164,13 @@ func statusVerbose(cmd *cobra.Command) bool {
 	return false
 }
 
-// resolveAgentFilter validates the --agent values against the known agent set
-// and the currently-enabled set, returning the de-duplicated selection in the
-// order given. An unknown name or an agent that exists but is not enabled is a
-// hard error — silently dropping it would make `status --agent typo` look clean.
+// resolveAgentFilter validates the (already comma-split) --agents values against
+// the known agent set and the currently-enabled set, returning the de-duplicated
+// selection in the order given. An unknown name or an agent that exists but is
+// not enabled is a hard error — silently dropping it would make
+// `status --agents typo` look clean. Callers split + reject the empty case
+// before calling (mirroring `mcp add --agents`), so a non-empty input that
+// resolves to nothing here is itself an error.
 func resolveAgentFilter(want []string, enabled map[string]bool) ([]string, error) {
 	var out []string
 	seen := map[string]bool{}
@@ -180,6 +187,9 @@ func resolveAgentFilter(want []string, enabled map[string]bool) ([]string, error
 			return nil, fmt.Errorf("agent %q is not enabled; run `agentsync agent add %s` first", a, a)
 		}
 		out = append(out, a)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--agents cannot be empty; name one or more enabled agents")
 	}
 	return out, nil
 }
@@ -339,6 +349,7 @@ func renderAgentItems(p *ui.Printer, items []statusItem, verbose bool) int {
 	// Group skill-directory items by their root, preserving first-appearance
 	// order; everything else (memory, subagents, commands, MCP/hook/LSP keys)
 	// stays an inline per-item row.
+	roots := skillRoots(items)
 	type entry struct {
 		item  statusItem
 		group *skillGroup
@@ -348,9 +359,7 @@ func renderAgentItems(p *ui.Printer, items []statusItem, verbose bool) int {
 	for _, it := range items {
 		root := ""
 		if it.Pointer == "" {
-			if r, ok := skillRoot(it.Path); ok {
-				root = r
-			}
+			root = skillRootOf(it.Path, roots)
 		}
 		if root == "" {
 			order = append(order, entry{item: it})
@@ -403,21 +412,41 @@ func renderSkillGroup(p *ui.Printer, g *skillGroup) {
 	fmt.Fprintf(p.Out, "  %s %s  %s\n", color(label), g.Root+string(filepath.Separator), p.Faint(skillSummary(g.Items)))
 }
 
-// skillRoot returns the …/skills/<name> directory a path lives under and true if
-// the path is inside one. Every adapter renders skills to a `skills/<name>/`
-// subtree (Claude `~/.claude/skills`, the cross-vendor `~/.agents/skills`, each
-// generic spec's own dir), so the first `skills` path segment plus the next
-// segment is the skill root for any of them. A nested `upstream/SKILL.md` falls
-// under the same outer root, keeping a multi-variant skill on one row.
-func skillRoot(path string) (string, bool) {
-	sep := string(filepath.Separator)
-	parts := strings.Split(path, sep)
-	for i, seg := range parts {
-		if seg == "skills" && i+1 < len(parts) {
-			return strings.Join(parts[:i+2], sep), true
+// skillRoots returns the skill directories present among items, anchored on an
+// actual SKILL.md — the dir of every `…/skills/<name>/SKILL.md` item (one whose
+// grandparent dir is `skills`, the shape every adapter renders: Claude
+// `~/.claude/skills`, the cross-vendor `~/.agents/skills`, each generic spec's
+// own dir). Anchoring on a real SKILL.md rather than merely a `skills` path
+// SEGMENT is deliberate: a user whose $HOME or project root happens to contain a
+// `skills` ancestor (e.g. `/home/skills/user`) would otherwise see EVERY dest
+// path — including a drifted memory/subagent file — swept into one bogus
+// "skill" group and hidden from the per-row view. A skill whose SKILL.md is gone
+// (a true orphan) simply isn't collapsed; its lingering files list individually,
+// which is the clearer view for cleanup anyway.
+func skillRoots(items []statusItem) map[string]bool {
+	roots := map[string]bool{}
+	for _, it := range items {
+		if it.Pointer != "" || filepath.Base(it.Path) != "SKILL.md" {
+			continue
+		}
+		dir := filepath.Dir(it.Path) // …/skills/<name>
+		if filepath.Base(filepath.Dir(dir)) == "skills" {
+			roots[dir] = true
 		}
 	}
-	return "", false
+	return roots
+}
+
+// skillRootOf returns the skill root in roots that contains path (path is the
+// root's SKILL.md or any descendant of it), or "" if none. Roots never nest —
+// each is a distinct `skills/<name>` — so the first match is unambiguous.
+func skillRootOf(path string, roots map[string]bool) string {
+	for r := range roots {
+		if path == r || strings.HasPrefix(path, r+string(filepath.Separator)) {
+			return r
+		}
+	}
+	return ""
 }
 
 // mostSevereClass returns the highest-severity drift class present among items,
@@ -531,7 +560,7 @@ func renderStatusLegend(p *ui.Printer, summary map[string]int) {
 // a removed/disabled agent, and native plugins not yet declared in source.
 // These are not part of the status model (and not the --json payload).
 //
-// orphan detection uses the full enabled set so a `--agent`-narrowed report
+// orphan detection uses the full enabled set so a `--agents`-narrowed report
 // never mistakes a deselected-but-enabled agent for an orphan; the
 // undeclared-plugin nudge follows the selected set so it stays scoped to what
 // the report shows.

--- a/internal/cli/status_internal_test.go
+++ b/internal/cli/status_internal_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// abs builds an absolute, OS-correct path from slash-separated segments so these
+// table tests read the same on any platform.
+func abs(segs ...string) string {
+	return string(filepath.Separator) + filepath.Join(segs...)
+}
+
+// TestSkillRoots_AnchorsOnSkillMD is the unit guard for the adversarial finding:
+// grouping must key off an actual `…/skills/<name>/SKILL.md`, never a bare
+// `skills` path SEGMENT — otherwise an ancestor directory literally named
+// `skills` (e.g. $HOME=/home/skills/user) would sweep unrelated files into a
+// bogus group and hide their drift.
+func TestSkillRoots_AnchorsOnSkillMD(t *testing.T) {
+	greet := abs("u", ".claude", "skills", "greet")
+	build := abs("home", "skills", "user", ".claude", "skills", "build")
+	tests := []struct {
+		name  string
+		items []statusItem
+		want  map[string]bool
+	}{
+		{
+			name: "normal skill dir is a root",
+			items: []statusItem{
+				{Path: filepath.Join(greet, "SKILL.md")},
+				{Path: filepath.Join(greet, "references", "notes.md")},
+			},
+			want: map[string]bool{greet: true},
+		},
+		{
+			name: "ancestor named skills does not create a root for non-skill files",
+			items: []statusItem{
+				{Path: abs("home", "skills", "user", ".claude", "CLAUDE.md")},
+				{Path: abs("home", "skills", "user", ".claude", "agents", "x.md")},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "real skill under a skills-named ancestor is still detected",
+			items: []statusItem{
+				{Path: abs("home", "skills", "user", ".claude", "CLAUDE.md")},
+				{Path: filepath.Join(build, "SKILL.md")},
+				{Path: filepath.Join(build, "references", "x.md")},
+			},
+			want: map[string]bool{build: true},
+		},
+		{
+			name: "nested references/SKILL.md is NOT a root (grandparent is the skill name, not skills)",
+			items: []statusItem{
+				{Path: filepath.Join(greet, "SKILL.md")},
+				{Path: filepath.Join(greet, "references", "SKILL.md")},
+			},
+			want: map[string]bool{greet: true},
+		},
+		{
+			name: "a key-merge item that happens to end in SKILL.md is ignored",
+			items: []statusItem{
+				{Path: filepath.Join(greet, "SKILL.md"), Pointer: "/mcpServers/x"},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name:  "no SKILL.md anywhere yields no roots (orphan bundles list individually)",
+			items: []statusItem{{Path: filepath.Join(greet, "references", "notes.md")}},
+			want:  map[string]bool{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skillRoots(tc.items)
+			if len(got) != len(tc.want) {
+				t.Fatalf("roots = %v, want %v", got, tc.want)
+			}
+			for r := range tc.want {
+				if !got[r] {
+					t.Errorf("missing root %q in %v", r, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSkillRootOf(t *testing.T) {
+	greet := abs("u", ".claude", "skills", "greet")
+	other := abs("u", ".claude", "skills", "other")
+	roots := map[string]bool{greet: true}
+	tests := []struct {
+		path string
+		want string
+	}{
+		{filepath.Join(greet, "SKILL.md"), greet},
+		{filepath.Join(greet, "references", "notes.md"), greet},
+		{filepath.Join(other, "SKILL.md"), ""},            // not a known root
+		{abs("u", ".claude", "skills", "greetzilla"), ""}, // prefix-but-not-a-child
+	}
+	for _, tc := range tests {
+		if got := skillRootOf(tc.path, roots); got != tc.want {
+			t.Errorf("skillRootOf(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestMostSevereClass(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []statusItem
+		want  string
+	}{
+		{"mixed picks the most severe", []statusItem{{Class: "clean"}, {Class: "drift"}, {Class: "new"}}, "drift"},
+		{"conflict outranks orphan and pending", []statusItem{{Class: "orphan"}, {Class: "conflict"}, {Class: "pending"}}, "conflict"},
+		{"uniform clean stays clean", []statusItem{{Class: "clean"}, {Class: "clean"}}, "clean"},
+		{"unknown class falls back to first item", []statusItem{{Class: "weird"}}, "weird"},
+		{"empty yields empty", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mostSevereClass(tc.items); got != tc.want {
+				t.Errorf("mostSevereClass = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSkillSummary(t *testing.T) {
+	skillMD := statusItem{Path: abs("u", "skills", "greet", "SKILL.md"), Class: "clean"}
+	ref := func(name, cls string) statusItem {
+		return statusItem{Path: abs("u", "skills", "greet", "references", name), Class: cls}
+	}
+	tests := []struct {
+		name  string
+		items []statusItem
+		want  string
+	}{
+		{"uniform with SKILL.md", []statusItem{skillMD, ref("a.md", "clean")}, "(SKILL.md + 1 file)"},
+		{"plural files", []statusItem{skillMD, ref("a.md", "clean"), ref("b.md", "clean")}, "(SKILL.md + 2 files)"},
+		{
+			"mixed appends a class breakdown in classOrder",
+			[]statusItem{{Path: skillMD.Path, Class: "drift"}, ref("a.md", "clean")},
+			"(SKILL.md + 1 file; 1 clean, 1 drift)",
+		},
+		{
+			"no SKILL.md uses bare file count",
+			[]statusItem{ref("a.md", "clean"), ref("b.md", "clean")},
+			"(2 files)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := skillSummary(tc.items); got != tc.want {
+				t.Errorf("skillSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/status_internal_test.go
+++ b/internal/cli/status_internal_test.go
@@ -71,6 +71,27 @@ func TestSkillRoots_AnchorsOnSkillMD(t *testing.T) {
 			want: map[string]bool{greet: true},
 		},
 		{
+			// Sibling skills whose names share a prefix are INDEPENDENT roots —
+			// the nesting filter must not drop `greet` just because `greetzilla`
+			// HasPrefix("…/greet…"). Guards hasAncestorIn's `+sep` boundary at the
+			// skillRoots level (skillRootOf's boundary is covered separately).
+			name: "sibling skills with a shared name prefix are both roots",
+			items: []statusItem{
+				{Path: filepath.Join(greet, "SKILL.md")},
+				{Path: filepath.Join(abs("u", ".claude", "skills", "greetzilla"), "SKILL.md")},
+			},
+			want: map[string]bool{greet: true, abs("u", ".claude", "skills", "greetzilla"): true},
+		},
+		{
+			// A skill literally named `skills` still anchors correctly: the dir is
+			// `…/skills/skills` whose grandparent base is `skills`.
+			name: "a skill named skills is a valid root",
+			items: []statusItem{
+				{Path: abs("u", ".claude", "skills", "skills", "SKILL.md")},
+			},
+			want: map[string]bool{abs("u", ".claude", "skills", "skills"): true},
+		},
+		{
 			name: "a key-merge item that happens to end in SKILL.md is ignored",
 			items: []statusItem{
 				{Path: filepath.Join(greet, "SKILL.md"), Pointer: "/mcpServers/x"},

--- a/internal/cli/status_internal_test.go
+++ b/internal/cli/status_internal_test.go
@@ -58,6 +58,19 @@ func TestSkillRoots_AnchorsOnSkillMD(t *testing.T) {
 			want: map[string]bool{greet: true},
 		},
 		{
+			// A skill bundling its own `skills/<sub>/SKILL.md` must NOT spawn a
+			// second inner root (which the inner SKILL.md would match alongside
+			// the outer one — ambiguous under map iteration). Only the outermost
+			// root survives, so the whole skill collapses onto one row.
+			name: "a bundled skills/<sub>/SKILL.md does not create a nested root",
+			items: []statusItem{
+				{Path: filepath.Join(greet, "SKILL.md")},
+				{Path: filepath.Join(greet, "skills", "sub", "SKILL.md")},
+				{Path: filepath.Join(greet, "references", "x.md")},
+			},
+			want: map[string]bool{greet: true},
+		},
+		{
 			name: "a key-merge item that happens to end in SKILL.md is ignored",
 			items: []statusItem{
 				{Path: filepath.Join(greet, "SKILL.md"), Pointer: "/mcpServers/x"},
@@ -95,8 +108,9 @@ func TestSkillRootOf(t *testing.T) {
 	}{
 		{filepath.Join(greet, "SKILL.md"), greet},
 		{filepath.Join(greet, "references", "notes.md"), greet},
-		{filepath.Join(other, "SKILL.md"), ""},            // not a known root
-		{abs("u", ".claude", "skills", "greetzilla"), ""}, // prefix-but-not-a-child
+		{filepath.Join(greet, "skills", "sub", "SKILL.md"), greet}, // nested bundle maps to the outer root
+		{filepath.Join(other, "SKILL.md"), ""},                     // not a known root
+		{abs("u", ".claude", "skills", "greetzilla"), ""},          // prefix-but-not-a-child
 	}
 	for _, tc := range tests {
 		if got := skillRootOf(tc.path, roots); got != tc.want {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -173,6 +173,170 @@ func TestStatus_CleanAfterApply(t *testing.T) {
 	}
 }
 
+// TestStatus_CollapsesSkillDirectory locks in the default digestible view: a
+// skill directory with bundled files renders as a single summary row (the skill
+// dir + a "SKILL.md + N files" count) instead of one row per file, so a skill
+// shipping hundreds of assets no longer floods the report. --verbose restores
+// the full per-file listing.
+func TestStatus_CollapsesSkillDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	sk := filepath.Join(tmp, ".agentsync", "skills", "build123d")
+	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
+	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: build123d\ndescription: d\n---\nbody\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	// The collapsed row carries the file-count summary and the discoverability
+	// hint, but NOT the individual bundled-file path.
+	if !strings.Contains(out, "SKILL.md + 1 file") {
+		t.Errorf("expected a collapsed skill summary; got:\n%s", out)
+	}
+	if strings.Contains(out, "notes.md") {
+		t.Errorf("default status should not list bundled skill files; got:\n%s", out)
+	}
+	if !strings.Contains(out, "--verbose") {
+		t.Errorf("expected a hint pointing at --verbose; got:\n%s", out)
+	}
+
+	vout, err := runCLI(t, env, "status", "--verbose")
+	if err != nil {
+		t.Fatalf("status --verbose: %v\n%s", err, vout)
+	}
+	if !strings.Contains(vout, filepath.Join("references", "notes.md")) {
+		t.Errorf("--verbose should list every bundled file; got:\n%s", vout)
+	}
+	if strings.Contains(vout, "SKILL.md + 1 file") {
+		t.Errorf("--verbose should not collapse; got:\n%s", vout)
+	}
+}
+
+// TestStatus_CollapsedSkillShowsMostSevereClass guards that collapsing never
+// hides a problem: a drifted SKILL.md inside an otherwise-clean skill must make
+// the collapsed headline red (drift), and the faint summary must spell out the
+// mixed per-class breakdown.
+func TestStatus_CollapsedSkillShowsMostSevereClass(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	sk := filepath.Join(tmp, ".agentsync", "skills", "greet")
+	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
+	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: greet\ndescription: d\n---\nbody\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	// Hand-edit only the rendered SKILL.md so the skill is now 1 drift + 1 clean.
+	dst := filepath.Join(tmp, ".claude", "skills", "greet", "SKILL.md")
+	if err := os.WriteFile(dst, []byte("---\nname: greet\ndescription: d\n---\nHAND EDIT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "drift") {
+		t.Errorf("collapsed headline should surface the drift; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 clean, 1 drift") {
+		t.Errorf("collapsed summary should break down the mixed classes; got:\n%s", out)
+	}
+	if strings.Contains(out, "notes.md") {
+		t.Errorf("collapsed view should still hide the clean bundled file; got:\n%s", out)
+	}
+}
+
+// TestStatus_AgentFilter locks in --agent: it scopes the report to the named
+// agent(s), and rejects an unknown or not-enabled agent rather than silently
+// reporting nothing.
+func TestStatus_AgentFilter(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status", "--agent", "codex")
+	if err != nil {
+		t.Fatalf("status --agent codex: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[codex]") {
+		t.Errorf("expected the codex section; got:\n%s", out)
+	}
+	if strings.Contains(out, "[claude]") {
+		t.Errorf("--agent codex should not report claude; got:\n%s", out)
+	}
+
+	if _, err := runCLI(t, env, "status", "--agent", "bogus"); err == nil {
+		t.Errorf("expected an error for an unknown agent")
+	}
+	// opencode is a valid agent name but was never enabled here.
+	if _, err := runCLI(t, env, "status", "--agent", "opencode"); err == nil {
+		t.Errorf("expected an error for a valid-but-not-enabled agent")
+	}
+}
+
+// TestStatus_JSONNotCollapsed pins that the machine-readable payload is never
+// collapsed: scripts must see every tracked file regardless of the human view.
+func TestStatus_JSONNotCollapsed(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	sk := filepath.Join(tmp, ".agentsync", "skills", "build123d")
+	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
+	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: build123d\ndescription: d\n---\nbody\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "notes.md") {
+		t.Errorf("--json must list every bundled file (no collapse); got:\n%s", out)
+	}
+	if strings.Contains(out, "SKILL.md + 1 file") {
+		t.Errorf("--json must not carry the human collapse summary; got:\n%s", out)
+	}
+}
+
 // TestStatus_JSONOutput locks in the contract that --json emits the structured
 // drift model: a per-agent items list keyed by drift class plus a summary
 // tally. Scripts (CI gates, dashboards) consume this — its shape and the

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func TestStatus_DriftAfterDirectEdit(t *testing.T) {
@@ -173,24 +175,65 @@ func TestStatus_CleanAfterApply(t *testing.T) {
 	}
 }
 
+// statusEnv runs `init` then `agent add` for each named agent in a fresh temp
+// target root, returning the root and the env to pass to runCLI. It collapses
+// the init/add boilerplate the status collapse/filter tests share.
+func statusEnv(t *testing.T, agents ...string) (string, map[string]string) {
+	t.Helper()
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	for _, a := range agents {
+		if _, err := runCLI(t, env, "agent", "add", a); err != nil {
+			t.Fatalf("agent add %s: %v", a, err)
+		}
+	}
+	return tmp, env
+}
+
+// writeSkill creates .agentsync/skills/<name>/SKILL.md plus the given bundled
+// files (relative slash-paths → contents). Pass a nil map for a single-file skill.
+func writeSkill(t *testing.T, tmp, name string, bundled map[string]string) {
+	t.Helper()
+	dir := filepath.Join(tmp, ".agentsync", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: "+name+"\ndescription: d\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for rel, body := range bundled {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// lineContaining returns the first line of s that contains sub, or "".
+func lineContaining(s, sub string) string {
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.Contains(ln, sub) {
+			return ln
+		}
+	}
+	return ""
+}
+
 // TestStatus_CollapsesSkillDirectory locks in the default digestible view: a
 // skill directory with bundled files renders as a single summary row (the skill
 // dir + a "SKILL.md + N files" count) instead of one row per file, so a skill
 // shipping hundreds of assets no longer floods the report. --verbose restores
 // the full per-file listing.
 func TestStatus_CollapsesSkillDirectory(t *testing.T) {
-	tmp := t.TempDir()
-	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-	if _, err := runCLI(t, env, "init"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
-		t.Fatal(err)
-	}
-	sk := filepath.Join(tmp, ".agentsync", "skills", "build123d")
-	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
-	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: build123d\ndescription: d\n---\nbody\n"), 0o644)
-	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	tmp, env := statusEnv(t, "claude")
+	writeSkill(t, tmp, "build123d", map[string]string{"references/notes.md": "notes\n"})
 	if _, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatal(err)
 	}
@@ -207,6 +250,9 @@ func TestStatus_CollapsesSkillDirectory(t *testing.T) {
 	if strings.Contains(out, "notes.md") {
 		t.Errorf("default status should not list bundled skill files; got:\n%s", out)
 	}
+	if !strings.Contains(out, "1 skill directory collapsed") {
+		t.Errorf("expected the singular collapse hint; got:\n%s", out)
+	}
 	if !strings.Contains(out, "--verbose") {
 		t.Errorf("expected a hint pointing at --verbose; got:\n%s", out)
 	}
@@ -221,25 +267,39 @@ func TestStatus_CollapsesSkillDirectory(t *testing.T) {
 	if strings.Contains(vout, "SKILL.md + 1 file") {
 		t.Errorf("--verbose should not collapse; got:\n%s", vout)
 	}
+	if strings.Contains(vout, "collapsed") {
+		t.Errorf("--verbose should not print the collapse hint; got:\n%s", vout)
+	}
+}
+
+// TestStatus_SingleFileSkillNotCollapsed pins the "collapsing hides nothing"
+// promise: a skill that is just a SKILL.md (no bundled files) stays a normal
+// per-file row — collapsing a one-file group would only obscure its path.
+func TestStatus_SingleFileSkillNotCollapsed(t *testing.T) {
+	tmp, env := statusEnv(t, "claude")
+	writeSkill(t, tmp, "solo", nil)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, filepath.Join("skills", "solo", "SKILL.md")) {
+		t.Errorf("a single-file skill should render its SKILL.md path as a row; got:\n%s", out)
+	}
+	if strings.Contains(out, "SKILL.md +") || strings.Contains(out, "collapsed") {
+		t.Errorf("a single-file skill must not be collapsed; got:\n%s", out)
+	}
 }
 
 // TestStatus_CollapsedSkillShowsMostSevereClass guards that collapsing never
 // hides a problem: a drifted SKILL.md inside an otherwise-clean skill must make
-// the collapsed headline red (drift), and the faint summary must spell out the
-// mixed per-class breakdown.
+// the collapsed *headline* red (drift) — not merely mention "drift" somewhere —
+// and the faint summary must spell out the mixed per-class breakdown.
 func TestStatus_CollapsedSkillShowsMostSevereClass(t *testing.T) {
-	tmp := t.TempDir()
-	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-	if _, err := runCLI(t, env, "init"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
-		t.Fatal(err)
-	}
-	sk := filepath.Join(tmp, ".agentsync", "skills", "greet")
-	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
-	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: greet\ndescription: d\n---\nbody\n"), 0o644)
-	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	tmp, env := statusEnv(t, "claude")
+	writeSkill(t, tmp, "greet", map[string]string{"references/notes.md": "notes\n"})
 	if _, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatal(err)
 	}
@@ -253,32 +313,52 @@ func TestStatus_CollapsedSkillShowsMostSevereClass(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "drift") {
-		t.Errorf("collapsed headline should surface the drift; got:\n%s", out)
+	// Isolate the collapsed skill row itself (uniquely identified by its file
+	// count) so the assertion can't be satisfied by the word "drift" leaking in
+	// from the footer/legend/breakdown — the vacuous-green trap.
+	row := lineContaining(out, "SKILL.md + 1 file")
+	if row == "" {
+		t.Fatalf("expected a collapsed skill row; got:\n%s", out)
 	}
-	if !strings.Contains(out, "1 clean, 1 drift") {
-		t.Errorf("collapsed summary should break down the mixed classes; got:\n%s", out)
+	// Glyphs are always emitted (color is stripped in tests), so the headline is
+	// "✗ drift", and a green regression would render "✓ clean" on this row.
+	if !strings.Contains(row, ui.GlyphErr+" drift") {
+		t.Errorf("collapsed headline must be the most-severe class (✗ drift); row:\n%s", row)
+	}
+	if strings.Contains(row, ui.GlyphOK+" clean") {
+		t.Errorf("collapsed headline regressed to green; row:\n%s", row)
+	}
+	if !strings.Contains(row, "1 clean, 1 drift") {
+		t.Errorf("collapsed summary should break down the mixed classes; row:\n%s", row)
 	}
 	if strings.Contains(out, "notes.md") {
 		t.Errorf("collapsed view should still hide the clean bundled file; got:\n%s", out)
 	}
 }
 
-// TestStatus_AgentFilter locks in --agent: it scopes the report to the named
-// agent(s), and rejects an unknown or not-enabled agent rather than silently
-// reporting nothing.
+// TestStatus_CollapseHintPluralizes pins the plural branch of the collapse hint
+// (the singular branch is covered by TestStatus_CollapsesSkillDirectory).
+func TestStatus_CollapseHintPluralizes(t *testing.T) {
+	tmp, env := statusEnv(t, "claude")
+	writeSkill(t, tmp, "alpha", map[string]string{"references/a.md": "a\n"})
+	writeSkill(t, tmp, "beta", map[string]string{"references/b.md": "b\n"})
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "2 skill directories collapsed") {
+		t.Errorf("expected the plural collapse hint; got:\n%s", out)
+	}
+}
+
+// TestStatus_AgentFilter locks in --agents: it scopes the report to the named
+// agent(s), rejects unknown / not-enabled / empty inputs with a clear message,
+// and the (uncollapsed) --json payload honors the same scope.
 func TestStatus_AgentFilter(t *testing.T) {
-	tmp := t.TempDir()
-	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-	if _, err := runCLI(t, env, "init"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
-		t.Fatal(err)
-	}
+	tmp, env := statusEnv(t, "claude", "codex")
 	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
 	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
 	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
@@ -286,41 +366,79 @@ func TestStatus_AgentFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := runCLI(t, env, "status", "--agent", "codex")
+	out, err := runCLI(t, env, "status", "--agents", "codex")
 	if err != nil {
-		t.Fatalf("status --agent codex: %v\n%s", err, out)
+		t.Fatalf("status --agents codex: %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "[codex]") {
 		t.Errorf("expected the codex section; got:\n%s", out)
 	}
 	if strings.Contains(out, "[claude]") {
-		t.Errorf("--agent codex should not report claude; got:\n%s", out)
+		t.Errorf("--agents codex should not report claude; got:\n%s", out)
 	}
 
-	if _, err := runCLI(t, env, "status", "--agent", "bogus"); err == nil {
-		t.Errorf("expected an error for an unknown agent")
+	// --json honors the filter and stays parseable.
+	jout, err := runCLI(t, env, "status", "--agents", "claude", "--json")
+	if err != nil {
+		t.Fatalf("status --agents claude --json: %v\n%s", err, jout)
+	}
+	var got struct {
+		Agents []struct {
+			Agent string `json:"agent"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal([]byte(jout), &got); err != nil {
+		t.Fatalf("--agents --json not valid JSON: %v\n%s", err, jout)
+	}
+	if len(got.Agents) != 1 || got.Agents[0].Agent != "claude" {
+		t.Errorf("--agents claude --json should carry only claude; got %#v", got.Agents)
+	}
+
+	// Error paths assert the message, not just non-nil — a clear message is the
+	// whole point of failing instead of silently reporting nothing.
+	if _, err := runCLI(t, env, "status", "--agents", "bogus"); err == nil ||
+		!strings.Contains(err.Error(), "unknown agent") {
+		t.Errorf("expected an 'unknown agent' error; got %v", err)
 	}
 	// opencode is a valid agent name but was never enabled here.
-	if _, err := runCLI(t, env, "status", "--agent", "opencode"); err == nil {
-		t.Errorf("expected an error for a valid-but-not-enabled agent")
+	if _, err := runCLI(t, env, "status", "--agents", "opencode"); err == nil ||
+		!strings.Contains(err.Error(), "not enabled") {
+		t.Errorf("expected a 'not enabled' error; got %v", err)
+	}
+	// An explicitly-empty filter is a clear error, not the misleading
+	// "no agents enabled" message (agents ARE enabled here).
+	if _, err := runCLI(t, env, "status", "--agents", ",,"); err == nil ||
+		!strings.Contains(err.Error(), "cannot be empty") {
+		t.Errorf("expected a 'cannot be empty' error for a blank filter; got %v", err)
+	}
+}
+
+// TestStatus_AgentFilterKeepsOrphanWarningsGlobal pins the invariant that
+// narrowing the report with --agents must NOT make a still-enabled but
+// deselected agent look orphaned — orphan detection uses the full enabled set,
+// not the selection. Swapping the two would re-flag codex here.
+func TestStatus_AgentFilterKeepsOrphanWarningsGlobal(t *testing.T) {
+	tmp, env := statusEnv(t, "claude", "codex")
+	mcp := filepath.Join(tmp, ".agentsync", "mcp", "github.toml")
+	_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+	_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "status", "--agents", "claude")
+	if err != nil {
+		t.Fatalf("status --agents claude: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "is not enabled but still owns") {
+		t.Errorf("filtering to claude must not mislabel the still-enabled codex as orphaned; got:\n%s", out)
 	}
 }
 
 // TestStatus_JSONNotCollapsed pins that the machine-readable payload is never
 // collapsed: scripts must see every tracked file regardless of the human view.
 func TestStatus_JSONNotCollapsed(t *testing.T) {
-	tmp := t.TempDir()
-	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-	if _, err := runCLI(t, env, "init"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
-		t.Fatal(err)
-	}
-	sk := filepath.Join(tmp, ".agentsync", "skills", "build123d")
-	_ = os.MkdirAll(filepath.Join(sk, "references"), 0o755)
-	_ = os.WriteFile(filepath.Join(sk, "SKILL.md"), []byte("---\nname: build123d\ndescription: d\n---\nbody\n"), 0o644)
-	_ = os.WriteFile(filepath.Join(sk, "references", "notes.md"), []byte("notes\n"), 0o644)
+	tmp, env := statusEnv(t, "claude")
+	writeSkill(t, tmp, "build123d", map[string]string{"references/notes.md": "notes\n"})
 	if _, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -377,6 +377,15 @@ func TestStatus_AgentFilter(t *testing.T) {
 		t.Errorf("--agents codex should not report claude; got:\n%s", out)
 	}
 
+	// "*" means all enabled, matching `mcp add --agents` (not an "unknown agent").
+	star, err := runCLI(t, env, "status", "--agents", "*")
+	if err != nil {
+		t.Fatalf("status --agents '*': %v\n%s", err, star)
+	}
+	if !strings.Contains(star, "[claude]") || !strings.Contains(star, "[codex]") {
+		t.Errorf("--agents '*' should report all enabled agents; got:\n%s", star)
+	}
+
 	// --json honors the filter and stays parseable.
 	jout, err := runCLI(t, env, "status", "--agents", "claude", "--json")
 	if err != nil {

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -157,10 +157,10 @@ present (`new` will be created, `pending` will be updated to match source,
 `drift` will be overwritten — use `reconcile` to keep the edit, etc.). Clean
 items are tallied but never glossed.
 
-Use `--agents <list>` (a comma-separated allowlist, matching `mcp add --agents`)
-to scope the report — `agentsync status --agents claude` shows just Claude Code.
-Orphaned-state warnings still consider the full enabled set, so narrowing the
-view never mislabels a deselected agent as an orphan.
+Use `--agents <list>` (a comma-separated allowlist, matching `mcp add --agents`;
+`*` = all enabled) to scope the report — `agentsync status --agents claude` shows
+just Claude Code. Orphaned-state warnings still consider the full enabled set, so
+narrowing the view never mislabels a deselected agent as an orphan.
 
 Pass `--json` to emit the structured drift report (per-agent items + a summary
 tally keyed by drift class) for CI gates or dashboards; advisory diagnostics
@@ -243,6 +243,6 @@ agentsync explain --list
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
 | `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). `explain --list --json` emits a `plugins` array; `explain` with ids/`--all` emits the translation `rows`. |
-| `--agents <list>` | status | Scope the report to a comma-separated agent allowlist (matches `mcp add --agents`). |
+| `--agents <list>` | status | Scope the report to a comma-separated agent allowlist (`*` = all enabled; matches `mcp add --agents`). |
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. In `status`, also expands each collapsed skill directory back to one row per bundled file. |

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -28,7 +28,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift / pending across agents. | `--scope --project` |
+| `status` | Summarize drift / pending across agents (skill dirs collapse by default). | `--agent --verbose --json --scope --project` |
 | `diff [<path>]` | Show pending / drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source. `--scope project` captures the agent's native project-scope config into the project tree. | `--dry-run --scope --project` |
@@ -146,15 +146,27 @@ agentsync apply
 
 ### `status`
 Summarizes what's out of sync across all agents — pending source changes and
-destination drift. A one-line summary footer tallies items by drift class, and
+destination drift. To stay readable, each **skill directory collapses to one
+row** by default (the skill dir, its most-severe drift class, and a faint
+`SKILL.md + N files` count — with a per-class breakdown when the bundled files
+don't all share one class), so a skill shipping hundreds of assets no longer
+floods the report. Pass `-v`/`--verbose` to expand every skill back to one row
+per bundled file. A one-line summary footer tallies items by drift class, and
 a brief "What `apply` will do:" legend follows it, explaining each class
 present (`new` will be created, `pending` will be updated to match source,
 `drift` will be overwritten — use `reconcile` to keep the edit, etc.). Clean
-items are tallied but never glossed. Pass `--json` to emit the structured
-drift report (per-agent items + a summary tally keyed by drift class) for CI
-gates or dashboards; advisory diagnostics still flow to stderr so the JSON
-payload stays clean. `--json` output omits the legend (the class field is the
-machine contract).
+items are tallied but never glossed.
+
+Use `--agent <name>` (repeatable or comma-separated) to scope the report to
+specific agents — `agentsync status --agent claude` shows just Claude Code.
+Orphaned-state warnings still consider the full enabled set, so narrowing the
+view never mislabels a deselected agent as an orphan.
+
+Pass `--json` to emit the structured drift report (per-agent items + a summary
+tally keyed by drift class) for CI gates or dashboards; advisory diagnostics
+still flow to stderr so the JSON payload stays clean. `--json` is **never
+collapsed** — it carries every tracked file regardless of the human view — and
+omits the legend (the class field is the machine contract).
 
 ### `diff [<path>]`
 Shows the pending / drift changes in detail. **Resolved secrets are redacted**, so
@@ -231,5 +243,6 @@ agentsync explain --list
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
 | `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). `explain --list --json` emits a `plugins` array; `explain` with ids/`--all` emits the translation `rows`. |
+| `--agent <name>` | status | Scope the report to specific agent(s); repeatable or comma-separated. |
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
-| `-v`, `--verbose` | all | Verbose logging. |
+| `-v`, `--verbose` | all | Verbose logging. In `status`, also expands each collapsed skill directory back to one row per bundled file. |

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -28,7 +28,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
-| `status` | Summarize drift / pending across agents (skill dirs collapse by default). | `--agent --verbose --json --scope --project` |
+| `status` | Summarize drift / pending across agents (skill dirs collapse by default). | `--agents --verbose --json --scope --project` |
 | `diff [<path>]` | Show pending / drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source. `--scope project` captures the agent's native project-scope config into the project tree. | `--dry-run --scope --project` |
@@ -157,8 +157,8 @@ present (`new` will be created, `pending` will be updated to match source,
 `drift` will be overwritten — use `reconcile` to keep the edit, etc.). Clean
 items are tallied but never glossed.
 
-Use `--agent <name>` (repeatable or comma-separated) to scope the report to
-specific agents — `agentsync status --agent claude` shows just Claude Code.
+Use `--agents <list>` (a comma-separated allowlist, matching `mcp add --agents`)
+to scope the report — `agentsync status --agents claude` shows just Claude Code.
 Orphaned-state warnings still consider the full enabled set, so narrowing the
 view never mislabels a deselected agent as an orphan.
 
@@ -243,6 +243,6 @@ agentsync explain --list
 | `--dry-run` | apply, import | Preview without writing. |
 | `--auto-safe` | reconcile, update | Auto-resolve only no-risk changes. |
 | `--json` | status, diff, explain | Emit the structured payload to stdout (advisory diagnostics still go to stderr). `explain --list --json` emits a `plugins` array; `explain` with ids/`--all` emits the translation `rows`. |
-| `--agent <name>` | status | Scope the report to specific agent(s); repeatable or comma-separated. |
+| `--agents <list>` | status | Scope the report to a comma-separated agent allowlist (matches `mcp add --agents`). |
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. In `status`, also expands each collapsed skill directory back to one row per bundled file. |


### PR DESCRIPTION
## Why

`agentsync status` printed **one row per tracked file**. A few asset-heavy skills (fonts, XSD schemas, reference trees) could push the report past a thousand lines and bury the drift that actually matters — e.g. a real-world run produced **1,844 rows** where a handful of conflicts hid among them.

## What changed

**Default view now collapses each skill directory to a single row** — the skill dir, its *most-severe* drift class, and a faint `SKILL.md + N files` count:

```
[claude]
  ✗ conflict           /Users/steven/.claude/skills/build123d/  (SKILL.md + 39 files; 1 conflict, 39 clean)
  → new                /Users/steven/.claude/skills/canvas-design/  (SKILL.md + 78 files)
  ...

40 clean  ·  1844 new  ·  3 pending  ·  4 conflict

1820 skill directories collapsed; pass --verbose to list every bundled file.
```

Design choices that keep it honest:
- **Most-severe class drives the headline**, so a drifted/conflicted `SKILL.md` hiding among clean assets still shows **red** — the count never masks a problem.
- **Mixed directories get a per-class breakdown** (`1 conflict, 39 clean`); uniform ones just show the count.
- **Single-file skills stay as normal rows** (collapsing them hides nothing).
- The summary footer still tallies every file, so the totals are unchanged.

**New flags:**
- `-v` / `--verbose` — expand every skill back to one row per bundled file (the previous view). Reuses the existing global verbose flag, which was otherwise a no-op.
- `--agent <name>` (repeatable or comma-separated) — scope the report to specific agents; unknown or not-enabled names are a hard error. Orphaned-state warnings still consider the **full** enabled set, so narrowing never mislabels a deselected agent as an orphan.

**`--json` is unchanged and never collapsed** — it carries every tracked file, keeping the machine contract stable.

## Tests

New `TestStatus_*` cases cover: skill collapse + `--verbose` expansion, most-severe-class surfacing on a mixed skill, `--agent` filtering and its error paths (unknown / not-enabled), and the JSON-stays-full guarantee. Existing status tests still pass.

`go build ./...`, the `internal/cli` + `internal/render` suites, and `golangci-lint` (0 issues) are all green; gofumpt clean.

## Docs

Updated in the same commit: `docs/user-guide.md` command reference + global-flags note, the website CLI reference (`website/src/content/docs/reference/cli.mdx`), and `CHANGELOG.md` (`[Unreleased]`).

## Heads-up

Collapse keys off the universal `skills/<name>/` path segment every adapter renders into — robust today. If an adapter ever rendered skills without that segment, those files would simply fall back to per-file rows (safe, just not collapsed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwUUEnvCWxYg5xYysTf8zq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwUUEnvCWxYg5xYysTf8zq)_