### PR TITLE
ci: extract docs-publish into a reusable, manually-triggerable workflow

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,49 @@
+name: docs-publish
+# Rebuild the agentsync.cc site and force-push it to the gh-pages branch — this is
+# exactly `just docs-publish` (clean website/dist, rebuild, force-push dist/ as a
+# single commit). GitHub Pages serves gh-pages via "deploy from a branch", so no
+# extra Actions minutes are spent rendering the site.
+#
+# Two ways in, both landing in the single `docs` job below:
+#   1. trigger manually from the GitHub UI / mobile app ("Actions → docs-publish →
+#      Run workflow") to redeploy the live docs out of band — e.g. a docs-only fix
+#      between releases — without cutting a CLI release.
+#   2. called by the `release` workflow (`workflow_call`) after a successful
+#      publish, so the live docs always track the just-shipped CLI version. This is
+#      the shared component: the release pipeline references this workflow rather
+#      than duplicating the build/push steps.
+on:
+  workflow_dispatch:
+  workflow_call:
+
+# The job force-pushes the rebuilt site to the gh-pages branch, which needs
+# contents:write. When called from `release`, the effective token is the caller's,
+# which also grants contents:write.
+permissions:
+  contents: write
+
+# Serialize deploys so a manual dispatch and a release-triggered call (or two
+# manual dispatches) can't race to force-push gh-pages. We never cancel an
+# in-flight deploy — a half-finished force-push is worse than waiting.
+concurrency:
+  group: docs-publish
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    name: docs-publish (agentsync.cc)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: extractions/setup-just@v3
+      # `just docs-publish` runs `git push` from a throwaway repo it inits inside
+      # website/dist, which inherits none of actions/checkout's auth. Inject the
+      # workflow token for github.com transports so that force-push to gh-pages
+      # authenticates (contents:write, granted above).
+      - name: Authenticate git pushes to GitHub
+        run: |
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "https://github.com/"
+      - run: just docs-publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,10 @@ name: release
 # Publish a GitHub Release + update the Homebrew tap. CI (ci.yml) only ever runs
 # goreleaser in `--snapshot --skip publish` mode to prove the cross-build stays
 # viable; this workflow is the one that actually ships. Once the release
-# publishes, the `docs` job rebuilds and redeploys the agentsync.cc site so the
-# live docs always track the just-shipped CLI version.
+# publishes, the `docs` job calls the reusable `docs-publish` workflow
+# (.github/workflows/docs-publish.yml) to rebuild and redeploy the agentsync.cc
+# site so the live docs always track the just-shipped CLI version. That same
+# workflow can be run manually to redeploy the docs out of band.
 #
 # Two ways in, both landing in the single `goreleaser` job below:
 #   1. push an annotated `vX.Y.Z` tag on a green commit (the laptop path —
@@ -164,11 +166,13 @@ jobs:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
   # Redeploy agentsync.cc after a successful publish so the live docs always
-  # track the just-released CLI. This is exactly `just docs-publish` (rebuild
-  # website/ and force-push dist/ to the gh-pages branch); GitHub Pages serves
-  # gh-pages via "deploy from a branch", so no extra Actions minutes are spent
-  # rendering the site. Gated on `goreleaser` so a failed publish never ships
-  # docs claiming a version that isn't out.
+  # track the just-released CLI. The build/force-push steps live in the reusable
+  # `docs-publish` workflow (.github/workflows/docs-publish.yml) — which can also
+  # be run manually to redeploy out of band — and we call it here as a shared
+  # component rather than duplicating it. Gated on `goreleaser` so a failed
+  # publish never ships docs claiming a version that isn't out. `uses:` runs the
+  # called workflow with this run's token, which carries the contents:write
+  # granted above (the force-push to gh-pages needs it).
   #
   # NOTE: because choco now runs inside the `goreleaser` job, a `choco push`
   # failure fails that job and skips this deploy even though the Release already
@@ -176,23 +180,8 @@ jobs:
   # the failed `goreleaser` job re-publishes idempotently
   # (release.replace_existing_artifacts) and re-runs this job. If a push
   # half-succeeded (the version is already on choco, so a re-push 409s), re-run
-  # THIS job alone — or run `just docs-publish` locally — to ship the docs without
-  # re-pushing choco.
+  # the `docs-publish` workflow alone — or run `just docs-publish` locally — to
+  # ship the docs without re-pushing choco.
   docs:
-    name: docs-publish (agentsync.cc)
     needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - uses: extractions/setup-just@v3
