### PR TITLE
feat(release): wire Windows Scoop + Chocolatey distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
+          # Validate the ENTIRE .goreleaser.yaml first — including the
+          # publish-phase scoop/chocolatey blocks the snapshot below skips and
+          # the templated release.disable — so a schema/template typo fails CI
+          # in ~1s instead of mid-release at tag-cut (and can't silently break
+          # the existing homebrew/deb/rpm path). Needs no secrets or Windows.
+          args: check
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
           # --skip publish already skips the (publish-phase) scoop/chocolatey
           # pipes; chocolatey is also named explicitly because its pack step
           # shells out to the Windows-only `choco` CLI, which isn't on this Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,8 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --snapshot --skip publish --clean
+          # --skip publish already skips the (publish-phase) scoop/chocolatey
+          # pipes; chocolatey is also named explicitly because its pack step
+          # shells out to the Windows-only `choco` CLI, which isn't on this Linux
+          # runner. This job only proves the cross-build stays viable.
+          args: release --snapshot --skip=publish,chocolatey --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,27 @@ jobs:
   goreleaser:
     name: goreleaser (publish)
     runs-on: ubuntu-latest
+    # Surface whether the Chocolatey credential exists as a job output so the
+    # windows-latest `chocolatey` job can gate on it. A job-level `if:` cannot
+    # read the `secrets` context (only github/needs/vars/inputs are available
+    # there), so we detect the secret HERE — where a step can read it via env —
+    # and publish a plain boolean. This keeps Chocolatey's "just add the key to
+    # go live" UX symmetric with Scoop (which self-gates on its token).
+    outputs:
+      choco_enabled: ${{ steps.choco_flag.outputs.enabled }}
     steps:
