### PR TITLE
feat(website): add build commit hash to docs footer

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -74,6 +74,14 @@ CLI. The custom domain is set via [`public/CNAME`](public/CNAME).
 To redeploy out of band (e.g. a docs-only fix between releases), run
 `just docs-publish` locally — it does the same rebuild + force-push to `gh-pages`.
 
+The page footer's "Last updated" line carries a **build/deploy commit hash** — a
+short SHA linked to the exact commit on GitHub, so the live site always shows
+"what's currently live." It's a Starlight component override
+([`src/components/LastUpdated.astro`](src/components/LastUpdated.astro)); the SHA
+is resolved at build time in [`astro.config.mjs`](astro.config.mjs) (CI's
+`GITHUB_SHA`, falling back to local `git rev-parse HEAD`) and injected as
+`PUBLIC_COMMIT_SHA`. If neither is available the hash is simply omitted.
+
 One-time setup in the GitHub repo: **Settings → Pages → Source: Deploy from a
 branch → `gh-pages` / `(root)`**, with `agentsync.cc` as the custom domain (the
 `CNAME` file re-enforces it on each deploy).

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 The source for **[agentsync.cc](https://agentsync.cc)** — an
 [Astro Starlight](https://starlight.astro.build) site, deployed to GitHub Pages by
-[`.github/workflows/docs.yml`](../.github/workflows/docs.yml).
+the `docs` job in [`.github/workflows/release.yml`](../.github/workflows/release.yml).
 
 ## Develop
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,11 +1,37 @@
 // @ts-check
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import mermaid from 'astro-mermaid';
 
+// The commit the live site was built from — surfaced in the footer as a
+// "what's currently live" breadcrumb (see src/components/LastUpdated.astro).
+// Prefer the CI-provided SHA (GitHub Actions sets GITHUB_SHA; other hosts set
+// their own), then fall back to the local git HEAD for `just docs-publish` and
+// local builds. Empty string if neither is available (the footer hides it).
+function resolveCommitSha() {
+	const fromEnv =
+		process.env.GITHUB_SHA ||
+		process.env.COMMIT_SHA ||
+		process.env.VERCEL_GIT_COMMIT_SHA ||
+		process.env.CF_PAGES_COMMIT_SHA;
+	if (fromEnv) return fromEnv.trim();
+	try {
+		return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+	} catch {
+		return '';
+	}
+}
+const commitSha = resolveCommitSha();
+
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://agentsync.cc',
+	vite: {
+		define: {
+			'import.meta.env.PUBLIC_COMMIT_SHA': JSON.stringify(commitSha),
+		},
+	},
 	integrations: [
 		// Must run before Starlight so it can claim ```mermaid fences before
 		// Expressive Code highlights them. Renders client-side (no headless
@@ -22,6 +48,10 @@ export default defineConfig({
 			favicon: '/favicon.svg',
 			tagline: 'One source of truth for every AI coding agent on your machine.',
 			lastUpdated: true,
+			components: {
+				// Append the build/deploy commit hash to the "Last updated" footer.
+				LastUpdated: './src/components/LastUpdated.astro',
+			},
 			social: [
 				{
 					icon: 'github',

--- a/website/src/components/LastUpdated.astro
+++ b/website/src/components/LastUpdated.astro
@@ -1,0 +1,63 @@
+---
+// Override of Starlight's built-in LastUpdated footer component.
+//
+// Starlight's default renders just the per-page "Last updated: <date>". We
+// extend it with the build/deploy commit hash — a single sitewide breadcrumb
+// for "what's currently live" — linked to the exact commit on GitHub.
+//
+// The SHA is resolved at build time in astro.config.mjs (CI's GITHUB_SHA, then
+// a `git rev-parse HEAD` fallback) and injected as PUBLIC_COMMIT_SHA. We keep
+// the default's markup (a single <p>) so the Footer's flex layout is unchanged.
+const { lang, lastUpdated } = Astro.locals.starlightRoute;
+
+const commitSha = (import.meta.env.PUBLIC_COMMIT_SHA ?? '').trim();
+const shortSha = commitSha.slice(0, 7);
+const commitUrl = commitSha
+	? `https://github.com/spxrogers/agentsync/commit/${commitSha}`
+	: undefined;
+---
+
+{
+	(lastUpdated || commitUrl) && (
+		<p>
+			{lastUpdated && (
+				<>
+					{Astro.locals.t('page.lastUpdated')}{' '}
+					<time datetime={lastUpdated.toISOString()}>
+						{lastUpdated.toLocaleDateString(lang, { dateStyle: 'medium', timeZone: 'UTC' })}
+					</time>
+				</>
+			)}
+			{commitUrl && (
+				<>
+					{lastUpdated && <span class="sep" aria-hidden="true"> · </span>}
+					<a
+						class="commit-link"
+						href={commitUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						title={`Live build — deployed from commit ${commitSha}`}
+					>
+						<code>{shortSha}</code>
+					</a>
+				</>
+			)}
+		</p>
+	)
+}
+
+<style>
+	.sep {
+		color: var(--sl-color-gray-4);
+	}
+	.commit-link {
+		color: var(--sl-color-gray-3);
+		text-decoration: none;
+	}
+	.commit-link:hover {
+		color: var(--sl-color-text-accent);
+	}
+	.commit-link code {
+		font-size: 0.9em;
+	}
+</style>


### PR DESCRIPTION
## What

Extends Starlight's "Last updated" footer with the **build/deploy commit hash** — a single sitewide breadcrumb for "what's currently live" — linked to the exact commit on GitHub.

The footer now reads:

> Last updated: Jun 19, 2026 **· `149c6b9`**

…where the short hash links to `https://github.com/spxrogers/agentsync/commit/<full-sha>`.

## How

- **`website/src/components/LastUpdated.astro`** — a Starlight component override. Keeps the default's single-`<p>` markup (so the existing footer flex layout is untouched) and appends ` · <short-sha>` linking to the GitHub commit. Opens in a new tab; full SHA in the `title` tooltip.
- **`website/astro.config.mjs`** — resolves the SHA at build time and injects it as `PUBLIC_COMMIT_SHA`. Source priority: `GITHUB_SHA` (set by `release.yml` / `just docs-publish` in CI) → other host vars → local `git rev-parse HEAD`. If none resolve, the hash is omitted and the date still shows.
- **`website/README.md`** — documented under Deploy.

## Notes

- The hash is the **build/deploy commit** (one SHA sitewide), not a per-page edit commit — so it always points at the commit the live site was built from. Because "Last updated" is per-page while the SHA is global, the date and hash can refer to different commits; that's the intended trade-off.

## Verification

`bun run build` succeeds (31 pages). Rendered HTML confirms the link:

```html
Last updated: <time …>Jun 19, 2026</time> · 
<a class="commit-link" href="…/commit/149c6b9a63af…" target="_blank" rel="noopener noreferrer"
   title="Live build — deployed from commit 149c6b9a63af…"><code>149c6b9</code></a>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xue9Tr7E16QvJRPSqqB7xh)_