-      # `just docs-publish` runs `git push` from a throwaway repo it inits inside
-      # website/dist, which inherits none of actions/checkout's auth. Inject the
-      # workflow token for github.com transports so that force-push to gh-pages
-      # authenticates (contents:write, granted above).
-      - name: Authenticate git pushes to GitHub
-        run: |
-          git config --global \
-            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
-            "https://github.com/"
-      - run: just docs-publish
+    uses: ./.github/workflows/docs-publish.yml

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 The source for **[agentsync.cc](https://agentsync.cc)** — an
 [Astro Starlight](https://starlight.astro.build) site, deployed to GitHub Pages by
-the `docs` job in [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+the reusable [`docs-publish` workflow](../.github/workflows/docs-publish.yml).
 
 ## Develop
 
@@ -65,14 +65,18 @@ relevant page under `reference/` (the sync table in `CLAUDE.md` lists this).
 ## Deploy
 
 The site is served by GitHub Pages from the `gh-pages` branch ("deploy from a
-branch"), so serving it costs no GitHub Actions minutes. Cutting a release —
+branch"), so serving it costs no GitHub Actions minutes. The build + force-push of
+`dist/` to `gh-pages` lives in the reusable
+[`docs-publish` workflow](../.github/workflows/docs-publish.yml). Cutting a release —
 pushing a `vX.Y.Z` tag — runs the [`release` workflow](../.github/workflows/release.yml),
-whose `docs` job rebuilds `website/` and force-pushes `dist/` to `gh-pages` once
-the CLI is published. The result: the live docs always track the latest released
-CLI. The custom domain is set via [`public/CNAME`](public/CNAME).
+which calls `docs-publish` once the CLI is published. The result: the live docs
+always track the latest released CLI. The custom domain is set via
+[`public/CNAME`](public/CNAME).
 
-To redeploy out of band (e.g. a docs-only fix between releases), run
-`just docs-publish` locally — it does the same rebuild + force-push to `gh-pages`.
+To redeploy out of band (e.g. a docs-only fix between releases), trigger the
+[`docs-publish` workflow](../.github/workflows/docs-publish.yml) manually from the
+GitHub UI ("Actions → docs-publish → Run workflow"), or run `just docs-publish`
+locally — all three do the same rebuild + force-push to `gh-pages`.
 
 The page footer's "Last updated" line carries a **build/deploy commit hash** — a
 short SHA linked to the exact commit on GitHub, so the live site always shows


### PR DESCRIPTION
## Summary

The release pipeline previously inlined the agentsync.cc docs deploy as a `docs` job. This splits that out so the docs deploy can be triggered on its own and reused.

- **New `.github/workflows/docs-publish.yml`** — a standalone workflow with two entry points:
  - `workflow_dispatch` — run it manually from **Actions → docs-publish → Run workflow** to redeploy the site out of band (e.g. a docs-only fix between releases).
  - `workflow_call` — exposes it as a shared component for other workflows to invoke.

  It carries the same steps the release pipeline used to inline (checkout → setup-bun → setup-just → git push auth → `just docs-publish`), its own `permissions: contents: write`, and a `docs-publish` concurrency group so a manual run and a release-triggered run can't race the force-push to `gh-pages`.
- **`.github/workflows/release.yml`** — the `docs` job no longer duplicates those steps; it now references the shared workflow via `uses: ./.github/workflows/docs-publish.yml` (still gated on `needs: goreleaser`). The `uses:` job runs with this run's token, which already carries the `contents: write` granted at the top of the workflow.
- **`website/README.md`** — updated to point at the new workflow and document the manual-trigger path alongside the existing local `just docs-publish` option.

`GITHUB_TOKEN` is automatically available to the called workflow, so no `secrets: inherit` is needed (docs-publish uses only that token). Behavior on the release path is unchanged; the only new capability is the manual trigger.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Refactor (no behavior change)
- [ ] Docs
- [x] Tests / CI / tooling

## Test plan

- Both workflow YAML files parse cleanly (`yaml.safe_load`).
- No Go code touched, so `just test-release` / `just lint` are unaffected by this change.
- [ ] `just test-release` is green (the release bar)
- [ ] `just lint` is clean

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [ ] Tests added/updated for the behavior changed. — n/a, CI workflow refactor with no behavior change
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants — n/a, not touched.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed (`website/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GAjknxUvXYNMS7BK7JMfB

---
_Generated by [Claude Code](https://claude.ai/code/session_014GAjknxUvXYNMS7BK7JMfB)_