### PR TITLE
ci(release): add manual workflow_dispatch path to cut releases without a laptop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - run: just lint
       - name: Verify formatting & go.mod/go.sum are committed
         run: git diff --exit-code
+      # Pin the release-version rule (scripts/release-tag.sh) so the v+semver
+      # validator both release paths share can't silently rot. Pure bash, no git
+      # side effects.
+      - name: Pin release-version validation (scripts/release-tag.sh --self-test)
+        run: ./scripts/release-tag.sh --self-test
 
   goreleaser-snapshot:
     name: goreleaser-snapshot (cross-build matrix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ on:
 permissions:
   contents: write
 
+# Serialize releases so a manual dispatch and a tag push (or two dispatches)
+# can't race to tag/publish the same version. We never cancel an in-flight
+# release — interrupting goreleaser mid-publish is worse than waiting.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
     name: goreleaser (publish)
@@ -48,30 +55,23 @@ jobs:
         with: { fetch-depth: 0 }
       # Manual-dispatch only: validate the requested version and create + push
       # the annotated tag at HEAD so goreleaser (which derives the version from
-      # the tag at HEAD) has one to release. Mirrors the `just release` recipe's
-      # validation. The version is read via env, never interpolated into the
-      # script body, so a hostile input can't inject shell. Uses the persisted
-      # GITHUB_TOKEN from actions/checkout (contents:write, granted below).
+      # the tag at HEAD) has one to release. Delegates to scripts/release-tag.sh
+      # — the SAME validator the `just release` laptop path uses, so the two
+      # paths can't drift (and CI self-tests that script). The version is read
+      # via env and passed as a single quoted arg; the script validates it before
+      # any git command, so a hostile input can't reach `git tag`/`push` or
+      # inject shell. The tag push uses the persisted GITHUB_TOKEN from
+      # actions/checkout (contents:write, granted below); a GITHUB_TOKEN-pushed
+      # tag deliberately does NOT re-trigger this workflow, which is why we tag
+      # and publish in one run instead of relying on the `push: tags` trigger.
       - name: Validate version and create release tag (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
-          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-          if [[ ! "$VERSION" =~ $semver ]]; then
-            echo "release: '$VERSION' must start with 'v' and be valid semver (e.g. v0.1.0, v1.2.3-rc.1)" >&2
-            exit 1
-          fi
-          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-            echo "release: tag '$VERSION' already exists" >&2
-            exit 1
-          fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git tag -a "$VERSION" -m "agentsync $VERSION"
-          git push origin "$VERSION"
-          echo "release: created and pushed $VERSION — publishing it now."
+          scripts/release-tag.sh "$VERSION"
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,33 @@
 name: release
-# Tag-triggered publish. CI (ci.yml) only ever runs goreleaser in
-# `--snapshot --skip publish` mode to prove the cross-build stays viable; this
-# workflow is the one that actually cuts a GitHub Release and updates the
-# Homebrew tap. Push an annotated `vX.Y.Z` tag on a green `main` commit and
-# GoReleaser takes it from there. Once the release publishes, the `docs` job
-# rebuilds and redeploys the agentsync.cc site so the live docs always track the
-# just-shipped CLI version.
+# Publish a GitHub Release + update the Homebrew tap. CI (ci.yml) only ever runs
+# goreleaser in `--snapshot --skip publish` mode to prove the cross-build stays
+# viable; this workflow is the one that actually ships. Once the release
+# publishes, the `docs` job rebuilds and redeploys the agentsync.cc site so the
+# live docs always track the just-shipped CLI version.
+#
+# Two ways in, both landing in the single `goreleaser` job below:
+#   1. push an annotated `vX.Y.Z` tag on a green commit (the laptop path —
+#      `just release vX.Y.Z`); the `push: tags` trigger fires.
+#   2. trigger this workflow manually from the GitHub UI / mobile app
+#      ("Actions → release → Run workflow") with a `version` input. The job
+#      validates it, creates + pushes the tag at the dispatched ref's HEAD, then
+#      publishes — all in one run. This is the no-laptop path.
+#
+# Why the manual path tags AND publishes in the same run instead of just pushing
+# a tag and letting trigger #1 fire: a tag pushed with the default GITHUB_TOKEN
+# does NOT start a new workflow run (GitHub's loop-prevention rule), so a
+# "push the tag and walk away" job would tag the repo but never publish. Doing
+# both here sidesteps that entirely — and the token-pushed tag silently not
+# re-triggering this workflow is exactly what stops a double release.
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release — v + semver, e.g. v0.6.0 or v1.2.3-rc.1"
+        required: true
+        type: string
 
 # goreleaser needs to create the GitHub Release + upload assets in THIS repo,
 # and the `docs` job force-pushes the rebuilt site to the gh-pages branch — both
@@ -23,8 +42,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         # Full history + tags so goreleaser can build the changelog and derive
-        # the version from the tag.
+        # the version from the tag. On `push: tags` the checked-out ref IS the
+        # tag; on `workflow_dispatch` it's the dispatched branch, and the step
+        # below creates the tag at its HEAD.
         with: { fetch-depth: 0 }
+      # Manual-dispatch only: validate the requested version and create + push
+      # the annotated tag at HEAD so goreleaser (which derives the version from
+      # the tag at HEAD) has one to release. Mirrors the `just release` recipe's
+      # validation. The version is read via env, never interpolated into the
+      # script body, so a hostile input can't inject shell. Uses the persisted
+      # GITHUB_TOKEN from actions/checkout (contents:write, granted below).
+      - name: Validate version and create release tag (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          if [[ ! "$VERSION" =~ $semver ]]; then
+            echo "release: '$VERSION' must start with 'v' and be valid semver (e.g. v0.1.0, v1.2.3-rc.1)" >&2
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "release: tag '$VERSION' already exists" >&2
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" -m "agentsync $VERSION"
+          git push origin "$VERSION"
+          echo "release: created and pushed $VERSION — publishing it now."
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **Releases can now be cut from the GitHub UI / mobile app, no laptop
+  required.** The `release` workflow grew a `workflow_dispatch` trigger with a
+  `version` input alongside the existing `push: tags` one: "Actions → release →
+  Run workflow → enter `vX.Y.Z`" validates the version (same `v`+semver check as
+  the `just release` recipe), creates and pushes the annotated tag at the
+  dispatched ref's HEAD, then publishes — all in a single run. Tagging and
+  publishing happen in the same job on purpose: a tag pushed with the default
+  `GITHUB_TOKEN` does not start a new workflow run, so a "push the tag and let
+  the tag trigger fire" design would tag but never publish (and conversely, that
+  same rule is what stops the manual run from kicking off a duplicate release).
+  The laptop path (`just release vX.Y.Z`) is unchanged.
 - **Untrusted plugin/marketplace metadata is now sanitized by type, not by
   convention (`internal/untrusted`).** Issue #93 / PR #100 sanitized ~24 terminal
   print sites by hand-wrapping each fetched id/version/marketplace-name in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `GITHUB_TOKEN` does not start a new workflow run, so a "push the tag and let
   the tag trigger fire" design would tag but never publish (and conversely, that
   same rule is what stops the manual run from kicking off a duplicate release).
