### PR TITLE
fix(release): pin archive file-modes + GoReleaser version for cross-host reproducibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,14 @@ jobs:
           go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          # PINNED, and MUST equal the chocolatey job's version below. The two
+          # jobs build the Windows .zip independently and choco verifies the
+          # Linux-built Release archive against the sha256 the Windows job baked
+          # into the package. `version: latest` is resolved per job at run time,
+          # so a goreleaser release landing between this job and a later choco
+          # re-run would change the archive bytes and break verification. Bump
+          # both jobs together. (Go is already pinned via go-version-file.)
+          version: "2.16.0"
           # Everything EXCEPT chocolatey: that pipe shells out to the Windows-only
           # `choco` CLI, so it runs on the separate windows-latest `chocolatey`
           # job below. This job creates the Release + uploads archives/checksums/
@@ -160,7 +167,10 @@ jobs:
           go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          # PINNED — keep identical to the goreleaser job's version above (see the
+          # rationale there). A version skew between the two jobs changes the
+          # Windows .zip bytes and breaks choco checksum verification.
+          version: "2.16.0"
           # Only the chocolatey pipe: skip the publishers the Linux job owns.
           args: release --clean --skip=homebrew,scoop,nfpm
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,19 +46,31 @@ archives:
       - goos: windows
         formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    # Reproducible archives (see builds[].mod_timestamp for the why). The binary's
-    # in-archive mtime tracks builds[].mod_timestamp, but goreleaser's *default*
-    # bundled files (LICENSE*, README*) carry each runner's `actions/checkout`
-    # mtime — divergent across runners and enough to change the .zip's sha256. We
-    # restate the default file set with the mtime pinned to the commit date so the
-    # archive is byte-identical on the Linux and windows-latest runners. Keep this
-    # list in sync with goreleaser's default globs if more docs are bundled.
+    # Reproducible archives across runners — load-bearing for Chocolatey. The
+    # Linux job uploads this .zip to the Release; the windows-latest choco job
+    # rebuilds it and bakes its sha256 into the package, so the two builds' bytes
+    # MUST match. A .zip carries two host-dependent inputs, and BOTH must be pinned:
+    #   1. mtime — pinned to the commit (binary via builds[].mod_timestamp; the
+    #      bundled LICENSE/README via files[].info.mtime below), else each runner's
+    #      `actions/checkout` time leaks in.
+    #   2. Unix file-mode bits — a .zip records os.FileInfo.Mode(), which is
+    #      0755/0644 on Linux but ~0666 (no exec bit) on Windows, so an unpinned
+    #      archive differs by build-host OS. v0.7.2 failed *verification* on exactly
+    #      this: validation passed, then the Linux Release .zip and the
+    #      Windows-rebuilt nupkg disagreed on the sha256. builds_info.mode pins the
+    #      binary's mode; files[].info.mode pins the bundled docs'.
+    # We restate goreleaser's default bundled-file globs (LICENSE*, README*) to
+    # attach the pinned info; keep this list in sync if more docs are bundled.
+    builds_info:
+      mode: 0755
     files:
       - src: LICENSE*
         info:
+          mode: 0644
           mtime: "{{ .CommitDate }}"
       - src: README*
         info:
+          mode: 0644
           mtime: "{{ .CommitDate }}"
 
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `actions/checkout`'s per-runner timestamps no longer change the `.zip` bytes.
   Re-cutting the release regenerates the Release archive and the Chocolatey package
   together, so their checksums agree.
