### PR TITLE
docs(changelog): restore the 0.1.0 heading and file reproducibility fixes under 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `/spxrogers/agentsync` Context7 source) via a `script` tag in Starlight's
   `head` config (`website/astro.config.mjs`).
 
+## [0.7.3] — 2026-06-20
+
 ### Fixed
 
 - **Chocolatey packages now build reproducibly across runners (fixes the v0.7.1
@@ -429,6 +431,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   run jobs — or a later single-job re-run — can't reintroduce the divergence.
   Verified locally: forcing the archive modes to `0666` changes the `.zip` hash,
   while with the modes pinned the hash is invariant to on-disk permissions.
+
+## [0.1.0] — 2026-06-05
 
 The first public release (beta). Functional end-to-end (green under
 `just test-release`): Claude Code, OpenCode, and Codex adapters plus the full


### PR DESCRIPTION
Tidy-up of the two loose ends from the Chocolatey reproducibility work. **One of them turned out to be a real bug, not cosmetic**; the other I'm recommending against — details below.

## ✅ Done — CHANGELOG (fixes a regression I introduced)

While poking at this I found that the *first* reproducible-build changelog edit (in #112) accidentally **replaced the `## [0.1.0] — 2026-06-05` version heading** with a `### Fixed` subsection. The result:
- every 0.1.0 entry (the "first public release" block onward) was left **dangling under `[Unreleased]`**, so the changelog claimed all of 0.1.0 was unreleased; and
- the two reproducibility notes sat as a **stray, duplicate `### Fixed`** inside `[Unreleased]`.

This PR:
- **restores the `## [0.1.0] — 2026-06-05` heading**, re-parenting its entries correctly; and
- **moves the two reproducibility fixes** (the v0.7.1 → v0.7.3 Chocolatey checksum saga) into a proper `## [0.7.3] — 2026-06-20` section.

Structure only — no entry text changed. Result is well-formed and in order: `[Unreleased]` → `[0.7.3]` → `[0.1.0]`.

> Note: the broader gap (0.2.0–0.7.2 were never written up; `[Unreleased]` still holds a large backlog of already-shipped features) is pre-existing and out of scope here — it'd need release-by-release archaeology. Happy to tackle that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZYQWDcCaPU9tpWxVJz5sF)_