+      - name: Detect Chocolatey credential
+        id: choco_flag
+        shell: bash
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          # Emit ONLY a boolean — never the key value (job outputs aren't masked).
+          if [ -n "$CHOCOLATEY_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v4
         # Full history + tags so goreleaser can build the changelog and derive
         # the version from the tag. On `push: tags` the checked-out ref IS the
@@ -103,16 +123,15 @@ jobs:
   # so it can't run on the Linux `goreleaser` job above — hence this dedicated
   # runner. GitHub's windows-latest image ships choco pre-installed.
   #
-  # Gated on the ENABLE_CHOCOLATEY repo variable so it doesn't burn Windows
-  # minutes (billed at a higher rate) until you opt in: Settings → Secrets and
-  # variables → Actions → Variables → ENABLE_CHOCOLATEY=true. `needs: goreleaser`
-  # runs it only after the Linux job published the Release. It reuses the SAME
-  # .goreleaser.yaml but sets AGENTSYNC_DISABLE_GH_RELEASE=true so it builds and
-  # pushes ONLY the .nupkg and never re-creates that Release; it skips the
-  # homebrew/scoop/nfpm pipes the Linux job already handled. Flip the variable
-  # and add CHOCOLATEY_API_KEY together: with the variable on but no key, the
-  # `choco push` would fail (goreleaser's skip_publish is a hard bool, so the
-  # config can't self-gate the push the way Scoop's templated skip_upload does).
+  # Gated purely on the presence of CHOCOLATEY_API_KEY (surfaced as the
+  # `choco_enabled` output of the goreleaser job above), so it doesn't burn
+  # Windows minutes — billed at a higher rate — until you add the key. Adding
+  # the secret is the entire "pull the trigger" step for Chocolatey; no separate
+  # enable flag to remember. `needs: goreleaser` also means it runs only after
+  # the Linux job published the Release. It reuses the SAME .goreleaser.yaml but
+  # sets AGENTSYNC_DISABLE_GH_RELEASE=true so it builds and pushes ONLY the
+  # .nupkg and never re-creates that Release; it skips the homebrew/scoop/nfpm
+  # pipes the Linux job already handled.
   #
   # NOTE (OSS goreleaser): built artifacts can't be shared across runners — that
   # cross-runner split/merge is a Pro feature — so this re-runs the build. It's
@@ -120,7 +139,7 @@ jobs:
   chocolatey:
     name: chocolatey (windows)
     needs: goreleaser
-    if: ${{ vars.ENABLE_CHOCOLATEY == 'true' }}
+    if: ${{ needs.goreleaser.outputs.choco_enabled == 'true' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,8 +158,8 @@ jobs:
           args: release --clean --skip=homebrew,scoop,nfpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # `choco push` credential — add it together with the ENABLE_CHOCOLATEY
-          # variable that gates this job (see the job-level comment above).
+          # `choco push` credential. Its mere presence is what gates this whole
+          # job (via the goreleaser job's `choco_enabled` output).
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           # Build + push only the .nupkg; do NOT re-create the GitHub Release the
           # Linux job already published (see `release.disable` in .goreleaser.yaml).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,11 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean
+          # Everything EXCEPT chocolatey: that pipe shells out to the Windows-only
+          # `choco` CLI, so it runs on the separate windows-latest `chocolatey`
+          # job below. This job creates the Release + uploads archives/checksums/
+          # deb/rpm and pushes the Homebrew cask + (once enabled) the Scoop bucket.
+          args: release --clean --skip=chocolatey
         env:
           # Creates the Release + uploads archives/checksums/deb/rpm here.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,6 +91,60 @@ jobs:
           # with contents:write on the tap. If this secret is unset the brew step
           # fails; everything else (GitHub Release, deb/rpm) still publishes.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Pushes bucket/agentsync.json to spxrogers/scoop-bucket (another repo
+          # the default GITHUB_TOKEN can't write). The `scoops` block self-gates
+          # on this: while the secret is unset it resolves to empty and Scoop is
+          # a no-op (skip_upload=true), so this is safe to ship before the bucket
+          # repo + token exist. Add the secret to "pull the trigger" on Scoop.
+          SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
+
+  # Windows-only channel: build + push the Chocolatey package (issue #75).
+  # goreleaser's chocolatey pipe shells out to the `choco` CLI (Windows-only),
+  # so it can't run on the Linux `goreleaser` job above — hence this dedicated
+  # runner. GitHub's windows-latest image ships choco pre-installed.
+  #
+  # Gated on the ENABLE_CHOCOLATEY repo variable so it doesn't burn Windows
+  # minutes (billed at a higher rate) until you opt in: Settings → Secrets and
+  # variables → Actions → Variables → ENABLE_CHOCOLATEY=true. `needs: goreleaser`
+  # runs it only after the Linux job published the Release. It reuses the SAME
+  # .goreleaser.yaml but sets AGENTSYNC_DISABLE_GH_RELEASE=true so it builds and
+  # pushes ONLY the .nupkg and never re-creates that Release; it skips the
+  # homebrew/scoop/nfpm pipes the Linux job already handled. Flip the variable
+  # and add CHOCOLATEY_API_KEY together: with the variable on but no key, the
+  # `choco push` would fail (goreleaser's skip_publish is a hard bool, so the
+  # config can't self-gate the push the way Scoop's templated skip_upload does).
+  #
+  # NOTE (OSS goreleaser): built artifacts can't be shared across runners — that
+  # cross-runner split/merge is a Pro feature — so this re-runs the build. It's
+  # cheap: one small Go cross-build.
+  chocolatey:
+    name: chocolatey (windows)
+    needs: goreleaser
+    if: ${{ vars.ENABLE_CHOCOLATEY == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        # Full history + tags so goreleaser derives the version from the tag the
+        # `goreleaser` job released: on `push: tags` the ref IS the tag; on
+        # `workflow_dispatch` that job created the tag at the dispatched HEAD,
+        # which this checkout (run after it, via `needs`) fetches.
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          # Only the chocolatey pipe: skip the publishers the Linux job owns.
+          args: release --clean --skip=homebrew,scoop,nfpm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `choco push` credential — add it together with the ENABLE_CHOCOLATEY
+          # variable that gates this job (see the job-level comment above).
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          # Build + push only the .nupkg; do NOT re-create the GitHub Release the
+          # Linux job already published (see `release.disable` in .goreleaser.yaml).
+          AGENTSYNC_DISABLE_GH_RELEASE: "true"
 
   # Redeploy agentsync.cc after a successful publish so the live docs always
   # track the just-released CLI. This is exactly `just docs-publish` (rebuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
         run: |
           # Emit ONLY a boolean — never the key value (job outputs aren't masked).
-          if [ -n "$CHOCOLATEY_API_KEY" ]; then
+          # Strip whitespace first so a blank or whitespace/newline-only secret
+          # counts as absent, rather than spinning up the higher-billed Windows
+          # runner for a `choco push` that would just fail on a bogus key.
+          if [ -n "${CHOCOLATEY_API_KEY//[[:space:]]/}" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -143,11 +146,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        # Full history + tags so goreleaser derives the version from the tag the
-        # `goreleaser` job released: on `push: tags` the ref IS the tag; on
-        # `workflow_dispatch` that job created the tag at the dispatched HEAD,
-        # which this checkout (run after it, via `needs`) fetches.
-        with: { fetch-depth: 0 }
+        # Check out the EXACT tag the `goreleaser` job released, not the branch
+        # HEAD: on `push: tags` that's github.ref; on `workflow_dispatch` it's
+        # the tag that job just created (named after the version input). Pinning
+        # to the tag rather than the branch means a commit landing on the branch
+        # mid-release can't make goreleaser's --exact-match tag check miss.
+        # fetch-depth: 0 brings full history + tags for changelog/version.
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -162,7 +162,7 @@ chocolateys:
     project_url: https://github.com/spxrogers/agentsync
     project_source_url: https://github.com/spxrogers/agentsync
     package_source_url: https://github.com/spxrogers/agentsync
-    docs_url: https://github.com/spxrogers/agentsync/blob/main/README.md
+    docs_url: https://agentsync.cc/
     bug_tracker_url: https://github.com/spxrogers/agentsync/issues
     license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
     require_license_acceptance: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,9 +144,10 @@ scoops:
 # new packages through a moderation queue, so the first push won't be publicly
 # installable until it clears review.
 #
-# NOTE: the chocolatey pipe packages a single Windows amd64 binary; the
-# windows/arm64 build is not included. Verify on a clean Windows box at the
-# first release (issue #75).
+# NOTE: the chocolatey pipe packages the Windows amd64 binary only —
+# goreleaser's own arch filter selects amd64/386 and excludes arm64 — so the
+# windows/arm64 build is intentionally absent from the package. Verify on a
+# clean Windows box at the first release (issue #75).
 # --------------------------------------------------------------------------
 chocolateys:
   - name: agentsync
@@ -176,6 +177,13 @@ chocolateys:
 # --------------------------------------------------------------------------
 # AUR (Arch) — deliberately NOT enabled yet. Uncomment once its companion repo /
 # credential exists and you're ready to ship it. Tracked in issue #13.
+#
+# ⚠️ When enabling this — or ANY new publisher that pushes to an external target
+# — add its pipe to the `--skip=` list in the `chocolatey` job of
+# .github/workflows/release.yml. That job reuses this same config with
+# release.disable=true, which suppresses only the GitHub Release, NOT external
+# publishers; an un-skipped publisher would double-publish from the Windows
+# runner (once from the Linux job, again from the Windows job).
 # --------------------------------------------------------------------------
 
 # aurs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,14 @@ version: 2
 
 project_name: agentsync
 
+# GitHub Release creation. Templated `disable` so the Windows chocolatey-only
+# job (.github/workflows/release.yml) can reuse this SAME config to build +
+# push the .nupkg WITHOUT trying to re-create the Release the Linux job already
+# made: that job sets AGENTSYNC_DISABLE_GH_RELEASE=true. Everywhere else the var
+# is unset, so envOrDefault yields "false" and the Release is created as normal.
+release:
+  disable: '{{ envOrDefault "AGENTSYNC_DISABLE_GH_RELEASE" "false" }}'
+
 builds:
   - id: agentsync
     main: ./cmd/agentsync
@@ -92,27 +100,84 @@ homebrew_casks:
           end
 
 # --------------------------------------------------------------------------
-# Remaining publishing channels — deliberately NOT enabled yet. Uncomment each
-# once its companion repo / credential exists and you're ready to ship it.
-# Tracked in https://github.com/spxrogers/agentsync/issues/13.
+# Windows — Scoop (issue #74). Writes bucket/agentsync.json into
+# spxrogers/scoop-bucket on every tagged release, pointing at the Windows .zip
+# already built above, so `scoop install agentsync` works. Runs from the Linux
+# release job — pure Go + git, no Windows tooling. The default Actions
+# GITHUB_TOKEN can't write a *second* repo, so the workflow supplies
+# SCOOP_BUCKET_GITHUB_TOKEN (contents:write on the bucket) — same constraint as
+# the Homebrew tap.
+#
+# Self-gating: skip_upload stays true until SCOOP_BUCKET_GITHUB_TOKEN exists, so
+# this is a harmless no-op (manifest built, never pushed) until you create the
+# bucket repo + add the secret. No code change needed to "pull the trigger".
 # --------------------------------------------------------------------------
+scoops:
+  - name: agentsync
+    repository:
+      owner: spxrogers
+      name: scoop-bucket
+      branch: main
+      token: '{{ envOrDefault "SCOOP_BUCKET_GITHUB_TOKEN" "" }}'
+    directory: bucket
+    url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser@users.noreply.github.com
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: https://github.com/spxrogers/agentsync
+    description: Centrally manage AI coding-agent configurations.
+    license: MIT
+    skip_upload: '{{ if isEnvSet "SCOOP_BUCKET_GITHUB_TOKEN" }}false{{ else }}true{{ end }}'
 
-# scoops:
-#   - name: agentsync
-#     repository:
-#       owner: spxrogers
-#       name: scoop-bucket
-#     homepage: https://github.com/spxrogers/agentsync
-#     description: Centrally manage AI coding-agent configurations
-#     license: MIT
+# --------------------------------------------------------------------------
+# Windows — Chocolatey (issue #75). Builds the .nupkg and `choco push`es it so
+# `choco install agentsync` works. goreleaser shells out to the `choco` CLI,
+# which is Windows-only, so unlike every other channel this CANNOT run on the
+# Linux release job — the workflow runs it from a dedicated windows-latest job
+# (.github/workflows/release.yml), gated on the ENABLE_CHOCOLATEY repo variable.
+# choco is pre-installed on GitHub's windows-latest runners.
+#
+# Gating lives in the workflow, not here: goreleaser's `skip_publish` is a hard
+# bool (not templateable like scoop's skip_upload), so the Windows job is gated
+# on the ENABLE_CHOCOLATEY repo variable instead — flip it + add
+# CHOCOLATEY_API_KEY together to go live. Chocolatey's community repo also runs
+# new packages through a moderation queue, so the first push won't be publicly
+# installable until it clears review.
+#
+# NOTE: the chocolatey pipe packages a single Windows amd64 binary; the
+# windows/arm64 build is not included. Verify on a clean Windows box at the
+# first release (issue #75).
+# --------------------------------------------------------------------------
+chocolateys:
+  - name: agentsync
+    ids: [default]
+    title: agentsync
+    authors: spxrogers
+    owners: spxrogers
+    summary: Centrally manage AI coding-agent configurations.
+    description: |
+      agentsync centrally manages AI coding-agent configurations from one
+      canonical source and renders them into each agent's native config.
+    project_url: https://github.com/spxrogers/agentsync
+    project_source_url: https://github.com/spxrogers/agentsync
+    package_source_url: https://github.com/spxrogers/agentsync
+    docs_url: https://github.com/spxrogers/agentsync/blob/main/README.md
+    bug_tracker_url: https://github.com/spxrogers/agentsync/issues
+    license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
+    require_license_acceptance: false
+    copyright: 2026 spxrogers
+    tags: "agentsync cli ai coding agents configuration claude codex cursor dotfiles"
+    release_notes: "https://github.com/spxrogers/agentsync/releases/tag/{{ .Tag }}"
+    url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    api_key: '{{ envOrDefault "CHOCOLATEY_API_KEY" "" }}'
+    source_repo: "https://push.chocolatey.org/"
+    goamd64: v1
 
-# chocolateys:
-#   - name: agentsync
-#     api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
-#     title: agentsync
-#     project_url: https://github.com/spxrogers/agentsync
-#     license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
-#     summary: Centrally manage AI coding-agent configurations
+# --------------------------------------------------------------------------
+# AUR (Arch) — deliberately NOT enabled yet. Uncomment once its companion repo /
+# credential exists and you're ready to ship it. Tracked in issue #13.
+# --------------------------------------------------------------------------
 
 # aurs:
 #   - name: agentsync-bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,13 +135,12 @@ scoops:
 # `choco install agentsync` works. goreleaser shells out to the `choco` CLI,
 # which is Windows-only, so unlike every other channel this CANNOT run on the
 # Linux release job — the workflow runs it from a dedicated windows-latest job
-# (.github/workflows/release.yml), gated on the ENABLE_CHOCOLATEY repo variable.
-# choco is pre-installed on GitHub's windows-latest runners.
+# (.github/workflows/release.yml). choco is pre-installed on those runners.
 #
 # Gating lives in the workflow, not here: goreleaser's `skip_publish` is a hard
-# bool (not templateable like scoop's skip_upload), so the Windows job is gated
-# on the ENABLE_CHOCOLATEY repo variable instead — flip it + add
-# CHOCOLATEY_API_KEY together to go live. Chocolatey's community repo also runs
+# bool (not templateable like scoop's skip_upload), so instead the Windows job
+# is gated on the *presence* of CHOCOLATEY_API_KEY — adding that secret is the
+# whole "go live" step. Chocolatey's community repo also runs
 # new packages through a moderation queue, so the first push won't be publicly
 # installable until it clears review.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **Windows distribution via Scoop and Chocolatey is wired and ready to ship
+  (issues #74, #75).** `.goreleaser.yaml` now carries fully-configured `scoops`
+  and `chocolateys` blocks. Scoop runs from the existing Linux release job (pure
+  Go + git — it pushes `bucket/agentsync.json` to `spxrogers/scoop-bucket`).
+  Chocolatey shells out to the Windows-only `choco` CLI, so the `release`
+  workflow gained a dedicated `windows-latest` job that builds and `choco
+  push`es only the `.nupkg`, reusing the same config with
+  `AGENTSYNC_DISABLE_GH_RELEASE=true` so it never re-creates the Release the
+  Linux job published. The whole thing ships as a safe no-op until you opt in:
+  Scoop's `skip_upload` templates off `SCOOP_BUCKET_GITHUB_TOKEN` (no token →
+  manifest built but never pushed), and the Windows job is gated on the
+  `ENABLE_CHOCOLATEY` repo variable (flip it + add `CHOCOLATEY_API_KEY` to go
+  live). The CI snapshot job explicitly skips chocolatey (the Linux runner has
+  no `choco`).
 - **Releases can now be cut from the GitHub UI / mobile app, no laptop
   required.** The `release` workflow grew a `workflow_dispatch` trigger with a
   `version` input alongside the existing `push: tags` one: "Actions → release →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   workflow gained a dedicated `windows-latest` job that builds and `choco
   push`es only the `.nupkg`, reusing the same config with
   `AGENTSYNC_DISABLE_GH_RELEASE=true` so it never re-creates the Release the
-  Linux job published. The whole thing ships as a safe no-op until you opt in:
-  Scoop's `skip_upload` templates off `SCOOP_BUCKET_GITHUB_TOKEN` (no token →
-  manifest built but never pushed), and the Windows job is gated on the
-  `ENABLE_CHOCOLATEY` repo variable (flip it + add `CHOCOLATEY_API_KEY` to go
-  live). The CI snapshot job explicitly skips chocolatey (the Linux runner has
-  no `choco`).
+  Linux job published. The whole thing ships as a safe no-op until you add each
+  channel's credential: Scoop's `skip_upload` templates off
+  `SCOOP_BUCKET_GITHUB_TOKEN` (no token → manifest built but never pushed), and
+  the Windows job is gated on the *presence* of `CHOCOLATEY_API_KEY` (surfaced
+  as a job output, since a job-level `if:` can't read `secrets`) — so the
+  windows-latest runner only spins up once the key exists. The CI snapshot job
+  explicitly skips chocolatey (the Linux runner has no `choco`).
 - **Releases can now be cut from the GitHub UI / mobile app, no laptop
   required.** The `release` workflow grew a `workflow_dispatch` trigger with a
   `version` input alongside the existing `push: tags` one: "Actions → release →

--- a/README.md
+++ b/README.md
@@ -112,13 +112,27 @@ RPM:
 
     sudo rpm -i https://github.com/spxrogers/agentsync/releases/latest/download/agentsync_linux_amd64.rpm
 
+### Windows — Scoop or Chocolatey
+
+Scoop:
+
+    scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
+    scoop install agentsync
+
+Chocolatey:
+
+    choco install agentsync
+
+Chocolatey packages pass through the community moderation queue before they're
+publicly installable, so a freshly published version can lag the other channels
+by a day or two.
+
 ### Any platform — prebuilt binary
 
 Download the archive for your OS/arch from the
 [latest release](https://github.com/spxrogers/agentsync/releases/latest)
 (`linux` / `darwin` / `windows` × `amd64` / `arm64`), extract it, and put the
-`agentsync` binary on your `PATH`. This is the install path for Windows until
-Scoop/Chocolatey land.
+`agentsync` binary on your `PATH`.
 
 ### From source
 
@@ -128,10 +142,9 @@ or clone and `go build ./cmd/agentsync`.
 
 ### Coming soon
 
-Scoop (Windows), Chocolatey (Windows), and AUR (Arch) packaging is wired in
-`.goreleaser.yaml` but not published yet — tracked in
-[issue #13](https://github.com/spxrogers/agentsync/issues/13). Until then, use the
-prebuilt binary or `go install` above.
+AUR (Arch) packaging is wired in `.goreleaser.yaml` but not published yet —
+tracked in [issue #13](https://github.com/spxrogers/agentsync/issues/13). Until
+then, use the prebuilt binary or `go install` above.
 
 ## Cross-machine sync
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,8 +91,8 @@ scoop install agentsync
 choco install agentsync
 ```
 
-**Linux** — `.deb`/`.rpm` on the [Releases page](https://github.com/spxrogers/agentsync/releases),
-or `yay -S agentsync-bin` (AUR).
+**Linux** — `.deb`/`.rpm` on the [Releases page](https://github.com/spxrogers/agentsync/releases).
+(AUR packaging is wired but not published yet — [issue #13](https://github.com/spxrogers/agentsync/issues/13).)
 
 Verify:
 

--- a/website/src/content/docs/getting-started/install.mdx
+++ b/website/src/content/docs/getting-started/install.mdx
@@ -68,7 +68,9 @@ You'll need Go ≥ 1.26.2 (the version pinned in `go.mod`).
 		sudo rpm -i https://github.com/spxrogers/agentsync/releases/latest/download/agentsync_linux_amd64.rpm
 		```
 
-		Arch (AUR):
+		Arch (AUR) — wired but not published yet
+		([issue #13](https://github.com/spxrogers/agentsync/issues/13)); use the
+		`.deb`/`.rpm` or prebuilt binary for now:
 
 		```bash
 		yay -S agentsync-bin


### PR DESCRIPTION
Stages the two deferred Windows distribution channels (#74 Scoop, #75 Chocolatey) so they can be switched on with **no further code changes** once the companion repo and API key exist — "Option B": keep the fast Linux job as the default path, and use a Windows runner only for the one pipe that genuinely needs it.

## Why a Windows runner only for Chocolatey
- **Scoop** is pure Go + git (it writes a JSON manifest and pushes it to a bucket repo). It runs fine on the existing `ubuntu-latest` job.
- **Chocolatey** shells out to the Windows-only `choco` CLI, so it gets a dedicated `windows-latest` job. `choco` is pre-installed on those runners.

## What's wired

**`.goreleaser.yaml`**
- Fully-configured `scoops` and `chocolateys` blocks (replacing the commented stubs).
- Scoop **self-gates** on `SCOOP_BUCKET_GITHUB_TOKEN` via a templated `skip_upload` — until the token exists it's a no-op (manifest built, never pushed).
- New templated `release.disable` (`AGENTSYNC_DISABLE_GH_RELEASE`) so the Windows job can reuse this config to push only the `.nupkg` without re-creating the GitHub Release the Linux job already made.

**`.github/workflows/release.yml`**
- Linux `goreleaser` job runs `--skip=chocolatey`, gains `SCOOP_BUCKET_GITHUB_TOKEN`, and publishes a boolean `choco_enabled` output (detected from the secret in a step, because a job-level `if:` can't read the `secrets` context).
- New `chocolatey` job on `windows-latest`, gated purely on `needs.goreleaser.outputs.choco_enabled` — i.e. on the **presence of `CHOCOLATEY_API_KEY`**, so the runner only spins up once the key exists. Mirrors how Scoop self-gates on its token; no separate enable flag. Its checkout is pinned to the exact released tag.

**`.github/workflows/ci.yml`**
- Snapshot job explicitly skips chocolatey so the Linux CI runner never invokes `choco`, and now runs `goreleaser check` to validate the full config (incl. the publish-phase blocks) on every PR.

**Docs** — README / user-guide / website install page flip Scoop + Chocolatey from "coming soon" to documented install paths (AUR stays deferred); `CHANGELOG` records it.

Validated with `goreleaser check`; hardened over two adversarial review rounds (config-validation gap, tag-pin race, whitespace-key gate, fragile-skip-list doc).

## Prerequisites — now all in place ✅
- `spxrogers/scoop-bucket` repo created.
- `SCOOP_BUCKET_GITHUB_TOKEN` secret set on this repo.
- `CHOCOLATEY_API_KEY` secret set on this repo.

So merging this PR and cutting a release publishes both channels: Scoop immediately; Chocolatey after it clears the community moderation queue.

## Verify at first release
GoReleaser's chocolatey pipe packages a single Windows **amd64** binary (arm64 excluded by goreleaser's own arch filter) — confirm `choco install agentsync && agentsync --version` on a clean Windows box per #75.

Closes #74. Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)