+- **Reproducible builds, take two: pin archive file-modes and the GoReleaser
+  version (the v0.7.2 verification fix).** The first pass pinned the build's
+  embedded path/date and the bundled files' mtime — enough to make the archive
+  reproducible *on one host*, but not across the Linux Release job and the
+  `windows-latest` Chocolatey job. A `.zip` also records each entry's Unix mode
+  (`os.FileInfo.Mode()`): `0755`/`0644` on Linux vs `~0666` (no exec bit) on
+  Windows. That lone metadata difference made the two builds' archives disagree, so
+  v0.7.2 *passed validation but failed verification* on a checksum mismatch between
+  the Linux Release archive and the Windows-built `.nupkg`. The archive now pins
+  every in-archive Unix mode (`builds_info.mode` for the binary, `files[].info.mode`
+  for the bundled docs), making the `.zip` byte-identical regardless of build-host
+  OS (the binary itself was already host-independent via `-trimpath` + a pinned Go
+  toolchain). Both release jobs additionally pin GoReleaser to an exact version
+  (`2.16.0`) instead of `latest`, so a version skew between the two independently
+  run jobs — or a later single-job re-run — can't reintroduce the divergence.
+  Verified locally: forcing the archive modes to `0666` changes the `.zip` hash,
+  while with the modes pinned the hash is invariant to on-disk permissions.
 
 The first public release (beta). Functional end-to-end (green under
 `just test-release`): Claude Code, OpenCode, and Codex adapters plus the full


### PR DESCRIPTION
## Why

v0.7.2 **passed Chocolatey validation but failed verification** ([gist](https://gist.github.com/choco-bot/400dd072f8a74bc554b12dff388a6dec)) — another checksum mismatch, but a *different* hash than #112 fixed. The Linux job's published Release `.zip` is `faaa7e6…`, but the `windows-latest` choco job's rebuilt `.nupkg` embedded `31d02073…`.

#112 made the archive reproducible **on a single host** (pinned the binary's embedded path/date and the bundled files' mtime). But the two builds run on **different host OSes**, and a `.zip` also records each entry's **Unix file-mode** (`os.FileInfo.Mode()`):

- Linux runner → `0755` (binary) / `0644` (docs)
- Windows runner → `~0666`, no exec bit

That lone metadata difference changed the archive bytes between the Linux Release build and the Windows choco rebuild → checksum mismatch.

## Diagnosis (proven locally, not guessed)

Built the v0.7.2 Windows zip on Linux several ways:

| Build | Config | `windows_amd64.zip` sha256 |
|---|---|---|
| A | current | `2867262a…` |
| **W** | all modes forced `0666` (≈Windows) | **`7e844683…`** ≠ A |
| F1 | modes pinned (`0755`/`0644`) | `f0dfedbb…` |
| F2 | same, but docs `chmod 0666` on disk | `f0dfedbb…` **= F1** |

**W ≠ A** ⇒ file-mode bits change the hash. **F1 == F2** ⇒ pinning the modes makes the archive invariant to host/on-disk permissions. (`A ≠ faaa7e6` was just my local `go run` pulling go1.26.4 vs CI's go1.26.2 — both CI jobs already used the same GoReleaser 2.16.0 + Go 1.26.2, so the *only* CI-side differ was the mode.)

## Changes

- **`.goreleaser.yaml`** — pin every in-archive Unix mode: `builds_info.mode: 0755` (binary, kept executable for the tar.gz consumers) and `files[].info.mode: 0644` (bundled `LICENSE`/`README`). Makes the `.zip` byte-identical regardless of build-host OS.
- **`.github/workflows/release.yml`** — pin `goreleaser-action` to `2.16.0` in **both** jobs instead of `latest`. The two jobs resolve `latest` independently (and re-runs happen days apart), so a GoReleaser release landing between them could re-introduce exactly this divergence. Go is already pinned via `go-version-file`; this brings the archiver to parity.
- **`CHANGELOG.md`** — documents the second-pass fix under `[Unreleased] → Fixed`.

`goreleaser check` passes. Verified octal parsing: the pinned config produces `-rwxr-xr-x agentsync` / `-rw-r--r-- LICENSE` with commit-pinned mtimes — no regression to the executable bit.

## Follow-up to actually clear 0.7.2

As with #112, this config change must land in a tagged build, and the Release archive + the package must be regenerated **together** from a commit containing it. Cleanest path (consistent with the earlier 0.7.1→0.7.2 decision to avoid mutating a published release): **self-reject 0.7.2** in Chocolatey's queue, then cut **v0.7.3** off this once merged — every channel advances together and choco gets a fresh, reproducible submission. (Re-cutting v0.7.2 in place also works but means deleting the tag/Release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF)_