-  The laptop path (`just release vX.Y.Z`) is unchanged.
+  The laptop path (`just release vX.Y.Z`) is unchanged. Both paths now share a
+  single validator, `scripts/release-tag.sh` (CI exercises it via `--self-test`),
+  so the `v`+semver rule lives in exactly one place; the workflow also gained a
+  `concurrency` guard so a dispatch and a tag push can't race to publish the same
+  version.
 - **Untrusted plugin/marketplace metadata is now sanitized by type, not by
   convention (`internal/untrusted`).** Issue #93 / PR #100 sanitized ~24 terminal
   print sites by hand-wrapping each fetched id/version/marketplace-name in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,21 @@ cover.
 For anything security-sensitive, **don't** open a public PR/issue first — use the
 private reporting path in [`SECURITY.md`](SECURITY.md).
 
+## Cutting a release
+
+Releases are an annotated `vX.Y.Z` tag on a green commit; pushing the tag fires
+`.github/workflows/release.yml`, which runs GoReleaser (GitHub Release +
+Homebrew tap) and redeploys the docs site. Two equivalent ways to trigger it:
+
+- **From a laptop:** `just release vX.Y.Z` — validates `v`+semver, then tags and
+  pushes.
+- **From the GitHub UI / mobile app (no laptop):** Actions → **release** → **Run
+  workflow**, enter the version. The workflow validates it, creates and pushes
+  the tag at the selected ref's HEAD, and publishes in the same run.
+
+Either way, make sure the commit you're tagging is green and the `CHANGELOG.md`
+`[Unreleased]` section has been promoted to the new version first.
+
 ## Reporting bugs & requesting features
 
 Use the [issue templates](.github/ISSUE_TEMPLATE/). Bug reports are far easier to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,21 @@ Homebrew tap) and redeploys the docs site. Two equivalent ways to trigger it:
   workflow**, enter the version. The workflow validates it, creates and pushes
   the tag at the selected ref's HEAD, and publishes in the same run.
 
