### PR TITLE
fix(release): use plain .Env token for scoop/choco (envOrDefault unavailable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
       # side effects.
       - name: Pin release-version validation (scripts/release-tag.sh --self-test)
         run: ./scripts/release-tag.sh --self-test
+      # GoReleaser renders publisher credential fields (`token`, `private_key`)
+      # with the env-only template context (ApplySingleEnvOnly): only bare
+      # `{{ .Env.X }}` works there — function calls like envOrDefault/isEnvSet are
+      # NOT available and fail ONLY at real publish time (`goreleaser check` and
+      # snapshot can't catch it; it broke the v0.7.0 release). Fail fast here.
+      - name: Guard against envOrDefault/isEnvSet in goreleaser token/private_key fields
+        run: |
+          if grep -nE '^[[:space:]]*(token|private_key):.*\{\{.*(envOrDefault|isEnvSet)' .goreleaser.yaml; then
+            echo "::error file=.goreleaser.yaml::publisher token/private_key must use a bare {{ .Env.X }} template — envOrDefault/isEnvSet are unavailable in that context and fail at publish"
+            exit 1
+          fi
 
   goreleaser-snapshot:
     name: goreleaser-snapshot (cross-build matrix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,10 +115,10 @@ jobs:
           # fails; everything else (GitHub Release, deb/rpm) still publishes.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           # Pushes bucket/agentsync.json to spxrogers/scoop-bucket (another repo
-          # the default GITHUB_TOKEN can't write). The `scoops` block self-gates
-          # on this: while the secret is unset it resolves to empty and Scoop is
-          # a no-op (skip_upload=true), so this is safe to ship before the bucket
-          # repo + token exist. Add the secret to "pull the trigger" on Scoop.
+          # the default GITHUB_TOKEN can't write). The `scoops` block's token is
+          # `{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}` — if this secret is unset it
+          # resolves empty and the scoop step FAILS the release (same as the brew
+          # token above); it is not a silent no-op.
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
 
   # Windows-only channel: build + push the Chocolatey package (issue #75).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,9 +108,13 @@ homebrew_casks:
 # SCOOP_BUCKET_GITHUB_TOKEN (contents:write on the bucket) — same constraint as
 # the Homebrew tap.
 #
-# Self-gating: skip_upload stays true until SCOOP_BUCKET_GITHUB_TOKEN exists, so
-# this is a harmless no-op (manifest built, never pushed) until you create the
-# bucket repo + add the secret. No code change needed to "pull the trigger".
+# The push token comes from SCOOP_BUCKET_GITHUB_TOKEN (a repo secret), templated
+# as plain `{{ .Env.… }}` exactly like the Homebrew cask's token. NOTE: credential
+# fields (repository.token, private_key) render via goreleaser's env-only context
+# (ApplySingleEnvOnly) — only bare `{{ .Env.X }}` works; envOrDefault/isEnvSet are
+# NOT available and fail the release at publish time (`function "envOrDefault" not
+# defined`). They ARE available in full-context fields like release.disable and
+# the chocolatey api_key. CI guards this (see ci.yml "Guard goreleaser token…").
 # --------------------------------------------------------------------------
 scoops:
   - name: agentsync
@@ -118,7 +122,7 @@ scoops:
       owner: spxrogers
       name: scoop-bucket
       branch: main
-      token: '{{ envOrDefault "SCOOP_BUCKET_GITHUB_TOKEN" "" }}'
+      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
     directory: bucket
     url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_author:
@@ -128,7 +132,6 @@ scoops:
     homepage: https://github.com/spxrogers/agentsync
     description: Centrally manage AI coding-agent configurations.
     license: MIT
-    skip_upload: '{{ if isEnvSet "SCOOP_BUCKET_GITHUB_TOKEN" }}false{{ else }}true{{ end }}'
 
 # --------------------------------------------------------------------------
 # Windows — Chocolatey (issue #75). Builds the .nupkg and `choco push`es it so
@@ -137,12 +140,11 @@ scoops:
 # Linux release job — the workflow runs it from a dedicated windows-latest job
 # (.github/workflows/release.yml). choco is pre-installed on those runners.
 #
-# Gating lives in the workflow, not here: goreleaser's `skip_publish` is a hard
-# bool (not templateable like scoop's skip_upload), so instead the Windows job
-# is gated on the *presence* of CHOCOLATEY_API_KEY — adding that secret is the
-# whole "go live" step. Chocolatey's community repo also runs
-# new packages through a moderation queue, so the first push won't be publicly
-# installable until it clears review.
+# Gating lives in the workflow, not here: the Windows job is gated on the
+# *presence* of CHOCOLATEY_API_KEY (via the goreleaser job's choco_enabled
+# output) — adding that secret is the whole "go live" step. Chocolatey's
+# community repo also runs new packages through a moderation queue, so the first
+# push won't be publicly installable until it clears review.
 #
 # NOTE: the chocolatey pipe packages the Windows amd64 binary only —
 # goreleaser's own arch filter selects amd64/386 and excludes arm64 — so the
@@ -170,7 +172,7 @@ chocolateys:
     tags: "agentsync cli ai coding agents configuration claude codex cursor dotfiles"
     release_notes: "https://github.com/spxrogers/agentsync/releases/tag/{{ .Tag }}"
     url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    api_key: '{{ envOrDefault "CHOCOLATEY_API_KEY" "" }}'
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
     goamd64: v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   workflow gained a dedicated `windows-latest` job that builds and `choco
   push`es only the `.nupkg`, reusing the same config with
   `AGENTSYNC_DISABLE_GH_RELEASE=true` so it never re-creates the Release the
-  Linux job published. The whole thing ships as a safe no-op until you add each
-  channel's credential: Scoop's `skip_upload` templates off
-  `SCOOP_BUCKET_GITHUB_TOKEN` (no token → manifest built but never pushed), and
-  the Windows job is gated on the *presence* of `CHOCOLATEY_API_KEY` (surfaced
-  as a job output, since a job-level `if:` can't read `secrets`) — so the
-  windows-latest runner only spins up once the key exists. The CI snapshot job
-  explicitly skips chocolatey (the Linux runner has no `choco`).
+  Linux job published. Scoop pushes with the `SCOOP_BUCKET_GITHUB_TOKEN` secret
+  (a plain `{{ .Env.… }}` token, like the Homebrew cask). The Windows chocolatey
+  job is gated on the *presence* of `CHOCOLATEY_API_KEY` (surfaced as a job
+  output, since a job-level `if:` can't read `secrets`), so the windows-latest
+  runner only spins up once the key exists. The CI snapshot job explicitly skips
+  chocolatey (the Linux runner has no `choco`).
 - **Releases can now be cut from the GitHub UI / mobile app, no laptop
   required.** The `release` workflow grew a `workflow_dispatch` trigger with a
   `version` input alongside the existing `push: tags` one: "Actions → release →


### PR DESCRIPTION
## What broke
The **v0.7.0 release failed** at the Scoop publish step ([run](https://github.com/spxrogers/agentsync/actions/runs/27853679820/job/82437143240)):

```
scoop manifests: template: failed to apply
"{{ envOrDefault "SCOOP_BUCKET_GITHUB_TOKEN" "" }}": function "envOrDefault" not defined
```

The GitHub Release, all archives/deb/rpm, and the Homebrew cask published fine — only Scoop failed, and the Chocolatey job was skipped (it `needs` the failed job).

## Root cause (traced in GoReleaser v2 source)
A publisher's **credential fields** (`repository.token`, `private_key`) are rendered by the env-only template context `ApplySingleEnvOnly`, which registers **no function map** and accepts only a bare `{{ .Env.X }}` reference. `envOrDefault`/`isEnvSet` are unavailable there and fail at publish. This is invisible to CI: `goreleaser check` doesn't execute templates, and `--snapshot` implies `--skip=publish` so token fields never render. The same-run proof: the Homebrew cask's plain `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}` token pushed fine via the identical code path.

(Note: chocolatey's `api_key` uses the **full** context `Apply`, so it was *not* actually broken — it's switched to `.Env` only for consistency with the other credential fields.)

## Fix
- Scoop `repository.token` → bare `{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}` (the actual bug).
- Drop the scoop `skip_upload` self-gate — it relied on the unavailable `isEnvSet`, and the "safe before the secret exists" phase is over (both secrets live). Scoop now always pushes; an unset token fails the release like Homebrew does.
- chocolatey `api_key` → bare `{{ .Env.CHOCOLATEY_API_KEY }}` (consistency; was never broken).
- `release.disable` keeps `envOrDefault` (full context, verified working).
- **New CI guard** (`ci.yml` lint job): fails if a `token:`/`private_key:` line uses `envOrDefault`/`isEnvSet` — closes the blind spot that let this reach release. Break-verified to catch the exact v0.7.0 pattern.
- Fixed the now-false "scoop self-gates / no-op" comment in `release.yml` and the CHANGELOG wording.

Validated with `goreleaser check` + the new guard. Hardened via a 4-lens review pass.

## After merge
The v0.7.0 tag/Release already exists (complete for binary/brew/deb/rpm, missing only Scoop + Choco). Cut a **patch release (`v0.7.1`)** to publish the two Windows channels cleanly — this is also the first real run of the Windows chocolatey job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)