### PR TITLE
fix(release): make builds reproducible so Chocolatey verification passes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,11 +18,26 @@ builds:
     env: [CGO_ENABLED=0]
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
+    # Reproducible builds — load-bearing for Chocolatey. The Linux release job
+    # uploads the Windows .zip to the GitHub Release; the separate windows-latest
+    # `chocolatey` job (release.yml) REBUILDS that .zip locally (OSS goreleaser
+    # can't share artifacts across runners) and bakes the sha256 of *its* copy
+    # into chocolateyinstall.ps1. choco then downloads the Linux job's .zip and
+    # checks it against that sha256 — so the two builds MUST be byte-identical or
+    # verification fails on a checksum mismatch (this sank v0.7.1). Three inputs
+    # made the builds diverge: (1) without -trimpath the binary embeds the
+    # per-runner GOPATH/module-cache path (Linux `/home/runner/...` vs Windows
+    # `C:\Users\runneradmin\...`); (2) `-X main.date={{.Date}}` stamped each run's
+    # wall-clock build time; (3) the default file mtime was the build time. Pin
+    # all three to the commit (same for both runners). Archive-side mtime
+    # normalization for the bundled LICENSE/README lives in `archives` below.
+    flags: [-trimpath]
+    mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
-      - -X main.date={{.Date}}
+      - -X main.date={{.CommitDate}}
 
 archives:
   - id: default
@@ -31,6 +46,20 @@ archives:
       - goos: windows
         formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Reproducible archives (see builds[].mod_timestamp for the why). The binary's
+    # in-archive mtime tracks builds[].mod_timestamp, but goreleaser's *default*
+    # bundled files (LICENSE*, README*) carry each runner's `actions/checkout`
+    # mtime — divergent across runners and enough to change the .zip's sha256. We
+    # restate the default file set with the mtime pinned to the commit date so the
+    # archive is byte-identical on the Linux and windows-latest runners. Keep this
+    # list in sync with goreleaser's default globs if more docs are bundled.
+    files:
+      - src: LICENSE*
+        info:
+          mtime: "{{ .CommitDate }}"
+      - src: README*
+        info:
+          mtime: "{{ .CommitDate }}"
 
 checksum:
   name_template: "checksums.txt"
@@ -148,8 +177,14 @@ scoops:
 #
 # NOTE: the chocolatey pipe packages the Windows amd64 binary only —
 # goreleaser's own arch filter selects amd64/386 and excludes arm64 — so the
-# windows/arm64 build is intentionally absent from the package. Verify on a
-# clean Windows box at the first release (issue #75).
+# windows/arm64 build is intentionally absent from the package.
+#
+# The generated chocolateyinstall.ps1 downloads the .zip from the GitHub Release
+# (built by the Linux job) and verifies it against a sha256 computed from THIS
+# runner's local rebuild. Those bytes match only because the build is now
+# reproducible across runners — see builds[].mod_timestamp / -trimpath and the
+# archive `files` mtime pinning above. v0.7.1 failed choco verification on a
+# checksum mismatch before that was in place; do not regress it.
 # --------------------------------------------------------------------------
 chocolateys:
   - name: agentsync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,7 +395,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `/spxrogers/agentsync` Context7 source) via a `script` tag in Starlight's
   `head` config (`website/astro.config.mjs`).
 
-## [0.1.0] — 2026-06-05
+### Fixed
+
+- **Chocolatey packages now build reproducibly across runners (fixes the v0.7.1
+  verification failure).** The release pipeline builds the Windows `.zip` twice —
+  once on the Linux job that uploads it to the GitHub Release, and again on the
+  windows-latest `chocolatey` job, which bakes the sha256 of its *local* rebuild
+  into `chocolateyinstall.ps1`. choco downloads the Release `.zip` and checks it
+  against that sha256, so the two builds must be byte-identical; they weren't, and
+  v0.7.1 failed automated verification with `Checksum … did not meet …`. The two
+  builds diverged on three non-deterministic inputs, now all pinned to the commit:
+  `-trimpath` strips the per-runner GOPATH/module-cache path baked into the binary,
+  `-X main.date` is set from `{{ .CommitDate }}` instead of the wall-clock build
+  time, and `builds[].mod_timestamp` plus the archive's `files[].info.mtime` pin
+  every in-archive mtime (binary and bundled `LICENSE`/`README`) to the commit so
+  `actions/checkout`'s per-runner timestamps no longer change the `.zip` bytes.
+  Re-cutting the release regenerates the Release archive and the Chocolatey package
+  together, so their checksums agree.
 
 The first public release (beta). Functional end-to-end (green under
 `just test-release`): Claude Code, OpenCode, and Codex adapters plus the full


### PR DESCRIPTION
## Why

`agentsync` v0.7.1 failed Chocolatey automated verification with a **checksum mismatch** ([gist](https://gist.github.com/choco-bot/d8fe2892e9b5ec3fe1d1a139d876386e)):

> `ERROR: Checksum for '…agentsync_0.7.1_windows_amd64.zip' did not meet '1b29f49…b19774' for checksum type 'sha256'.` → exit code 1, package quarantined.

**Root cause:** the release builds the Windows `.zip` twice. The Linux job builds it and uploads it to the GitHub Release; the separate `windows-latest` chocolatey job *rebuilds* it locally (OSS GoReleaser can't share artifacts across runners) and bakes *that* rebuild's SHA256 into `chocolateyinstall.ps1`. choco downloads the Linux job's `.zip` and verifies it against that SHA256, so the two builds must be byte-identical — they weren't.

## What changed (`.goreleaser.yaml`)

Three non-deterministic inputs, now all pinned to the commit so both runners emit identical bytes:

| Divergence | Fix |
|---|---|
| binary embedded the per-runner GOPATH/module-cache path (`/home/runner/…` vs `C:\Users\runneradmin\…`) | `flags: [-trimpath]` |
| `-X main.date={{.Date}}` stamped each run's wall-clock build time | `-X main.date={{.CommitDate}}` |
| in-archive mtimes came from each runner's `actions/checkout` time | `builds[].mod_timestamp: {{.CommitTimestamp}}` + archive `files[].info.mtime: {{.CommitDate}}` on the bundled `LICENSE`/`README` |

Also refreshed the now-stale "verify on a clean Windows box" config comment and added a `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

- `goreleaser check` passes.
- Built the snapshot from **two different absolute paths at different wall-clock times** (a faithful stand-in for the two CI runners — same tag commit, different host path, different time). `windows_amd64.zip` came out to the **same `a2c73da…` SHA256** both times; all six archives matched byte-for-byte. (Build B reusing build A's cache in ~5s is itself evidence `-trimpath` normalized the differing source paths into identical cache keys.)

## Follow-up to actually clear the submission

This config fix alone won't unstick 0.7.1: the `.zip` already on the v0.7.1 Release was built with the old config, so a freshly-built package would compute the new reproducible hash and still mismatch the uploaded file. After this merges, the Release archive and the package must be regenerated **together** from a commit containing this fix — either by re-cutting v0.7.1 (delete the existing tag + Release first; also regenerates the Scoop/Homebrew manifests whose checksums would otherwise break) or by cutting a fresh v0.7.2. Then self-reject the stuck 0.7.1 in Chocolatey's queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF)_