+Both paths share one validator, `scripts/release-tag.sh` (CI self-tests it via
+`--self-test`), so the version rule can't drift between them.
+
 Either way, make sure the commit you're tagging is green and the `CHANGELOG.md`
 `[Unreleased]` section has been promoted to the new version first.
+
+**If a publish fails after the tag was pushed.** CI runs GoReleaser only in
+`--snapshot --skip publish` mode, so the real publish stanza (GitHub Release
+upload, the Homebrew-tap push) is first exercised at release time — a broken
+`.goreleaser.yaml` publish step or a missing `HOMEBREW_TAP_GITHUB_TOKEN` can fail
+*after* the tag already exists. The tag-exists guard then blocks a re-run for
+that version. To recover: fix the cause, delete the tag locally and on the
+remote (`git push origin :vX.Y.Z`), and re-cut it — or, if the tag is fine and
+only publishing failed, re-run GoReleaser against the existing tag
+(`goreleaser release --clean`).
 
 ## Reporting bugs & requesting features
 

--- a/justfile
+++ b/justfile
@@ -118,21 +118,7 @@ ci: lint test-release
 # Actions -> "release" -> "Run workflow" -> enter the version. That path validates,
 # tags, and publishes in one run (see .github/workflows/release.yml).
 release version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    version="{{ version }}"
-    semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-    if [[ ! "$version" =~ $semver ]]; then
-        echo "release: '$version' must start with 'v' and be valid semver (e.g. v0.1.0, v1.2.3-rc.1)" >&2
-        exit 1
-    fi
-    if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
-        echo "release: tag '$version' already exists" >&2
-        exit 1
-    fi
-    git tag -a "$version" -m "agentsync $version"
-    git push origin "$version"
-    echo "release: pushed $version — CI's release workflow will build and publish it."
+    scripts/release-tag.sh "{{ version }}"
 
 # Remove generated artefacts (binaries, dist, coverage reports).
 clean:

--- a/justfile
+++ b/justfile
@@ -114,6 +114,9 @@ ci: lint test-release
     goreleaser release --snapshot --skip=publish --clean
 
 # Cut a release: validate `v`+semver, then tag & push (which fires the release workflow). Usage: `just release v0.1.0`
+# No laptop? Trigger the same release from the GitHub UI/mobile app instead:
+# Actions -> "release" -> "Run workflow" -> enter the version. That path validates,
+# tags, and publishes in one run (see .github/workflows/release.yml).
 release version:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -26,7 +26,7 @@ version_valid() {
 # one. Pure — touches no git state. Exits non-zero (failing CI) on any mismatch.
 self_test() {
 	local good=(v0.0.0 v0.1.0 v0.6.0 v1.2.3 v10.20.30 v1.2.3-rc.1 v1.2.3-0.3.7 v1.0.0-alpha v1.0.0-alpha.1 v1.0.0+build.1 v1.2.3-rc.1+build.5)
-	local bad=("" 1.2.3 v1.2 v1 vfoo v1.2.3. v01.2.3 v1.02.3 "v1.2.3 " " v1.2.3" v1.2.3- V1.2.3)
+	local bad=("" 1.2.3 v1.2 v1 vfoo v1.2.3. v01.2.3 v1.02.3 "v1.2.3 " " v1.2.3" v1.2.3- V1.2.3 $'v1.2.3\nrm -rf x')
 	local rc=0 v
 	for v in "${good[@]}"; do
 		if ! version_valid "$v"; then

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Single source of truth for cutting a release tag: validate a `v`+SemVer-2.0.0
+# version, refuse a duplicate, then create the annotated tag and push it (which
+# fires .github/workflows/release.yml). Both release entry points call this so
+# the version rule lives in exactly ONE place — no drift between them:
+#   - `just release vX.Y.Z`                      (the laptop path)
+#   - the `release` workflow's manual-dispatch step (the no-laptop path; it sets
+#     a bot git identity, then calls this)
+#
+# `scripts/release-tag.sh --self-test` exercises the validator against a table of
+# good/bad versions and makes no git changes; CI runs it (ci.yml) so the regex
+# cannot silently rot. The script does NOT configure git identity (the caller's
+# identity is used) and validates the version BEFORE any git command runs, so a
+# malformed/hostile string can never reach `git tag`/`git push`.
+set -euo pipefail
+
+# The ONE copy of the version rule: anchored `v` + SemVer 2.0.0 (semver.org).
+SEMVER='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+
+# version_valid <string>: exit 0 if it matches the v+semver rule, else 1.
+version_valid() {
+	[[ "$1" =~ $SEMVER ]]
+}
+
+# self_test: assert the validator accepts every good case and rejects every bad
+# one. Pure — touches no git state. Exits non-zero (failing CI) on any mismatch.
+self_test() {
+	local good=(v0.0.0 v0.1.0 v0.6.0 v1.2.3 v10.20.30 v1.2.3-rc.1 v1.2.3-0.3.7 v1.0.0-alpha v1.0.0-alpha.1 v1.0.0+build.1 v1.2.3-rc.1+build.5)
+	local bad=("" 1.2.3 v1.2 v1 vfoo v1.2.3. v01.2.3 v1.02.3 "v1.2.3 " " v1.2.3" v1.2.3- V1.2.3)
+	local rc=0 v
+	for v in "${good[@]}"; do
+		if ! version_valid "$v"; then
+			echo "self-test FAIL: '$v' should be VALID" >&2
+			rc=1
+		fi
+	done
+	for v in "${bad[@]}"; do
+		if version_valid "$v"; then
+			echo "self-test FAIL: '$v' should be INVALID" >&2
+			rc=1
+		fi
+	done
+	if [[ $rc -eq 0 ]]; then
+		echo "release-tag self-test: OK (${#good[@]} valid, ${#bad[@]} invalid cases)"
+	fi
+	return $rc
+}
+
+main() {
+	if [[ "${1:-}" == "--self-test" ]]; then
+		self_test
+		return
+	fi
+
+	local version="${1:-}"
+	if [[ -z "$version" ]]; then
+		echo "usage: release-tag.sh <vX.Y.Z> | --self-test" >&2
+		exit 2
+	fi
+	if ! version_valid "$version"; then
+		echo "release: '$version' must start with 'v' and be valid semver (e.g. v0.1.0, v1.2.3-rc.1)" >&2
+		exit 1
+	fi
+	if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+		echo "release: tag '$version' already exists" >&2
+		exit 1
+	fi
+
+	git tag -a "$version" -m "agentsync $version"
+	git push origin "$version"
+	echo "release: pushed $version — the release workflow will build and publish it."
+}
+
+main "$@"


### PR DESCRIPTION
## Why

Cutting a release required `push: tags` — i.e. a local checkout with push rights. That's unusable from the GitHub UI or a phone (and the sandboxed remote-session git proxy rejects tag pushes outright with a 403), so there was no no-laptop path to ship.

## What

Add a `workflow_dispatch` trigger with a `version` input alongside the existing `push: tags` one. **Both paths still work** — the laptop path is untouched:

- **Laptop:** `just release vX.Y.Z` → pushes an annotated tag → `push: tags` fires → publishes (unchanged).
- **Mobile / UI:** Actions → **release** → **Run workflow** → enter `vX.Y.Z` → validates the version (same `v`+semver check as `just release`), creates + pushes the annotated tag at the dispatched ref's HEAD, then publishes — all in one run.

The tag-creation step is gated on `if: github.event_name == 'workflow_dispatch'`, so the `just release` path skips it (the tag already exists) and GoReleaser runs exactly as before.

## The one design decision worth knowing

The manual path **tags *and* publishes in the same job** rather than pushing a tag and letting the `push: tags` trigger catch it. A tag pushed with the default `GITHUB_TOKEN` does **not** start a new workflow run (GitHub's loop-prevention rule), so a "push the tag and walk away" design would tag the repo but never publish. Doing both in one run sidesteps that — and that same rule conveniently stops the manual run from spawning a duplicate release. The `version` input is passed via env, never interpolated into the script body, so a hostile input can't inject shell.

## Docs

- `CHANGELOG.md` — `[Unreleased]` entry.
- `CONTRIBUTING.md` — new "Cutting a release" section documenting both paths.
- `justfile` — pointer comment on the `release` recipe.

## Test plan / caveats

- `release.yml` YAML parses clean; dispatch logic mirrors the proven `just release` recipe.
- `workflow_dispatch` can't be exercised until this workflow definition is on `main` (Actions runs the dispatch definition from the default branch), so its first real run will be the first manual release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bhpLPV6KgvGkrrM5u3QaL)_