### PR TITLE
feat: destination auto-git versioning + `agentsync revert` (#118)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,7 +84,7 @@ linters:
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # CLI files writing to ~/.agentsync/* (canonical source).
-      - path: '(^|/)internal/cli/(plugin|marketplace|agent|reconcile|update)\.go$'
+      - path: '(^|/)internal/cli/(plugin|marketplace|agent|gitbackup_config|reconcile|update)\.go$'
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # The PassThroughWriter test helper deliberately delegates to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 ### Added
 
 - **Destination dirs can be git-versioned for one-command rollback (issue #118).**
-  `agentsync apply` now optionally keeps each rendered destination agent dir
-  (`~/.claude`, `~/.codex`, …) in its own **local-only** git repo, recording a
-  checkpoint commit after every apply that changes managed files there. A new
-  first-class **`agentsync revert <agent>`** rolls a dir back to a prior checkpoint
-  (append-only — it records a new commit, never rewrites history; `--to` picks a
-  checkpoint, `--all` covers every managed dir, `--dry-run` previews) and warns you
-  to reconcile before the next apply. Behavior is controlled by a new global
+  `agentsync apply` now optionally keeps each rendered destination dir in its own
+  **local-only** git repo, recording a checkpoint commit after every apply that
+  changes managed files there. The unit is the **directory**: every agent's config
+  dir (`~/.claude`, `~/.codex`, …) plus shared cross-agent dirs (e.g.
+  `~/.agents/skills`, which Codex and several agents all write to) are versioned,
+  with shared dirs de-duplicated to a single repo and nested dirs collapsed (no
+  repo inside a repo). A new first-class **`agentsync revert <agent>`** rolls a
+  dir back to a prior checkpoint (append-only — it records a new commit, never
+  rewrites history; uncommitted hand-edits to tracked files are preserved as a
+  snapshot first, so nothing is lost; `--to` picks a checkpoint, `--all` covers
+  every managed dir, `--dry-run` previews) and warns you to reconcile before the
+  next apply. Behavior is controlled by a new global
   `[destination_directory_git_backup]` table in `agentsync.toml`
   (`mode = "prompt"` (default) `| "on" | "off"`, plus optional `author_name` /
   `author_email`); the first apply to an untracked dir **prompts** (opt-out), and
@@ -26,8 +31,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   the current mode and per-dir status. These repos are **never pushed** — the
   history may hold the cleartext secrets the rendered files already contain, which
   is acceptable precisely because it stays local (the canonical `~/.agentsync/`
-  source you push still carries only secret *references*). Covers the nine deep
-  adapters; an existing user-managed repo in a destination dir is left untouched.
+  source you push still carries only secret *references*). An existing user-managed
+  repo in a destination dir is detected and left untouched.
 - **Windows distribution via Scoop and Chocolatey is wired and ready to ship
   (issues #74, #75).** `.goreleaser.yaml` now carries fully-configured `scoops`
   and `chocolateys` blocks, and the whole release — GitHub Release, archives,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **Destination dirs can be git-versioned for one-command rollback (issue #118).**
+  `agentsync apply` now optionally keeps each rendered destination agent dir
+  (`~/.claude`, `~/.codex`, …) in its own **local-only** git repo, recording a
+  checkpoint commit after every apply that changes managed files there. A new
+  first-class **`agentsync revert <agent>`** rolls a dir back to a prior checkpoint
+  (append-only — it records a new commit, never rewrites history; `--to` picks a
+  checkpoint, `--all` covers every managed dir, `--dry-run` previews) and warns you
+  to reconcile before the next apply. Behavior is controlled by a new global
+  `[destination_directory_git_backup]` table in `agentsync.toml`
+  (`mode = "prompt"` (default) `| "on" | "off"`, plus optional `author_name` /
+  `author_email`); the first apply to an untracked dir **prompts** (opt-out), and
+  `apply --no-git-backup` bypasses it for CI/scripting. `agentsync doctor` shows
+  the current mode and per-dir status. These repos are **never pushed** — the
+  history may hold the cleartext secrets the rendered files already contain, which
+  is acceptable precisely because it stays local (the canonical `~/.agentsync/`
+  source you push still carries only secret *references*). Covers the nine deep
+  adapters; an existing user-managed repo in a destination dir is left untouched.
 - **Windows distribution via Scoop and Chocolatey is wired and ready to ship
   (issues #74, #75).** `.goreleaser.yaml` now carries fully-configured `scoops`
   and `chocolateys` blocks, and the whole release — GitHub Release, archives,

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ configs quietly drift apart. agentsync fixes the fan-out:
 - **Secrets stay secret.** Reference `${secret:github.token}`; agentsync resolves
   it at apply time from an age-encrypted vault and **never** writes the cleartext
   back into your (committable) source.
+- **A bad apply is revertible.** `apply` keeps each destination dir (`~/.claude`,
+  …) in a **local-only** git history (opt-out, never pushed), so `agentsync revert`
+  rolls back to a prior checkpoint.
 
 New here? The **[User guide](docs/user-guide.md)** takes you 0→100.
 
@@ -48,6 +51,8 @@ New here? The **[User guide](docs/user-guide.md)** takes you 0→100.
     agentsync mcp add github --command npx --args "-y,@modelcontextprotocol/server-github"
     agentsync apply --dry-run    # preview what would change vs. is already synced
     agentsync apply
+    # … later, if an apply goes wrong:
+    agentsync revert claude      # roll ~/.claude back to the previous checkpoint
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,11 +363,25 @@ Key stages:
    foreign-collision backups (`internal/render`, `internal/iox`).
 8. **Record** new hashes in `targets.json` (`internal/state`) and print the
    translation report.
+9. **Git-backup** (issue #118) — for a user-scope apply, checkpoint each deep
+   agent's destination dir into its own **local-only** git repo
+   (`internal/cli/gitbackup.go` → `internal/git`). The managed-file set is the
+   `written` set from step 7, grouped per agent by the optional
+   `adapter.VersionedHome` extension (each deep adapter exposes its single config
+   dir; the breadth tier abstains, with no safe single dir to init). This step is
+   **best-effort** (the files are already written and state already saved, so a git
+   failure never fails the apply), **opt-out** (the
+   `[destination_directory_git_backup]` mode — `prompt`/`on`/`off` — plus the
+   `apply --no-git-backup` per-run bypass), and **never pushes**: `internal/git`
+   exposes no remote/push surface at all (a source-scanning guard test,
+   `TestNoPushSurface`, keeps it that way). `agentsync revert` rolls a dir back to a
+   prior checkpoint append-only. `.state/` is **untouched** by this step — the two
+   are complementary (operational memory vs. user-facing rollback history).
 
 `--dry-run` runs steps 1–6, then a non-writing pass of step 7 (the writer's merge
 + convergence check, no disk write) so it can label each destination `✓ synced`
 vs `→ write` and preview foreign-collision backups, and prints the plan/report —
-all without writing a byte.
+all without writing a byte (and it skips the git-backup step 9 entirely).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -372,7 +372,11 @@ Key stages:
    `~/.claude/skills`). The apply tail **unions** those roots, **de-nests** them
    (drops a root nested under another, so there's never a repo inside a repo), and
    **de-dups** them (a shared dir is one repo, checkpointed once with all its files
-   regardless of how many agents wrote there). The managed-file set committed under
+   regardless of how many agents wrote there). De-nesting only sees the current
+   run's roots, so before initializing a dir agentsync also scans the filesystem
+   (`git.HasNestedRepoBelow`) and **refuses to init a repo that would wrap an
+   existing one** — the cross-run case where a child dir was versioned before a
+   parent-dir agent was enabled. The managed-file set committed under
    each root is the `written` set from step 7 plus any tracked deletions; `$HOME`-
    level strays (Claude's `~/.claude.json`) are never versioned (agentsync never
    inits a repo at `$HOME`). This step is **best-effort** (the files are already

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,19 +363,27 @@ Key stages:
    foreign-collision backups (`internal/render`, `internal/iox`).
 8. **Record** new hashes in `targets.json` (`internal/state`) and print the
    translation report.
-9. **Git-backup** (issue #118) — for a user-scope apply, checkpoint each deep
-   agent's destination dir into its own **local-only** git repo
-   (`internal/cli/gitbackup.go` → `internal/git`). The managed-file set is the
-   `written` set from step 7, grouped per agent by the optional
-   `adapter.VersionedHome` extension (each deep adapter exposes its single config
-   dir; the breadth tier abstains, with no safe single dir to init). This step is
-   **best-effort** (the files are already written and state already saved, so a git
-   failure never fails the apply), **opt-out** (the
-   `[destination_directory_git_backup]` mode — `prompt`/`on`/`off` — plus the
-   `apply --no-git-backup` per-run bypass), and **never pushes**: `internal/git`
-   exposes no remote/push surface at all (a source-scanning guard test,
-   `TestNoPushSurface`, keeps it that way). `agentsync revert` rolls a dir back to a
-   prior checkpoint append-only. `.state/` is **untouched** by this step — the two
+9. **Git-backup** (issue #118) — for a user-scope apply, checkpoint each destination
+   **directory** into its own **local-only** git repo (`internal/cli/gitbackup.go`
+   → `internal/git`). The unit is the directory, not the agent: every enabled
+   adapter declares its version roots via the optional `adapter.VersionedDirs`
+   extension (its config dir plus any shared cross-agent dir it writes — Codex and
+   several breadth agents all target `~/.agents/skills`; OpenCode targets
+   `~/.claude/skills`). The apply tail **unions** those roots, **de-nests** them
+   (drops a root nested under another, so there's never a repo inside a repo), and
+   **de-dups** them (a shared dir is one repo, checkpointed once with all its files
+   regardless of how many agents wrote there). The managed-file set committed under
+   each root is the `written` set from step 7 plus any tracked deletions; `$HOME`-
+   level strays (Claude's `~/.claude.json`) are never versioned (agentsync never
+   inits a repo at `$HOME`). This step is **best-effort** (the files are already
+   written and state already saved, so a git failure never fails the apply),
+   **opt-out** (the `[destination_directory_git_backup]` mode — `prompt`/`on`/`off`
+   — plus the `apply --no-git-backup` per-run bypass), and **never pushes**:
+   `internal/git` exposes no remote/push surface at all (a source-scanning guard
+   test, `TestNoPushSurface`, keeps it that way). `agentsync revert` (which takes
+   the same global lock apply holds) rolls a dir back to a prior checkpoint
+   append-only, first snapshotting any uncommitted hand-edits to tracked files so
+   the rollback can't lose them. `.state/` is **untouched** by this step — the two
    are complementary (operational memory vs. user-facing rollback history).
 
 `--dry-run` runs steps 1–6, then a non-writing pass of step 7 (the writer's merge

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -143,6 +143,20 @@ detection possible), the apply lock, the two-phase write staging dir, first-appl
 backups, and the marketplace/plugin cache. Keys are stored `${HOME}`-relative so
 state is portable across machines.
 
+### Destination git backup (rollback history)
+Optionally, each **user-scope destination dir** (`~/.claude`, `~/.codex`, …) gets
+its **own local-only git repo**: `apply` records a checkpoint commit after every
+run that changes managed files there, and `agentsync revert` rolls a dir back to a
+prior checkpoint. This is distinct from `.state/` — `.state/` is agentsync's
+operational memory (hashes for drift, narrow capped foreign-collision backups),
+whereas these repos are a durable, browsable, revertible rollback history for the
+*rendered destination files*. They are governed by the
+`[destination_directory_git_backup]` table and are **never pushed** — the rendered
+files hold secrets in cleartext, so the history stays local (the canonical source
+you push still carries only `${secret:…}` references). See `apply`/`revert` in the
+[user guide](user-guide.md#command-reference) and
+[architecture §4](architecture.md).
+
 ### Marketplace / Plugin / Projection
 A **marketplace** is a registry of plugins (Claude's marketplace format). A
 **plugin** is a bag of components — MCP servers, skills, subagents, commands,

--- a/docs/superpowers/plans/2026-06-28-destination-git-versioning.md
+++ b/docs/superpowers/plans/2026-06-28-destination-git-versioning.md
@@ -1,0 +1,948 @@
+# Implementation Plan — Destination auto-git versioning + `agentsync revert`
+
+**Date:** 2026-06-28
+**Issue:** [#118](https://github.com/spxrogers/agentsync/issues/118)
+**Spec:** [`docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md`](../specs/2026-06-28-destination-git-versioning-design.md)
+**PR:** [#119](https://github.com/spxrogers/agentsync/pull/119)
+
+---
+
+## Goal
+
+Give each **user-scope** destination agent dir (`~/.claude`, `~/.codex`, `~/.cursor`,
+…) its own **local-only** git repo so every `apply` that changes managed files
+leaves a checkpoint commit, and ship `agentsync revert` to roll a dir back to a
+prior checkpoint (append-only). Add a `[destination_directory_git_backup]` config
+table, an `apply --no-git-backup` bypass, and a read-only `agentsync doctor` status
+line. Never push these repos.
+
+## Architecture (where each piece lands)
+
+```
+internal/git/                    NEW package — the only go-git surface for this feature.
+  git.go        Repo open/init/detect, Identity, marker, notice, perms.
+  commit.go     Stage specific files + commit with the dedicated signature.
+  restore.go    Append-only restore: materialize a checkpoint's tree, commit on top.
+  log.go        List checkpoints (short hash, subject, time).
+  (NO remote.go / push — the absence IS the never-push invariant.)
+
+internal/adapter/adapter.go      NEW optional interface: VersionedHome.
+internal/adapter/<each>/*.go     Implement HomeDir(scope, project) (string, bool).
+
+internal/source/schema.go        NEW DestinationGitBackupConfig + Config field.
+internal/project/project.go      Merge the new table in the project overlay.
+
+internal/cli/gitbackup.go        NEW: apply-tail orchestration (group written → per
+                                 agent → detect/prompt/init/commit) + mode persistence.
+internal/cli/apply.go            Add --no-git-backup; call the orchestration after
+                                 PruneBackups (line ~222).
+internal/cli/revert.go           NEW `agentsync revert` command.
+internal/cli/doctor.go           NEW "Destination git backup" section.
+internal/cli/root.go             Register newRevertCmd().
+
+docs/…, README.md, website/…, CHANGELOG.md, init.go initialAgentsyncTOML.
+```
+
+## Tech stack / facts the implementer must not re-derive
+
+- **go-git is already vendored:** `github.com/go-git/go-git/v5 v5.18.0` (used today
+  only by `git.PlainClone` in `internal/cli/init.go:244`). No new dependency.
+- **The managed-file set** is the `written map[string]bool` returned by
+  `render.Apply(...)` — see `internal/cli/apply.go:178`:
+  `collisions, written, unchanged, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)`.
+  Keys are **absolute** destination paths actually written this run.
+- **The apply tail hook point** is `internal/cli/apply.go` immediately after
+  `_ = render.PruneBackups(home, render.DefaultBackupKeep)` (line ~222) and before
+  the success message (line ~224). State is already saved; `written`, `plan`, `reg`,
+  `agents`, `sc`, `projectRoot`, `userHome`, `home`, `p` are all in scope.
+- **Registry:** `reg.Lookup(name) adapter.Adapter` and `reg.Names() []string`
+  (`internal/adapter/registry.go:25,28`). Adapters are constructed with
+  `Options{TargetRoot: home}` where `home = paths.HomeDir(paths.OSEnv{})`
+  (`internal/cli/registry_internal.go`). Registered: claude, opencode, codex,
+  cursor, gemini, continuedev, windsurf, roo, cline + one `generic.New(spec,…)` per
+  `generic.Specs()`.
+- **Each adapter resolves its own config dir** via `ResolvePaths(targetRoot,
+  project, projectScope)` returning a struct with a `ConfigDir` field (e.g.
+  `cursor/paths.go:13` → `~/.cursor`). That `ConfigDir` at user scope IS the git
+  root. (Claude additionally writes `~/.claude.json` at `$HOME` — **out of scope**,
+  decision #10.)
+- **TTY / non-interactive helpers already exist** in `internal/cli/apply.go`:
+  `stdinIsTerminal(cmd)` (line 495) and `noInputFlag(cmd)` (line 481); the prompt
+  idiom is `promptScopeChoice` (line 504, `bufio.NewReader(cmd.InOrStdin())`).
+- **In-place `agentsync.toml` edits** preserve everything outside the edited
+  section via a line-splice + `iox.AtomicWrite(p, …, 0o644)` — see
+  `writeAgents`/`readAgentsyncTOML` in `internal/cli/agent.go:144–240`. Persisting
+  `mode` follows the same pattern; do NOT `toml.Marshal` the whole `Config` (it
+  nukes comments).
+- **Atomic writes:** `iox.AtomicWrite(dest, data, mode)` (`internal/iox/atomic.go`)
+  writes `0o600` first then chmods. Rendered files are already `0o600`.
+- **`time.Now()` caveat applies only to `internal/render` / `internal/state`** —
+  `internal/git` and `internal/cli` may call `time.Now().UTC()` directly (commit
+  timestamps don't feed a hash). Confirmed in `CLAUDE.md`.
+
+## Global constraints (apply to every task)
+
+- **Stdlib testing only**, table-driven with a `name` field + `t.Run`; `t.Helper()`
+  in fatal helpers. No testify/gomega.
+- **FS-touching tests** use `t.TempDir()` (real FS — go-git needs a real worktree,
+  `afero.MemMapFs` won't back go-git) and **must** call
+  `testenv.RequireContainer(t)` / `MustRunInContainer()` so they refuse to run on a
+  host without `AGENTSYNC_TEST_IN_CONTAINER=1`.
+- **Errors** wrap: `fmt.Errorf("doing X: %w", err)`; match with `errors.Is/As`.
+- **Never** add a git remote or call any push API anywhere under `internal/git`.
+- **Commits**: conventional, scoped — `feat(git):`, `feat(adapter):`,
+  `feat(cli):`, `feat(source):`, `docs(...):`, `test(...):`.
+- Run `just build` then `just test-fast` after each task; the lint quirk for
+  containers is `GOTOOLCHAIN=go1.26.2 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`
+  (see `CLAUDE.md` "container/cloud sessions" note). Re-stage anything `just lint`
+  rewrites before committing.
+
+## How to work this plan
+
+Milestones are ordered so each builds on the last and stays green. **M0** (the
+`internal/git` package) is fully isolated and unit-tested with zero agentsync
+coupling — build and land it first. **M1** adds the canonical/adapter plumbing.
+**M2** wires the apply tail. **M3** adds `revert`. **M4** is doctor + docs (the
+`CLAUDE.md` doc-sync rule means docs land in the same PR as the behavior). Check
+off each `[ ]` as you go.
+
+---
+
+# Milestone 0 — `internal/git` helper package (isolated, unit-tested)
+
+No agentsync types here — pure git mechanics over a real directory. This is the
+entire go-git surface for the feature; keeping it in one package makes the
+never-push invariant auditable (there is simply no push function to call).
+
+## Task 0.1 — Package skeleton, `Identity`, work-tree detection
+
+**Files**
+- create `internal/git/git.go`
+- create `internal/git/git_test.go`
+
+**Interface this task exposes**
+```go
+package git
+
+// Identity is the author/committer for checkpoint commits.
+type Identity struct{ Name, Email string }
+
+// DefaultIdentity is used when the config overrides are empty.
+var DefaultIdentity = Identity{Name: "agentsync", Email: "agentsync@localhost"}
+
+// State classifies a destination dir for the apply tail.
+type State int
+const (
+    StateUntracked      State = iota // no work tree anywhere at/above dir
+    StateAgentsyncOwned              // a work tree WE created (carries the marker)
+    StateForeign                     // a work tree the user owns (no marker) — leave alone
+)
+
+// Detect reports how dir is tracked. It uses DetectDotGit so a dir nested inside
+// a user's existing repo (dotfiles) is StateForeign, not StateUntracked.
+func Detect(dir string) (State, error)
+```
+
+**Steps**
+- [ ] Write `git.go` with the import `gogit "github.com/go-git/go-git/v5"` and
+  `"github.com/go-git/go-git/v5/config"`.
+- [ ] Implement `Detect`:
+  ```go
+  const markerSection = "agentsync"
+  const markerOption  = "managed"
+
+  func Detect(dir string) (State, error) {
+      repo, err := gogit.PlainOpenWithOptions(dir, &gogit.PlainOpenOptions{DetectDotGit: true})
+      if errors.Is(err, gogit.ErrRepositoryNotExists) {
+          return StateUntracked, nil
+      }
+      if err != nil {
+          return StateUntracked, fmt.Errorf("opening git repo at %s: %w", dir, err)
+      }
+      cfg, err := repo.Config()
+      if err != nil {
+          return StateForeign, fmt.Errorf("reading git config at %s: %w", dir, err)
+      }
+      if cfg.Raw.Section(markerSection).Option(markerOption) == "true" {
+          return StateAgentsyncOwned, nil
+      }
+      return StateForeign, nil
+  }
+  ```
+- [ ] Write `git_test.go`. First line of every FS test body:
+  `testenv.RequireContainer(t)`. Cases (table-driven where natural):
+  - empty `t.TempDir()` → `StateUntracked`.
+  - `gogit.PlainInit(dir, false)` with the marker set → `StateAgentsyncOwned`.
+  - `gogit.PlainInit(dir, false)` WITHOUT the marker → `StateForeign`.
+  - init a repo at `t.TempDir()`, make a child subdir, `Detect(child)` →
+    `StateForeign` (proves `DetectDotGit`).
+
+**Test command + expected**
+```
+AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -run TestDetect -count=1
+# ok  github.com/spxrogers/agentsync/internal/git
+```
+
+**Commit:** `feat(git): add internal/git package with work-tree state detection`
+
+## Task 0.2 — `Init`: create an agentsync-owned repo (marker, notice, perms)
+
+**Files**
+- create `internal/git/init.go`
+- modify `internal/git/git_test.go` (add `TestInit`)
+
+**Interface**
+```go
+// Init creates a new agentsync-owned git repo at dir: PlainInit, stamp the
+// [agentsync] managed=true marker into .git/config, write the local-only notice
+// file, tighten .git to 0o700. Idempotent-safe: errors if dir already holds a repo
+// (callers gate on Detect == StateUntracked first).
+func Init(dir string) (*Repo, error)
+
+// Repo wraps a go-git repository + its absolute work-tree root.
+type Repo struct {
+    dir  string
+    repo *gogit.Repository
+}
+
+// Open opens an existing agentsync-owned repo (no marker check here; callers use
+// Detect). Returns the wrapper used by Commit/Restore/Log.
+func Open(dir string) (*Repo, error)
+
+const NoticeFile = "AGENTSYNC_LOCAL_HISTORY.md"
+```
+
+**Steps**
+- [ ] `Init`:
+  ```go
+  func Init(dir string) (*Repo, error) {
+      repo, err := gogit.PlainInit(dir, false)
+      if err != nil {
+          return nil, fmt.Errorf("git init %s: %w", dir, err)
+      }
+      // Marker — distinguishes our repo from a user's own (Detect reads it back).
+      cfg, err := repo.Config()
+      if err != nil {
+          return nil, fmt.Errorf("read fresh git config: %w", err)
+      }
+      cfg.Raw.Section(markerSection).SetOption(markerOption, "true")
+      if err := repo.SetConfig(cfg); err != nil {
+          return nil, fmt.Errorf("write marker to git config: %w", err)
+      }
+      // Privacy: history may carry cleartext secrets; keep .git user-only.
+      if err := os.Chmod(filepath.Join(dir, ".git"), 0o700); err != nil {
+          return nil, fmt.Errorf("chmod .git: %w", err)
+      }
+      if err := os.WriteFile(filepath.Join(dir, NoticeFile), []byte(noticeBody), 0o600); err != nil {
+          return nil, fmt.Errorf("write %s: %w", NoticeFile, err)
+      }
+      return &Repo{dir: dir, repo: repo}, nil
+  }
+  ```
+- [ ] Define `noticeBody` (a `const string`) covering: local-only agentsync
+  rollback history; MAY contain cleartext secrets; MUST NOT be pushed; roll back
+  with `agentsync revert <agent>`.
+- [ ] `Open`: `gogit.PlainOpen(dir)` → wrap; wrap `gogit.ErrRepositoryNotExists`
+  in a clear error.
+- [ ] `TestInit` (container): after `Init`, assert `.git` exists, `Detect` →
+  `StateAgentsyncOwned`, `NoticeFile` exists with mode `0o600`, and (best-effort,
+  skip on Windows) `.git` mode is `0o700`.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -run TestInit -count=1` → `ok`
+
+**Commit:** `feat(git): Init creates agentsync-owned repo with marker + local-only notice`
+
+## Task 0.3 — `Commit`: stage specific files + commit with the dedicated signature
+
+**Files**
+- create `internal/git/commit.go`
+- modify `internal/git/git_test.go` (add `TestCommit`)
+
+**Interface**
+```go
+// Commit stages exactly relPaths (slash-relative to the repo root) and records one
+// commit authored by id. Returns the new commit hash. relPaths may include
+// deletions (a path that no longer exists on disk is staged as a removal). Returns
+// (zeroHash, nil) and commits nothing when there is nothing to stage.
+func (r *Repo) Commit(relPaths []string, message string, id Identity) (string, error)
+```
+
+**Steps**
+- [ ] Implement:
+  ```go
+  func (r *Repo) Commit(relPaths []string, message string, id Identity) (string, error) {
+      wt, err := r.repo.Worktree()
+      if err != nil {
+          return "", fmt.Errorf("worktree: %w", err)
+      }
+      staged := 0
+      for _, rel := range relPaths {
+          // wt.Add stages both modifications and deletions for an existing index
+          // entry; for a brand-new file it stages the addition.
+          if _, err := wt.Add(rel); err != nil {
+              return "", fmt.Errorf("git add %s: %w", rel, err)
+          }
+          staged++
+      }
+      if staged == 0 {
+          return "", nil
+      }
+      if id.Name == "" { id = DefaultIdentity }
+      sig := &object.Signature{Name: id.Name, Email: id.Email, When: time.Now().UTC()}
+      h, err := wt.Commit(message, &gogit.CommitOptions{Author: sig, Committer: sig})
+      if err != nil {
+          return "", fmt.Errorf("git commit: %w", err)
+      }
+      return h.String(), nil
+  }
+  ```
+- [ ] `TestCommit` (container): `Init` a dir, write `a.txt`, `Commit(["a.txt"],
+  "first", DefaultIdentity)` → non-empty hash; `Log` (next task, or read via
+  go-git directly in this test) shows author `agentsync <agentsync@localhost>`.
+  Second case: overwrite `a.txt`, commit again → new distinct hash whose parent is
+  the first. Third: empty `relPaths` → returns `("", nil)`, no new commit.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -run TestCommit -count=1` → `ok`
+
+**Commit:** `feat(git): Commit stages named files and records the agentsync checkpoint`
+
+## Task 0.4 — `Log`: list checkpoints
+
+**Files**
+- create `internal/git/log.go`
+- modify `internal/git/git_test.go` (add `TestLog`)
+
+**Interface**
+```go
+// Checkpoint is one commit in a destination repo's history.
+type Checkpoint struct {
+    Hash    string    // full hash
+    Short   string    // first 7 chars
+    Subject string    // first line of the message
+    When    time.Time
+}
+
+// Log returns up to n checkpoints, newest first (n<=0 → all).
+func (r *Repo) Log(n int) ([]Checkpoint, error)
+
+// Resolve turns a revision (e.g. "HEAD", "HEAD~1", a short/long hash) into a full
+// hash, erroring clearly if it doesn't resolve.
+func (r *Repo) Resolve(rev string) (string, error)
+```
+
+**Steps**
+- [ ] `Log`: `r.repo.Log(&gogit.LogOptions{})` → iterate `iter.ForEach`, build
+  `Checkpoint`s, stop at `n`. Subject = `strings.SplitN(c.Message, "\n", 2)[0]`.
+- [ ] `Resolve`: `r.repo.ResolveRevision(plumbing.Revision(rev))`; wrap a
+  not-found in `fmt.Errorf("no such checkpoint %q in %s: %w", rev, r.dir, err)`.
+- [ ] `TestLog` (container): three commits → `Log(0)` returns 3 newest-first;
+  `Log(2)` returns 2; `Resolve("HEAD~1")` equals the 2nd-newest hash;
+  `Resolve("deadbeef")` errors.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -run TestLog -count=1` → `ok`
+
+**Commit:** `feat(git): Log + Resolve for browsing destination checkpoints`
+
+## Task 0.5 — `Restore`: append-only roll-back to a checkpoint
+
+**Files**
+- create `internal/git/restore.go`
+- modify `internal/git/git_test.go` (add `TestRestore`)
+
+**Interface**
+```go
+// FileChange describes one file a restore would touch (for --dry-run preview).
+type FileChange struct {
+    Path string
+    Kind string // "modify" | "create" | "delete"
+}
+
+// Plan computes what Restore(target) would change vs the current worktree HEAD,
+// WITHOUT writing anything.
+func (r *Repo) Plan(targetRev string) (targetHash string, changes []FileChange, err error)
+
+// Restore makes the worktree match the targetRev checkpoint and records the result
+// as a NEW commit on top of HEAD (append-only — HEAD advances, nothing is
+// rewritten or lost). Returns the new commit hash. Commits nothing and returns
+// (zeroHash, nil) when the worktree already matches target.
+func (r *Repo) Restore(targetRev, message string, id Identity) (string, error)
+```
+
+**Steps**
+- [ ] Helper `treeOf(rev)`: `Resolve` → `r.repo.CommitObject(hash)` → `c.Tree()`.
+- [ ] `Plan`: diff HEAD tree vs target tree:
+  ```go
+  headTree, _ := r.headTree()      // CommitObject(HEAD).Tree()
+  tgtHash, _ := r.Resolve(targetRev)
+  tgtTree, _ := r.treeOfHash(tgtHash)
+  changes, err := headTree.Diff(tgtTree)   // object.Changes: HEAD -> target
+  // For each *object.Change: action, _ := ch.Action()
+  //   merkletrie.Insert -> file exists in target, not HEAD  => Kind "create"
+  //   merkletrie.Delete -> file exists in HEAD,  not target => Kind "delete"
+  //   merkletrie.Modify -> Kind "modify"
+  ```
+  Build `[]FileChange` (use `ch.To.Name` for create/modify, `ch.From.Name` for
+  delete).
+- [ ] `Restore`: call `Plan`; if no changes return `("", nil)`. Else apply each
+  change to the worktree on the real FS under `r.dir`:
+  - create/modify → read target blob (`tgtTree.File(name)` → `f.Contents()`),
+    `os.MkdirAll(parent, 0o700)`, `os.WriteFile(abs, []byte(content), 0o600)`.
+  - delete → `os.Remove(abs)`.
+  Collect the touched rel-paths, then `r.Commit(touched, message, id)` to record
+  the append-only checkpoint.
+- [ ] `TestRestore` (container): commit `v1` of `a.txt`; commit `v2`; add `b.txt`
+  in a 3rd commit. `Restore("HEAD~2", "revert", id)`:
+  - `a.txt` bytes == `v1`, `b.txt` is gone.
+  - a NEW commit exists whose parent is the prior HEAD (assert via `Log` length +
+    parent), proving append-only (HEAD~2 commit still reachable in `Log`).
+  - `Plan` on an already-matching target returns no changes; `Restore` returns
+    `("", nil)`.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -run TestRestore -count=1` → `ok`
+
+**Commit:** `feat(git): append-only Restore to roll a worktree back to a checkpoint`
+
+## Task 0.6 — Never-push guard test
+
+**Files**
+- create `internal/git/nopush_test.go`
+
+**Steps**
+- [ ] A reflection/source guard that fails if the package ever grows a remote/push
+  surface. Simplest robust form: statically scan the package's own `.go` source
+  (non-test) for the tokens `Push`, `CreateRemote`, `remote(`, `Remote(`:
+  ```go
+  func TestNoPushSurface(t *testing.T) {
+      files, _ := filepath.Glob("*.go")
+      for _, f := range files {
+          if strings.HasSuffix(f, "_test.go") { continue }
+          b, err := os.ReadFile(f); if err != nil { t.Fatal(err) }
+          for _, bad := range []string{"Push", "CreateRemote", ".Remote(", "Remotes("} {
+              if bytes.Contains(b, []byte(bad)) {
+                  t.Errorf("%s references %q — internal/git must never push or add a remote (issue #118)", f, bad)
+              }
+          }
+      }
+  }
+  ```
+- [ ] Document the rule in the package doc comment so the intent is discoverable.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/git/ -count=1` → all green.
+
+**Commit:** `test(git): guard that internal/git exposes no remote/push surface`
+
+---
+
+# Milestone 1 — canonical config + `VersionedHome`
+
+## Task 1.1 — `DestinationGitBackupConfig` in the canonical schema
+
+**Files**
+- modify `internal/source/schema.go`
+- create/extend `internal/source/schema_test.go` (or the existing loader test) with
+  a parse case.
+
+**Steps**
+- [ ] Add to `Config` (after `Memory`):
+  ```go
+  DestinationGitBackup DestinationGitBackupConfig `toml:"destination_directory_git_backup"`
+  ```
+- [ ] Add the struct + mode constants:
+  ```go
+  // DestinationGitBackupConfig mirrors [destination_directory_git_backup] in
+  // agentsync.toml. It controls whether `apply` git-versions the rendered
+  // destination dirs (a local-only rollback history; never pushed — see issue
+  // #118 and the secret-handling note in CLAUDE.md). Empty Mode == ModePrompt.
+  type DestinationGitBackupConfig struct {
+      Mode        string `toml:"mode,omitempty"`         // "prompt" | "on" | "off"
+      AuthorName  string `toml:"author_name,omitempty"`
+      AuthorEmail string `toml:"author_email,omitempty"`
+  }
+
+  const (
+      GitBackupModePrompt = "prompt" // default: ask on first untracked write
+      GitBackupModeOn     = "on"     // init + checkpoint silently
+      GitBackupModeOff    = "off"    // never init/commit/prompt
+  )
+
+  // EffectiveMode returns Mode or GitBackupModePrompt when unset.
+  func (g DestinationGitBackupConfig) EffectiveMode() string {
+      if g.Mode == "" { return GitBackupModePrompt }
+      return g.Mode
+  }
+  ```
+- [ ] Test: unmarshal a fixture with
+  `[destination_directory_git_backup]\nmode = "on"\nauthor_name = "x"` and assert
+  the fields; assert an absent table yields `EffectiveMode() == "prompt"`.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/source/ -run GitBackup -count=1` → `ok`
+
+**Commit:** `feat(source): add [destination_directory_git_backup] to the canonical schema`
+
+## Task 1.2 — project-overlay merge for the new table
+
+**Files**
+- modify `internal/project/project.go` (the `Merge` function — see how
+  `UpdateDefaults`/`MemoryConfig` are merged today)
+- modify the project merge test.
+
+**Steps**
+- [ ] In `project.Merge`, after the existing `Updates`/`Memory` merge, override the
+  base `DestinationGitBackup` with the project's non-zero fields (project wins when
+  set; inherit base otherwise), matching the precedence the sibling tables use.
+  (Functionally this is a user-scope concern, but keeping the merge symmetric
+  avoids a surprising "project config silently ignored" gap.)
+- [ ] Test: base mode `"on"`, project mode `""` → merged `"on"`; project mode
+  `"off"` → merged `"off"`.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/project/ -count=1` → `ok`
+
+**Commit:** `feat(project): merge [destination_directory_git_backup] in the project overlay`
+
+## Task 1.3 — `VersionedHome` optional adapter interface + implementations
+
+**Files**
+- modify `internal/adapter/adapter.go` (declare the interface)
+- modify each deep adapter: `internal/adapter/{claude,opencode,codex,cursor,gemini,continuedev,windsurf,roo,cline}/*.go`
+- modify `internal/adapter/generic/*.go`
+- create `internal/adapter/versionedhome_test.go` (registry-wide behavioral guard)
+
+**Interface (in `adapter.go`, near `PluginIngester`/`WarnEmitter`)**
+```go
+// VersionedHome is an OPTIONAL Adapter extension. An adapter that writes into a
+// single coherent on-disk config directory declares it so the apply tail can
+// git-init and checkpoint that directory (issue #118). Adapters with no single
+// versionable root return ("", false).
+//
+// Read-only and user-scope-focused: HomeDir reports the dir to back up; it does
+// NOT widen the render/Apply contract. At ScopeProject it SHOULD return ("",false)
+// — project destinations live inside the user's own project repo and are left to
+// that repo's source control.
+type VersionedHome interface {
+    HomeDir(scope Scope, project string) (string, bool)
+}
+```
+
+**Steps**
+- [ ] Add the interface to `adapter.go` with the doc comment above.
+- [ ] For each deep adapter, add a method that returns its user-scope `ConfigDir`.
+  Each adapter already stores its target root (`a.opts.TargetRoot`) and has a
+  `ResolvePaths`. Example (cursor):
+  ```go
+  func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+      if scope != adapter.ScopeUser {
+          return "", false
+      }
+      cd := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+      if cd == "" {
+          return "", false
+      }
+      return cd, true
+  }
+  ```
+  Mirror per adapter using that adapter's own paths accessor + `ConfigDir`/root
+  field name. **Claude:** return `~/.claude` (its `ConfigDir`), NOT `$HOME` — the
+  stray `~/.claude.json` is intentionally excluded (decision #10).
+- [ ] **Generic adapter:** implement `HomeDir` by reading the dir from
+  `generic.Spec` (the Spec already encodes the agent's config dir/root used by its
+  Render paths). Return ("", false) only if a Spec genuinely has no single root.
+- [ ] Guard test `versionedhome_test.go`: build `registryFactory()`, iterate
+  `reg.Names()`, assert **every** registered adapter implements `VersionedHome` and
+  returns a non-empty absolute dir at `ScopeUser` that sits under the test target
+  root, AND returns `("", false)` at `ScopeProject`. (This is the analogue of
+  `TestEveryAdapterClassifiesSkips` — it pins the capability in code so a new
+  adapter can't silently skip git-backup support.) Use `AGENTSYNC_TARGET_ROOT` via
+  the existing test env helpers so the dirs resolve under a temp root.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/adapter/... -run VersionedHome -count=1` → `ok`
+
+**Commit:** `feat(adapter): VersionedHome extension exposing each agent's versionable dir`
+
+## Task 1.4 — persist `mode` back to `agentsync.toml` (comment-preserving)
+
+**Files**
+- create `internal/cli/gitbackup_config.go`
+- create `internal/cli/gitbackup_config_test.go`
+
+**Interface**
+```go
+// setDestinationGitBackupMode writes mode into the [destination_directory_git_backup]
+// table of ~/.agentsync/agentsync.toml, preserving everything outside that table
+// (comments, key order, other sections) via a line-splice — never a full marshal.
+// Creates the table if absent.
+func setDestinationGitBackupMode(home, mode string) error
+```
+
+**Steps**
+- [ ] Implement with the same line-splice strategy as `writeAgents`
+  (`agent.go:185`): read raw, drop the existing
+  `[destination_directory_git_backup]` section's lines, splice in a regenerated
+  block (`mode = "<mode>"` plus any preserved `author_name`/`author_email`), write
+  via `iox.AtomicWrite(p, …, 0o644)`. Re-emit only the `mode` line plus author
+  lines that were already present (parse them out before dropping), so an edit
+  doesn't silently delete a user's identity overrides.
+- [ ] Test (container): start from a fixture `agentsync.toml` with comments and an
+  `[updates]` table; `setDestinationGitBackupMode(home, "on")` then reload via
+  `source.Load` → mode `"on"`, `[updates]` intact, leading comments intact. Run it
+  twice → no duplicate table, spacing stable (mirror the `writeAgents` idempotency
+  assertion).
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run GitBackupConfig -count=1` → `ok`
+
+**Commit:** `feat(cli): persist destination-git-backup mode without clobbering agentsync.toml`
+
+---
+
+# Milestone 2 — apply-tail checkpoint hook
+
+## Task 2.1 — `apply --no-git-backup` flag
+
+**Files**
+- modify `internal/cli/apply.go`
+
+**Steps**
+- [ ] Add `var noGitBackup bool` in `newApplyCmd`; register
+  `cmd.Flags().BoolVar(&noGitBackup, "no-git-backup", false, "skip destination git
+  versioning/checkpoint for this run (CI/scripting); does not modify
+  agentsync.toml")`.
+- [ ] Thread it into `applyRun` (add a `noGitBackup bool` param; pass through both
+  call sites at lines 42 and 45).
+- [ ] No behavior yet beyond plumbing; build only.
+
+**Test:** `go build ./... && AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run Apply -count=1` → `ok` (existing apply tests still pass).
+
+**Commit:** `feat(cli): add apply --no-git-backup flag (plumbing)`
+
+## Task 2.2 — checkpoint orchestration (group `written` → per agent → init/commit)
+
+**Files**
+- create `internal/cli/gitbackup.go`
+- create `internal/cli/gitbackup_test.go`
+
+**Interface**
+```go
+// runDestinationGitBackup checkpoints each user-scope agent dir that got managed
+// writes this apply. It is a no-op (returns nil) for: project scope, --no-git-backup,
+// mode "off", an empty `written` set, or an agent whose dir is foreign-tracked.
+// Best-effort by contract: a git failure for one agent is reported to p.Err and
+// does NOT fail the apply (the files are already written + state saved).
+func runDestinationGitBackup(
+    cmd *cobra.Command, p *ui.Printer, reg *adapter.Registry, agents []string,
+    sc adapter.Scope, projectRoot, home, userHome string,
+    cfg source.DestinationGitBackupConfig, written map[string]bool, noGitBackup bool,
+) error
+```
+
+**Steps**
+- [ ] Early returns: `sc != adapter.ScopeUser`, `noGitBackup`, or
+  `cfg.EffectiveMode() == GitBackupModeOff`, or `len(written) == 0` → return nil.
+- [ ] Build the dedicated identity: `id := agitgit.Identity{Name: cfg.AuthorName,
+  Email: cfg.AuthorEmail}` (empty fields fall back to `DefaultIdentity` inside
+  `Commit`). (Alias the package, e.g. `import agit "…/internal/git"`, to avoid
+  colliding with go-git if both are ever imported.)
+- [ ] For each enabled agent name in `agents`:
+  - `ad := reg.Lookup(name)`; `vh, ok := ad.(adapter.VersionedHome)`; if `!ok`
+    continue.
+  - `dir, ok := vh.HomeDir(sc, projectRoot)`; if `!ok` continue.
+  - Select this agent's written files under `dir`:
+    ```go
+    var rels []string
+    for abs := range written {
+        if underDir(dir, abs) {            // filepath.Rel + no ".." prefix
+            rels = append(rels, relSlash(dir, abs))
+        }
+    }
+    if len(rels) == 0 { continue }         // nothing managed under this dir changed
+    sort.Strings(rels)
+    ```
+  - `st, err := agit.Detect(dir)`; on error → warn to `p.Err`, continue.
+  - `switch st`:
+    - `StateForeign` → optional one-line hint (only once per dir), continue (decision #5).
+    - `StateUntracked` → consult `mode`:
+      - `GitBackupModeOn` → `repo, err := agit.Init(dir)`.
+      - `GitBackupModePrompt` → call `promptInitGitBackup(cmd, p, dir)` (Task 2.3).
+        On "yes" → `Init` + persist `setDestinationGitBackupMode(home, "on")`. On
+        "no" → continue. On "no, don't ask again" → persist
+        `setDestinationGitBackupMode(home, "off")` and continue. On no-TTY/no-input
+        → print a one-line hint and continue (can't ask).
+    - `StateAgentsyncOwned` → `repo, err := agit.Open(dir)`.
+  - With `repo` in hand: also stage the notice file if it's new (Init already wrote
+    it; include `agit.NoticeFile` in `rels` on the first commit so it's tracked).
+  - `msg := fmt.Sprintf("agentsync apply: %s (%s) — %d file(s)\n\n%s", name, sc, len(rels), strings.Join(rels, "\n"))`.
+  - `h, err := repo.Commit(rels, msg, id)`; on error → warn, continue. On success
+    with non-empty `h` → optional faint confirmation line to `p.Err`.
+- [ ] Helpers `underDir(dir, abs) bool` and `relSlash(dir, abs) string`
+  (`filepath.Rel` + `filepath.ToSlash`, reject `..`).
+- [ ] `gitbackup_test.go` (container, real FS): drive the orchestration directly
+  (not through full apply) with a fake registry whose adapter's `HomeDir` returns a
+  temp dir and a `written` map of files under it. Assert:
+  - mode `"on"`, untracked dir → exactly one commit, contains the written files +
+    notice, NOT unrelated files placed in the dir.
+  - empty `written` → no repo created.
+  - foreign dir (pre-`PlainInit` without marker) → no agentsync commits added.
+  - `--no-git-backup` / mode `"off"` → no-op.
+  - project scope → no-op.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run GitBackup -count=1` → `ok`
+
+**Commit:** `feat(cli): checkpoint each user-scope agent dir after a writing apply`
+
+## Task 2.3 — the opt-out init prompt
+
+**Files**
+- modify `internal/cli/gitbackup.go`
+- modify `internal/cli/gitbackup_test.go`
+
+**Interface**
+```go
+type promptResult int
+const (
+    promptYes promptResult = iota
+    promptNo
+    promptNever      // "no, and don't ask again"
+    promptUnavailable // no TTY / --no-input — caller skips silently with a hint
+)
+
+func promptInitGitBackup(cmd *cobra.Command, p *ui.Printer, dir string) promptResult
+```
+
+**Steps**
+- [ ] If `noInputFlag(cmd) || !stdinIsTerminal(cmd)` → `promptUnavailable`.
+- [ ] Otherwise prompt with the `bufio.NewReader(cmd.InOrStdin())` idiom from
+  `promptScopeChoice` (apply.go:504). Offer `[y] yes  [n] not now  [d] don't ask
+  again`, re-prompting on invalid input up to 5 times; EOF → `promptNo`. Make the
+  copy explicit that this creates a **local-only, never-pushed** history that may
+  contain secrets.
+- [ ] Tests: feed `cmd.SetIn(strings.NewReader("y\n"))` etc. — but note these run
+  via the orchestration which gates on `stdinIsTerminal`; for unit-testing the
+  prompt parsing, test `promptInitGitBackup` with an injected reader and a forced
+  TTY shim, OR (simpler) test the three persisted outcomes through the
+  orchestration with `--no-input` unset by stubbing the terminal check. Keep at
+  least: "y" → repo created + mode persisted `"on"`; "d" → no repo + mode `"off"`;
+  no-TTY → no repo, mode unchanged.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run GitBackupPrompt -count=1` → `ok`
+
+**Commit:** `feat(cli): opt-out prompt to git-init a destination dir on first apply`
+
+## Task 2.4 — wire the orchestration into the apply tail
+
+**Files**
+- modify `internal/cli/apply.go`
+
+**Steps**
+- [ ] After `_ = render.PruneBackups(home, render.DefaultBackupKeep)` (line ~222)
+  and before the success print (line ~224), insert:
+  ```go
+  // Destination git backup (issue #118): checkpoint the user-scope agent dirs we
+  // just wrote, so a bad apply is a `git revert` / `agentsync revert` away. Local-
+  // only, never pushed. Best-effort — never fails an otherwise-successful apply.
+  if err := runDestinationGitBackup(cmd, p, reg, agents, sc, projectRoot, home, userHome,
+      c.Config.DestinationGitBackup, written, noGitBackup); err != nil {
+      fmt.Fprintf(p.Err, "%s destination git backup: %v\n", p.Yellow("agentsync:"), err)
+  }
+  ```
+  (`c` is the loaded canonical in scope; `c.Config.DestinationGitBackup` carries
+  the merged config.)
+- [ ] Full integration test in `internal/cli` (real FS, container): seed a minimal
+  canonical with one enabled agent, `mode = "on"`, run the real `apply` command
+  end-to-end, assert the agent dir is now an agentsync-owned repo with one
+  checkpoint; run `apply` again with no source change → no second commit (the
+  "apply changed nothing" path leaves `written` empty/unchanged). Use the existing
+  apply integration-test harness/fixtures as the template.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run Apply -count=1` → `ok`
+
+**Commit:** `feat(cli): run destination git backup in the apply tail`
+
+---
+
+# Milestone 3 — `agentsync revert`
+
+## Task 3.1 — command skeleton + flags
+
+**Files**
+- create `internal/cli/revert.go`
+- modify `internal/cli/root.go` (register `newRevertCmd()`)
+
+**Steps**
+- [ ] Model on `newVerifyCmd`/`newDoctorCmd`. Surface:
+  ```
+  agentsync revert <agent> [--to <ref>] [--all] [--dry-run]
+  ```
+  Flags: `--to` (string), `--all` (bool), `--dry-run` (bool). `Args:
+  cobra.MaximumNArgs(1)`. Reject `--all` together with a positional `<agent>`
+  (`return fmt.Errorf("--all reverts every managed dir; do not also pass an agent")`).
+  Require exactly one of {positional agent, `--all`}.
+- [ ] Add `newRevertCmd()` to the `cmd.AddCommand(...)` block in `root.go:42`.
+- [ ] Wire `home`, `reg := registryFactory()`, `userHome`, and resolve target dirs
+  via `VersionedHome.HomeDir(adapter.ScopeUser, "")` for the named agent (or all
+  registered agents for `--all`).
+
+**Test:** `go build ./... && agentsync revert --help` shows the surface; an unknown
+agent name errors. Add a `internal/cli` test for arg validation.
+
+**Commit:** `feat(cli): scaffold agentsync revert command`
+
+## Task 3.2 — revert behavior (resolve target, restore, out-of-sync notice)
+
+**Files**
+- modify `internal/cli/revert.go`
+- create `internal/cli/revert_test.go`
+
+**Steps**
+- [ ] For the target agent: `dir, ok := vh.HomeDir(...)`; `st, _ := agit.Detect(dir)`.
+  - `st != StateAgentsyncOwned` → clear error: not an agentsync-managed repo;
+    suggest enabling backups + running `apply` first.
+- [ ] `repo, _ := agit.Open(dir)`. Resolve the target rev:
+  - `--to` set → that rev.
+  - default → `"HEAD~1"` (undo the most recent apply — decision #17). If the repo
+    has only one commit, error: nothing earlier to revert to.
+- [ ] `--dry-run` → `repo.Plan(target)` → print target short hash + subject (via
+  `Log`) and the `[]FileChange`; exit without writing.
+- [ ] Else `repo.Restore(target, fmt.Sprintf("agentsync revert: %s → %s", name, short), id)`.
+  On a no-op (`("", nil)`) tell the user the dir already matches that checkpoint.
+- [ ] Always print the out-of-sync notice on a real revert (decision #4):
+  > `agentsync revert` completed. The destination directory `<dir>` is now out of
+  > sync with the agentsync configuration. Please reconcile as needed (e.g.
+  > `agentsync reconcile` / `agentsync import`) before your next `agentsync apply`
+  > to avoid re-losing these changes.
+- [ ] Tests (container): build a repo with 2 checkpoints (simulate two applies by
+  writing+`Commit` directly, or by running apply twice). `revert <agent>`:
+  - files match the earlier checkpoint; a NEW commit exists (append-only);
+  - stdout carries the out-of-sync notice.
+  - `--to <hash>` targets a specific checkpoint.
+  - `--dry-run` writes nothing (worktree unchanged) and lists the changes.
+  - un-inited dir / unknown `--to` → clear errors, no writes.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run Revert -count=1` → `ok`
+
+**Commit:** `feat(cli): agentsync revert restores a destination dir to a checkpoint`
+
+## Task 3.3 — `--all`
+
+**Files**
+- modify `internal/cli/revert.go`
+- modify `internal/cli/revert_test.go`
+
+**Steps**
+- [ ] `--all`: iterate every registered agent; for each `StateAgentsyncOwned` dir,
+  run the same default-`HEAD~1` revert; skip (with a faint note) dirs that are
+  untracked/foreign or have only one checkpoint. Aggregate a summary; print the
+  out-of-sync notice once, listing each reverted dir. `--to` is rejected with
+  `--all` (a ref is per-repo and meaningless across dirs) — error clearly.
+- [ ] `--dry-run --all` previews each.
+- [ ] Test: two managed agent dirs + one foreign → `--all` reverts the two, skips
+  the foreign, notice lists both.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run RevertAll -count=1` → `ok`
+
+**Commit:** `feat(cli): agentsync revert --all across every managed destination dir`
+
+---
+
+# Milestone 4 — doctor status + docs (same PR — `CLAUDE.md` doc-sync rule)
+
+## Task 4.1 — `agentsync doctor` "Destination git backup" section
+
+**Files**
+- modify `internal/cli/doctor.go`
+- modify the doctor test (the existing `internal/cli` doctor test pins substrings).
+
+**Steps**
+- [ ] After the "Plugins" section, add:
+  ```go
+  fmt.Fprintln(p.Out, "")
+  p.Section("Destination git backup")
+  checkDestinationGitBackup(p, home)
+  ```
+- [ ] `checkDestinationGitBackup(p, home)`: load config (`source.Load`); print the
+  effective mode (`okCheck`/`warnCheck` with label `mode       `). Then for each
+  registered agent with a `VersionedHome` dir that exists on disk, print one line:
+  `agentsync-versioned` (✓), `foreign source control` (ℹ), or `untracked` (ℹ),
+  using `agit.Detect`. Informational only — never increments `fails`.
+- [ ] Update the doctor test's expected substrings (it asserts contiguous
+  `<label><status>`); add a case asserting the new section header + the mode line.
+
+**Test:** `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli/ -run Doctor -count=1` → `ok`
+
+**Commit:** `feat(cli): doctor surfaces destination-git-backup status (read-only)`
+
+## Task 4.2 — docs + changelog + scaffold
+
+**Files**
+- modify `docs/user-guide.md` — command reference: add `revert`, the `apply
+  --no-git-backup` flag, the new `doctor` line, the
+  `[destination_directory_git_backup]` table in the `agentsync.toml` layout block,
+  and a short "destination versioning" concept blurb.
+- modify `README.md` — quick-reference table: add `revert`; one line noting
+  local-only auto-versioning.
+- modify `website/src/content/docs/reference/cli.mdx` — "At a glance" table row +
+  a `### revert` section + the `apply --no-git-backup` flag.
+- modify `docs/concepts.md` — note destination dirs may carry a local-only git
+  history, distinct from `.state/`.
+- modify `docs/architecture.md` — where the checkpoint step sits in the apply tail;
+  the never-push invariant; `.state/` untouched.
+- modify `internal/cli/init.go` — add a commented
+  `[destination_directory_git_backup]` block to `initialAgentsyncTOML` (mirrors the
+  commented `[secrets]` block style).
+- modify `CHANGELOG.md` — under `[Unreleased] / Added`:
+  - `agentsync revert` — roll a destination agent dir back to a prior apply checkpoint.
+  - Destination dirs are auto-versioned with a local-only git repo (opt-out;
+    `[destination_directory_git_backup]`); `apply --no-git-backup` bypasses it.
+
+**Steps**
+- [ ] Make each edit; keep the matrices/contract pages untouched (this is not a
+  per-agent component capability — the capability matrix does NOT change).
+- [ ] Verify the website doc build still passes if the repo builds it
+  (`website/` — only the authored pages above; the generated contract pages are
+  untouched).
+
+**Test:** `go build ./... && AGENTSYNC_TEST_IN_CONTAINER=1 just test-fast`; then the
+container lint:
+`GOTOOLCHAIN=go1.26.2 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`
+→ clean. Re-stage any files `just lint` rewrote.
+
+**Commit:** `docs: document destination git backup + agentsync revert`
+
+---
+
+## Spec-coverage map (every requirement → task)
+
+| Spec requirement | Task(s) |
+|---|---|
+| Per-destination repo, user scope | 1.3, 2.2 |
+| Opt-out prompt + sticky "don't ask again" | 2.3, 1.4 |
+| `mode = prompt/on/off` config table | 1.1, 1.2 |
+| `--no-git-backup` CI bypass | 2.1, 2.2 |
+| Commit each writing apply; no-op when in sync | 2.2, 2.4 |
+| Whole-file commit scope; no unrelated files | 2.2 |
+| Stray `$HOME` files excluded (gap) | 1.3 (Claude HomeDir=`~/.claude`) |
+| Respect existing source control | 0.1 (Detect), 2.2 |
+| `VersionedHome` git-root mechanism | 1.3 |
+| Dedicated commit identity (overridable) | 0.3, 1.1, 2.2 |
+| Auto-created marker + notice file | 0.2 |
+| `.git` 0o700 / files 0o600 | 0.2 |
+| Never push (no remote API) | M0 (no surface), 0.6 guard |
+| `agentsync revert <agent>` default last | 3.1, 3.2 |
+| Append-only restore | 0.5, 3.2 |
+| `--to`, `--all`, `--dry-run` | 3.1, 3.2, 3.3 |
+| Out-of-sync notice | 3.2, 3.3 |
+| `doctor` status (no `git` command) | 4.1 |
+| Docs in same PR | 4.2 |
+| `.state/` untouched | (no task modifies it — verified by absence) |
+
+## Risks / watch-items for the implementer
+
+- **go-git `wt.Add` of a deletion:** confirm v5.18.0 stages a removed file via
+  `wt.Add(rel)`; if not, use `wt.Remove(rel)` for the delete branch in `Commit`.
+  Task 0.3's test must include a deletion to catch this.
+- **Real FS required:** go-git won't operate on `afero.MemMapFs`; all M0/M2/M3
+  tests use `t.TempDir()` + `testenv.RequireContainer`.
+- **Generic adapter dir source:** verify `generic.Spec` truly exposes a single
+  config dir before asserting `HomeDir`; if a Spec lacks one, return `("",false)`
+  and let the registry guard (1.3) document the abstention rather than inventing a
+  path (per the "cross-reference upstream harness docs" rule).
+- **`apply` integration fixtures:** reuse the existing `internal/cli` apply test
+  harness rather than hand-rolling a canonical; match its scope/target-root env
+  setup so the new dirs resolve under the temp root.

--- a/docs/superpowers/plans/2026-06-28-destination-git-versioning.md
+++ b/docs/superpowers/plans/2026-06-28-destination-git-versioning.md
@@ -5,6 +5,15 @@
 **Spec:** [`docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md`](../specs/2026-06-28-destination-git-versioning-design.md)
 **PR:** [#119](https://github.com/spxrogers/agentsync/pull/119)
 
+> **Note (post-implementation):** during review the design evolved in two ways the
+> plan below predates — see the spec for the final design. (1) The optional adapter
+> extension is **`VersionedDirs.VersionRoots() []string`** (a *set* of dirs), not
+> `VersionedHome.HomeDir() (string,bool)`; **every** adapter implements it (deep +
+> breadth), and the apply tail unions/de-nests/de-dups the roots so **shared
+> cross-agent dirs like `~/.agents/skills` are versioned, deduped to one repo**.
+> (2) `revert` takes the global lock and snapshots uncommitted tracked edits before
+> its hard reset (no data loss).
+
 ---
 
 ## Goal

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -1,0 +1,464 @@
+# Destination auto-git versioning + `agentsync revert` — Design Spec
+
+**Date:** 2026-06-28
+**Status:** Draft for review — design first, implementation plan to follow.
+**Issue:** [#118 — Auto-version the destination agent dirs with git so a bad `apply` is revertible](https://github.com/spxrogers/agentsync/issues/118)
+
+---
+
+## Summary
+
+`agentsync apply` renders the canonical `~/.agentsync/` config into each agent's
+native config dir (`~/.claude`, `~/.codex`, `~/.cursor`, …), overwriting real
+files those tools read. Today the only destination-side safety net is the narrow,
+ephemeral, foreign-collision-only backup under the gitignored
+`~/.agentsync/.state/backups/<ts>/` (capped at the 20 most recent), and there is
+no undo path at all.
+
+This feature gives each destination agent dir its **own local-only git repo** so
+that every `apply` leaves a clean, browsable checkpoint, and adds a first-class
+`agentsync revert` command to roll a destination back to a prior checkpoint. The
+repos are **never pushed to a remote** — they exist solely for local rollback —
+which is what makes it acceptable for them to hold the cleartext secrets the
+rendered files already contain.
+
+Two user-visible surfaces ship together:
+
+1. **Auto-versioning** — on the first write to an untracked destination dir,
+   prompt (opt-out) to `git init` it; after each successful apply that changed
+   managed files there, `git add` + commit a checkpoint.
+2. **`agentsync revert <agent>`** — restore a destination dir to a prior
+   checkpoint (last by default), append-only, then print an out-of-sync notice
+   telling the user to reconcile before the next apply.
+
+A new global `[git]` table in `agentsync.toml` holds the mode (prompt / auto /
+off) and optional commit-identity overrides; `apply --no-git` bypasses everything
+for CI/scripting.
+
+---
+
+## Goals / Non-goals
+
+**Goals**
+
+- A durable, browsable, revertible **local** history of agentsync's writes into
+  each destination agent dir, scoped per agent.
+- A clean per-apply checkpoint commit — only when the apply actually changed
+  managed files (apply is a no-op when in sync, and so is the commit step).
+- A first-class `agentsync revert` that doesn't make users hand-drive git, and
+  that is honest about leaving the destination out of sync with canonical.
+- Zero new third-party dependencies — reuse the already-vendored
+  `github.com/go-git/go-git/v5` (`v5.18.0`, used today in `internal/cli/init.go`).
+- Keep `~/.agentsync/.state/` (hashes + foreign-collision backups + its pruning)
+  exactly as-is; this complements it, it does not replace it.
+
+**Non-goals**
+
+- Pushing any destination repo to a remote (local-only by design — see Secrets).
+- Versioning the canonical `~/.agentsync/` source dir (users already keep that in
+  their own dotfiles repo, with secret *references* only).
+- Snapshotting stray `$HOME`-level managed files (e.g. `~/.claude.json`) into the
+  git net — see "Commit scope & git root" for the decided boundary and gap.
+- Sub-file / per-JSON-pointer staging of shared files — shared files are committed
+  whole (KISS, per the issue).
+
+---
+
+## Locked decisions
+
+These are settled — from the issue's "Decisions" section plus the four design
+questions resolved up front for this spec.
+
+| # | Decision | Source |
+|---|---|---|
+| 1 | **Per-destination repo, not an umbrella repo.** Each agent dir gets its own independent repo (`~/.claude/.git`, `~/.codex/.git`, …). | Issue |
+| 2 | **Opt-out** with a CLI bypass and a sticky "don't ask again." Default = prompt on first untracked write; CI/scripting flag skips it; a remembered decline is persisted in `agentsync.toml`. | Issue |
+| 3 | **Commit scope = agentsync-managed changes; KISS on shared files.** For a wholly-owned file, just that file; for a shared file (e.g. `settings.json`) where agentsync owns only some keys, `git add` + commit the whole file as written — no per-pointer slicing. Don't sweep in entirely-unrelated files agentsync never touched. | Issue |
+| 4 | **Ship a first-class `agentsync revert`** that rolls a destination back to a prior apply checkpoint and prints an out-of-sync reconcile notice on completion. | Issue |
+| 5 | **Respect existing source control.** If a destination dir is already a git work tree (or nested in one — e.g. `~/.claude` kept in dotfiles), do **not** init or auto-commit; at most surface a hint. | Issue |
+| 6 | **Local-only, never pushed.** Never `git remote add`, never `git push` from agentsync for these repos. Cleartext secrets in this local history are an accepted tradeoff. | Issue |
+| 7 | **Leave `.state/` (incl. `.state/backups/` and its pruning) exactly as-is.** | Issue |
+| 8 | **Revert is append-only.** `revert` re-materializes files from the chosen checkpoint and records a **new** commit; history is never rewritten, so the bad apply stays auditable and the revert is itself revertible. | Q (this spec) |
+| 9 | **`agentsync revert <agent>` defaults to the last checkpoint**, with `--to <ref>`, `--all`, and `--dry-run`. | Q (this spec) |
+| 10 | **Git root = the agent's own config dir only.** Stray `$HOME`-level managed files (e.g. `~/.claude.json`) stay out of git (we never init a repo at `$HOME`) and keep relying on `.state/backups`. Documented as a known gap. | Q (this spec) |
+| 11 | **Dedicated agentsync commit identity** (`agentsync <agentsync@localhost>`), overridable via `[git]`. Works even when no global git identity is set. | Q (this spec) |
+
+---
+
+## Architecture
+
+The feature lives almost entirely in the apply tail and a new `revert` command,
+plus a thin git helper. It does **not** touch the render/classify/write core, the
+drift classifier, the secret invariants, or `.state/`.
+
+```
+agentsync apply  ──► render.Apply(...) ──► written map[string]bool (abs dest paths)
+                                              │
+                          (existing pipeline) │  state saved, backups pruned
+                                              ▼
+                                   ┌────────────────────────┐
+                                   │  NEW: destination git   │   internal/git (new)
+                                   │  checkpoint step        │   + apply.go hook
+                                   └────────────────────────┘
+                                              │
+              per agent that wrote files this run:
+              1. resolve agent's git root dir (user scope)
+              2. is it already a work tree?  ── yes ─► skip (decision #5), hint
+              3. untracked + mode=prompt + TTY ─► prompt to init (opt-out)
+              4. mode=auto / accepted ─► git init (first time) + add changed
+                 managed files under root + commit checkpoint
+```
+
+```
+agentsync revert <agent> [--to <ref>] [--all] [--dry-run]
+   └─► open agent's git root repo ─► resolve target checkpoint (default: prev)
+        └─► restore worktree files from that checkpoint ─► commit "revert to <ref>"
+             └─► print: destination now OUT OF SYNC with canonical; reconcile first
+```
+
+### Where it hooks in (concrete anchors)
+
+- **Apply tail** — `internal/cli/apply.go`, after the successful state save
+  (`state.Save(statePath, s)`, ~line 217) and backup prune
+  (`render.PruneBackups(home, render.DefaultBackupKeep)`, ~line 222), before the
+  final success message. The managed-file set is the `written map[string]bool`
+  returned by `render.Apply` (`internal/render/pipeline.go`, `applyPlan` returns
+  `reports, written, unchanged, err`). All paths in `written` are absolute. The
+  checkpoint step is **skipped entirely** in `--dry-run` (no writes happen) and is
+  a no-op when `written` is empty (apply changed nothing).
+- **New command** — `internal/cli/revert.go`, registered in
+  `internal/cli/root.go`'s `NewRoot()` `cmd.AddCommand(...)` list, structured like
+  the existing simple commands (`newDoctorCmd` / `newVerifyCmd`).
+- **New helper package** — `internal/git/git.go`, a thin wrapper over go-git:
+  `IsWorkTree(dir) bool`, `Init(dir) error`, `Open(dir) (*Repo, error)`,
+  `AddAndCommit(repo, paths, msg, author) (commitHash, error)`,
+  `RestoreToCheckpoint(repo, ref) error`, `Log(repo, n) ([]Checkpoint, error)`,
+  `IsClean(repo) (bool, error)`. Today go-git usage is a single inline
+  `git.PlainClone` in `init.go`; this consolidates the new surface in one place
+  with one author-signature path. (Note: go-git's `Worktree.Commit` requires an
+  `object.Signature`; the dedicated identity lives here, decision #11.)
+
+### Commit scope & git root
+
+The unit of versioning is **the agent's own config directory at user scope**.
+
+- **Git root resolution.** Each adapter already resolves its own destination paths
+  via a per-adapter `ResolvePaths` returning an adapter-specific `Paths` struct
+  (e.g. Cursor's `Paths.ConfigDir = ~/.cursor`). There is no shared accessor on
+  the `Adapter` interface today. **Recommended:** add a small **optional extension
+  interface** (mirroring the existing `PluginIngester` / `WarnEmitter` idiom) so an
+  adapter can declare its versionable root:
+
+  ```go
+  // VersionedHome is an OPTIONAL Adapter extension: an adapter that writes into a
+  // single coherent on-disk config dir declares it so the apply tail can git-init
+  // and checkpoint that dir. Adapters that resolve no single root (noop) don't
+  // implement it and are skipped.
+  type VersionedHome interface {
+      // HomeDir returns the absolute config-dir root to version for this scope,
+      // or ("", false) if there is none (e.g. project scope, or no coherent root).
+      HomeDir(scope Scope, project string) (string, bool)
+  }
+  ```
+
+  All nine deep adapters and the data-driven `generic` tier implement it (the
+  generic adapter reads the root from its `generic.Spec`); `noop` does not. This
+  keeps the core `Adapter` contract unchanged and lets edge adapters abstain — the
+  same pattern the codebase already uses for optional capabilities.
+
+  *Alternative considered:* derive the root from the `written` paths or keep a
+  central agent→dir table in `internal/git`. Rejected as primary because deriving
+  "the config dir" from a flat path set is ambiguous (`~/.claude` vs
+  `~/.claude/skills`), and a central table duplicates path knowledge the adapters
+  already own. Flagged as an open implementation detail below.
+
+- **Which files get staged.** Only managed files written under that root this run
+  — i.e. `written ∩ {files under HomeDir}`. For shared files (e.g.
+  `~/.claude/settings.json`) the **whole file** is staged as written (decision #3),
+  co-located user keys included. We do not `git add -A` the whole tree, so
+  unrelated files the user dropped in the agent dir aren't swept in. (A `.git` that
+  already tracks more is the user's existing-repo case → decision #5, we don't
+  touch it.)
+
+- **Stray `$HOME`-level files are out of scope (decided gap).** Claude writes
+  `~/.claude/` *and* `~/.claude.json` directly in `$HOME`. We will **not** init a
+  repo at `$HOME`. So `~/.claude.json` (and any other top-level managed file) is
+  **not** captured in the git history; it continues to rely on the existing
+  `.state/backups` foreign-collision backup exactly as today. This is documented as
+  a known limitation in the user guide and the `revert` help text.
+
+- **Scope.** This targets **user-scope** destinations. Project-scope rendering
+  writes into the project tree (e.g. `<repo>/.cursor/…`), which is virtually
+  always already a git work tree → decision #5 makes it a natural no-op. The
+  checkpoint step only runs for user scope; `agentsync revert` operates on
+  user-scope agent dirs.
+
+### Detecting an existing work tree (decision #5)
+
+Use go-git `PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true})`
+so a destination **nested inside** an existing repo (dotfiles user) is detected,
+not just a `.git` exactly at the root. If detected and the repo is **not** one
+agentsync itself created (see "marker" below), agentsync neither inits nor
+auto-commits; it may print a one-line hint that auto-versioning is disabled
+because the dir is already under source control.
+
+**Repo marker.** To tell "a repo agentsync auto-created" from "the user's own
+repo," the auto-init writes a small marker (the generated `README` / notice file,
+below, plus optionally a config key under the repo's own `.git/config`, e.g.
+`[agentsync] managed = true`). Auto-commit only runs against repos carrying the
+marker. A user's pre-existing repo never gets the marker, so agentsync stays out
+of it.
+
+### Auto-init repo contents
+
+On first init, agentsync writes a generated notice file at the repo root (e.g.
+`AGENTSYNC_LOCAL_HISTORY.md`) making clear:
+
+- this is a **local-only** agentsync rollback history,
+- it **may contain cleartext secrets** and **must never be pushed**,
+- how to roll back (`agentsync revert <agent>`).
+
+The notice is itself committed in the initial checkpoint. Repo privacy: rendered
+files are already `0o600` (`internal/iox/atomic.go`); the `.git` dir is created
+`0o700` so the history is user-only.
+
+---
+
+## Config schema — the `[git]` table
+
+New global table in `~/.agentsync/agentsync.toml`, parsed into a `GitConfig`
+struct added to `source.Config` (`internal/source/schema.go`, alongside `Agents`,
+`Updates`, `Secrets`, `Memory`). Project overlay merges like the others
+(`internal/project`), though git settings are a user-scope concern in practice.
+
+```toml
+[git]
+# Destination auto-versioning behavior. Tri-state:
+#   "prompt" (default) — on first write to an untracked agent dir, ask to init.
+#   "auto"             — init + checkpoint silently (set after the user says yes).
+#   "off"              — never init/commit/prompt (set by "don't ask again").
+mode = "prompt"
+
+# Optional commit-identity overrides (defaults shown).
+author_name  = "agentsync"
+author_email = "agentsync@localhost"
+```
+
+State transitions:
+
+| Event | Result |
+|---|---|
+| Table absent / `mode` unset | Treated as `"prompt"`. |
+| User answers **yes** at the init prompt | Persist `mode = "auto"`. |
+| User answers **no** | Skip this run; leave `mode = "prompt"` (will ask again). |
+| User answers **no + don't ask again** | Persist `mode = "off"`. |
+| `apply --no-git` (per run) | Force-skip init/commit for that invocation, regardless of `mode`. Never mutates config. |
+| Re-enable later | User edits `agentsync.toml` (`mode = "prompt"`/`"auto"`). |
+
+Writing the persisted `mode` back into `agentsync.toml` goes through the existing
+canonical TOML writer (comment- and order-preserving), the same path
+`agentsync mcp add` etc. use — it must not clobber the user's hand-edits.
+
+---
+
+## CLI surface
+
+### `agentsync apply` — one new flag
+
+```
+--no-git    Skip destination git init/checkpoint for this run (CI/scripting).
+            Does not modify agentsync.toml.
+```
+
+Everything else about apply is unchanged. In `--no-git` or non-interactive
+(`--no-input` / no TTY) runs, agentsync never prompts; with `mode = "auto"` it
+still checkpoints silently (no prompt needed), with `mode = "prompt"` and no TTY
+it skips init (can't ask) and prints a one-line hint.
+
+### `agentsync revert` — new command
+
+```
+agentsync revert <agent> [flags]
+
+  Restore an agent's destination dir to a prior apply checkpoint. Append-only:
+  records a new commit; never rewrites history.
+
+Flags:
+  --to <ref>     Checkpoint to restore (commit hash / relative like HEAD~2).
+                 Default: the previous checkpoint (undo the most recent apply).
+  --all          Revert every agentsync-managed destination dir to its last
+                 checkpoint. Mutually exclusive with a positional <agent>.
+  --dry-run      Show what would change (files + target commit) without writing.
+  --scope        user (default). Project dirs are left to their own repo.
+```
+
+Behavior:
+
+1. Resolve the agent's git root (user scope). Error clearly if the dir isn't an
+   agentsync-managed repo (no marker / never inited).
+2. Resolve the target checkpoint (`--to` or the previous checkpoint by default).
+3. Restore the worktree files to that checkpoint's content and record a new commit
+   `agentsync revert: <agent> → <short-ref>`. Append-only (decision #8).
+4. Print the **out-of-sync notice** (decision #4):
+
+   > `agentsync revert` completed. The destination directory `<dir>` is now out
+   > of sync with the agentsync configuration. Please reconcile as needed (e.g.
+   > `agentsync reconcile` / `agentsync import`) before your next `agentsync
+   > apply` to avoid re-losing these changes.
+
+`--dry-run` prints the target commit and the file diff summary and exits without
+committing.
+
+### Commit message format
+
+Per-apply checkpoint:
+
+```
+agentsync apply: <agent> (<scope>) — <n> file(s)
+
+<rel/path/under/root/1>
+<rel/path/under/root/2>
+…
+```
+
+Revert checkpoint:
+
+```
+agentsync revert: <agent> → <short-target-ref>
+```
+
+Both authored by the dedicated identity (decision #11).
+
+---
+
+## Secrets — local-only guardrails (unchanged invariants)
+
+The rendered destination files contain secrets resolved to **cleartext** at apply
+time (the canonical source holds `${secret:…}`/`${env:…}` references; that is
+unchanged). The destination git repos therefore hold cleartext secrets in history.
+This is the deliberately accepted tradeoff from the issue, made safe by keeping the
+repos **local-only**:
+
+- **Never `git remote add`, never `git push`** from agentsync for these repos. The
+  `internal/git` helper exposes no push/remote surface at all — there is no code
+  path that could add a remote, so this can't regress by accident.
+- The generated repo notice warns the history is local-only and may contain
+  secrets and must never be pushed.
+- `.git` dir is `0o700`; rendered files remain `0o600`.
+
+This **does not touch** the agentsync secret invariants: no `secrets.Resolved` is
+written back to canonical, `walkSecretFields` is unchanged, `capture.Capture`'s
+fail-closed backstop is unchanged. The git step only commits files that already
+exist on disk in the destination — it never round-trips through the canonical
+source.
+
+---
+
+## Edge cases
+
+- **Apply changed nothing** → `written` empty for that agent → no commit (clean
+  history, no empty checkpoints).
+- **Dir already a work tree / nested in one** → no init, no auto-commit
+  (decision #5), one-line hint.
+- **No TTY and `mode = "prompt"`** → can't ask → skip init, hint; never block.
+- **`mode = "off"` or `--no-git`** → skip entirely.
+- **Multiple agents in one apply** → one checkpoint commit per agent repo (the
+  per-agent grouping is natural: each agent has its own root + repo).
+- **`revert` on an agent that was never inited** → clear error, suggest running an
+  apply with auto-versioning enabled first.
+- **`revert --to` an unknown ref** → clear error, no changes.
+- **go-git unavailable feature / commit with no identity** → the dedicated identity
+  removes the common "no git identity configured" failure; surface any go-git error
+  wrapped (`fmt.Errorf("committing checkpoint for %s: %w", agent, err)`).
+- **Stray `$HOME` file changed but agent dir unchanged** → no checkpoint (gap is
+  documented; `.state/backups` still covers the foreign-collision case).
+
+---
+
+## Docs to update (same change, per `CLAUDE.md`)
+
+A new command + a new `agentsync.toml` table is a CLI-surface + schema change, so
+the same PR must update:
+
+- `docs/user-guide.md` — command reference (`apply --no-git`, new `revert`
+  section), the `agentsync.toml` layout block (`[git]` table), and the
+  destination-versioning concept.
+- `README.md` — quickstart / quick-reference table (add `revert`; note
+  auto-versioning).
+- `website/src/content/docs/reference/cli.mdx` — "At a glance" table row + a
+  `### revert` section + the `apply --no-git` flag.
+- `docs/concepts.md` — the three-state model: note destination dirs may now carry
+  a local-only git history (distinct from `.state/`).
+- `docs/architecture.md` — where the checkpoint step sits in the apply tail; the
+  never-push invariant; that `.state/` is untouched.
+- `internal/cli/init.go` `initialAgentsyncTOML` constant — add a commented `[git]`
+  example so `agentsync init` scaffolds it.
+- `CHANGELOG.md` — `[Unreleased] / Added`.
+
+The capability matrix is **not** affected (this isn't a per-agent component
+capability).
+
+---
+
+## Open decisions (please weigh in via PR comments)
+
+1. **Git-root resolution mechanism.** Recommended: optional `VersionedHome`
+   adapter extension (above). Alternative: central agent→dir table in
+   `internal/git`. Either works; the extension interface is more faithful to
+   "adapters own their paths."
+2. **`--no-git` flag name.** Alternatives: `--no-autocommit`, `--no-version`,
+   `--git=false`. Picked `--no-git` for brevity; open to a clearer name.
+3. **`[git].mode` values.** `"prompt" | "auto" | "off"` — open to naming (e.g.
+   `"ask"`/`"on"`/`"disabled"`).
+4. **Re-enable ergonomics.** Editing `agentsync.toml` is the documented re-enable
+   path. Worth a tiny `agentsync git enable/disable` (or folding into `doctor`)? I
+   lean "no, keep it config-only" for v1 to avoid surface creep — flagging in case
+   you want the command.
+5. **Generated notice filename.** `AGENTSYNC_LOCAL_HISTORY.md` at repo root — open
+   to a different name / location, and whether to also drop a `[agentsync]
+   managed = true` marker in the repo's `.git/config` vs relying on the notice
+   file alone for the "agentsync-created" check.
+6. **`revert` checkpoint default.** "Previous checkpoint = undo the most recent
+   apply." Confirm that's the intended default (vs "restore to the most recent
+   checkpoint," which is a no-op right after an apply).
+
+---
+
+## Test plan / success criteria
+
+All FS-touching tests run in-container (`testenv.RequireContainer`) on
+`afero`/`t.TempDir`, stdlib `testing`, table-driven.
+
+- **Helper unit tests** (`internal/git`): init creates a `.git` (0o700) with the
+  notice committed; add+commit stages only the given paths and authors with the
+  dedicated identity; `IsWorkTree` detects both a `.git` at root and a nested one;
+  restore-to-checkpoint reproduces prior bytes; `IsClean` correct.
+- **Apply-tail integration** (`internal/cli`): first apply to an untracked dir with
+  `mode = "auto"` produces exactly one checkpoint containing the written managed
+  files and **not** unrelated files; a no-op apply produces no new commit; a dir
+  that's already a work tree is left untouched (no agentsync commits added);
+  `--no-git` and `mode = "off"` skip; stray `~/.claude.json` is absent from the
+  claude repo history.
+- **Prompt behavior**: TTY + `mode="prompt"` → prompts; "no" leaves `mode=prompt`;
+  "no + don't ask again" persists `mode=off`; non-interactive never blocks.
+- **`revert`**: default reverts the last apply (files match the prior checkpoint),
+  records a new append-only commit, prints the out-of-sync notice; `--to`,
+  `--all`, `--dry-run` behave; unknown ref / un-inited dir error clearly.
+- **Never-push invariant**: a test (or the absence of any remote/push symbol in
+  `internal/git`) asserts no remote is ever configured and no push API exists.
+- **Secret invariants unchanged**: existing `internal/secrets` /
+  `internal/capture` guards still pass; no `secrets.Resolved` reaches a source
+  writer (this feature adds no dest→source path).
+- **Config round-trip**: `[git]` table parses; persisting `mode` preserves
+  comments/key order in `agentsync.toml`.
+
+---
+
+## Out of scope (for now)
+
+- Pushing any destination repo to a remote.
+- Versioning the canonical `~/.agentsync/` source dir.
+- Sub-file / per-pointer staging of shared files.
+- Capturing stray `$HOME`-level managed files into git (documented gap).
+- A scheduled/automatic prune of destination git history (git itself + the
+  local-only scope make this low-priority; revisit if histories grow unwieldy).

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -168,10 +168,20 @@ The unit of versioning is **the agent's own config directory at user scope**.
   }
   ```
 
-  All nine deep adapters and the data-driven `generic` tier implement it (the
-  generic adapter reads the root from its `generic.Spec`); `noop` does not. This
-  keeps the core `Adapter` contract unchanged and lets edge adapters abstain — the
-  same pattern the codebase already uses for optional capabilities.
+  **Only the nine deep adapters implement it** — each has a single, coherent
+  user-scope config dir (`~/.claude`, `~/.config/opencode`, `~/.codex`, `~/.cursor`,
+  `~/.gemini`, `~/.continue`, `~/.codeium/windsurf`, `~/.roo`, `~/.cline`). The
+  data-driven `generic` breadth tier **deliberately abstains** (does not implement
+  the interface): its agents' user-scope targets are scattered across multiple
+  top-level dirs and shared cross-agent locations (e.g. `~/.agents/skills`, which
+  several breadth agents and Codex all write to), so there is no safe single dir to
+  `git init` — and `git init`-ing a shared dir like `~/.agents` would violate the
+  per-destination-repo model. Breadth-tier writes therefore keep relying on
+  `.state/backups` (the same accepted gap as stray `$HOME`-level files). This keeps
+  the core `Adapter` contract unchanged and lets non-participating adapters abstain
+  — the same optional-extension pattern as `PluginIngester`/`WarnEmitter`. The
+  decision is pinned in code by `TestVersionedHomeContract` (deep adapters expose a
+  valid dir; breadth adapters must NOT implement the interface).
 
   *Alternative considered and rejected:* derive the root from the `written` paths
   or keep a central agent→dir table in `internal/git`. Deriving "the config dir"

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -80,9 +80,9 @@ questions resolved up front for this spec.
 | 7 | **Leave `.state/` (incl. `.state/backups/` and its pruning) exactly as-is.** | Issue |
 | 8 | **Revert is append-only.** `revert` re-materializes files from the chosen checkpoint and records a **new** commit; history is never rewritten, so the bad apply stays auditable and the revert is itself revertible. | Q (this spec) |
 | 9 | **`agentsync revert <agent>` defaults to the last checkpoint**, with `--to <ref>`, `--all`, and `--dry-run`. | Q (this spec) |
-| 10 | **Git root = the agent's own config dir only.** Stray `$HOME`-level managed files (e.g. `~/.claude.json`) stay out of git (we never init a repo at `$HOME`) and keep relying on `.state/backups`. Documented as a known gap. | Q (this spec) |
+| 10 | **Git roots = every destination dir, incl. shared cross-agent dirs** (e.g. `~/.agents/skills`), de-duped to one repo each. Stray `$HOME`-level managed files (e.g. `~/.claude.json`) stay out of git (we never init a repo at `$HOME`) and keep relying on `.state/backups`. (Revised from "agent's own dir only" per maintainer directive.) | Q + maintainer |
 | 11 | **Dedicated agentsync commit identity** (`agentsync <agentsync@localhost>`), overridable via `[destination_directory_git_backup]`. Works even when no global git identity is set. | Q (this spec) |
-| 12 | **Git root via the optional `VersionedHome` adapter extension** — adapters declare their versionable config dir; `noop` abstains. | Review #119 |
+| 12 | **Git roots via the optional `VersionedDirs` adapter extension** — every adapter declares the SET of dirs it writes (config dir + shared dirs); the apply tail unions/de-nests/de-dups them so a shared dir like `~/.agents/skills` is one repo. (Evolved from "config dir only" per maintainer directive to version shared dirs.) | Review #119 + maintainer |
 | 13 | **CI/scripting bypass flag = `apply --no-git-backup`.** | Review #119 |
 | 14 | **Config table = `[destination_directory_git_backup]`, `mode = "prompt" \| "on" \| "off"`** (default `prompt`). | Review #119 |
 | 15 | **No `agentsync git` command — config-edit only; `agentsync doctor` surfaces status read-only.** | Review #119 |
@@ -146,55 +146,51 @@ agentsync revert <agent> [--to <ref>] [--all] [--dry-run]
 
 ### Commit scope & git root
 
-The unit of versioning is **the agent's own config directory at user scope**.
+> **Updated during implementation (per maintainer directive):** the unit of
+> versioning is the **destination directory**, and **shared cross-agent dirs
+> (e.g. `~/.agents/skills`) ARE versioned** — deduped to a single repo. This
+> supersedes the earlier "agent's own config dir only / breadth tier abstains"
+> framing below.
 
-- **Git root resolution — `VersionedHome` adapter extension (decided, PR #119).**
-  Each adapter already resolves its own destination paths via a per-adapter
-  `ResolvePaths` returning an adapter-specific `Paths` struct (e.g. Cursor's
-  `Paths.ConfigDir = ~/.cursor`). There is no shared accessor on the `Adapter`
-  interface today, so we add a small **optional extension interface** (mirroring
-  the existing `PluginIngester` / `WarnEmitter` idiom) so an adapter declares its
-  versionable root:
+The unit of versioning is **a destination directory at user scope** — each agent's
+config dir plus any shared dir it writes into.
+
+- **Git root resolution — `VersionedDirs` adapter extension.** Each adapter already
+  resolves its own destination paths via a per-adapter `ResolvePaths`. We add a
+  small **optional extension interface** (mirroring the `PluginIngester` /
+  `WarnEmitter` idiom) so an adapter declares the **set** of dirs it writes into:
 
   ```go
-  // VersionedHome is an OPTIONAL Adapter extension: an adapter that writes into a
-  // single coherent on-disk config dir declares it so the apply tail can git-init
-  // and checkpoint that dir. Adapters that resolve no single root (noop) don't
-  // implement it and are skipped.
-  type VersionedHome interface {
-      // HomeDir returns the absolute config-dir root to version for this scope,
-      // or ("", false) if there is none (e.g. project scope, or no coherent root).
-      HomeDir(scope Scope, project string) (string, bool)
+  // VersionedDirs is an OPTIONAL Adapter extension: an adapter declares the dirs
+  // it writes into (its config dir + any SHARED cross-agent dir) so the apply tail
+  // can git-version them. nil at project scope.
+  type VersionedDirs interface {
+      VersionRoots(scope Scope, project string) []string
   }
   ```
 
-  **Only the nine deep adapters implement it** — each has a single, coherent
-  user-scope config dir (`~/.claude`, `~/.config/opencode`, `~/.codex`, `~/.cursor`,
-  `~/.gemini`, `~/.continue`, `~/.codeium/windsurf`, `~/.roo`, `~/.cline`). The
-  data-driven `generic` breadth tier **deliberately abstains** (does not implement
-  the interface): its agents' user-scope targets are scattered across multiple
-  top-level dirs and shared cross-agent locations (e.g. `~/.agents/skills`, which
-  several breadth agents and Codex all write to), so there is no safe single dir to
-  `git init` — and `git init`-ing a shared dir like `~/.agents` would violate the
-  per-destination-repo model. Breadth-tier writes therefore keep relying on
-  `.state/backups` (the same accepted gap as stray `$HOME`-level files). This keeps
-  the core `Adapter` contract unchanged and lets non-participating adapters abstain
-  — the same optional-extension pattern as `PluginIngester`/`WarnEmitter`. The
-  decision is pinned in code by `TestVersionedHomeContract` (deep adapters expose a
-  valid dir; breadth adapters must NOT implement the interface).
+  **Every adapter implements it** (deep and breadth). Deep adapters return their
+  config dir plus their shared skill dir (Codex → `~/.codex` + `~/.agents/skills`;
+  OpenCode → `~/.config/opencode` + `~/.claude/skills`). The breadth tier derives
+  its roots from its `generic.Spec` targets. The apply tail then **unions** all
+  roots across enabled adapters, **de-nests** (drops a root nested under another —
+  `~/.claude/skills` folds into `~/.claude` — so there's never a repo inside a
+  repo), and **de-dups** (a shared dir like `~/.agents/skills`, declared by Codex
+  and several breadth agents, is one repo, checkpointed once with all its files).
+  Project scope returns nil (those dirs live in the user's own project repo).
+  Pinned by `TestVersionedDirsContract` + `TestEnabledVersionRoots_DedupAndDenest`.
 
-  *Alternative considered and rejected:* derive the root from the `written` paths
-  or keep a central agent→dir table in `internal/git`. Deriving "the config dir"
-  from a flat path set is ambiguous (`~/.claude` vs `~/.claude/skills`), and a
-  central table duplicates path knowledge the adapters already own.
+  *Alternative considered and rejected:* derive roots purely from the `written`
+  paths. The skills-dir root (`~/.agents/skills`) has no file whose parent is
+  exactly that dir (skills live at `<root>/<name>/SKILL.md`), so leaf-derivation
+  can't recover it; adapters declaring their roots is the clean answer.
 
-- **Which files get staged.** Only managed files written under that root this run
-  — i.e. `written ∩ {files under HomeDir}`. For shared files (e.g.
-  `~/.claude/settings.json`) the **whole file** is staged as written (decision #3),
-  co-located user keys included. We do not `git add -A` the whole tree, so
-  unrelated files the user dropped in the agent dir aren't swept in. (A `.git` that
-  already tracks more is the user's existing-repo case → decision #5, we don't
-  touch it.)
+- **Which files get staged.** Managed files written under each root this run, plus
+  any tracked deletions (a delete-only apply still checkpoints). For shared files
+  (e.g. `~/.claude/settings.json`) the **whole file** is staged as written
+  (decision #3), co-located user keys included. We never `git add -A`, so untracked
+  files the user dropped in the dir aren't swept in. (A `.git` that already tracks
+  more is the user's existing-repo case → decision #5, we don't touch it.)
 
 - **Stray `$HOME`-level files are out of scope (decided gap).** Claude writes
   `~/.claude/` *and* `~/.claude.json` directly in `$HOME`. We will **not** init a
@@ -446,7 +442,8 @@ capability).
 All previously-open decisions were settled in the first spec review — folded into
 the body above and the locked-decisions table (rows 12–17):
 
-1. **Git-root mechanism** → the optional `VersionedHome` adapter extension. ✅
+1. **Git-root mechanism** → the optional `VersionedDirs` adapter extension (a SET
+   of dirs per adapter, unioned/de-nested/de-duped by the apply tail). ✅
 2. **CI bypass flag name** → `apply --no-git-backup`. ✅
 3. **Config table + mode values** → `[destination_directory_git_backup]` with
    `mode = "prompt" | "on" | "off"` (the opposite of `off` is `on`). ✅

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -1,7 +1,7 @@
 # Destination auto-git versioning + `agentsync revert` — Design Spec
 
 **Date:** 2026-06-28
-**Status:** Draft for review — design first, implementation plan to follow.
+**Status:** Approved in first review ([PR #119](https://github.com/spxrogers/agentsync/pull/119)). Implementation plan: `docs/superpowers/plans/2026-06-28-destination-git-versioning.md`.
 **Issue:** [#118 — Auto-version the destination agent dirs with git so a bad `apply` is revertible](https://github.com/spxrogers/agentsync/issues/118)
 
 ---
@@ -31,9 +31,9 @@ Two user-visible surfaces ship together:
    checkpoint (last by default), append-only, then print an out-of-sync notice
    telling the user to reconcile before the next apply.
 
-A new global `[git]` table in `agentsync.toml` holds the mode (prompt / auto /
-off) and optional commit-identity overrides; `apply --no-git` bypasses everything
-for CI/scripting.
+A new global `[destination_directory_git_backup]` table in `agentsync.toml` holds
+the mode (`prompt` / `on` / `off`) and optional commit-identity overrides;
+`apply --no-git-backup` bypasses everything for CI/scripting.
 
 ---
 
@@ -81,7 +81,13 @@ questions resolved up front for this spec.
 | 8 | **Revert is append-only.** `revert` re-materializes files from the chosen checkpoint and records a **new** commit; history is never rewritten, so the bad apply stays auditable and the revert is itself revertible. | Q (this spec) |
 | 9 | **`agentsync revert <agent>` defaults to the last checkpoint**, with `--to <ref>`, `--all`, and `--dry-run`. | Q (this spec) |
 | 10 | **Git root = the agent's own config dir only.** Stray `$HOME`-level managed files (e.g. `~/.claude.json`) stay out of git (we never init a repo at `$HOME`) and keep relying on `.state/backups`. Documented as a known gap. | Q (this spec) |
-| 11 | **Dedicated agentsync commit identity** (`agentsync <agentsync@localhost>`), overridable via `[git]`. Works even when no global git identity is set. | Q (this spec) |
+| 11 | **Dedicated agentsync commit identity** (`agentsync <agentsync@localhost>`), overridable via `[destination_directory_git_backup]`. Works even when no global git identity is set. | Q (this spec) |
+| 12 | **Git root via the optional `VersionedHome` adapter extension** — adapters declare their versionable config dir; `noop` abstains. | Review #119 |
+| 13 | **CI/scripting bypass flag = `apply --no-git-backup`.** | Review #119 |
+| 14 | **Config table = `[destination_directory_git_backup]`, `mode = "prompt" \| "on" \| "off"`** (default `prompt`). | Review #119 |
+| 15 | **No `agentsync git` command — config-edit only; `agentsync doctor` surfaces status read-only.** | Review #119 |
+| 16 | **Auto-created marker = `AGENTSYNC_LOCAL_HISTORY.md` at repo root + `[agentsync] managed = true` in the repo's `.git/config`.** | Review #119 |
+| 17 | **`revert` default = undo the most recent apply** (restore `HEAD~1` content, commit append-only). | Review #119 |
 
 ---
 
@@ -105,7 +111,7 @@ agentsync apply  ──► render.Apply(...) ──► written map[string]bool (
               1. resolve agent's git root dir (user scope)
               2. is it already a work tree?  ── yes ─► skip (decision #5), hint
               3. untracked + mode=prompt + TTY ─► prompt to init (opt-out)
-              4. mode=auto / accepted ─► git init (first time) + add changed
+              4. mode=on / accepted ─► git init (first time) + add changed
                  managed files under root + commit checkpoint
 ```
 
@@ -142,12 +148,13 @@ agentsync revert <agent> [--to <ref>] [--all] [--dry-run]
 
 The unit of versioning is **the agent's own config directory at user scope**.
 
-- **Git root resolution.** Each adapter already resolves its own destination paths
-  via a per-adapter `ResolvePaths` returning an adapter-specific `Paths` struct
-  (e.g. Cursor's `Paths.ConfigDir = ~/.cursor`). There is no shared accessor on
-  the `Adapter` interface today. **Recommended:** add a small **optional extension
-  interface** (mirroring the existing `PluginIngester` / `WarnEmitter` idiom) so an
-  adapter can declare its versionable root:
+- **Git root resolution — `VersionedHome` adapter extension (decided, PR #119).**
+  Each adapter already resolves its own destination paths via a per-adapter
+  `ResolvePaths` returning an adapter-specific `Paths` struct (e.g. Cursor's
+  `Paths.ConfigDir = ~/.cursor`). There is no shared accessor on the `Adapter`
+  interface today, so we add a small **optional extension interface** (mirroring
+  the existing `PluginIngester` / `WarnEmitter` idiom) so an adapter declares its
+  versionable root:
 
   ```go
   // VersionedHome is an OPTIONAL Adapter extension: an adapter that writes into a
@@ -166,11 +173,10 @@ The unit of versioning is **the agent's own config directory at user scope**.
   keeps the core `Adapter` contract unchanged and lets edge adapters abstain — the
   same pattern the codebase already uses for optional capabilities.
 
-  *Alternative considered:* derive the root from the `written` paths or keep a
-  central agent→dir table in `internal/git`. Rejected as primary because deriving
-  "the config dir" from a flat path set is ambiguous (`~/.claude` vs
-  `~/.claude/skills`), and a central table duplicates path knowledge the adapters
-  already own. Flagged as an open implementation detail below.
+  *Alternative considered and rejected:* derive the root from the `written` paths
+  or keep a central agent→dir table in `internal/git`. Deriving "the config dir"
+  from a flat path set is ambiguous (`~/.claude` vs `~/.claude/skills`), and a
+  central table duplicates path knowledge the adapters already own.
 
 - **Which files get staged.** Only managed files written under that root this run
   — i.e. `written ∩ {files under HomeDir}`. For shared files (e.g.
@@ -202,12 +208,12 @@ agentsync itself created (see "marker" below), agentsync neither inits nor
 auto-commits; it may print a one-line hint that auto-versioning is disabled
 because the dir is already under source control.
 
-**Repo marker.** To tell "a repo agentsync auto-created" from "the user's own
-repo," the auto-init writes a small marker (the generated `README` / notice file,
-below, plus optionally a config key under the repo's own `.git/config`, e.g.
-`[agentsync] managed = true`). Auto-commit only runs against repos carrying the
-marker. A user's pre-existing repo never gets the marker, so agentsync stays out
-of it.
+**Repo marker (decision #16).** To tell "a repo agentsync auto-created" from "the
+user's own repo," the auto-init writes a `[agentsync] managed = true` key into the
+repo's own `.git/config`, alongside the generated `AGENTSYNC_LOCAL_HISTORY.md`
+notice file (below). Auto-commit and `agentsync revert` only operate on repos
+carrying this marker. A user's pre-existing repo never gets the marker, so
+agentsync stays out of it.
 
 ### Auto-init repo contents
 
@@ -224,18 +230,21 @@ files are already `0o600` (`internal/iox/atomic.go`); the `.git` dir is created
 
 ---
 
-## Config schema — the `[git]` table
+## Config schema — the `[destination_directory_git_backup]` table
 
-New global table in `~/.agentsync/agentsync.toml`, parsed into a `GitConfig`
-struct added to `source.Config` (`internal/source/schema.go`, alongside `Agents`,
-`Updates`, `Secrets`, `Memory`). Project overlay merges like the others
-(`internal/project`), though git settings are a user-scope concern in practice.
+New global table in `~/.agentsync/agentsync.toml`, parsed into a
+`DestinationGitBackupConfig` struct added to `source.Config`
+(`internal/source/schema.go`, alongside `Agents`, `Updates`, `Secrets`,
+`Memory`). The table name is deliberately explicit — these repos are a backup of
+the *destination directories*, not general "git" config. Project overlay merges
+like the others (`internal/project`), though it is a user-scope concern in
+practice.
 
 ```toml
-[git]
-# Destination auto-versioning behavior. Tri-state:
+[destination_directory_git_backup]
+# Behavior for git-backing the rendered destination dirs. Tri-state:
 #   "prompt" (default) — on first write to an untracked agent dir, ask to init.
-#   "auto"             — init + checkpoint silently (set after the user says yes).
+#   "on"               — init + checkpoint silently (set after the user says yes).
 #   "off"              — never init/commit/prompt (set by "don't ask again").
 mode = "prompt"
 
@@ -244,20 +253,32 @@ author_name  = "agentsync"
 author_email = "agentsync@localhost"
 ```
 
+```go
+// internal/source/schema.go
+type DestinationGitBackupConfig struct {
+    Mode        string `toml:"mode,omitempty"`         // "prompt" (default) | "on" | "off"
+    AuthorName  string `toml:"author_name,omitempty"`
+    AuthorEmail string `toml:"author_email,omitempty"`
+}
+// added to Config as:
+//   DestinationGitBackup DestinationGitBackupConfig `toml:"destination_directory_git_backup"`
+```
+
 State transitions:
 
 | Event | Result |
 |---|---|
 | Table absent / `mode` unset | Treated as `"prompt"`. |
-| User answers **yes** at the init prompt | Persist `mode = "auto"`. |
+| User answers **yes** at the init prompt | Persist `mode = "on"`. |
 | User answers **no** | Skip this run; leave `mode = "prompt"` (will ask again). |
 | User answers **no + don't ask again** | Persist `mode = "off"`. |
-| `apply --no-git` (per run) | Force-skip init/commit for that invocation, regardless of `mode`. Never mutates config. |
-| Re-enable later | User edits `agentsync.toml` (`mode = "prompt"`/`"auto"`). |
+| `apply --no-git-backup` (per run) | Force-skip init/commit for that invocation, regardless of `mode`. Never mutates config. |
+| Re-enable later | User edits `agentsync.toml` (`mode = "prompt"`/`"on"`). |
 
 Writing the persisted `mode` back into `agentsync.toml` goes through the existing
 canonical TOML writer (comment- and order-preserving), the same path
-`agentsync mcp add` etc. use — it must not clobber the user's hand-edits.
+`agentsync mcp add` etc. use — it must not clobber the user's hand-edits. The
+current mode is also surfaced read-only by `agentsync doctor` (see CLI surface).
 
 ---
 
@@ -266,14 +287,23 @@ canonical TOML writer (comment- and order-preserving), the same path
 ### `agentsync apply` — one new flag
 
 ```
---no-git    Skip destination git init/checkpoint for this run (CI/scripting).
-            Does not modify agentsync.toml.
+--no-git-backup   Skip destination git init/checkpoint for this run (CI/scripting).
+                  Does not modify agentsync.toml.
 ```
 
-Everything else about apply is unchanged. In `--no-git` or non-interactive
-(`--no-input` / no TTY) runs, agentsync never prompts; with `mode = "auto"` it
+Everything else about apply is unchanged. In `--no-git-backup` or non-interactive
+(`--no-input` / no TTY) runs, agentsync never prompts; with `mode = "on"` it
 still checkpoints silently (no prompt needed), with `mode = "prompt"` and no TTY
 it skips init (can't ask) and prints a one-line hint.
+
+### `agentsync doctor` — surface status (no new command)
+
+There is **no** dedicated `agentsync git`/enable/disable command (kept config-only
+given the triviality — decided, PR #119). Instead, `agentsync doctor`
+(`internal/cli/doctor.go`) gains a small read-only check reporting the
+destination-git-backup mode and, per managed agent dir, whether it is
+agentsync-versioned, already under foreign source control, or untracked. Changing
+the behavior is a one-line `agentsync.toml` edit.
 
 ### `agentsync revert` — new command
 
@@ -361,7 +391,7 @@ source.
 - **Dir already a work tree / nested in one** → no init, no auto-commit
   (decision #5), one-line hint.
 - **No TTY and `mode = "prompt"`** → can't ask → skip init, hint; never block.
-- **`mode = "off"` or `--no-git`** → skip entirely.
+- **`mode = "off"` or `--no-git-backup`** → skip entirely.
 - **Multiple agents in one apply** → one checkpoint commit per agent repo (the
   per-agent grouping is natural: each agent has its own root + repo).
 - **`revert` on an agent that was never inited** → clear error, suggest running an
@@ -380,19 +410,20 @@ source.
 A new command + a new `agentsync.toml` table is a CLI-surface + schema change, so
 the same PR must update:
 
-- `docs/user-guide.md` — command reference (`apply --no-git`, new `revert`
-  section), the `agentsync.toml` layout block (`[git]` table), and the
-  destination-versioning concept.
+- `docs/user-guide.md` — command reference (`apply --no-git-backup`, new `revert`
+  section, the new `doctor` status line), the `agentsync.toml` layout block
+  (`[destination_directory_git_backup]` table), and the destination-versioning
+  concept.
 - `README.md` — quickstart / quick-reference table (add `revert`; note
   auto-versioning).
 - `website/src/content/docs/reference/cli.mdx` — "At a glance" table row + a
-  `### revert` section + the `apply --no-git` flag.
+  `### revert` section + the `apply --no-git-backup` flag.
 - `docs/concepts.md` — the three-state model: note destination dirs may now carry
   a local-only git history (distinct from `.state/`).
 - `docs/architecture.md` — where the checkpoint step sits in the apply tail; the
   never-push invariant; that `.state/` is untouched.
-- `internal/cli/init.go` `initialAgentsyncTOML` constant — add a commented `[git]`
-  example so `agentsync init` scaffolds it.
+- `internal/cli/init.go` `initialAgentsyncTOML` constant — add a commented
+  `[destination_directory_git_backup]` example so `agentsync init` scaffolds it.
 - `CHANGELOG.md` — `[Unreleased] / Added`.
 
 The capability matrix is **not** affected (this isn't a per-agent component
@@ -400,27 +431,22 @@ capability).
 
 ---
 
-## Open decisions (please weigh in via PR comments)
+## Resolved in review (PR #119)
 
-1. **Git-root resolution mechanism.** Recommended: optional `VersionedHome`
-   adapter extension (above). Alternative: central agent→dir table in
-   `internal/git`. Either works; the extension interface is more faithful to
-   "adapters own their paths."
-2. **`--no-git` flag name.** Alternatives: `--no-autocommit`, `--no-version`,
-   `--git=false`. Picked `--no-git` for brevity; open to a clearer name.
-3. **`[git].mode` values.** `"prompt" | "auto" | "off"` — open to naming (e.g.
-   `"ask"`/`"on"`/`"disabled"`).
-4. **Re-enable ergonomics.** Editing `agentsync.toml` is the documented re-enable
-   path. Worth a tiny `agentsync git enable/disable` (or folding into `doctor`)? I
-   lean "no, keep it config-only" for v1 to avoid surface creep — flagging in case
-   you want the command.
-5. **Generated notice filename.** `AGENTSYNC_LOCAL_HISTORY.md` at repo root — open
-   to a different name / location, and whether to also drop a `[agentsync]
-   managed = true` marker in the repo's `.git/config` vs relying on the notice
-   file alone for the "agentsync-created" check.
-6. **`revert` checkpoint default.** "Previous checkpoint = undo the most recent
-   apply." Confirm that's the intended default (vs "restore to the most recent
-   checkpoint," which is a no-op right after an apply).
+All previously-open decisions were settled in the first spec review — folded into
+the body above and the locked-decisions table (rows 12–17):
+
+1. **Git-root mechanism** → the optional `VersionedHome` adapter extension. ✅
+2. **CI bypass flag name** → `apply --no-git-backup`. ✅
+3. **Config table + mode values** → `[destination_directory_git_backup]` with
+   `mode = "prompt" | "on" | "off"` (the opposite of `off` is `on`). ✅
+4. **Re-enable ergonomics** → config-edit only; **no** `agentsync git` command;
+   `agentsync doctor` surfaces the current status read-only. ✅
+5. **Notice file + marker** → `AGENTSYNC_LOCAL_HISTORY.md` at the repo root plus a
+   `[agentsync] managed = true` key in the repo's own `.git/config` as the
+   "agentsync-created" marker. ✅
+6. **`revert` default** → undo the most recent apply, i.e. restore the checkpoint
+   *before* `HEAD` (`HEAD~1` content) and commit it append-only. ✅
 
 ---
 
@@ -434,10 +460,10 @@ All FS-touching tests run in-container (`testenv.RequireContainer`) on
   dedicated identity; `IsWorkTree` detects both a `.git` at root and a nested one;
   restore-to-checkpoint reproduces prior bytes; `IsClean` correct.
 - **Apply-tail integration** (`internal/cli`): first apply to an untracked dir with
-  `mode = "auto"` produces exactly one checkpoint containing the written managed
+  `mode = "on"` produces exactly one checkpoint containing the written managed
   files and **not** unrelated files; a no-op apply produces no new commit; a dir
   that's already a work tree is left untouched (no agentsync commits added);
-  `--no-git` and `mode = "off"` skip; stray `~/.claude.json` is absent from the
+  `--no-git-backup` and `mode = "off"` skip; stray `~/.claude.json` is absent from the
   claude repo history.
 - **Prompt behavior**: TTY + `mode="prompt"` → prompts; "no" leaves `mode=prompt`;
   "no + don't ask again" persists `mode=off`; non-interactive never blocks.
@@ -449,8 +475,8 @@ All FS-touching tests run in-container (`testenv.RequireContainer`) on
 - **Secret invariants unchanged**: existing `internal/secrets` /
   `internal/capture` guards still pass; no `secrets.Resolved` reaches a source
   writer (this feature adds no dest→source path).
-- **Config round-trip**: `[git]` table parses; persisting `mode` preserves
-  comments/key order in `agentsync.toml`.
+- **Config round-trip**: `[destination_directory_git_backup]` table parses;
+  persisting `mode` preserves comments/key order in `agentsync.toml`.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -276,7 +276,9 @@ The unit is the **directory**, not the agent: each agent's config dir plus any
 shared cross-agent dir it writes (e.g. `~/.agents/skills`, which Codex and several
 agents share) is versioned — shared dirs are de-duplicated to a single repo, and a
 dir nested under another (like `~/.claude/skills` under `~/.claude`) is folded into
-the parent, so there's never a repo inside a repo.
+the parent, so there's never a repo inside a repo. Because a shared dir is one
+repo, `revert <agent>` of a shared dir rolls back *every* agent's files in it —
+revert warns you when that happens.
 
 These repos are **never pushed**. The rendered files they version contain secrets
 resolved to **cleartext** (unlike the canonical source, which keeps `${secret:…}`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -253,9 +253,11 @@ agentsync revert --all --dry-run     # preview reverting every managed dir
 ```
 
 `revert` is **append-only** — it records a new commit rather than rewriting
-history, so the bad apply stays in the log and the revert is itself revertible. It
-moves only the *destination*, so afterwards it reminds you to **reconcile** (or fix
-the canonical source) before the next `apply` re-renders over it.
+history, so the bad apply stays in the log and the revert is itself revertible. If
+you hand-edited a tracked file after the last apply, revert snapshots that edit
+into history first, so **nothing is lost** (recover it with `revert --to <snapshot>`).
+It moves only the *destination*, so afterwards it reminds you to **reconcile** (or
+fix the canonical source) before the next `apply` re-renders over it.
 
 The first apply to an untracked dir **asks** before initializing the repo
 (opt-out). Answer once and it's remembered in `agentsync.toml`:
@@ -270,14 +272,20 @@ mode = "on"          # "prompt" (default) | "on" | "off"
 `apply --no-git-backup` skips it for one run (CI/scripting) without touching
 config, and `agentsync doctor` shows the current mode and per-dir status.
 
+The unit is the **directory**, not the agent: each agent's config dir plus any
+shared cross-agent dir it writes (e.g. `~/.agents/skills`, which Codex and several
+agents share) is versioned — shared dirs are de-duplicated to a single repo, and a
+dir nested under another (like `~/.claude/skills` under `~/.claude`) is folded into
+the parent, so there's never a repo inside a repo.
+
 These repos are **never pushed**. The rendered files they version contain secrets
 resolved to **cleartext** (unlike the canonical source, which keeps `${secret:…}`
 references), so the history can hold secrets — which is fine precisely because it
 stays local. The thing you commit and push is still `~/.agentsync/`, references
 only. A destination dir you already keep under your own git (e.g. `~/.claude` in a
-dotfiles repo) is detected and left untouched. Coverage is the nine deep adapters;
-the breadth tier's scattered/shared dirs are not versioned (they keep the existing
-`.state/backups` safety net).
+dotfiles repo) is detected and left untouched. (`~/.claude.json`, written directly
+in `$HOME`, is not versioned — agentsync never inits a repo at `$HOME`; it keeps the
+existing `.state/backups` safety net.)
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -240,6 +240,47 @@ auto-resolves changes that can't lose work).
 
 ---
 
+## Rolling back a bad apply
+
+`apply` can keep each user-scope destination dir (`~/.claude`, `~/.codex`, …) in
+its **own local-only git repo**, recording a checkpoint commit after every apply
+that changes managed files there. If an apply ever goes wrong, roll it back:
+
+```bash
+agentsync revert claude              # undo the most recent apply to ~/.claude
+agentsync revert claude --to HEAD~3  # roll back to an older checkpoint
+agentsync revert --all --dry-run     # preview reverting every managed dir
+```
+
+`revert` is **append-only** — it records a new commit rather than rewriting
+history, so the bad apply stays in the log and the revert is itself revertible. It
+moves only the *destination*, so afterwards it reminds you to **reconcile** (or fix
+the canonical source) before the next `apply` re-renders over it.
+
+The first apply to an untracked dir **asks** before initializing the repo
+(opt-out). Answer once and it's remembered in `agentsync.toml`:
+
+```toml
+[destination_directory_git_backup]
+mode = "on"          # "prompt" (default) | "on" | "off"
+# author_name  = "agentsync"      # optional commit-identity overrides
+# author_email = "agentsync@localhost"
+```
+
+`apply --no-git-backup` skips it for one run (CI/scripting) without touching
+config, and `agentsync doctor` shows the current mode and per-dir status.
+
+These repos are **never pushed**. The rendered files they version contain secrets
+resolved to **cleartext** (unlike the canonical source, which keeps `${secret:…}`
+references), so the history can hold secrets — which is fine precisely because it
+stays local. The thing you commit and push is still `~/.agentsync/`, references
+only. A destination dir you already keep under your own git (e.g. `~/.claude` in a
+dotfiles repo) is detected and left untouched. Coverage is the nine deep adapters;
+the breadth tier's scattered/shared dirs are not versioned (they keep the existing
+`.state/backups` safety net).
+
+---
+
 ## Building your config
 
 `~/.agentsync/` is just files. Use the CLI or edit them in `$EDITOR` — both are
@@ -247,7 +288,7 @@ first-class. Layout:
 
 ```
 ~/.agentsync/
-├── agentsync.toml            # agents, update defaults, secrets backend, [memory] banner
+├── agentsync.toml            # agents, update defaults, secrets backend, [memory] banner, [destination_directory_git_backup]
 ├── mcp/<server>.toml         # one MCP server per file
 ├── lsp/<server>.toml         # one LSP server per file
 ├── agents/<name>.md          # one subagent per file
@@ -631,7 +672,8 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
-| `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
+| `apply` | Render source → write agent configs (offline). Git-versions each user-scope destination dir into a local-only repo (opt-out) so a bad apply is revertible. | `--dry-run --scope --project --no-git-backup` |
+| `revert <agent>` | Roll a destination dir back to a prior apply checkpoint (append-only). Default undoes the most recent apply; prints an out-of-sync notice. | `--to --all --dry-run` |
 | `status` | Summarize drift/pending across agents; notes natively-installed plugins not yet in source. Skill directories collapse to one summary row by default (`--verbose` expands them). | `--agents --verbose --scope --project --json` |
 | `diff [<path>]` | Show pending/drift changes; secrets redacted. | `--scope --project --json` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -275,6 +275,25 @@ type PluginIngester interface {
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
 }
 
+// VersionedHome is an OPTIONAL extension to Adapter: an adapter that writes into a
+// single coherent on-disk config directory declares it so the apply tail can
+// git-init and checkpoint that directory as a local-only rollback history (issue
+// #118). An adapter with no single versionable root (e.g. noop) does not implement
+// it and is skipped.
+//
+// HomeDir is READ-ONLY and user-scope-focused — it reports the directory to back
+// up; it does not widen the Render/Apply contract. At ScopeProject it MUST return
+// ("", false): project destinations live inside the user's own project repo, which
+// is left to that repo's source control. It also returns ("", false) at user scope
+// for an agent whose root is empty (e.g. an agent that only writes a single file
+// elsewhere). The dir is absolute (after AGENTSYNC_TARGET_ROOT redirection),
+// matching FileOp.Path. Note a deep agent may also write a stray top-level file
+// outside this dir (Claude's ~/.claude.json); those are intentionally NOT
+// versioned — only this dir is. See docs/architecture.md.
+type VersionedHome interface {
+	HomeDir(scope Scope, project string) (string, bool)
+}
+
 // WarnEmitter is an OPTIONAL extension to Adapter: an adapter that emits
 // Ingest warnings implements it to let callers redirect the stream away
 // from the default (os.Stderr). Implementors are SOURCES of warnings that

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -299,6 +299,19 @@ type VersionedDirs interface {
 	VersionRoots(scope Scope, project string) []string
 }
 
+// NonEmptyDirs returns the non-empty arguments as a slice — a small shared helper
+// for adapters assembling their VersionRoots from a Paths struct whose fields may
+// be "" at a given scope.
+func NonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
 // WarnEmitter is an OPTIONAL extension to Adapter: an adapter that emits
 // Ingest warnings implements it to let callers redirect the stream away
 // from the default (os.Stderr). Implementors are SOURCES of warnings that

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -275,23 +275,28 @@ type PluginIngester interface {
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
 }
 
-// VersionedHome is an OPTIONAL extension to Adapter: an adapter that writes into a
-// single coherent on-disk config directory declares it so the apply tail can
-// git-init and checkpoint that directory as a local-only rollback history (issue
-// #118). An adapter with no single versionable root (e.g. noop) does not implement
-// it and is skipped.
+// VersionedDirs is an OPTIONAL extension to Adapter: an adapter that writes into
+// one or more on-disk directories declares them so the apply tail can git-init and
+// checkpoint those directories as a local-only rollback history (issue #118). An
+// adapter with no versionable directory (e.g. noop) does not implement it.
 //
-// HomeDir is READ-ONLY and user-scope-focused — it reports the directory to back
-// up; it does not widen the Render/Apply contract. At ScopeProject it MUST return
-// ("", false): project destinations live inside the user's own project repo, which
-// is left to that repo's source control. It also returns ("", false) at user scope
-// for an agent whose root is empty (e.g. an agent that only writes a single file
-// elsewhere). The dir is absolute (after AGENTSYNC_TARGET_ROOT redirection),
-// matching FileOp.Path. Note a deep agent may also write a stray top-level file
-// outside this dir (Claude's ~/.claude.json); those are intentionally NOT
-// versioned — only this dir is. See docs/architecture.md.
-type VersionedHome interface {
-	HomeDir(scope Scope, project string) (string, bool)
+// VersionRoots is READ-ONLY and user-scope-focused — it reports the directories to
+// back up; it does not widen the Render/Apply contract. The unit of versioning is
+// the DIRECTORY, not the agent: an adapter returns its own config dir PLUS any
+// SHARED cross-agent dir it writes into (e.g. Codex and several breadth agents all
+// write skills to ~/.agents/skills; OpenCode writes skills to ~/.claude/skills).
+// The apply tail unions these across all enabled adapters, drops any root nested
+// under another (no repo inside a repo), and de-duplicates — so a shared dir is
+// versioned exactly ONCE no matter how many adapters target it.
+//
+// At ScopeProject it MUST return nil: project destinations live inside the user's
+// own project repo, left to that repo's source control. Each returned path is
+// absolute (after AGENTSYNC_TARGET_ROOT redirection), matching FileOp.Path. A deep
+// agent may also write a stray top-level file outside any returned dir (Claude's
+// ~/.claude.json); those are intentionally NOT versioned — agentsync never inits a
+// repo at $HOME. See docs/architecture.md.
+type VersionedDirs interface {
+	VersionRoots(scope Scope, project string) []string
 }
 
 // WarnEmitter is an OPTIONAL extension to Adapter: an adapter that emits

--- a/internal/adapter/claude/homedir.go
+++ b/internal/adapter/claude/homedir.go
@@ -13,16 +13,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.Home)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.Home)
 }

--- a/internal/adapter/claude/homedir.go
+++ b/internal/adapter/claude/homedir.go
@@ -2,19 +2,27 @@ package claude
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.claude config dir is
-// the local-only git-backup root (issue #118). Returns ("", false) at project
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.claude config
+// dir is the local-only git-backup root (issue #118). Returns nil at project
 // scope — project destinations live in the user's own repo. Note ~/.claude.json
 // (written at $HOME, OUTSIDE ~/.claude) is intentionally NOT versioned; only this
 // dir is — it keeps relying on the existing .state/backups foreign-collision
-// backup. See docs/architecture.md.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// backup. (~/.claude/skills, which OpenCode also writes to, is captured here.)
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	home := ResolvePaths(a.opts.TargetRoot, "", false).Home
-	if home == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.Home)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return home, true
+	return out
 }

--- a/internal/adapter/claude/homedir.go
+++ b/internal/adapter/claude/homedir.go
@@ -1,0 +1,20 @@
+package claude
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.claude config dir is
+// the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope — project destinations live in the user's own repo. Note ~/.claude.json
+// (written at $HOME, OUTSIDE ~/.claude) is intentionally NOT versioned; only this
+// dir is — it keeps relying on the existing .state/backups foreign-collision
+// backup. See docs/architecture.md.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	home := ResolvePaths(a.opts.TargetRoot, "", false).Home
+	if home == "" {
+		return "", false
+	}
+	return home, true
+}

--- a/internal/adapter/cline/homedir.go
+++ b/internal/adapter/cline/homedir.go
@@ -2,17 +2,25 @@ package cline
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.cline config dir is
-// the local-only git-backup root (issue #118). Returns ("", false) at project
-// scope. (At user scope Cline only writes ~/.cline/mcp.json; its global rules live
-// in a non-XDG app path agentsync does not target.)
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.cline config dir
+// is the local-only git-backup root (issue #118). Returns nil at project scope.
+// (At user scope Cline only writes ~/.cline/mcp.json; its global rules live in a
+// non-XDG app path agentsync does not target.)
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/cline/homedir.go
+++ b/internal/adapter/cline/homedir.go
@@ -11,16 +11,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/adapter/cline/homedir.go
+++ b/internal/adapter/cline/homedir.go
@@ -1,0 +1,18 @@
+package cline
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.cline config dir is
+// the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope. (At user scope Cline only writes ~/.cline/mcp.json; its global rules live
+// in a non-XDG app path agentsync does not target.)
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/codex/homedir.go
+++ b/internal/adapter/codex/homedir.go
@@ -12,16 +12,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir, p.SkillsDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir, p.SkillsDir)
 }

--- a/internal/adapter/codex/homedir.go
+++ b/internal/adapter/codex/homedir.go
@@ -2,18 +2,26 @@ package codex
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.codex config dir is
-// the local-only git-backup root (issue #118). Returns ("", false) at project
-// scope. (Codex skills live in the shared ~/.agents/skills dir, OUTSIDE ~/.codex,
-// so they are not versioned here — an accepted cross-agent gap, like Claude's
-// ~/.claude.json; they keep relying on .state/backups.)
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: ~/.codex (its config dir) plus
+// ~/.agents/skills (the shared cross-vendor Agent-Skills dir Codex and several
+// breadth agents all write to). The apply tail de-dups ~/.agents/skills so it is
+// versioned exactly once regardless of how many agents target it. Returns nil at
+// project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir, p.SkillsDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/codex/homedir.go
+++ b/internal/adapter/codex/homedir.go
@@ -1,0 +1,19 @@
+package codex
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.codex config dir is
+// the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope. (Codex skills live in the shared ~/.agents/skills dir, OUTSIDE ~/.codex,
+// so they are not versioned here — an accepted cross-agent gap, like Claude's
+// ~/.claude.json; they keep relying on .state/backups.)
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/continuedev/homedir.go
+++ b/internal/adapter/continuedev/homedir.go
@@ -2,16 +2,23 @@ package continuedev
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.continue config dir
-// is the local-only git-backup root (issue #118). Returns ("", false) at project
-// scope.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.continue config
+// dir is the local-only git-backup root (issue #118). Returns nil at project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/continuedev/homedir.go
+++ b/internal/adapter/continuedev/homedir.go
@@ -1,0 +1,17 @@
+package continuedev
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.continue config dir
+// is the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/continuedev/homedir.go
+++ b/internal/adapter/continuedev/homedir.go
@@ -9,16 +9,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/adapter/cursor/homedir.go
+++ b/internal/adapter/cursor/homedir.go
@@ -2,16 +2,23 @@ package cursor
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.cursor config dir is
-// the local-only git-backup root (issue #118). Returns ("", false) at project
-// scope.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.cursor config
+// dir is the local-only git-backup root (issue #118). Returns nil at project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/cursor/homedir.go
+++ b/internal/adapter/cursor/homedir.go
@@ -1,0 +1,17 @@
+package cursor
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.cursor config dir is
+// the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/cursor/homedir.go
+++ b/internal/adapter/cursor/homedir.go
@@ -9,16 +9,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/adapter/gemini/homedir.go
+++ b/internal/adapter/gemini/homedir.go
@@ -2,16 +2,23 @@ package gemini
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.gemini config dir is
-// the local-only git-backup root (issue #118). Returns ("", false) at project
-// scope.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.gemini config
+// dir is the local-only git-backup root (issue #118). Returns nil at project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/gemini/homedir.go
+++ b/internal/adapter/gemini/homedir.go
@@ -9,16 +9,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/adapter/gemini/homedir.go
+++ b/internal/adapter/gemini/homedir.go
@@ -1,0 +1,17 @@
+package gemini
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.gemini config dir is
+// the local-only git-backup root (issue #118). Returns ("", false) at project
+// scope.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/generic/homedir.go
+++ b/internal/adapter/generic/homedir.go
@@ -1,0 +1,57 @@
+package generic
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// VersionRoots implements adapter.VersionedDirs: the set of top-level directories
+// this breadth-tier agent writes into at user scope, so the apply tail can version
+// them as a local-only rollback history (issue #118). Derived from the Spec's
+// user-scope targets. The apply tail unions, de-nests, and de-dups these across all
+// enabled adapters, so a shared cross-agent dir (e.g. ~/.agents/skills, which many
+// breadth agents and Codex all target) is versioned exactly once. Returns nil at
+// project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
+	if scope != adapter.ScopeUser {
+		return nil
+	}
+	seen := map[string]bool{}
+	var roots []string
+	add := func(rel string) {
+		if rel == "" {
+			return
+		}
+		root := versionRootOf(a.opts.TargetRoot, rel)
+		if root == "" || seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	add(a.spec.Memory.User)
+	add(a.spec.MCP.User)
+	add(a.spec.Skills.User)
+	return roots
+}
+
+// versionRootOf maps a user-scope relative target path to the agent's top-level
+// version-root directory under targetRoot. Most breadth agents live under a single
+// dotted segment (~/.qwen); a known set of multi-segment bases keeps two segments
+// (~/.config/<x>, ~/.aws/<x>, ~/.agents/skills, ~/.pi/agent, ~/.gemini/config) so a
+// shared dir resolves to a stable shared root. Returns "" for a bare $HOME-level
+// file — agentsync never inits a repo at $HOME.
+func versionRootOf(targetRoot, rel string) string {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 {
+		return "" // a bare file directly in $HOME is not versionable
+	}
+	switch parts[0] {
+	case ".config", ".aws", ".agents", ".pi", ".gemini":
+		return filepath.Join(targetRoot, parts[0], parts[1])
+	default:
+		return filepath.Join(targetRoot, parts[0])
+	}
+}

--- a/internal/adapter/generic/homedir.go
+++ b/internal/adapter/generic/homedir.go
@@ -44,9 +44,12 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 // shared dir resolves to a stable shared root. Returns "" for a bare $HOME-level
 // file — agentsync never inits a repo at $HOME.
 func versionRootOf(targetRoot, rel string) string {
-	parts := strings.Split(filepath.ToSlash(rel), "/")
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(rel)), "/")
 	if len(parts) < 2 {
 		return "" // a bare file directly in $HOME is not versionable
+	}
+	if parts[0] == ".." || parts[0] == "." || parts[0] == "" {
+		return "" // defense-in-depth: a target must stay under $HOME, never escape it
 	}
 	switch parts[0] {
 	case ".config", ".aws", ".agents", ".pi", ".gemini":

--- a/internal/adapter/generic/homedir_test.go
+++ b/internal/adapter/generic/homedir_test.go
@@ -1,0 +1,132 @@
+package generic
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// TestVersionRoots_AllSpecs pins the exact user-scope version roots for EVERY
+// breadth-tier spec, so a wrong `versionRootOf` mapping (too broad, too deep, or
+// uncovered) for any current or future spec fails loudly rather than shipping
+// silently. Each entry lists the dirs (relative to the target root) the spec must
+// version at user scope; a project-scope-only agent maps to the empty set.
+func TestVersionRoots_AllSpecs(t *testing.T) {
+	const root = "/home/u"
+	want := map[string][]string{
+		"qwen":        {".qwen"},
+		"warp":        {".warp", ".agents/skills"},
+		"junie":       {".junie"},
+		"kiro":        {".kiro"},
+		"kilocode":    {".kilo"},
+		"amazonq":     {".aws/amazonq"},
+		"factory":     {".factory"},
+		"pi":          {".pi/agent", ".agents/skills"},
+		"zed":         {".config/zed", ".agents/skills"},
+		"firebase":    {},
+		"copilot":     {".copilot"},
+		"copilot-cli": {".copilot", ".agents/skills"},
+		"crush":       {".config/crush"},
+		"amp":         {".config/amp", ".config/agents"},
+		"antigravity": {".gemini/config"},
+		"goose":       {".agents/skills"},
+		"jules":       {},
+		"openhands":   {},
+		"trae":        {},
+		"jetbrains":   {},
+		"augmentcode": {".augment", ".agents/skills"},
+		"mistral":     {".vibe"},
+	}
+
+	specs := Specs()
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		seen[spec.Name] = true
+		exp, ok := want[spec.Name]
+		if !ok {
+			t.Errorf("spec %q has no expected-roots row; add one (forces deliberate review of new specs)", spec.Name)
+			continue
+		}
+		a := New(spec, Options{TargetRoot: root})
+
+		// Exact set (order-independent).
+		got := a.VersionRoots(adapter.ScopeUser, "")
+		var wantAbs []string
+		for _, rel := range exp {
+			wantAbs = append(wantAbs, filepath.Join(root, filepath.FromSlash(rel)))
+		}
+		if !sameSet(got, wantAbs) {
+			t.Errorf("%s.VersionRoots(user) = %v, want %v", spec.Name, got, wantAbs)
+		}
+
+		// Invariant: every user-scope target the spec declares is under exactly one
+		// returned root, and no root is $HOME or escapes it.
+		for _, target := range []string{spec.Memory.User, spec.MCP.User, spec.Skills.User} {
+			if target == "" {
+				continue
+			}
+			abs := filepath.Join(root, filepath.FromSlash(target))
+			n := 0
+			for _, r := range got {
+				if r == root {
+					t.Errorf("%s: root %q is $HOME — must never init a repo at $HOME", spec.Name, r)
+				}
+				if under(abs, r) {
+					n++
+				}
+			}
+			if n != 1 {
+				t.Errorf("%s: user target %q is under %d roots, want exactly 1 (roots=%v)", spec.Name, target, n, got)
+			}
+		}
+
+		// Project scope abstains.
+		if p := a.VersionRoots(adapter.ScopeProject, "/proj"); len(p) != 0 {
+			t.Errorf("%s.VersionRoots(project) = %v, want nil", spec.Name, p)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("expected-roots row %q has no matching spec (stale row?)", name)
+		}
+	}
+}
+
+func TestVersionRootOf_RejectsEscapes(t *testing.T) {
+	const root = "/home/u"
+	for _, bad := range []string{"../.ssh/id", "../../etc/passwd", "AGENTS.md", "", "."} {
+		if got := versionRootOf(root, bad); got != "" {
+			t.Errorf("versionRootOf(%q) = %q, want \"\" (must not escape $HOME or version a bare file)", bad, got)
+		}
+	}
+}
+
+func sameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func under(child, parent string) bool {
+	if child == parent {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/adapter/opencode/homedir.go
+++ b/internal/adapter/opencode/homedir.go
@@ -12,16 +12,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir, p.ClaudeSkillsDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir, p.ClaudeSkillsDir)
 }

--- a/internal/adapter/opencode/homedir.go
+++ b/internal/adapter/opencode/homedir.go
@@ -2,17 +2,26 @@ package opencode
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.config/opencode
-// config dir is the local-only git-backup root (issue #118). Returns ("", false)
-// at project scope. (OpenCode also writes user skills under ~/.claude/skills,
-// which the Claude repo captures; nothing is lost.)
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: ~/.config/opencode (its config
+// dir) plus ~/.claude/skills (the shared Claude skills dir OpenCode also writes
+// to). The apply tail de-nests + de-dups across adapters, so when Claude is also
+// enabled, ~/.claude/skills is captured by Claude's ~/.claude repo instead of
+// getting its own. Returns nil at project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir, p.ClaudeSkillsDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/opencode/homedir.go
+++ b/internal/adapter/opencode/homedir.go
@@ -1,0 +1,18 @@
+package opencode
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.config/opencode
+// config dir is the local-only git-backup root (issue #118). Returns ("", false)
+// at project scope. (OpenCode also writes user skills under ~/.claude/skills,
+// which the Claude repo captures; nothing is lost.)
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/roo/homedir.go
+++ b/internal/adapter/roo/homedir.go
@@ -1,0 +1,16 @@
+package roo
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.roo config dir is the
+// local-only git-backup root (issue #118). Returns ("", false) at project scope.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/roo/homedir.go
+++ b/internal/adapter/roo/homedir.go
@@ -9,16 +9,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/adapter/roo/homedir.go
+++ b/internal/adapter/roo/homedir.go
@@ -2,15 +2,23 @@ package roo
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.roo config dir is the
-// local-only git-backup root (issue #118). Returns ("", false) at project scope.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.roo config dir
+// is the local-only git-backup root (issue #118). Returns nil at project scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/windsurf/homedir.go
+++ b/internal/adapter/windsurf/homedir.go
@@ -2,16 +2,24 @@ package windsurf
 
 import "github.com/spxrogers/agentsync/internal/adapter"
 
-// HomeDir implements adapter.VersionedHome: the user-scope ~/.codeium/windsurf
-// config dir is the local-only git-backup root (issue #118). Returns ("", false)
-// at project scope.
-func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+// VersionRoots implements adapter.VersionedDirs: the user-scope ~/.codeium/windsurf
+// config dir is the local-only git-backup root (issue #118). Returns nil at project
+// scope.
+func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 	if scope != adapter.ScopeUser {
-		return "", false
+		return nil
 	}
-	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
-	if dir == "" {
-		return "", false
+	p := ResolvePaths(a.opts.TargetRoot, "", false)
+	return nonEmptyDirs(p.ConfigDir)
+}
+
+// nonEmptyDirs returns the non-empty arguments as a slice.
+func nonEmptyDirs(dirs ...string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, d)
+		}
 	}
-	return dir, true
+	return out
 }

--- a/internal/adapter/windsurf/homedir.go
+++ b/internal/adapter/windsurf/homedir.go
@@ -1,0 +1,17 @@
+package windsurf
+
+import "github.com/spxrogers/agentsync/internal/adapter"
+
+// HomeDir implements adapter.VersionedHome: the user-scope ~/.codeium/windsurf
+// config dir is the local-only git-backup root (issue #118). Returns ("", false)
+// at project scope.
+func (a *Adapter) HomeDir(scope adapter.Scope, project string) (string, bool) {
+	if scope != adapter.ScopeUser {
+		return "", false
+	}
+	dir := ResolvePaths(a.opts.TargetRoot, "", false).ConfigDir
+	if dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/adapter/windsurf/homedir.go
+++ b/internal/adapter/windsurf/homedir.go
@@ -10,16 +10,5 @@ func (a *Adapter) VersionRoots(scope adapter.Scope, project string) []string {
 		return nil
 	}
 	p := ResolvePaths(a.opts.TargetRoot, "", false)
-	return nonEmptyDirs(p.ConfigDir)
-}
-
-// nonEmptyDirs returns the non-empty arguments as a slice.
-func nonEmptyDirs(dirs ...string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, d := range dirs {
-		if d != "" {
-			out = append(out, d)
-		}
-	}
-	return out
+	return adapter.NonEmptyDirs(p.ConfigDir)
 }

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -27,6 +27,7 @@ func newApplyCmd() *cobra.Command {
 		dryRun      bool
 		scopeFlag   string
 		projectFlag string
+		noGitBackup bool
 	)
 	cmd := &cobra.Command{
 		Use:   "apply",
@@ -39,22 +40,23 @@ func newApplyCmd() *cobra.Command {
 			// concurrent `status` / `diff` / other dry-runs behind a long
 			// real apply.
 			if dryRun {
-				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag)
+				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag, noGitBackup)
 			}
 			return withGlobalLock(home, func() error {
-				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag)
+				return applyRun(cmd, home, dryRun, scopeFlag, projectFlag, noGitBackup)
 			})
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "compute plan without writing destinations")
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
 	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	cmd.Flags().BoolVar(&noGitBackup, "no-git-backup", false, "skip destination git versioning/checkpoint for this run (CI/scripting); does not modify agentsync.toml")
 	return cmd
 }
 
 // applyRun is the lock-protected body of the apply command. It is split
 // out from newApplyCmd so the lock acquisition lives in one obvious place.
-func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFlag string) error {
+func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFlag string, noGitBackup bool) error {
 	p, err := newPrinter(cmd)
 	if err != nil {
 		return err
@@ -220,6 +222,15 @@ func applyRun(cmd *cobra.Command, home string, dryRun bool, scopeFlag, projectFl
 	// Bound backup growth (each is a verbatim, possibly-secret-bearing copy
 	// of a pre-existing native file). Best-effort; never fails the apply.
 	_ = render.PruneBackups(home, render.DefaultBackupKeep)
+
+	// Destination git backup (issue #118): checkpoint the user-scope agent dirs we
+	// just wrote into their own local-only git repos, so a bad apply is an
+	// `agentsync revert` away. Never pushed. Best-effort — a git failure here must
+	// not fail an apply whose files are already written and state already saved.
+	if err := runDestinationGitBackup(cmd, p, reg, agents, sc, projectRoot, home,
+		c.Config.DestinationGitBackup, written, noGitBackup); err != nil {
+		fmt.Fprintf(p.Err, "%s destination git backup: %v\n", p.Yellow("agentsync:"), err)
+	}
 
 	w := p.Out
 	// Report a clean no-op distinctly from real work: when every destination

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/adapter"
+	agit "github.com/spxrogers/agentsync/internal/git"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -73,6 +75,14 @@ func newDoctorCmd() *cobra.Command {
 			p.Section("Plugins")
 			if schemaOK {
 				checkPlugins(p, home)
+			} else {
+				fmt.Fprintln(p.Out, "  skipped (schema invalid above)")
+			}
+
+			fmt.Fprintln(p.Out, "")
+			p.Section("Destination git backup")
+			if schemaOK {
+				checkDestinationGitBackup(p, cfg.DestinationGitBackup)
 			} else {
 				fmt.Fprintln(p.Out, "  skipped (schema invalid above)")
 			}
@@ -208,6 +218,47 @@ func checkPlugins(p *ui.Printer, home string) {
 		// manual ui.Sanitize is needed here.
 		warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf("%d not in source: %s — run `agentsync import %s:plugin`",
 			len(missing), untrusted.Join(missing, ", "), name))
+	}
+}
+
+// checkDestinationGitBackup reports the destination-git-backup mode and, per
+// deep agent whose dir exists on disk, whether it is agentsync-versioned, under
+// foreign source control, or untracked. Informational only — never a failure.
+// Changing the mode is a one-line agentsync.toml edit (there is no `agentsync git`
+// command, by design — issue #118).
+func checkDestinationGitBackup(p *ui.Printer, cfg source.DestinationGitBackupConfig) {
+	switch cfg.EffectiveMode() {
+	case source.GitBackupModeOff:
+		warnCheck(p, "mode       ", "off (rendered destination dirs are not versioned)")
+	case source.GitBackupModeOn:
+		okCheck(p, "mode       ", "on")
+	default:
+		okCheck(p, "mode       ", "prompt (asks on first apply to an untracked dir)")
+	}
+
+	reg := registryFactory()
+	for _, name := range reg.Names() {
+		vh, ok := reg.Lookup(name).(adapter.VersionedHome)
+		if !ok {
+			continue // breadth tier abstains
+		}
+		dir, ok := vh.HomeDir(adapter.ScopeUser, "")
+		if !ok || dir == "" {
+			continue
+		}
+		if _, err := os.Stat(dir); err != nil {
+			continue // dir not created yet — nothing to report
+		}
+		st, err := agit.Detect(dir)
+		if err != nil {
+			continue
+		}
+		label := fmt.Sprintf("%-10s ", name)
+		if st == agit.StateAgentsyncOwned {
+			okCheck(p, label, st.String())
+		} else {
+			fmt.Fprintf(p.Out, "  %s %s%s\n", p.Faint(ui.GlyphInfo), label, p.Faint(st.String()))
+		}
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -232,28 +232,24 @@ func checkDestinationGitBackup(p *ui.Printer, cfg source.DestinationGitBackupCon
 		warnCheck(p, "mode       ", "off (rendered destination dirs are not versioned)")
 	case source.GitBackupModeOn:
 		okCheck(p, "mode       ", "on")
-	default:
+	case source.GitBackupModePrompt:
 		okCheck(p, "mode       ", "prompt (asks on first apply to an untracked dir)")
+	default:
+		warnCheck(p, "mode       ", fmt.Sprintf("unknown value %q — use \"prompt\", \"on\", or \"off\"", cfg.Mode))
 	}
 
+	// Report per VERSION ROOT (deduped/de-nested across all agents), since a shared
+	// dir like ~/.agents/skills belongs to several agents but is one repo.
 	reg := registryFactory()
-	for _, name := range reg.Names() {
-		vh, ok := reg.Lookup(name).(adapter.VersionedHome)
-		if !ok {
-			continue // breadth tier abstains
-		}
-		dir, ok := vh.HomeDir(adapter.ScopeUser, "")
-		if !ok || dir == "" {
-			continue
-		}
-		if _, err := os.Stat(dir); err != nil {
+	for _, root := range enabledVersionRoots(reg, reg.Names(), adapter.ScopeUser, "") {
+		if _, err := os.Stat(root); err != nil {
 			continue // dir not created yet — nothing to report
 		}
-		st, err := agit.Detect(dir)
+		st, err := agit.Detect(root)
 		if err != nil {
 			continue
 		}
-		label := fmt.Sprintf("%-10s ", name)
+		label := root + " — "
 		if st == agit.StateAgentsyncOwned {
 			okCheck(p, label, st.String())
 		} else {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -20,6 +20,7 @@ func TestDoctor_PrintsEnvAndAgents(t *testing.T) {
 		"AGENTSYNC_HOME", "Go version", "OS",
 		"home dir   ok", ".state/    ok", "schema     ok",
 		"claude", "opencode",
+		"Destination git backup", "mode       prompt",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing %q. Got:\n%s", want, out)

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -138,6 +138,50 @@ func enabledVersionRoots(reg *adapter.Registry, agents []string, sc adapter.Scop
 	return denestRoots(all)
 }
 
+// versionRootOwners maps each post-de-nest version root to the sorted set of
+// agents whose declared dirs land under it. A root with more than one owner is
+// SHARED (e.g. ~/.agents/skills ← codex + warp + …) — reverting it rolls back every
+// owner's files, which the revert path warns about.
+func versionRootOwners(reg *adapter.Registry, agents []string, sc adapter.Scope, project string) map[string][]string {
+	roots := enabledVersionRoots(reg, agents, sc, project)
+	owners := map[string]map[string]bool{}
+	for _, name := range agents {
+		ad := reg.Lookup(name)
+		if ad == nil {
+			continue
+		}
+		vd, ok := ad.(adapter.VersionedDirs)
+		if !ok {
+			continue
+		}
+		for _, r := range vd.VersionRoots(sc, project) {
+			if r == "" {
+				continue
+			}
+			c := filepath.Clean(r)
+			for _, root := range roots {
+				if isUnderDir(c, root) {
+					if owners[root] == nil {
+						owners[root] = map[string]bool{}
+					}
+					owners[root][name] = true
+					break
+				}
+			}
+		}
+	}
+	out := make(map[string][]string, len(owners))
+	for root, set := range owners {
+		names := make([]string, 0, len(set))
+		for n := range set {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		out[root] = names
+	}
+	return out
+}
+
 // denestRoots returns roots sorted, with any root nested under another removed.
 // Lexical sort places an ancestor before its descendants (the ancestor path is a
 // prefix), so a single forward pass keeping non-nested roots is sufficient.
@@ -178,15 +222,16 @@ func isUnderDir(child, parent string) bool {
 func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mode *string, hintedUnavailable *bool) (*agit.Repo, error) {
 	switch *mode {
 	case source.GitBackupModeOn:
-		return agit.Init(dir)
+		return initGuarded(p, dir)
 	case source.GitBackupModePrompt:
 		switch gitBackupPrompter(cmd, p, dir) {
 		case promptYes:
-			repo, err := agit.Init(dir)
+			repo, err := initGuarded(p, dir)
 			if err != nil {
 				return nil, err
 			}
-			// Sticky "yes": stop asking on future applies.
+			// Sticky "yes": stop asking on future applies (even if THIS dir was
+			// skipped for a nesting conflict — other dirs should still auto-init).
 			if perr := setDestinationGitBackupMode(home, source.GitBackupModeOn); perr != nil {
 				fmt.Fprintf(p.Err, "%s could not persist git-backup mode: %v\n", p.Yellow("agentsync:"), perr)
 			}
@@ -211,6 +256,24 @@ func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mo
 		}
 	}
 	return nil, nil // mode "off" reached here only if flipped mid-run
+}
+
+// initGuarded inits an agentsync repo at dir UNLESS dir already contains a nested
+// git repo below it — agentsync never creates a repo that would wrap another (the
+// cross-run nesting hazard: a child dir was versioned in an earlier run, before a
+// parent-dir agent was enabled). Returns (nil, nil) and warns when it skips.
+func initGuarded(p *ui.Printer, dir string) (*agit.Repo, error) {
+	nested, err := agit.HasNestedRepoBelow(dir)
+	if err != nil {
+		return nil, err
+	}
+	if nested {
+		fmt.Fprintf(p.Err, "%s %s contains a nested git repository; skipping agentsync git backup here "+
+			"to avoid a repo inside a repo (remove the inner .git or reconcile to merge).\n",
+			p.Yellow("agentsync:"), dir)
+		return nil, nil
+	}
+	return agit.Init(dir)
 }
 
 // managedRelsUnder returns the slash-relative paths of every written file that

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -83,10 +83,13 @@ func runDestinationGitBackup(
 			continue // declined / unavailable / now off — nothing to commit into
 		}
 
-		// Always include the notice file so a freshly-inited repo tracks it (a
-		// no-op on an already-owned repo).
-		stage := append(rels, agit.NoticeFile)
-		if err := repo.Stage(stage); err != nil {
+		// Stage the written files + the notice (so a freshly-inited repo tracks it,
+		// a no-op on an already-owned repo). Build a fresh slice — don't append onto
+		// rels' backing array.
+		toStage := make([]string, 0, len(rels)+1)
+		toStage = append(toStage, rels...)
+		toStage = append(toStage, agit.NoticeFile)
+		if err := repo.Stage(toStage); err != nil {
 			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
 			continue
 		}
@@ -95,7 +98,7 @@ func runDestinationGitBackup(
 			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
 			continue
 		}
-		staged := dedupeSorted(append(stage, deleted...))
+		staged := dedupeSorted(append(toStage, deleted...))
 		msg := checkpointMessage(name, sc, staged)
 		h, err := repo.CommitStaged(msg, id)
 		if err != nil {

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/adapter"
+	agit "github.com/spxrogers/agentsync/internal/git"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// runDestinationGitBackup checkpoints each user-scope agent dir that received
+// managed writes this apply, giving it a local-only git history so a bad apply is
+// revertible (issue #118). It is BEST-EFFORT by contract: the files are already
+// written and state is already saved, so a git failure here is reported but never
+// fails the apply. It is a no-op for project scope, --no-git-backup, mode "off",
+// an empty write set, or an agent dir under foreign source control.
+func runDestinationGitBackup(
+	cmd *cobra.Command, p *ui.Printer, reg *adapter.Registry, agents []string,
+	sc adapter.Scope, projectRoot, home string,
+	cfg source.DestinationGitBackupConfig, written map[string]bool, noGitBackup bool,
+) error {
+	if sc != adapter.ScopeUser || noGitBackup || len(written) == 0 {
+		return nil
+	}
+	mode := cfg.EffectiveMode()
+	if mode == source.GitBackupModeOff {
+		return nil
+	}
+	id := agit.Identity{Name: cfg.AuthorName, Email: cfg.AuthorEmail}
+
+	// Deterministic order so multi-agent output is stable.
+	names := append([]string(nil), agents...)
+	sort.Strings(names)
+
+	hintedUnavailable := false
+	for _, name := range names {
+		ad := reg.Lookup(name)
+		if ad == nil {
+			continue
+		}
+		vh, ok := ad.(adapter.VersionedHome)
+		if !ok {
+			continue // breadth tier abstains
+		}
+		dir, ok := vh.HomeDir(sc, projectRoot)
+		if !ok || dir == "" {
+			continue
+		}
+		rels := managedRelsUnder(dir, written)
+		if len(rels) == 0 {
+			continue // this agent's dir didn't change this run
+		}
+
+		st, err := agit.Detect(dir)
+		if err != nil {
+			fmt.Fprintf(p.Err, "%s git backup: %v\n", p.Yellow("agentsync:"), err)
+			continue
+		}
+
+		var repo *agit.Repo
+		switch st {
+		case agit.StateForeign:
+			// The user already source-controls this dir — stay out of their way.
+			fmt.Fprintf(p.Err, "%s %s is under your own source control; skipping agentsync git backup.\n",
+				p.Faint(ui.GlyphInfo), dir)
+			continue
+		case agit.StateAgentsyncOwned:
+			repo, err = agit.Open(dir)
+		case agit.StateUntracked:
+			repo, err = ensureUntrackedRepo(cmd, p, dir, home, &mode, &hintedUnavailable)
+		}
+		if err != nil {
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			continue
+		}
+		if repo == nil {
+			continue // declined / unavailable / now off — nothing to commit into
+		}
+
+		// Always include the notice file so a freshly-inited repo tracks it (a
+		// no-op on an already-owned repo).
+		stage := append(rels, agit.NoticeFile)
+		if err := repo.Stage(stage); err != nil {
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			continue
+		}
+		deleted, err := repo.StageTrackedDeletions()
+		if err != nil {
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			continue
+		}
+		staged := dedupeSorted(append(stage, deleted...))
+		msg := checkpointMessage(name, sc, staged)
+		h, err := repo.CommitStaged(msg, id)
+		if err != nil {
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			continue
+		}
+		if h != "" {
+			fmt.Fprintf(p.Err, "%s %s\n", p.Faint(ui.GlyphInfo),
+				p.Faint(fmt.Sprintf("git backup: checkpointed %s (%s)", name, dir)))
+		}
+	}
+	return nil
+}
+
+// ensureUntrackedRepo returns a repo to commit into for an untracked dir, honoring
+// the mode: "on" inits silently; "prompt" asks (opt-out) and persists the answer.
+// Returns (nil, nil) when init was declined or could not be offered. It may flip
+// *mode to "off" for the rest of this run when the user picks "don't ask again".
+func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mode *string, hintedUnavailable *bool) (*agit.Repo, error) {
+	switch *mode {
+	case source.GitBackupModeOn:
+		return agit.Init(dir)
+	case source.GitBackupModePrompt:
+		switch gitBackupPrompter(cmd, p, dir) {
+		case promptYes:
+			repo, err := agit.Init(dir)
+			if err != nil {
+				return nil, err
+			}
+			// Sticky "yes": stop asking on future applies.
+			if perr := setDestinationGitBackupMode(home, source.GitBackupModeOn); perr != nil {
+				fmt.Fprintf(p.Err, "%s could not persist git-backup mode: %v\n", p.Yellow("agentsync:"), perr)
+			}
+			*mode = source.GitBackupModeOn
+			return repo, nil
+		case promptNever:
+			if perr := setDestinationGitBackupMode(home, source.GitBackupModeOff); perr != nil {
+				fmt.Fprintf(p.Err, "%s could not persist git-backup mode: %v\n", p.Yellow("agentsync:"), perr)
+			}
+			*mode = source.GitBackupModeOff
+			fmt.Fprintf(p.Err, "%s destination git backup disabled; re-enable later by setting mode in agentsync.toml.\n", p.Faint(ui.GlyphInfo))
+			return nil, nil
+		case promptUnavailable:
+			if !*hintedUnavailable {
+				fmt.Fprintf(p.Err, "%s destination git backup is available — run `agentsync apply` interactively to enable it, "+
+					"or set [destination_directory_git_backup] mode = \"on\" in agentsync.toml.\n", p.Faint(ui.GlyphInfo))
+				*hintedUnavailable = true
+			}
+			return nil, nil
+		default: // promptNo
+			return nil, nil
+		}
+	}
+	return nil, nil // mode "off" reached here only if flipped mid-run
+}
+
+// managedRelsUnder returns the slash-relative paths of every written file that
+// lives under dir, sorted.
+func managedRelsUnder(dir string, written map[string]bool) []string {
+	var rels []string
+	for abs := range written {
+		rel, err := filepath.Rel(dir, abs)
+		if err != nil {
+			continue
+		}
+		if rel == "." || strings.HasPrefix(rel, "..") {
+			continue // not under dir
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+	}
+	sort.Strings(rels)
+	return rels
+}
+
+// dedupeSorted returns the unique, sorted elements of in.
+func dedupeSorted(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	sort.Strings(in)
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// checkpointMessage renders the per-apply commit message.
+func checkpointMessage(agent string, sc adapter.Scope, staged []string) string {
+	return fmt.Sprintf("agentsync apply: %s (%s) — %d file(s)\n\n%s",
+		agent, sc, len(staged), strings.Join(staged, "\n"))
+}
+
+// promptResult is the outcome of the opt-out git-init prompt.
+type promptResult int
+
+const (
+	promptYes         promptResult = iota // init + persist mode "on"
+	promptNo                              // skip this run, ask again next time
+	promptNever                           // persist mode "off", stop asking
+	promptUnavailable                     // no TTY / --no-input: caller hints + skips
+)
+
+// gitBackupPrompter is the interactive prompt, injectable so tests can drive the
+// yes/no/never branches without a real terminal.
+var gitBackupPrompter = promptInitGitBackup
+
+// promptInitGitBackup asks the user whether to start git-versioning an untracked
+// destination dir. It fails closed (promptUnavailable) when there is no terminal
+// or --no-input is set, so headless runs never block.
+func promptInitGitBackup(cmd *cobra.Command, p *ui.Printer, dir string) promptResult {
+	if noInputFlag(cmd) || !stdinIsTerminal(cmd) {
+		return promptUnavailable
+	}
+	w := cmd.OutOrStdout()
+	r := bufio.NewReader(cmd.InOrStdin())
+	fmt.Fprintf(w, "%s agentsync can keep a local rollback history of %s so a bad apply is revertible.\n", ui.GlyphInfo, dir)
+	fmt.Fprintf(w, "  This is a %s git repo (never pushed). It may contain secrets in cleartext, like the files it versions.\n", p.Bold("local-only"))
+	for attempts := 0; attempts < 5; attempts++ {
+		fmt.Fprintf(w, "  Enable git backup for this directory? [y]es / [n]ot now / [d]on't ask again: ")
+		line, err := r.ReadString('\n')
+		if res, ok := interpretPromptLine(line); ok {
+			return res
+		}
+		if err != nil {
+			return promptNo // EOF / closed stdin: treat as "not now", never loop forever
+		}
+		fmt.Fprintf(w, "  please enter y, n, or d.\n")
+	}
+	return promptNo
+}
+
+// interpretPromptLine maps a typed line to a promptResult; ok is false for an
+// unrecognized line (the caller re-prompts).
+func interpretPromptLine(line string) (promptResult, bool) {
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return promptYes, true
+	case "n", "no":
+		return promptNo, true
+	case "d", "dont", "don't":
+		return promptNever, true
+	}
+	return promptNo, false
+}

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -25,7 +25,7 @@ func runDestinationGitBackup(
 	sc adapter.Scope, projectRoot, home string,
 	cfg source.DestinationGitBackupConfig, written map[string]bool, noGitBackup bool,
 ) error {
-	if sc != adapter.ScopeUser || noGitBackup || len(written) == 0 {
+	if sc != adapter.ScopeUser || noGitBackup {
 		return nil
 	}
 	mode := cfg.EffectiveMode()
@@ -34,30 +34,17 @@ func runDestinationGitBackup(
 	}
 	id := agit.Identity{Name: cfg.AuthorName, Email: cfg.AuthorEmail}
 
-	// Deterministic order so multi-agent output is stable.
-	names := append([]string(nil), agents...)
-	sort.Strings(names)
+	// The unit of versioning is the DIRECTORY, not the agent: union every enabled
+	// agent's declared version roots, drop nested roots (no repo inside a repo), and
+	// de-dup, so a shared dir (e.g. ~/.agents/skills, written by Codex + several
+	// breadth agents) is checkpointed exactly once with all its files.
+	roots := enabledVersionRoots(reg, agents, sc, projectRoot)
 
 	hintedUnavailable := false
-	for _, name := range names {
-		ad := reg.Lookup(name)
-		if ad == nil {
-			continue
-		}
-		vh, ok := ad.(adapter.VersionedHome)
-		if !ok {
-			continue // breadth tier abstains
-		}
-		dir, ok := vh.HomeDir(sc, projectRoot)
-		if !ok || dir == "" {
-			continue
-		}
-		rels := managedRelsUnder(dir, written)
-		if len(rels) == 0 {
-			continue // this agent's dir didn't change this run
-		}
+	for _, root := range roots {
+		rels := managedRelsUnder(root, written)
 
-		st, err := agit.Detect(dir)
+		st, err := agit.Detect(root)
 		if err != nil {
 			fmt.Fprintf(p.Err, "%s git backup: %v\n", p.Yellow("agentsync:"), err)
 			continue
@@ -67,16 +54,23 @@ func runDestinationGitBackup(
 		switch st {
 		case agit.StateForeign:
 			// The user already source-controls this dir — stay out of their way.
-			fmt.Fprintf(p.Err, "%s %s is under your own source control; skipping agentsync git backup.\n",
-				p.Faint(ui.GlyphInfo), dir)
+			if len(rels) > 0 {
+				fmt.Fprintf(p.Err, "%s %s is under your own source control; skipping agentsync git backup.\n",
+					p.Faint(ui.GlyphInfo), root)
+			}
 			continue
 		case agit.StateAgentsyncOwned:
-			repo, err = agit.Open(dir)
+			// Open even when nothing was written under this root: a delete-only apply
+			// (a managed file removed, nothing added) still needs its checkpoint.
+			repo, err = agit.Open(root)
 		case agit.StateUntracked:
-			repo, err = ensureUntrackedRepo(cmd, p, dir, home, &mode, &hintedUnavailable)
+			if len(rels) == 0 {
+				continue // nothing written here and no existing repo to record into
+			}
+			repo, err = ensureUntrackedRepo(cmd, p, root, home, &mode, &hintedUnavailable)
 		}
 		if err != nil {
-			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), root, err)
 			continue
 		}
 		if repo == nil {
@@ -90,27 +84,91 @@ func runDestinationGitBackup(
 		toStage = append(toStage, rels...)
 		toStage = append(toStage, agit.NoticeFile)
 		if err := repo.Stage(toStage); err != nil {
-			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), root, err)
 			continue
 		}
 		deleted, err := repo.StageTrackedDeletions()
 		if err != nil {
-			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), root, err)
 			continue
 		}
 		staged := dedupeSorted(append(toStage, deleted...))
-		msg := checkpointMessage(name, sc, staged)
+		msg := checkpointMessage(root, staged)
 		h, err := repo.CommitStaged(msg, id)
 		if err != nil {
-			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), name, err)
+			fmt.Fprintf(p.Err, "%s git backup for %s: %v\n", p.Yellow("agentsync:"), root, err)
 			continue
 		}
 		if h != "" {
 			fmt.Fprintf(p.Err, "%s %s\n", p.Faint(ui.GlyphInfo),
-				p.Faint(fmt.Sprintf("git backup: checkpointed %s (%s)", name, dir)))
+				p.Faint(fmt.Sprintf("git backup: checkpointed %s", root)))
 		}
 	}
 	return nil
+}
+
+// enabledVersionRoots returns the de-duplicated, de-nested, sorted set of
+// version-root directories declared by the given agents at the scope. The unit is
+// the directory: a shared dir declared by several agents appears once, and a dir
+// nested under another (e.g. ~/.claude/skills under ~/.claude) is dropped in favor
+// of the ancestor — so agentsync never creates a repo inside another repo.
+func enabledVersionRoots(reg *adapter.Registry, agents []string, sc adapter.Scope, project string) []string {
+	seen := map[string]bool{}
+	var all []string
+	for _, name := range agents {
+		ad := reg.Lookup(name)
+		if ad == nil {
+			continue
+		}
+		vd, ok := ad.(adapter.VersionedDirs)
+		if !ok {
+			continue
+		}
+		for _, r := range vd.VersionRoots(sc, project) {
+			if r == "" {
+				continue
+			}
+			c := filepath.Clean(r)
+			if !seen[c] {
+				seen[c] = true
+				all = append(all, c)
+			}
+		}
+	}
+	return denestRoots(all)
+}
+
+// denestRoots returns roots sorted, with any root nested under another removed.
+// Lexical sort places an ancestor before its descendants (the ancestor path is a
+// prefix), so a single forward pass keeping non-nested roots is sufficient.
+func denestRoots(roots []string) []string {
+	sort.Strings(roots)
+	var kept []string
+	for _, r := range roots {
+		nested := false
+		for _, k := range kept {
+			if isUnderDir(r, k) {
+				nested = true
+				break
+			}
+		}
+		if !nested {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+// isUnderDir reports whether child is the same as, or nested under, parent.
+func isUnderDir(child, parent string) bool {
+	if child == parent {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // ensureUntrackedRepo returns a repo to commit into for an untracked dir, honoring
@@ -188,10 +246,10 @@ func dedupeSorted(in []string) []string {
 	return out
 }
 
-// checkpointMessage renders the per-apply commit message.
-func checkpointMessage(agent string, sc adapter.Scope, staged []string) string {
-	return fmt.Sprintf("agentsync apply: %s (%s) — %d file(s)\n\n%s",
-		agent, sc, len(staged), strings.Join(staged, "\n"))
+// checkpointMessage renders the per-apply commit message for a version root.
+func checkpointMessage(root string, staged []string) string {
+	return fmt.Sprintf("agentsync apply: %s — %d file(s)\n\n%s",
+		root, len(staged), strings.Join(staged, "\n"))
 }
 
 // promptResult is the outcome of the opt-out git-init prompt.

--- a/internal/cli/gitbackup_apply_test.go
+++ b/internal/cli/gitbackup_apply_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	agit "github.com/spxrogers/agentsync/internal/git"
@@ -70,6 +71,115 @@ func TestApply_GitBackupCheckpoint(t *testing.T) {
 	cps2, _ := repo.Log(0)
 	if len(cps2) != 1 {
 		t.Fatalf("re-apply recorded a checkpoint despite no change: %d commits", len(cps2))
+	}
+}
+
+// writeSkillSource writes a skill SKILL.md into the canonical source tree.
+func writeSkillSource(t *testing.T, tmp, name, body string) {
+	t.Helper()
+	p := filepath.Join(tmp, ".agentsync", "skills", name, "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("---\nname: "+name+"\ndescription: d\n---\n"+body+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func enableGitBackupOn(t *testing.T, tmp string) {
+	t.Helper()
+	f, err := os.OpenFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n")
+	_ = f.Close()
+}
+
+// TestApply_GitBackupRecordsDeletion proves a managed-file DELETION is committed to
+// the checkpoint (not left as silent worktree drift). If the deletion weren't
+// committed, the repo would be dirty (worktree missing a file HEAD still has).
+func TestApply_GitBackupRecordsDeletion(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	enableGitBackupOn(t, tmp)
+	writeSkillSource(t, tmp, "keep", "k")
+	writeSkillSource(t, tmp, "temp", "t")
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 1: %v\n%s", err, out)
+	}
+
+	tempDest := filepath.Join(tmp, ".claude", "skills", "temp", "SKILL.md")
+	if _, err := os.Stat(tempDest); err != nil {
+		t.Fatalf("precondition: temp skill should exist after apply 1: %v", err)
+	}
+
+	// Remove the temp skill from source and re-apply → its dest file is deleted.
+	if err := os.RemoveAll(filepath.Join(tmp, ".agentsync", "skills", "temp")); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 2: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(tempDest); !os.IsNotExist(err) {
+		t.Fatalf("temp dest skill should be deleted after apply 2, stat err = %v", err)
+	}
+
+	repo, err := agit.Open(filepath.Join(tmp, ".claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The deletion was committed iff the worktree matches HEAD (clean).
+	clean, err := repo.IsClean()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !clean {
+		t.Fatal("deletion was not committed to the checkpoint (repo is dirty vs HEAD)")
+	}
+	cps, _ := repo.Log(0)
+	if len(cps) < 2 {
+		t.Fatalf("want >=2 checkpoints (add, then delete), got %d", len(cps))
+	}
+}
+
+// TestApply_GitBackupVersionsSharedSkillsDir proves the shared cross-vendor
+// ~/.agents/skills dir is git-versioned (Codex declares it as a version root).
+func TestApply_GitBackupVersionsSharedSkillsDir(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "codex")
+	enableGitBackupOn(t, tmp)
+	writeSkillSource(t, tmp, "demo", "d")
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	shared := filepath.Join(tmp, ".agents", "skills")
+	if _, err := os.Stat(filepath.Join(shared, "demo", "SKILL.md")); err != nil {
+		t.Fatalf("codex should render the skill to %s: %v", shared, err)
+	}
+	st, err := agit.Detect(shared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != agit.StateAgentsyncOwned {
+		t.Fatalf("shared %s state = %v, want agentsync-versioned", shared, st)
+	}
+}
+
+// TestDoctor_ShowsVersionedRoot checks doctor reports a versioned dir's status.
+func TestDoctor_ShowsVersionedRoot(t *testing.T) {
+	_, env, _ := setupGitBackedClaude(t)
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "agentsync-versioned") {
+		t.Fatalf("doctor should report ~/.claude as agentsync-versioned; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/gitbackup_apply_test.go
+++ b/internal/cli/gitbackup_apply_test.go
@@ -1,0 +1,100 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	agit "github.com/spxrogers/agentsync/internal/git"
+)
+
+// TestApply_GitBackupCheckpoint is the end-to-end apply-tail test: with git backup
+// enabled, the first apply that writes under ~/.claude initializes a local repo and
+// records exactly one checkpoint; a re-apply with no source change records none.
+func TestApply_GitBackupCheckpoint(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	// No TTY in tests, so the prompt is unavailable — enable git backup via config.
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	// A skill renders to ~/.claude/skills/demo/SKILL.md — inside the versioned dir
+	// (an MCP-only config would only touch ~/.claude.json at $HOME, which is out of
+	// scope by design).
+	skill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skill), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skill, []byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	claude := filepath.Join(tmp, ".claude")
+	st, err := agit.Detect(claude)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != agit.StateAgentsyncOwned {
+		t.Fatalf("~/.claude state = %v, want agentsync-owned", st)
+	}
+	repo, err := agit.Open(claude)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cps, err := repo.Log(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cps) != 1 {
+		t.Fatalf("want exactly 1 checkpoint after first apply, got %d", len(cps))
+	}
+
+	// Re-apply with no source change → no new checkpoint (apply is a no-op).
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("re-apply: %v\n%s", err, out)
+	}
+	cps2, _ := repo.Log(0)
+	if len(cps2) != 1 {
+		t.Fatalf("re-apply recorded a checkpoint despite no change: %d commits", len(cps2))
+	}
+}
+
+// TestApply_NoGitBackupFlag verifies --no-git-backup skips versioning even when
+// mode is "on".
+func TestApply_NoGitBackupFlag(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	f, _ := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n")
+	_ = f.Close()
+
+	skill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	_ = os.MkdirAll(filepath.Dir(skill), 0o755)
+	_ = os.WriteFile(skill, []byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644)
+
+	if out, err := runCLI(t, env, "apply", "--no-git-backup"); err != nil {
+		t.Fatalf("apply --no-git-backup: %v\n%s", err, out)
+	}
+	st, _ := agit.Detect(filepath.Join(tmp, ".claude"))
+	if st == agit.StateAgentsyncOwned {
+		t.Fatal("--no-git-backup must not create a repo")
+	}
+}

--- a/internal/cli/gitbackup_apply_test.go
+++ b/internal/cli/gitbackup_apply_test.go
@@ -171,6 +171,60 @@ func TestApply_GitBackupVersionsSharedSkillsDir(t *testing.T) {
 	}
 }
 
+// TestApply_GitBackupGuardsAgainstNestedRepo is the regression for the cross-run
+// nesting BLOCKER: an earlier opencode-only apply versions ~/.claude/skills; later
+// enabling claude must NOT init a repo at ~/.claude that would wrap the child repo.
+func TestApply_GitBackupGuardsAgainstNestedRepo(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "opencode")
+	enableGitBackupOn(t, tmp)
+	writeSkillSource(t, tmp, "demo", "d")
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply (opencode): %v\n%s", err, out)
+	}
+	claudeSkills := filepath.Join(tmp, ".claude", "skills")
+	if st, _ := agit.Detect(claudeSkills); st != agit.StateAgentsyncOwned {
+		t.Fatalf("opencode should have versioned %s, state=%v", claudeSkills, st)
+	}
+
+	// Now add claude (whose root ~/.claude wraps the existing ~/.claude/skills repo).
+	mustRun(t, env, "agent", "add", "claude")
+	out, err := runCLI(t, env, "apply")
+	if err != nil {
+		t.Fatalf("apply (claude): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "nested git repository") {
+		t.Errorf("expected a nested-repo warning, got:\n%s", out)
+	}
+	// The guard fired: no repo was created at ~/.claude (it would wrap the child).
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", ".git")); !os.IsNotExist(err) {
+		t.Fatalf("~/.claude/.git should not exist (guard must skip the wrapping init); err=%v", err)
+	}
+	// The child repo is intact — no corruption.
+	if st, _ := agit.Detect(claudeSkills); st != agit.StateAgentsyncOwned {
+		t.Fatalf("child repo %s damaged, state=%v", claudeSkills, st)
+	}
+}
+
+// TestDoctor_WarnsUnknownGitBackupMode checks doctor flags a typo'd mode value.
+func TestDoctor_WarnsUnknownGitBackupMode(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	f, _ := os.OpenFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"bogus\"\n")
+	_ = f.Close()
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "unknown value") || !strings.Contains(out, "bogus") {
+		t.Fatalf("doctor should warn on the unknown mode; got:\n%s", out)
+	}
+}
+
 // TestDoctor_ShowsVersionedRoot checks doctor reports a versioned dir's status.
 func TestDoctor_ShowsVersionedRoot(t *testing.T) {
 	_, env, _ := setupGitBackedClaude(t)

--- a/internal/cli/gitbackup_config.go
+++ b/internal/cli/gitbackup_config.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+const gitBackupTableHeader = "[destination_directory_git_backup]"
+
+// setDestinationGitBackupMode writes mode into the
+// [destination_directory_git_backup] table of <home>/agentsync.toml, preserving
+// everything OUTSIDE that table (comments, key order, other sections) via a
+// line-splice — never a full marshal, which would strip the user's comments. Any
+// existing author_name/author_email overrides in the table are carried across.
+// Creates the table if absent.
+func setDestinationGitBackupMode(home, mode string) error {
+	p := filepath.Join(home, "agentsync.toml")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", p, err)
+	}
+	// Read just the table (not the whole source tree) to preserve author overrides.
+	var cfg struct {
+		Table source.DestinationGitBackupConfig `toml:"destination_directory_git_backup"`
+	}
+	if err := toml.Unmarshal(raw, &cfg); err != nil {
+		return fmt.Errorf("parse %s: %w", p, err)
+	}
+	block := buildGitBackupSection(mode, cfg.Table.AuthorName, cfg.Table.AuthorEmail)
+	out := spliceTOMLTable(string(raw), gitBackupTableHeader, block)
+	if err := iox.AtomicWrite(p, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", p, err)
+	}
+	return nil
+}
+
+// buildGitBackupSection renders the [destination_directory_git_backup] block,
+// emitting author lines only when set so we never write empty overrides.
+func buildGitBackupSection(mode, authorName, authorEmail string) string {
+	var sb strings.Builder
+	sb.WriteString(gitBackupTableHeader + "\n")
+	fmt.Fprintf(&sb, "mode = %q\n", mode)
+	if authorName != "" {
+		fmt.Fprintf(&sb, "author_name = %q\n", authorName)
+	}
+	if authorEmail != "" {
+		fmt.Fprintf(&sb, "author_email = %q\n", authorEmail)
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// spliceTOMLTable replaces the simple TOML table named by header (e.g.
+// "[destination_directory_git_backup]") with newBlock, preserving everything
+// outside it. A table runs from its header line to the next line beginning with
+// "[". If the table is absent, newBlock is appended after a blank-line separator.
+// Mirrors writeAgents' approach so config edits never clobber hand-written content.
+func spliceTOMLTable(raw, header, newBlock string) string {
+	newLines := strings.Split(newBlock, "\n")
+	lines := strings.Split(raw, "\n")
+	out := make([]string, 0, len(lines)+len(newLines))
+	insertAt := -1
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			// A new table header: ours iff it matches header exactly.
+			inSection = trimmed == header
+			if inSection {
+				if insertAt < 0 {
+					insertAt = len(out)
+				}
+				continue // drop the old header
+			}
+		}
+		if inSection {
+			continue // drop lines inside the old table
+		}
+		out = append(out, line)
+	}
+	if insertAt < 0 {
+		if len(out) > 0 && strings.TrimSpace(out[len(out)-1]) != "" {
+			out = append(out, "")
+		}
+		out = append(out, newLines...)
+	} else {
+		tail := append([]string(nil), out[insertAt:]...)
+		out = append(out[:insertAt], newLines...)
+		// Keep a blank line before whatever section follows so repeated edits
+		// don't collapse the file's spacing (the loop drops blanks inside the
+		// table, so one separator is re-added each run — no accumulation).
+		if len(tail) > 0 && strings.TrimSpace(tail[0]) != "" {
+			out = append(out, "")
+		}
+		out = append(out, tail...)
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/cli/gitbackup_config_test.go
+++ b/internal/cli/gitbackup_config_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+func TestSetDestinationGitBackupMode(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+	const initial = `# my agentsync config
+# keep these comments
+
+[agents]
+claude = { enabled = true, scope = "user" }
+
+[updates]
+default_mode = "track"
+`
+	p := filepath.Join(home, "agentsync.toml")
+	if err := os.WriteFile(p, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := setDestinationGitBackupMode(home, source.GitBackupModeOn); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	// Comments + the other section survive.
+	if !strings.Contains(s, "# keep these comments") {
+		t.Errorf("comments were lost:\n%s", s)
+	}
+	if !strings.Contains(s, `default_mode = "track"`) {
+		t.Errorf("[updates] table was lost:\n%s", s)
+	}
+	// The new table parses back to the persisted mode.
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Config.DestinationGitBackup.EffectiveMode() != source.GitBackupModeOn {
+		t.Fatalf("mode = %q, want on", c.Config.DestinationGitBackup.EffectiveMode())
+	}
+
+	// Idempotent: flipping to off twice leaves exactly one table, no dup headers.
+	if err := setDestinationGitBackupMode(home, source.GitBackupModeOff); err != nil {
+		t.Fatal(err)
+	}
+	if err := setDestinationGitBackupMode(home, source.GitBackupModeOff); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := os.ReadFile(p)
+	if n := strings.Count(string(got2), gitBackupTableHeader); n != 1 {
+		t.Fatalf("want exactly 1 %s table, got %d:\n%s", gitBackupTableHeader, n, got2)
+	}
+	c2, _ := source.Load(afero.NewOsFs(), home)
+	if c2.Config.DestinationGitBackup.Mode != source.GitBackupModeOff {
+		t.Fatalf("mode = %q, want off", c2.Config.DestinationGitBackup.Mode)
+	}
+}
+
+func TestSetDestinationGitBackupMode_PreservesAuthors(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+	const initial = `[destination_directory_git_backup]
+mode = "prompt"
+author_name = "Custom Bot"
+author_email = "bot@example.com"
+`
+	p := filepath.Join(home, "agentsync.toml")
+	if err := os.WriteFile(p, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := setDestinationGitBackupMode(home, source.GitBackupModeOn); err != nil {
+		t.Fatal(err)
+	}
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := c.Config.DestinationGitBackup
+	if g.Mode != source.GitBackupModeOn || g.AuthorName != "Custom Bot" || g.AuthorEmail != "bot@example.com" {
+		t.Fatalf("author overrides not preserved: %+v", g)
+	}
+}

--- a/internal/cli/gitbackup_test.go
+++ b/internal/cli/gitbackup_test.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/adapter"
+	agit "github.com/spxrogers/agentsync/internal/git"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// tracked reports whether rel is in the repo's HEAD tree.
+func tracked(t *testing.T, dir, rel string) bool {
+	t.Helper()
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree, err := c.Tree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tree.File(rel)
+	return err == nil
+}
+
+// gitPlainInit creates a bare-bones (non-agentsync) repo, simulating a user's
+// own source control over a destination dir.
+func gitPlainInit(dir string) (*gogit.Repository, error) {
+	return gogit.PlainInit(dir, false)
+}
+
+// stubPrompter overrides the interactive prompt to return res; the returned func
+// restores the original.
+func stubPrompter(res promptResult) func() {
+	orig := gitBackupPrompter
+	gitBackupPrompter = func(*cobra.Command, *ui.Printer, string) promptResult { return res }
+	return func() { gitBackupPrompter = orig }
+}
+
+// loadMode returns the persisted [destination_directory_git_backup] mode.
+func loadMode(t *testing.T, home string) string {
+	t.Helper()
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c.Config.DestinationGitBackup.Mode
+}
+
+// gbHarness wires runDestinationGitBackup against the real claude adapter rooted at
+// a temp target root, with agentsync home at a second temp dir.
+type gbHarness struct {
+	t        *testing.T
+	home     string // agentsync home (agentsync.toml lives here)
+	target   string // AGENTSYNC_TARGET_ROOT
+	claudDir string // <target>/.claude
+	cmd      *cobra.Command
+	p        *ui.Printer
+	reg      *adapter.Registry
+}
+
+func newGBHarness(t *testing.T) *gbHarness {
+	t.Helper()
+	testenv.RequireContainer(t)
+	target := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("AGENTSYNC_TARGET_ROOT", target)
+	// A minimal agentsync.toml so mode persistence has a file to edit.
+	if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte("[agents]\nclaude = { enabled = true }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{Use: "apply"}
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	return &gbHarness{
+		t:        t,
+		home:     home,
+		target:   target,
+		claudDir: filepath.Join(target, ".claude"),
+		cmd:      cmd,
+		p:        ui.New(os.Stdout, os.Stderr, ui.ColorNever),
+		reg:      registryFactory(),
+	}
+}
+
+// writeManaged simulates apply having written a managed file under ~/.claude and
+// returns the absolute path (for the `written` set).
+func (h *gbHarness) writeManaged(rel, content string) string {
+	h.t.Helper()
+	abs := filepath.Join(h.claudDir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		h.t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o600); err != nil {
+		h.t.Fatal(err)
+	}
+	return abs
+}
+
+func (h *gbHarness) run(cfg source.DestinationGitBackupConfig, written map[string]bool, noGitBackup bool) {
+	h.t.Helper()
+	err := runDestinationGitBackup(h.cmd, h.p, h.reg, []string{"claude"},
+		adapter.ScopeUser, "", h.home, cfg, written, noGitBackup)
+	if err != nil {
+		h.t.Fatalf("runDestinationGitBackup: %v", err)
+	}
+}
+
+func TestGitBackup_ModeOn_CheckpointsWrittenFiles(t *testing.T) {
+	h := newGBHarness(t)
+	abs := h.writeManaged("settings.json", `{"a":1}`)
+	// An UNtracked user file in the same dir must not be swept into the commit.
+	stray := filepath.Join(h.claudDir, "user-scratch.txt")
+	if err := os.WriteFile(stray, []byte("mine"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h.run(source.DestinationGitBackupConfig{Mode: source.GitBackupModeOn}, map[string]bool{abs: true}, false)
+
+	st, err := agit.Detect(h.claudDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != agit.StateAgentsyncOwned {
+		t.Fatalf("dir state = %v, want agentsync-owned", st)
+	}
+	repo, err := agit.Open(h.claudDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cps, _ := repo.Log(0)
+	if len(cps) != 1 {
+		t.Fatalf("want 1 checkpoint, got %d", len(cps))
+	}
+	// The checkpoint tracks settings.json + the notice, NOT the stray user file.
+	if !tracked(t, h.claudDir, "settings.json") {
+		t.Error("settings.json should be tracked")
+	}
+	if !tracked(t, h.claudDir, agit.NoticeFile) {
+		t.Error("notice file should be tracked")
+	}
+	if tracked(t, h.claudDir, "user-scratch.txt") {
+		t.Error("untracked user file must NOT be committed")
+	}
+}
+
+func TestGitBackup_NoOpPaths(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      source.DestinationGitBackupConfig
+		written  func(h *gbHarness) map[string]bool
+		noGit    bool
+		wantRepo bool
+	}{
+		{name: "off", cfg: source.DestinationGitBackupConfig{Mode: source.GitBackupModeOff}, wantRepo: false},
+		{name: "no-git-backup flag", cfg: source.DestinationGitBackupConfig{Mode: source.GitBackupModeOn}, noGit: true, wantRepo: false},
+		{name: "empty written", cfg: source.DestinationGitBackupConfig{Mode: source.GitBackupModeOn}, written: func(*gbHarness) map[string]bool { return nil }, wantRepo: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newGBHarness(t)
+			written := map[string]bool{h.writeManaged("settings.json", "{}"): true}
+			if tc.written != nil {
+				written = tc.written(h)
+			}
+			h.run(tc.cfg, written, tc.noGit)
+			st, _ := agit.Detect(h.claudDir)
+			if (st == agit.StateAgentsyncOwned) != tc.wantRepo {
+				t.Fatalf("repo created = %v, want %v (state %v)", st == agit.StateAgentsyncOwned, tc.wantRepo, st)
+			}
+		})
+	}
+}
+
+func TestGitBackup_ProjectScopeIsNoOp(t *testing.T) {
+	h := newGBHarness(t)
+	abs := h.writeManaged("settings.json", "{}")
+	err := runDestinationGitBackup(h.cmd, h.p, h.reg, []string{"claude"},
+		adapter.ScopeProject, filepath.Join(h.target, "proj"), h.home,
+		source.DestinationGitBackupConfig{Mode: source.GitBackupModeOn}, map[string]bool{abs: true}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, _ := agit.Detect(h.claudDir)
+	if st == agit.StateAgentsyncOwned {
+		t.Fatal("project scope must not init the user-scope dir")
+	}
+}
+
+func TestGitBackup_ForeignDirLeftAlone(t *testing.T) {
+	h := newGBHarness(t)
+	abs := h.writeManaged("settings.json", "{}")
+	// Pre-existing user repo (no agentsync marker).
+	if err := os.MkdirAll(h.claudDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gitPlainInit(h.claudDir); err != nil {
+		t.Fatal(err)
+	}
+	h.run(source.DestinationGitBackupConfig{Mode: source.GitBackupModeOn}, map[string]bool{abs: true}, false)
+	st, _ := agit.Detect(h.claudDir)
+	if st != agit.StateForeign {
+		t.Fatalf("foreign dir state = %v, want foreign (agentsync must not adopt it)", st)
+	}
+}
+
+func TestGitBackup_PromptYesPersistsOn(t *testing.T) {
+	h := newGBHarness(t)
+	abs := h.writeManaged("settings.json", "{}")
+	restore := stubPrompter(promptYes)
+	defer restore()
+
+	h.run(source.DestinationGitBackupConfig{Mode: source.GitBackupModePrompt}, map[string]bool{abs: true}, false)
+
+	if st, _ := agit.Detect(h.claudDir); st != agit.StateAgentsyncOwned {
+		t.Fatalf("after prompt-yes, dir state = %v, want owned", st)
+	}
+	// Sticky: mode persisted to "on".
+	if got := loadMode(t, h.home); got != source.GitBackupModeOn {
+		t.Fatalf("persisted mode = %q, want on", got)
+	}
+}
+
+func TestGitBackup_PromptNeverPersistsOff(t *testing.T) {
+	h := newGBHarness(t)
+	abs := h.writeManaged("settings.json", "{}")
+	restore := stubPrompter(promptNever)
+	defer restore()
+
+	h.run(source.DestinationGitBackupConfig{Mode: source.GitBackupModePrompt}, map[string]bool{abs: true}, false)
+
+	if st, _ := agit.Detect(h.claudDir); st == agit.StateAgentsyncOwned {
+		t.Fatal("after prompt-never, dir must not be inited")
+	}
+	if got := loadMode(t, h.home); got != source.GitBackupModeOff {
+		t.Fatalf("persisted mode = %q, want off", got)
+	}
+}
+
+func TestInterpretPromptLine(t *testing.T) {
+	cases := map[string]struct {
+		want promptResult
+		ok   bool
+	}{
+		"y\n": {promptYes, true}, "YES": {promptYes, true},
+		"n": {promptNo, true}, "no\n": {promptNo, true},
+		"d": {promptNever, true}, "don't": {promptNever, true},
+		"": {promptNo, false}, "maybe": {promptNo, false},
+	}
+	for in, want := range cases {
+		got, ok := interpretPromptLine(in)
+		if ok != want.ok || (ok && got != want.want) {
+			t.Errorf("interpretPromptLine(%q) = (%v,%v), want (%v,%v)", in, got, ok, want.want, want.ok)
+		}
+	}
+}

--- a/internal/cli/gitbackup_test.go
+++ b/internal/cli/gitbackup_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -14,6 +16,19 @@ import (
 	"github.com/spxrogers/agentsync/internal/testenv"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
+
+// TestPromptInitGitBackup_NonInteractive pins the headless "never block" guarantee:
+// with a non-terminal stdin the prompt returns promptUnavailable rather than
+// reading (which would hang a CI run). Even though a "y" is queued, it is ignored.
+func TestPromptInitGitBackup_NonInteractive(t *testing.T) {
+	cmd := &cobra.Command{Use: "apply"}
+	cmd.SetIn(strings.NewReader("y\n")) // a *strings.Reader is not an *os.File terminal
+	cmd.SetOut(io.Discard)
+	p := ui.New(io.Discard, io.Discard, ui.ColorNever)
+	if got := promptInitGitBackup(cmd, p, "/some/dir"); got != promptUnavailable {
+		t.Fatalf("non-interactive prompt = %v, want promptUnavailable", got)
+	}
+}
 
 // tracked reports whether rel is in the repo's HEAD tree.
 func tracked(t *testing.T, dir, rel string) bool {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,6 +40,15 @@ default_interval = "24h"
 # file          = "secrets/secrets.age"
 # recipient     = "age1...your-public-key..."
 # identity_file = "${env:HOME}/.config/agentsync/age.key"
+
+# [destination_directory_git_backup]
+# Keep a LOCAL-ONLY git history of each rendered destination dir (~/.claude, …)
+# so a bad apply is revertible with "agentsync revert". Never pushed. The history
+# may contain secrets in cleartext (like the files it versions), which is why it
+# stays local. mode: "prompt" (default, ask on first apply) | "on" | "off".
+# mode         = "prompt"
+# author_name  = "agentsync"
+# author_email = "agentsync@localhost"
 `
 
 func newInitCmd() *cobra.Command {

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -118,15 +119,16 @@ func revertAgent(p *ui.Printer, reg *adapter.Registry, name, toRef string, dryRu
 	if toRef != "" && len(roots) > 1 {
 		return fmt.Errorf("agent %q versions %d directories; --to is ambiguous — omit it to undo the most recent apply on each", name, len(roots))
 	}
-	var anyOwned bool
+	owners := versionRootOwners(reg, reg.Names(), adapter.ScopeUser, "")
+	var anyManaged bool
 	for _, root := range roots {
-		owned, err := revertRoot(p, root, toRef, dryRun, id, strict && len(roots) == 1)
+		managed, err := revertRoot(p, root, toRef, dryRun, id, sharedExcluding(owners[root], name), strict && len(roots) == 1)
 		if err != nil {
 			return err
 		}
-		anyOwned = anyOwned || owned
+		anyManaged = anyManaged || managed
 	}
-	if !anyOwned && strict {
+	if !anyManaged && strict {
 		return fmt.Errorf("none of %q's directories are agentsync-managed git backups; "+
 			"enable [destination_directory_git_backup] and run `agentsync apply` first", name)
 	}
@@ -138,11 +140,12 @@ func revertAll(p *ui.Printer, reg *adapter.Registry, dryRun bool, id agit.Identi
 	roots := enabledVersionRoots(reg, reg.Names(), adapter.ScopeUser, "")
 	var any bool
 	for _, root := range roots {
-		owned, err := revertRoot(p, root, "", dryRun, id, false)
+		// Under --all every owner is reverted anyway, so no cross-agent surprise.
+		managed, err := revertRoot(p, root, "", dryRun, id, nil, false)
 		if err != nil {
 			return err
 		}
-		any = any || owned
+		any = any || managed
 	}
 	if !any {
 		fmt.Fprintf(p.Out, "%s no agentsync-managed destination dirs to revert.\n", p.Faint(ui.GlyphInfo))
@@ -150,15 +153,42 @@ func revertAll(p *ui.Printer, reg *adapter.Registry, dryRun bool, id agit.Identi
 	return nil
 }
 
-// revertRoot reverts a single version-root dir. Returns whether the dir was an
-// agentsync-managed repo (so callers can report "nothing to do"). strict turns a
-// non-managed dir into an error instead of a skip.
-func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity, strict bool) (owned bool, err error) {
-	st, err := agit.Detect(root)
+// sharedExcluding returns the owners of a root other than `self` — i.e. the OTHER
+// agents whose files also live in this shared dir.
+func sharedExcluding(owners []string, self string) []string {
+	var others []string
+	for _, o := range owners {
+		if o != self {
+			others = append(others, o)
+		}
+	}
+	return others
+}
+
+// revertRoot reverts a single version-root dir. Returns whether the dir is an
+// agentsync-managed backup (exactly, or folded into a parent repo). strict turns an
+// unmanaged dir into an error instead of a skip. sharedWith lists OTHER agents that
+// also write into this dir (for the cross-agent rollback warning).
+func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity, sharedWith []string, strict bool) (managed bool, err error) {
+	// Act only on a repo whose EXACT dir is the agentsync root. Detect's upward
+	// search can match a PARENT repo (a folded child like ~/.claude/skills inside
+	// ~/.claude); in that case the dir is managed-by-parent — skip it, the parent's
+	// revert covers it.
+	exact, err := agit.OwnsExactly(root)
 	if err != nil {
 		return false, err
 	}
-	if st != agit.StateAgentsyncOwned {
+	if !exact {
+		st, derr := agit.Detect(root)
+		if derr != nil {
+			return false, derr
+		}
+		if st == agit.StateAgentsyncOwned {
+			// Folded into a parent agentsync repo — managed, but reverted via the parent.
+			fmt.Fprintf(p.Err, "%s %s is versioned as part of a parent directory; revert that to roll it back.\n",
+				p.Faint(ui.GlyphInfo), root)
+			return true, nil
+		}
 		if strict {
 			return false, fmt.Errorf("%s is not an agentsync-managed git backup (state: %s); "+
 				"enable [destination_directory_git_backup] and run `agentsync apply` first", root, st)
@@ -214,6 +244,10 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 		return true, nil
 	}
 	fmt.Fprintf(p.Out, "%s reverted %s to checkpoint %s\n", p.Green(ui.GlyphOK), root, shortRef(targetHash))
+	if len(sharedWith) > 0 {
+		fmt.Fprintf(p.Err, "%s %s is shared with %s — this also rolled back their files in it.\n",
+			p.Yellow(ui.GlyphWarn+" note:"), root, strings.Join(sharedWith, ", "))
+	}
 	printOutOfSyncNotice(p, root)
 	return true, nil
 }

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/adapter"
+	agit "github.com/spxrogers/agentsync/internal/git"
+	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+func newRevertCmd() *cobra.Command {
+	var (
+		toRef  string
+		all    bool
+		dryRun bool
+	)
+	cmd := &cobra.Command{
+		Use:   "revert [<agent>]",
+		Short: "roll a destination agent dir back to a prior apply checkpoint",
+		Long: `revert restores an agent's destination dir (e.g. ~/.claude) to a prior
+apply checkpoint from its local-only git history, recovering from a bad apply.
+
+It is append-only: revert records a NEW commit, so the history is never rewritten
+and the revert is itself revertible. By default it undoes the most recent apply
+(restores the previous checkpoint); --to picks a specific one.
+
+revert only moves the DESTINATION. The next 'agentsync apply' re-renders from the
+canonical config and would overwrite the reverted state, so revert prints a notice
+telling you to reconcile (agentsync reconcile / import) or fix the canonical source
+first.
+
+Only agentsync-managed (git-backed) user-scope dirs can be reverted; enable git
+backup ([destination_directory_git_backup]) and run an apply first.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := newPrinter(cmd)
+			if err != nil {
+				return err
+			}
+			if all && len(args) > 0 {
+				return fmt.Errorf("--all reverts every managed dir; do not also name an agent")
+			}
+			if all && toRef != "" {
+				return fmt.Errorf("--to names a checkpoint in one repo and can't apply across --all; revert a single agent with --to")
+			}
+			if !all && len(args) == 0 {
+				return fmt.Errorf("name an agent to revert (e.g. `agentsync revert claude`) or pass --all")
+			}
+
+			reg := registryFactory()
+			id := revertIdentity()
+
+			if all {
+				return revertAll(p, reg, dryRun, id)
+			}
+			return revertOne(p, reg, args[0], toRef, dryRun, id, true)
+		},
+	}
+	cmd.Flags().StringVar(&toRef, "to", "", "checkpoint to restore (commit hash or relative like HEAD~2); default: undo the most recent apply")
+	cmd.Flags().BoolVar(&all, "all", false, "revert every agentsync-managed destination dir to its last checkpoint")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would change without writing")
+	return cmd
+}
+
+// revertIdentity loads the commit identity from agentsync.toml (best-effort;
+// defaults when the config is absent or unreadable).
+func revertIdentity() agit.Identity {
+	home := paths.AgentsyncHome(paths.OSEnv{})
+	c, err := source.Load(afero.NewOsFs(), home)
+	if err != nil {
+		return agit.Identity{}
+	}
+	g := c.Config.DestinationGitBackup
+	return agit.Identity{Name: g.AuthorName, Email: g.AuthorEmail}
+}
+
+// revertOne reverts a single agent's dir. When strict is true (an explicit agent
+// arg) an unknown/unmanaged dir is an error; under --all it is a skip.
+func revertOne(p *ui.Printer, reg *adapter.Registry, name, toRef string, dryRun bool, id agit.Identity, strict bool) error {
+	ad := reg.Lookup(name)
+	if ad == nil {
+		if strict {
+			return fmt.Errorf("unknown agent %q", name)
+		}
+		return nil
+	}
+	vh, ok := ad.(adapter.VersionedHome)
+	if !ok {
+		if strict {
+			return fmt.Errorf("agent %q has no git-backed destination dir", name)
+		}
+		return nil
+	}
+	dir, ok := vh.HomeDir(adapter.ScopeUser, "")
+	if !ok || dir == "" {
+		if strict {
+			return fmt.Errorf("agent %q has no user-scope destination dir to revert", name)
+		}
+		return nil
+	}
+
+	st, err := agit.Detect(dir)
+	if err != nil {
+		return err
+	}
+	if st != agit.StateAgentsyncOwned {
+		if strict {
+			return fmt.Errorf("%s is not an agentsync-managed git backup (state: %s); "+
+				"enable [destination_directory_git_backup] and run `agentsync apply` first", dir, st)
+		}
+		fmt.Fprintf(p.Err, "%s %s: %s — skipping\n", p.Faint(ui.GlyphInfo), name, st)
+		return nil
+	}
+
+	repo, err := agit.Open(dir)
+	if err != nil {
+		return err
+	}
+
+	target := toRef
+	if target == "" {
+		multi, herr := repo.HasMultipleCheckpoints()
+		if herr != nil {
+			return herr
+		}
+		if !multi {
+			if strict {
+				return fmt.Errorf("%s has only one checkpoint; nothing earlier to revert to", dir)
+			}
+			fmt.Fprintf(p.Err, "%s %s: only one checkpoint — skipping\n", p.Faint(ui.GlyphInfo), name)
+			return nil
+		}
+		target = "HEAD~1"
+	}
+
+	if dryRun {
+		return previewRevert(p, repo, name, dir, target)
+	}
+
+	targetHash, err := repo.Resolve(target)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("agentsync revert: %s → %s", name, shortRef(targetHash))
+	h, err := repo.Restore(target, msg, id)
+	if err != nil {
+		return err
+	}
+	if h == "" {
+		fmt.Fprintf(p.Out, "%s %s already matches %s; nothing to revert.\n", p.Faint(ui.GlyphInfo), dir, shortRef(targetHash))
+		return nil
+	}
+	fmt.Fprintf(p.Out, "%s reverted %s to checkpoint %s\n", p.Green(ui.GlyphOK), dir, shortRef(targetHash))
+	printOutOfSyncNotice(p, dir)
+	return nil
+}
+
+// revertAll reverts every agentsync-managed dir to its previous checkpoint.
+func revertAll(p *ui.Printer, reg *adapter.Registry, dryRun bool, id agit.Identity) error {
+	names := reg.Names()
+	sort.Strings(names)
+	var reverted []string
+	for _, name := range names {
+		ad := reg.Lookup(name)
+		vh, ok := ad.(adapter.VersionedHome)
+		if !ok {
+			continue
+		}
+		dir, ok := vh.HomeDir(adapter.ScopeUser, "")
+		if !ok || dir == "" {
+			continue
+		}
+		if st, _ := agit.Detect(dir); st != agit.StateAgentsyncOwned {
+			continue // not ours / untracked — silently pass over under --all
+		}
+		if err := revertOne(p, reg, name, "", dryRun, id, false); err != nil {
+			return err
+		}
+		reverted = append(reverted, dir)
+	}
+	if len(reverted) == 0 {
+		fmt.Fprintf(p.Out, "%s no agentsync-managed destination dirs to revert.\n", p.Faint(ui.GlyphInfo))
+	}
+	return nil
+}
+
+// previewRevert prints what a revert would change, without writing.
+func previewRevert(p *ui.Printer, repo *agit.Repo, name, dir, target string) error {
+	targetHash, changes, err := repo.Plan(target)
+	if err != nil {
+		return err
+	}
+	subject := checkpointSubject(repo, targetHash)
+	fmt.Fprintf(p.Out, "%s would revert %s (%s) to %s%s\n",
+		p.Bold("dry-run:"), name, dir, p.Cyan(shortRef(targetHash)), subject)
+	if len(changes) == 0 {
+		fmt.Fprintf(p.Out, "  (already matches; nothing to change)\n")
+		return nil
+	}
+	for _, c := range changes {
+		fmt.Fprintf(p.Out, "    %s %-6s %s\n", p.Cyan(ui.GlyphArrow), c.Kind, c.Path)
+	}
+	return nil
+}
+
+// checkpointSubject returns " — <subject>" for the commit, or "" if not found.
+func checkpointSubject(repo *agit.Repo, hash string) string {
+	cps, err := repo.Log(0)
+	if err != nil {
+		return ""
+	}
+	for _, c := range cps {
+		if c.Hash == hash {
+			return " — " + c.Subject
+		}
+	}
+	return ""
+}
+
+// shortRef abbreviates a full hash to 7 chars for display.
+func shortRef(h string) string {
+	if len(h) >= 7 {
+		return h[:7]
+	}
+	return h
+}
+
+// printOutOfSyncNotice warns that the destination now diverges from canonical.
+func printOutOfSyncNotice(p *ui.Printer, dir string) {
+	fmt.Fprintf(p.Err, "%s the destination directory %s is now out of sync with the agentsync configuration.\n",
+		p.Yellow(ui.GlyphWarn+" note:"), dir)
+	fmt.Fprintf(p.Err, "  Reconcile as needed (`agentsync reconcile` / `agentsync import`) before your next "+
+		"`agentsync apply` to avoid re-losing these changes.\n")
+}

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"sort"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -26,22 +26,21 @@ func newRevertCmd() *cobra.Command {
 apply checkpoint from its local-only git history, recovering from a bad apply.
 
 It is append-only: revert records a NEW commit, so the history is never rewritten
-and the revert is itself revertible. By default it undoes the most recent apply
-(restores the previous checkpoint); --to picks a specific one.
+and the revert is itself revertible. Uncommitted hand-edits to tracked files are
+preserved as a snapshot commit first, so nothing is lost. By default it undoes the
+most recent apply (restores the previous checkpoint); --to picks a specific one.
 
 revert only moves the DESTINATION. The next 'agentsync apply' re-renders from the
 canonical config and would overwrite the reverted state, so revert prints a notice
 telling you to reconcile (agentsync reconcile / import) or fix the canonical source
 first.
 
-Only agentsync-managed (git-backed) user-scope dirs can be reverted; enable git
-backup ([destination_directory_git_backup]) and run an apply first.`,
+An agent may version more than one directory (its config dir plus a shared dir like
+~/.agents/skills); revert restores each one it owns. Only agentsync-managed
+(git-backed) user-scope dirs can be reverted; enable git backup
+([destination_directory_git_backup]) and run an apply first.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := newPrinter(cmd)
-			if err != nil {
-				return err
-			}
 			if all && len(args) > 0 {
 				return fmt.Errorf("--all reverts every managed dir; do not also name an agent")
 			}
@@ -51,14 +50,27 @@ backup ([destination_directory_git_backup]) and run an apply first.`,
 			if !all && len(args) == 0 {
 				return fmt.Errorf("name an agent to revert (e.g. `agentsync revert claude`) or pass --all")
 			}
-
-			reg := registryFactory()
-			id := revertIdentity()
-
-			if all {
-				return revertAll(p, reg, dryRun, id)
+			p, err := newPrinter(cmd)
+			if err != nil {
+				return err
 			}
-			return revertOne(p, reg, args[0], toRef, dryRun, id, true)
+			home := paths.AgentsyncHome(paths.OSEnv{})
+			reg := registryFactory()
+			id := revertIdentity(home)
+
+			// A revert mutates destination repos; take the same global lock apply
+			// holds so a concurrent apply/revert can't interleave go-git index writes
+			// on the same dir. Dry-run is read-only and skips the lock.
+			run := func() error {
+				if all {
+					return revertAll(p, reg, dryRun, id)
+				}
+				return revertAgent(p, reg, args[0], toRef, dryRun, id, true)
+			}
+			if dryRun {
+				return run()
+			}
+			return withGlobalLock(home, run)
 		},
 	}
 	cmd.Flags().StringVar(&toRef, "to", "", "checkpoint to restore (commit hash or relative like HEAD~2); default: undo the most recent apply")
@@ -69,8 +81,7 @@ backup ([destination_directory_git_backup]) and run an apply first.`,
 
 // revertIdentity loads the commit identity from agentsync.toml (best-effort;
 // defaults when the config is absent or unreadable).
-func revertIdentity() agit.Identity {
-	home := paths.AgentsyncHome(paths.OSEnv{})
+func revertIdentity(home string) agit.Identity {
 	c, err := source.Load(afero.NewOsFs(), home)
 	if err != nil {
 		return agit.Identity{}
@@ -79,9 +90,10 @@ func revertIdentity() agit.Identity {
 	return agit.Identity{Name: g.AuthorName, Email: g.AuthorEmail}
 }
 
-// revertOne reverts a single agent's dir. When strict is true (an explicit agent
-// arg) an unknown/unmanaged dir is an error; under --all it is a skip.
-func revertOne(p *ui.Printer, reg *adapter.Registry, name, toRef string, dryRun bool, id agit.Identity, strict bool) error {
+// revertAgent reverts every version root the named agent owns. When strict is true
+// (an explicit agent arg) an unknown agent / no-versioned-dir is an error; under
+// --all it is a skip.
+func revertAgent(p *ui.Printer, reg *adapter.Registry, name, toRef string, dryRun bool, id agit.Identity, strict bool) error {
 	ad := reg.Lookup(name)
 	if ad == nil {
 		if strict {
@@ -89,115 +101,135 @@ func revertOne(p *ui.Printer, reg *adapter.Registry, name, toRef string, dryRun 
 		}
 		return nil
 	}
-	vh, ok := ad.(adapter.VersionedHome)
+	vd, ok := ad.(adapter.VersionedDirs)
 	if !ok {
 		if strict {
 			return fmt.Errorf("agent %q has no git-backed destination dir", name)
 		}
 		return nil
 	}
-	dir, ok := vh.HomeDir(adapter.ScopeUser, "")
-	if !ok || dir == "" {
+	roots := denestRoots(cleanAll(vd.VersionRoots(adapter.ScopeUser, "")))
+	if len(roots) == 0 {
 		if strict {
 			return fmt.Errorf("agent %q has no user-scope destination dir to revert", name)
 		}
 		return nil
 	}
+	if toRef != "" && len(roots) > 1 {
+		return fmt.Errorf("agent %q versions %d directories; --to is ambiguous — omit it to undo the most recent apply on each", name, len(roots))
+	}
+	var anyOwned bool
+	for _, root := range roots {
+		owned, err := revertRoot(p, root, toRef, dryRun, id, strict && len(roots) == 1)
+		if err != nil {
+			return err
+		}
+		anyOwned = anyOwned || owned
+	}
+	if !anyOwned && strict {
+		return fmt.Errorf("none of %q's directories are agentsync-managed git backups; "+
+			"enable [destination_directory_git_backup] and run `agentsync apply` first", name)
+	}
+	return nil
+}
 
-	st, err := agit.Detect(dir)
+// revertAll reverts every agentsync-managed version root across all adapters.
+func revertAll(p *ui.Printer, reg *adapter.Registry, dryRun bool, id agit.Identity) error {
+	roots := enabledVersionRoots(reg, reg.Names(), adapter.ScopeUser, "")
+	var any bool
+	for _, root := range roots {
+		owned, err := revertRoot(p, root, "", dryRun, id, false)
+		if err != nil {
+			return err
+		}
+		any = any || owned
+	}
+	if !any {
+		fmt.Fprintf(p.Out, "%s no agentsync-managed destination dirs to revert.\n", p.Faint(ui.GlyphInfo))
+	}
+	return nil
+}
+
+// revertRoot reverts a single version-root dir. Returns whether the dir was an
+// agentsync-managed repo (so callers can report "nothing to do"). strict turns a
+// non-managed dir into an error instead of a skip.
+func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity, strict bool) (owned bool, err error) {
+	st, err := agit.Detect(root)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if st != agit.StateAgentsyncOwned {
 		if strict {
-			return fmt.Errorf("%s is not an agentsync-managed git backup (state: %s); "+
-				"enable [destination_directory_git_backup] and run `agentsync apply` first", dir, st)
+			return false, fmt.Errorf("%s is not an agentsync-managed git backup (state: %s); "+
+				"enable [destination_directory_git_backup] and run `agentsync apply` first", root, st)
 		}
-		fmt.Fprintf(p.Err, "%s %s: %s — skipping\n", p.Faint(ui.GlyphInfo), name, st)
-		return nil
+		return false, nil
 	}
-
-	repo, err := agit.Open(dir)
+	repo, err := agit.Open(root)
 	if err != nil {
-		return err
+		return true, err
 	}
 
 	target := toRef
 	if target == "" {
 		multi, herr := repo.HasMultipleCheckpoints()
 		if herr != nil {
-			return herr
+			return true, herr
 		}
 		if !multi {
-			if strict {
-				return fmt.Errorf("%s has only one checkpoint; nothing earlier to revert to", dir)
-			}
-			fmt.Fprintf(p.Err, "%s %s: only one checkpoint — skipping\n", p.Faint(ui.GlyphInfo), name)
-			return nil
+			fmt.Fprintf(p.Err, "%s %s: only one checkpoint — skipping\n", p.Faint(ui.GlyphInfo), root)
+			return true, nil
 		}
 		target = "HEAD~1"
 	}
 
 	if dryRun {
-		return previewRevert(p, repo, name, dir, target)
+		return true, previewRevert(p, repo, root, target)
 	}
 
+	// Resolve the target to a concrete hash BEFORE snapshotting — the snapshot below
+	// moves HEAD, after which a relative ref like "HEAD~1" would point elsewhere.
 	targetHash, err := repo.Resolve(target)
 	if err != nil {
-		return err
+		return true, err
 	}
-	msg := fmt.Sprintf("agentsync revert: %s → %s", name, shortRef(targetHash))
-	h, err := repo.Restore(target, msg, id)
+	// Preserve any uncommitted hand-edits to tracked files as a snapshot commit so
+	// the hard reset inside Restore can't lose them (untracked files are untouched).
+	snap, err := repo.SnapshotDirtyTracked("agentsync revert: snapshot uncommitted changes before revert", id)
 	if err != nil {
-		return err
+		return true, err
+	}
+	if snap != "" {
+		fmt.Fprintf(p.Out, "%s preserved uncommitted changes in %s as snapshot %s\n",
+			p.Faint(ui.GlyphInfo), root, shortRef(snap))
+	}
+
+	msg := fmt.Sprintf("agentsync revert: %s → %s", root, shortRef(targetHash))
+	h, err := repo.Restore(targetHash, msg, id)
+	if err != nil {
+		return true, err
 	}
 	if h == "" {
-		fmt.Fprintf(p.Out, "%s %s already matches %s; nothing to revert.\n", p.Faint(ui.GlyphInfo), dir, shortRef(targetHash))
-		return nil
+		fmt.Fprintf(p.Out, "%s %s already matches %s; nothing to revert.\n", p.Faint(ui.GlyphInfo), root, shortRef(targetHash))
+		return true, nil
 	}
-	fmt.Fprintf(p.Out, "%s reverted %s to checkpoint %s\n", p.Green(ui.GlyphOK), dir, shortRef(targetHash))
-	printOutOfSyncNotice(p, dir)
-	return nil
-}
-
-// revertAll reverts every agentsync-managed dir to its previous checkpoint.
-func revertAll(p *ui.Printer, reg *adapter.Registry, dryRun bool, id agit.Identity) error {
-	names := reg.Names()
-	sort.Strings(names)
-	var reverted []string
-	for _, name := range names {
-		ad := reg.Lookup(name)
-		vh, ok := ad.(adapter.VersionedHome)
-		if !ok {
-			continue
-		}
-		dir, ok := vh.HomeDir(adapter.ScopeUser, "")
-		if !ok || dir == "" {
-			continue
-		}
-		if st, _ := agit.Detect(dir); st != agit.StateAgentsyncOwned {
-			continue // not ours / untracked — silently pass over under --all
-		}
-		if err := revertOne(p, reg, name, "", dryRun, id, false); err != nil {
-			return err
-		}
-		reverted = append(reverted, dir)
-	}
-	if len(reverted) == 0 {
-		fmt.Fprintf(p.Out, "%s no agentsync-managed destination dirs to revert.\n", p.Faint(ui.GlyphInfo))
-	}
-	return nil
+	fmt.Fprintf(p.Out, "%s reverted %s to checkpoint %s\n", p.Green(ui.GlyphOK), root, shortRef(targetHash))
+	printOutOfSyncNotice(p, root)
+	return true, nil
 }
 
 // previewRevert prints what a revert would change, without writing.
-func previewRevert(p *ui.Printer, repo *agit.Repo, name, dir, target string) error {
+func previewRevert(p *ui.Printer, repo *agit.Repo, root, target string) error {
 	targetHash, changes, err := repo.Plan(target)
 	if err != nil {
 		return err
 	}
 	subject := checkpointSubject(repo, targetHash)
-	fmt.Fprintf(p.Out, "%s would revert %s (%s) to %s%s\n",
-		p.Bold("dry-run:"), name, dir, p.Cyan(shortRef(targetHash)), subject)
+	fmt.Fprintf(p.Out, "%s would revert %s to %s%s\n",
+		p.Bold("dry-run:"), root, p.Cyan(shortRef(targetHash)), subject)
+	if clean, _ := repo.IsClean(); !clean {
+		fmt.Fprintf(p.Out, "  (uncommitted changes to tracked files would be snapshotted first, then preserved in history)\n")
+	}
 	if len(changes) == 0 {
 		fmt.Fprintf(p.Out, "  (already matches; nothing to change)\n")
 		return nil
@@ -220,6 +252,17 @@ func checkpointSubject(repo *agit.Repo, hash string) string {
 		}
 	}
 	return ""
+}
+
+// cleanAll returns filepath.Clean of each path (dropping empties).
+func cleanAll(dirs []string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != "" {
+			out = append(out, filepath.Clean(d))
+		}
+	}
+	return out
 }
 
 // shortRef abbreviates a full hash to 7 chars for display.

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -1,0 +1,159 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agit "github.com/spxrogers/agentsync/internal/git"
+)
+
+// setupGitBackedClaude inits an agentsync home with claude + git backup on, then
+// applies twice (skill body "v1" then "v2") so ~/.claude has two checkpoints.
+// Returns tmp, env, and the destination skill path.
+func setupGitBackedClaude(t *testing.T) (string, map[string]string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n")
+	_ = f.Close()
+
+	srcSkill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(srcSkill), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	apply := func(body string) {
+		if err := os.WriteFile(srcSkill, []byte("---\nname: demo\ndescription: d\n---\n"+body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if out, err := runCLI(t, env, "apply"); err != nil {
+			t.Fatalf("apply: %v\n%s", err, out)
+		}
+	}
+	apply("v1")
+	apply("v2")
+
+	destSkill := filepath.Join(tmp, ".claude", "skills", "demo", "SKILL.md")
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v2") {
+		t.Fatalf("precondition: dest skill should hold v2:\n%s", b)
+	}
+	return tmp, env, destSkill
+}
+
+func TestRevert_DefaultUndoesLastApply(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+	repo, _ := agit.Open(claude)
+	before, _ := repo.Log(0)
+	if len(before) != 2 {
+		t.Fatalf("want 2 checkpoints before revert, got %d", len(before))
+	}
+
+	out, err := runCLI(t, env, "revert", "claude")
+	if err != nil {
+		t.Fatalf("revert: %v\n%s", err, out)
+	}
+	// Dest skill is back to v1.
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v1") || strings.Contains(string(b), "v2") {
+		t.Fatalf("after revert dest skill should hold v1:\n%s", b)
+	}
+	// Out-of-sync notice printed.
+	if !strings.Contains(out, "out of sync") {
+		t.Errorf("expected out-of-sync notice, got:\n%s", out)
+	}
+	// Append-only: a new commit on top (3 total), originals still reachable.
+	after, _ := repo.Log(0)
+	if len(after) != 3 {
+		t.Fatalf("want 3 checkpoints after revert (append-only), got %d", len(after))
+	}
+}
+
+func TestRevert_DryRunWritesNothing(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+	repo, _ := agit.Open(claude)
+	before, _ := repo.Log(0)
+
+	out, err := runCLI(t, env, "revert", "claude", "--dry-run")
+	if err != nil {
+		t.Fatalf("revert --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dry-run") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+	// Nothing changed on disk or in history.
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v2") {
+		t.Fatalf("dry-run mutated the dest skill:\n%s", b)
+	}
+	after, _ := repo.Log(0)
+	if len(after) != len(before) {
+		t.Fatalf("dry-run recorded a commit: %d -> %d", len(before), len(after))
+	}
+}
+
+func TestRevert_ToSpecificCheckpoint(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+	repo, _ := agit.Open(claude)
+	cps, _ := repo.Log(0)
+	oldest := cps[len(cps)-1].Hash // the v1 checkpoint (first apply)
+
+	if out, err := runCLI(t, env, "revert", "claude", "--to", oldest); err != nil {
+		t.Fatalf("revert --to: %v\n%s", err, out)
+	}
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v1") {
+		t.Fatalf("after revert --to oldest, dest skill should hold v1:\n%s", b)
+	}
+}
+
+func TestRevert_Errors(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	t.Run("conflicting flags", func(t *testing.T) {
+		if _, err := runCLI(t, env, "revert", "claude", "--all"); err == nil {
+			t.Fatal("expected error for agent + --all")
+		}
+	})
+	t.Run("no target", func(t *testing.T) {
+		if _, err := runCLI(t, env, "revert"); err == nil {
+			t.Fatal("expected error when neither agent nor --all given")
+		}
+	})
+	t.Run("unknown agent", func(t *testing.T) {
+		if _, err := runCLI(t, env, "revert", "bogus"); err == nil {
+			t.Fatal("expected error for unknown agent")
+		}
+	})
+	t.Run("unmanaged dir", func(t *testing.T) {
+		// claude was never git-backed (no apply with backup) → not an agentsync repo.
+		out, err := runCLI(t, env, "revert", "claude")
+		if err == nil {
+			t.Fatalf("expected error reverting an unmanaged dir, got:\n%s", out)
+		}
+		if !strings.Contains(err.Error(), "not an agentsync-managed") {
+			t.Errorf("error should explain the dir is unmanaged: %v", err)
+		}
+	})
+}
+
+func TestRevert_All(t *testing.T) {
+	_, env, destSkill := setupGitBackedClaude(t)
+	if out, err := runCLI(t, env, "revert", "--all"); err != nil {
+		t.Fatalf("revert --all: %v\n%s", err, out)
+	}
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v1") {
+		t.Fatalf("after revert --all, dest skill should hold v1:\n%s", b)
+	}
+}

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -148,6 +148,50 @@ func TestRevert_Errors(t *testing.T) {
 	})
 }
 
+// TestRevert_PreservesUncommittedEdits is the regression for the data-loss finding:
+// a hand-edit to a tracked file after the last apply must NOT be silently destroyed
+// by revert's hard reset. revert snapshots it first, so it stays recoverable.
+func TestRevert_PreservesUncommittedEdits(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+
+	// Hand-edit the rendered skill after the last apply (uncommitted drift).
+	if err := os.WriteFile(destSkill, []byte("HAND-EDITED-CONTENT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "revert", "claude")
+	if err != nil {
+		t.Fatalf("revert: %v\n%s", err, out)
+	}
+	// The revert happened (skill restored to the v1 checkpoint)...
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v1") {
+		t.Fatalf("revert should restore v1:\n%s", b)
+	}
+	// ...and the hand-edit was preserved as a snapshot, not lost.
+	if !strings.Contains(out, "preserved uncommitted changes") {
+		t.Errorf("expected a snapshot notice, got:\n%s", out)
+	}
+	repo, _ := agit.Open(claude)
+	cps, _ := repo.Log(0)
+	var snap string
+	for _, c := range cps {
+		if strings.Contains(c.Subject, "snapshot uncommitted changes") {
+			snap = c.Hash
+		}
+	}
+	if snap == "" {
+		t.Fatal("no snapshot commit recorded; the hand-edit was lost")
+	}
+	// Recoverable: reverting to the snapshot restores the hand-edit verbatim.
+	if out, err := runCLI(t, env, "revert", "claude", "--to", snap); err != nil {
+		t.Fatalf("revert --to snapshot: %v\n%s", err, out)
+	}
+	if b, _ := os.ReadFile(destSkill); string(b) != "HAND-EDITED-CONTENT" {
+		t.Fatalf("hand-edit not recoverable from the snapshot: %q", b)
+	}
+}
+
 func TestRevert_All(t *testing.T) {
 	_, env, destSkill := setupGitBackedClaude(t)
 	if out, err := runCLI(t, env, "revert", "--all"); err != nil {

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -225,6 +225,57 @@ func TestRevert_FoldedSharedDirNoted(t *testing.T) {
 	}
 }
 
+// TestRevert_SharedDirWarnsBlastRadius asserts the user-facing warning that
+// reverting a shared dir (~/.agents/skills, owned by codex + warp) rolls back the
+// other agent's files too.
+func TestRevert_SharedDirWarnsBlastRadius(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "codex")
+	mustRun(t, env, "agent", "add", "warp")
+	f, _ := os.OpenFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n")
+	_ = f.Close()
+	srcSkill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	_ = os.MkdirAll(filepath.Dir(srcSkill), 0o755)
+	apply := func(body string) {
+		_ = os.WriteFile(srcSkill, []byte("---\nname: demo\ndescription: d\n---\n"+body+"\n"), 0o644)
+		if out, err := runCLI(t, env, "apply"); err != nil {
+			t.Fatalf("apply: %v\n%s", err, out)
+		}
+	}
+	apply("v1")
+	apply("v2") // ~/.agents/skills now has two checkpoints
+
+	// ~/.agents/skills is its own repo, shared by codex + warp.
+	if st, _ := agit.Detect(filepath.Join(tmp, ".agents", "skills")); st != agit.StateAgentsyncOwned {
+		t.Fatalf("shared ~/.agents/skills should be versioned, state=%v", st)
+	}
+	out, err := runCLI(t, env, "revert", "codex")
+	if err != nil {
+		t.Fatalf("revert codex: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "shared with") || !strings.Contains(out, "warp") {
+		t.Fatalf("expected a shared-dir blast-radius warning naming warp; got:\n%s", out)
+	}
+}
+
+// TestRevert_ToAmbiguousMultiRoot: --to is rejected for an agent versioning >1 dir.
+func TestRevert_ToAmbiguousMultiRoot(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "codex") // codex versions ~/.codex AND ~/.agents/skills
+	_, err := runCLI(t, env, "revert", "codex", "--to", "HEAD~1")
+	if err == nil {
+		t.Fatal("expected an ambiguity error for --to on a multi-root agent")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should explain --to is ambiguous: %v", err)
+	}
+}
+
 func TestRevert_All(t *testing.T) {
 	_, env, destSkill := setupGitBackedClaude(t)
 	if out, err := runCLI(t, env, "revert", "--all"); err != nil {

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -192,6 +192,39 @@ func TestRevert_PreservesUncommittedEdits(t *testing.T) {
 	}
 }
 
+// TestRevert_FoldedSharedDirNoted is the regression for the folded-dir revert
+// ISSUE: ~/.claude/skills is versioned as part of ~/.claude (de-nested), so
+// `revert opencode` must NOT error trying to open a repo at ~/.claude/skills — it
+// notes the dir is covered by a parent and moves on.
+func TestRevert_FoldedSharedDirNoted(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "agent", "add", "opencode")
+	f, _ := os.OpenFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"), os.O_APPEND|os.O_WRONLY, 0o644)
+	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"on\"\n")
+	_ = f.Close()
+	srcSkill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
+	_ = os.MkdirAll(filepath.Dir(srcSkill), 0o755)
+	_ = os.WriteFile(srcSkill, []byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644)
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// ~/.claude/skills exists but has no .git of its own (folded into ~/.claude).
+	if _, err := os.Stat(filepath.Join(tmp, ".claude", "skills", ".git")); !os.IsNotExist(err) {
+		t.Fatalf("~/.claude/skills should be folded into ~/.claude, not its own repo; err=%v", err)
+	}
+	out, err := runCLI(t, env, "revert", "opencode")
+	if err != nil {
+		t.Fatalf("revert opencode must not error on a folded dir: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "versioned as part of a parent") {
+		t.Errorf("expected the folded-dir note for ~/.claude/skills; got:\n%s", out)
+	}
+}
+
 func TestRevert_All(t *testing.T) {
 	_, env, destSkill := setupGitBackedClaude(t)
 	if out, err := runCLI(t, env, "revert", "--all"); err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,7 @@ func NewRoot() *cobra.Command {
 		newDoctorCmd(),
 		newVerifyCmd(),
 		newApplyCmd(),
+		newRevertCmd(),
 		newStatusCmd(),
 		newDiffCmd(),
 		newReconcileCmd(),

--- a/internal/cli/versionedhome_test.go
+++ b/internal/cli/versionedhome_test.go
@@ -88,6 +88,24 @@ func TestEnabledVersionRoots_DedupAndDenest(t *testing.T) {
 	}
 }
 
+// TestVersionRootOwners_SharedDir proves the shared-dir blast-radius detection:
+// ~/.agents/skills is owned by both codex and warp, which the revert path warns on.
+func TestVersionRootOwners_SharedDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AGENTSYNC_TARGET_ROOT", root)
+	reg := registryFactory()
+	owners := versionRootOwners(reg, []string{"codex", "warp"}, adapter.ScopeUser, "")
+	agentsSkills := filepath.Join(root, ".agents", "skills")
+	got := owners[agentsSkills]
+	if !contains(got, "codex") || !contains(got, "warp") {
+		t.Fatalf("owners[%s] = %v, want both codex and warp", agentsSkills, got)
+	}
+	// codex's own ~/.codex is single-owner.
+	if o := owners[filepath.Join(root, ".codex")]; len(o) != 1 || o[0] != "codex" {
+		t.Errorf("owners[~/.codex] = %v, want [codex]", o)
+	}
+}
+
 func contains(ss []string, want string) bool {
 	for _, s := range ss {
 		if s == want {

--- a/internal/cli/versionedhome_test.go
+++ b/internal/cli/versionedhome_test.go
@@ -8,65 +8,101 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 )
 
-// deepVersionedAgents are the deep adapters whose single, coherent user-scope
-// config dir agentsync git-backs-up (issue #118). The breadth-tier (generic)
-// agents deliberately ABSTAIN: their user-scope targets are scattered across
-// multiple top-level dirs and shared cross-agent locations (e.g. ~/.agents/skills),
-// so there is no safe single dir to `git init` — versioning them is an accepted
-// gap, not a silent drop. See docs/architecture.md and the spec.
-var deepVersionedAgents = map[string]bool{
-	"claude": true, "opencode": true, "codex": true, "cursor": true,
-	"gemini": true, "continue": true, "windsurf": true, "roo": true, "cline": true,
-}
-
-// TestVersionedHomeContract pins the git-backup capability in code so it can't
-// silently drift: every DEEP adapter must expose a valid user-scope dir under the
-// target root and abstain at project scope, and every BREADTH-tier adapter must
-// NOT implement VersionedHome at all. The analogue of TestEveryAdapterClassifiesSkips.
-func TestVersionedHomeContract(t *testing.T) {
+// TestVersionedDirsContract pins the git-backup capability in code so it can't
+// silently drift: every registered adapter (deep AND breadth) must declare its
+// user-scope version roots as absolute dirs under the target root and abstain
+// (nil) at project scope. The unit is the directory — shared dirs are deduped by
+// the apply tail, not the adapter.
+func TestVersionedDirsContract(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("AGENTSYNC_TARGET_ROOT", root)
 
 	reg := registryFactory()
-	seenDeep := map[string]bool{}
 	for _, name := range reg.Names() {
 		ad := reg.Lookup(name)
-		vh, ok := ad.(adapter.VersionedHome)
-
-		if !deepVersionedAgents[name] {
-			// Breadth tier: must abstain.
-			if ok {
-				t.Errorf("breadth-tier agent %q implements VersionedHome; the generic tier must abstain (no safe single config dir to git-init)", name)
-			}
-			continue
-		}
-		seenDeep[name] = true
-
+		vd, ok := ad.(adapter.VersionedDirs)
 		if !ok {
-			t.Errorf("deep agent %q does not implement VersionedHome", name)
+			t.Errorf("adapter %q does not implement VersionedDirs", name)
 			continue
 		}
-		// User scope: a real, absolute dir under the target root.
-		dir, has := vh.HomeDir(adapter.ScopeUser, "")
-		if !has || dir == "" {
-			t.Errorf("%s.HomeDir(user) = (%q, %v); want a non-empty dir", name, dir, has)
-			continue
+		// Some breadth agents are project-scope only (cloud IDEs, project-only
+		// memory) and correctly declare NO user-scope root. What we pin: whatever is
+		// returned is a valid absolute dir under the target root, never $HOME.
+		dirs := vd.VersionRoots(adapter.ScopeUser, "")
+		for _, d := range dirs {
+			if !filepath.IsAbs(d) {
+				t.Errorf("%s.VersionRoots(user) = %q; want absolute", name, d)
+			}
+			if !strings.HasPrefix(d, root) {
+				t.Errorf("%s.VersionRoots(user) = %q; want under target root %q", name, d, root)
+			}
+			if d == root {
+				t.Errorf("%s.VersionRoots(user) returned the bare $HOME root %q; agentsync must never init a repo at $HOME", name, d)
+			}
 		}
-		if !filepath.IsAbs(dir) {
-			t.Errorf("%s.HomeDir(user) = %q; want an absolute path", name, dir)
-		}
-		if !strings.HasPrefix(dir, root) {
-			t.Errorf("%s.HomeDir(user) = %q; want it under target root %q", name, dir, root)
-		}
-		// Project scope: must abstain (project dirs live in the user's own repo).
-		if pdir, phas := vh.HomeDir(adapter.ScopeProject, filepath.Join(root, "proj")); phas || pdir != "" {
-			t.Errorf("%s.HomeDir(project) = (%q, %v); want (\"\", false)", name, pdir, phas)
+		// Project scope abstains.
+		if pdirs := vd.VersionRoots(adapter.ScopeProject, filepath.Join(root, "proj")); len(pdirs) != 0 {
+			t.Errorf("%s.VersionRoots(project) = %v; want nil", name, pdirs)
 		}
 	}
 
-	for name := range deepVersionedAgents {
-		if !seenDeep[name] {
-			t.Errorf("deep agent %q expected in the registry but not found", name)
+	// Codex declares the shared cross-vendor skills dir.
+	agentsSkills := filepath.Join(root, ".agents", "skills")
+	if !contains(reg.Lookup("codex").(adapter.VersionedDirs).VersionRoots(adapter.ScopeUser, ""), agentsSkills) {
+		t.Errorf("codex VersionRoots should include the shared %s", agentsSkills)
+	}
+}
+
+// TestEnabledVersionRoots_DedupAndDenest proves the apply-tail aggregation: a
+// shared dir declared by multiple agents appears once, and a nested dir is dropped
+// in favor of its ancestor.
+func TestEnabledVersionRoots_DedupAndDenest(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AGENTSYNC_TARGET_ROOT", root)
+	reg := registryFactory()
+
+	// codex + warp both write to ~/.agents/skills → it must appear exactly once.
+	roots := enabledVersionRoots(reg, []string{"codex", "warp"}, adapter.ScopeUser, "")
+	agentsSkills := filepath.Join(root, ".agents", "skills")
+	if n := countEq(roots, agentsSkills); n != 1 {
+		t.Errorf("shared %s appears %d times across codex+warp roots, want 1: %v", agentsSkills, n, roots)
+	}
+
+	// claude + opencode: opencode declares ~/.claude/skills, nested under claude's
+	// ~/.claude → de-nested away (claude's repo captures it).
+	roots = enabledVersionRoots(reg, []string{"claude", "opencode"}, adapter.ScopeUser, "")
+	claudeSkills := filepath.Join(root, ".claude", "skills")
+	if contains(roots, claudeSkills) {
+		t.Errorf("~/.claude/skills should be de-nested under ~/.claude, but appears in %v", roots)
+	}
+	if !contains(roots, filepath.Join(root, ".claude")) {
+		t.Errorf("~/.claude should be a root: %v", roots)
+	}
+	// No root may be nested under another.
+	for i := range roots {
+		for j := range roots {
+			if i != j && isUnderDir(roots[i], roots[j]) {
+				t.Errorf("root %q is nested under %q — de-nesting failed", roots[i], roots[j])
+			}
 		}
 	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countEq(ss []string, want string) int {
+	n := 0
+	for _, s := range ss {
+		if s == want {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/cli/versionedhome_test.go
+++ b/internal/cli/versionedhome_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// deepVersionedAgents are the deep adapters whose single, coherent user-scope
+// config dir agentsync git-backs-up (issue #118). The breadth-tier (generic)
+// agents deliberately ABSTAIN: their user-scope targets are scattered across
+// multiple top-level dirs and shared cross-agent locations (e.g. ~/.agents/skills),
+// so there is no safe single dir to `git init` — versioning them is an accepted
+// gap, not a silent drop. See docs/architecture.md and the spec.
+var deepVersionedAgents = map[string]bool{
+	"claude": true, "opencode": true, "codex": true, "cursor": true,
+	"gemini": true, "continue": true, "windsurf": true, "roo": true, "cline": true,
+}
+
+// TestVersionedHomeContract pins the git-backup capability in code so it can't
+// silently drift: every DEEP adapter must expose a valid user-scope dir under the
+// target root and abstain at project scope, and every BREADTH-tier adapter must
+// NOT implement VersionedHome at all. The analogue of TestEveryAdapterClassifiesSkips.
+func TestVersionedHomeContract(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AGENTSYNC_TARGET_ROOT", root)
+
+	reg := registryFactory()
+	seenDeep := map[string]bool{}
+	for _, name := range reg.Names() {
+		ad := reg.Lookup(name)
+		vh, ok := ad.(adapter.VersionedHome)
+
+		if !deepVersionedAgents[name] {
+			// Breadth tier: must abstain.
+			if ok {
+				t.Errorf("breadth-tier agent %q implements VersionedHome; the generic tier must abstain (no safe single config dir to git-init)", name)
+			}
+			continue
+		}
+		seenDeep[name] = true
+
+		if !ok {
+			t.Errorf("deep agent %q does not implement VersionedHome", name)
+			continue
+		}
+		// User scope: a real, absolute dir under the target root.
+		dir, has := vh.HomeDir(adapter.ScopeUser, "")
+		if !has || dir == "" {
+			t.Errorf("%s.HomeDir(user) = (%q, %v); want a non-empty dir", name, dir, has)
+			continue
+		}
+		if !filepath.IsAbs(dir) {
+			t.Errorf("%s.HomeDir(user) = %q; want an absolute path", name, dir)
+		}
+		if !strings.HasPrefix(dir, root) {
+			t.Errorf("%s.HomeDir(user) = %q; want it under target root %q", name, dir, root)
+		}
+		// Project scope: must abstain (project dirs live in the user's own repo).
+		if pdir, phas := vh.HomeDir(adapter.ScopeProject, filepath.Join(root, "proj")); phas || pdir != "" {
+			t.Errorf("%s.HomeDir(project) = (%q, %v); want (\"\", false)", name, pdir, phas)
+		}
+	}
+
+	for name := range deepVersionedAgents {
+		if !seenDeep[name] {
+			t.Errorf("deep agent %q expected in the registry but not found", name)
+		}
+	}
+}

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -78,14 +79,68 @@ func (r *Repo) CommitStaged(message string, id Identity) (string, error) {
 	return h.String(), nil
 }
 
-// Commit is the convenience that stages exactly relPaths and commits them. Returns
-// ("", nil) when nothing was staged. (The apply path composes Stage +
-// StageTrackedDeletions + CommitStaged instead, to also capture deletions.)
-func (r *Repo) Commit(relPaths []string, message string, id Identity) (string, error) {
-	if err := r.Stage(relPaths); err != nil {
-		return "", err
+// SnapshotDirtyTracked commits any uncommitted changes to already-TRACKED files
+// (modifications and deletions) as a safety checkpoint, so a subsequent
+// destructive operation (notably revert's hard reset) cannot lose them. Untracked
+// files — the user's own scratch files — are never touched. Returns the snapshot
+// commit hash, or ("", nil) when the worktree has no tracked changes. This is what
+// keeps the append-only promise true of the WORKTREE, not just of history.
+func (r *Repo) SnapshotDirtyTracked(message string, id Identity) (string, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	st, err := wt.Status()
+	if err != nil {
+		return "", fmt.Errorf("git status in %s: %w", r.dir, err)
+	}
+	var dirty []string
+	for path, fs := range st {
+		if isUntracked(fs) {
+			continue // the user's own files — never snapshot or touch them
+		}
+		if fs.Worktree != gogit.Unmodified || fs.Staging != gogit.Unmodified {
+			dirty = append(dirty, path)
+		}
+	}
+	if len(dirty) == 0 {
+		return "", nil
+	}
+	sort.Strings(dirty)
+	for _, p := range dirty {
+		if _, err := wt.Add(p); err != nil {
+			return "", fmt.Errorf("git add %s: %w", p, err)
+		}
 	}
 	return r.CommitStaged(message, id)
+}
+
+// IsClean reports whether the worktree has no uncommitted changes to TRACKED files
+// (untracked files are ignored — agentsync never commits them).
+func (r *Repo) IsClean() (bool, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return false, fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	st, err := wt.Status()
+	if err != nil {
+		return false, fmt.Errorf("git status in %s: %w", r.dir, err)
+	}
+	for _, fs := range st {
+		if isUntracked(fs) {
+			continue
+		}
+		if fs.Worktree != gogit.Unmodified || fs.Staging != gogit.Unmodified {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// isUntracked reports whether a status entry is a purely-untracked file (go-git
+// marks both columns Untracked for these).
+func isUntracked(fs *gogit.FileStatus) bool {
+	return fs.Worktree == gogit.Untracked && fs.Staging == gogit.Untracked
 }
 
 // signature builds the object.Signature for a checkpoint commit.

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -1,0 +1,112 @@
+package git
+
+import (
+	"fmt"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// now is the commit-timestamp source. It is a package var so tests can pin it;
+// the timestamp is purely informational (it feeds no content hash or comparison),
+// so a direct time.Now() is fine here — the render/state time.Now() caveat does
+// not apply to this package.
+var now = func() time.Time { return time.Now().UTC() }
+
+// Stage adds each of relPaths (slash-relative to the repo root) to the index. A
+// path that is gone from the worktree is staged as a deletion if it is tracked.
+func (r *Repo) Stage(relPaths []string) error {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	for _, rel := range relPaths {
+		if _, err := wt.Add(rel); err != nil {
+			return fmt.Errorf("git add %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// StageTrackedDeletions stages the removal of any already-TRACKED file that is now
+// missing from the worktree — so an apply that deleted a managed file (e.g. a
+// dropped MCP server) records that deletion in the checkpoint. It deliberately
+// does NOT touch untracked files (a `?` status) the user may have dropped into the
+// dir: agentsync only versions what it wrote. Returns the staged paths.
+func (r *Repo) StageTrackedDeletions() ([]string, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	st, err := wt.Status()
+	if err != nil {
+		return nil, fmt.Errorf("git status in %s: %w", r.dir, err)
+	}
+	var staged []string
+	for path, fs := range st {
+		if fs.Worktree == gogit.Deleted {
+			if _, err := wt.Add(path); err != nil {
+				return nil, fmt.Errorf("git add (delete) %s: %w", path, err)
+			}
+			staged = append(staged, path)
+		}
+	}
+	return staged, nil
+}
+
+// CommitStaged records one commit of the current index authored by id, or returns
+// ("", nil) when the index has nothing to commit (so an apply that changed nothing
+// produces no empty checkpoint).
+func (r *Repo) CommitStaged(message string, id Identity) (string, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	clean, err := indexClean(wt)
+	if err != nil {
+		return "", err
+	}
+	if clean {
+		return "", nil
+	}
+	sig := signature(id)
+	h, err := wt.Commit(message, &gogit.CommitOptions{Author: sig, Committer: sig})
+	if err != nil {
+		return "", fmt.Errorf("git commit in %s: %w", r.dir, err)
+	}
+	return h.String(), nil
+}
+
+// Commit is the convenience that stages exactly relPaths and commits them. Returns
+// ("", nil) when nothing was staged. (The apply path composes Stage +
+// StageTrackedDeletions + CommitStaged instead, to also capture deletions.)
+func (r *Repo) Commit(relPaths []string, message string, id Identity) (string, error) {
+	if err := r.Stage(relPaths); err != nil {
+		return "", err
+	}
+	return r.CommitStaged(message, id)
+}
+
+// signature builds the object.Signature for a checkpoint commit.
+func signature(id Identity) *object.Signature {
+	id = id.orDefault()
+	return &object.Signature{Name: id.Name, Email: id.Email, When: now()}
+}
+
+// indexClean reports whether the staging area has nothing to commit (matches HEAD).
+func indexClean(wt *gogit.Worktree) (bool, error) {
+	st, err := wt.Status()
+	if err != nil {
+		return false, fmt.Errorf("git status: %w", err)
+	}
+	// A repo is clean for commit purposes when no path has a staged change. We
+	// can't use st.IsClean() alone (it also reports untracked files as "not
+	// clean", which we intentionally never commit), so check the staging column.
+	for _, fs := range st {
+		if fs.Staging != gogit.Unmodified && fs.Staging != gogit.Untracked {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -150,6 +150,8 @@ func OwnsExactly(dir string) (bool, error) {
 // earlier run before a parent-dir agent was enabled). Short-circuits on the first
 // hit; a missing dir is reported as false.
 func HasNestedRepoBelow(dir string) (bool, error) {
+	dir = filepath.Clean(dir) // self-defend: the dir's-own-.git exclusion below
+	// compares against `dir`, so it must be clean (no trailing slash / "." / "..").
 	found := false
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,127 @@
+// Package git is agentsync's local-only destination-versioning helper. It wraps
+// go-git to give each rendered destination agent dir (~/.claude, ~/.codex, …) its
+// own git repo so a bad `agentsync apply` is a quick rollback away (issue #118).
+//
+// These repos are a LOCAL ROLLBACK HISTORY and are NEVER pushed to a remote. The
+// rendered files they version contain secrets resolved to cleartext at apply time;
+// keeping the repos local-only is what makes that acceptable (the canonical
+// ~/.agentsync/ source — the thing users commit and push — only ever holds secret
+// references). Accordingly this package exposes NO remote/push surface at all:
+// there is no function that adds a remote or pushes, and TestNoPushSurface guards
+// that the surface never grows one. Do not add one.
+package git
+
+import (
+	"errors"
+	"fmt"
+
+	gogit "github.com/go-git/go-git/v5"
+)
+
+// Identity is the author/committer recorded on checkpoint commits. agentsync uses
+// a dedicated identity (not the user's git identity) so machine-authored
+// checkpoints are distinct and committing works even when no global git identity
+// is configured.
+type Identity struct {
+	Name  string
+	Email string
+}
+
+// DefaultIdentity is used when the config supplies no override.
+var DefaultIdentity = Identity{Name: "agentsync", Email: "agentsync@localhost"}
+
+// orDefault fills empty fields from DefaultIdentity.
+func (id Identity) orDefault() Identity {
+	if id.Name == "" {
+		id.Name = DefaultIdentity.Name
+	}
+	if id.Email == "" {
+		id.Email = DefaultIdentity.Email
+	}
+	return id
+}
+
+// State classifies how a destination dir is tracked, so the apply tail knows
+// whether to init, commit, or stay out of the user's way.
+type State int
+
+const (
+	// StateUntracked: no git work tree at or above the dir — eligible for init.
+	StateUntracked State = iota
+	// StateAgentsyncOwned: a work tree agentsync created (carries the marker).
+	StateAgentsyncOwned
+	// StateForeign: a work tree the user owns (no marker) — leave it alone.
+	StateForeign
+)
+
+// String renders the state for diagnostics/doctor.
+func (s State) String() string {
+	switch s {
+	case StateAgentsyncOwned:
+		return "agentsync-versioned"
+	case StateForeign:
+		return "foreign source control"
+	default:
+		return "untracked"
+	}
+}
+
+// The marker lives in the repo's own .git/config as [agentsync] managed = true.
+// It is how Detect tells a repo agentsync auto-created from one the user keeps
+// (e.g. ~/.claude in their dotfiles), so agentsync only ever auto-commits into
+// its own repos.
+const (
+	markerSection = "agentsync"
+	markerOption  = "managed"
+	markerValue   = "true"
+)
+
+// Detect reports how dir is tracked. It uses DetectDotGit so a destination nested
+// inside an existing repo (a dotfiles user who keeps ~/.claude under git) is
+// reported StateForeign rather than StateUntracked — agentsync must not init a
+// nested repo or commit into someone else's history.
+func Detect(dir string) (State, error) {
+	repo, err := gogit.PlainOpenWithOptions(dir, &gogit.PlainOpenOptions{DetectDotGit: true})
+	if errors.Is(err, gogit.ErrRepositoryNotExists) {
+		return StateUntracked, nil
+	}
+	if err != nil {
+		return StateUntracked, fmt.Errorf("opening git repo at %s: %w", dir, err)
+	}
+	owned, err := hasMarker(repo)
+	if err != nil {
+		return StateForeign, err
+	}
+	if owned {
+		return StateAgentsyncOwned, nil
+	}
+	return StateForeign, nil
+}
+
+// hasMarker reports whether repo's config carries the agentsync-managed marker.
+func hasMarker(repo *gogit.Repository) (bool, error) {
+	cfg, err := repo.Config()
+	if err != nil {
+		return false, fmt.Errorf("reading git config: %w", err)
+	}
+	return cfg.Raw.Section(markerSection).Option(markerOption) == markerValue, nil
+}
+
+// Repo wraps a go-git repository plus its absolute work-tree root.
+type Repo struct {
+	dir  string
+	repo *gogit.Repository
+}
+
+// Dir returns the repo's work-tree root.
+func (r *Repo) Dir() string { return r.dir }
+
+// Open opens an existing repo at dir (an exact .git at dir, not a nested parent).
+// Callers gate on Detect first; Open does not re-check the marker.
+func Open(dir string) (*Repo, error) {
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		return nil, fmt.Errorf("opening git repo at %s: %w", dir, err)
+	}
+	return &Repo{dir: dir, repo: repo}, nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -14,6 +14,9 @@ package git
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 
 	gogit "github.com/go-git/go-git/v5"
 )
@@ -124,4 +127,45 @@ func Open(dir string) (*Repo, error) {
 		return nil, fmt.Errorf("opening git repo at %s: %w", dir, err)
 	}
 	return &Repo{dir: dir, repo: repo}, nil
+}
+
+// OwnsExactly reports whether dir is itself the root of an agentsync-owned repo —
+// an EXACT `.git` at dir carrying the marker — without the upward search Detect
+// does. Use this where you must act on the repo AT dir (Open/commit/revert), since
+// Detect's DetectDotGit can match a parent repo that merely contains dir.
+func OwnsExactly(dir string) (bool, error) {
+	repo, err := gogit.PlainOpen(dir) // exact: no DetectDotGit
+	if errors.Is(err, gogit.ErrRepositoryNotExists) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("opening git repo at %s: %w", dir, err)
+	}
+	return hasMarker(repo)
+}
+
+// HasNestedRepoBelow reports whether any git repository exists STRICTLY below dir
+// (a `.git` entry in a subdirectory). agentsync refuses to init a repo that would
+// wrap another repo (the cross-run nesting hazard: a child dir was versioned in an
+// earlier run before a parent-dir agent was enabled). Short-circuits on the first
+// hit; a missing dir is reported as false.
+func HasNestedRepoBelow(dir string) (bool, error) {
+	found := false
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil // unreadable entry — ignore, never fail the apply over this
+		}
+		if path == dir || d == nil || !d.IsDir() {
+			return nil
+		}
+		if d.Name() == ".git" {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return found, fmt.Errorf("scanning %s for nested repos: %w", dir, err)
+	}
+	return found, nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -155,10 +155,14 @@ func HasNestedRepoBelow(dir string) (bool, error) {
 		if walkErr != nil {
 			return nil // unreadable entry — ignore, never fail the apply over this
 		}
-		if path == dir || d == nil || !d.IsDir() {
+		if path == dir || d == nil {
 			return nil
 		}
-		if d.Name() == ".git" {
+		// Match ".git" whether it's a directory (normal repo) OR a file (a gitlink
+		// pointer used by submodules / `git worktree`) — both mean a repo lives here.
+		// Skip dir's OWN immediate .git (parent == dir): that's the repo AT dir, not
+		// one nested below it.
+		if d.Name() == ".git" && filepath.Dir(path) != dir {
 			found = true
 			return filepath.SkipAll
 		}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/spxrogers/agentsync/internal/testenv"
@@ -32,12 +33,14 @@ func readFile(t *testing.T, dir, rel string) string {
 	return string(b)
 }
 
-// commitFile writes rel then commits it through the agentsync API, returning the
-// new hash.
+// commitFile writes rel, stages it, and commits, returning the new hash.
 func commitFile(t *testing.T, r *Repo, dir, rel, content, msg string) string {
 	t.Helper()
 	writeFile(t, dir, rel, content)
-	h, err := r.Commit([]string{rel}, msg, DefaultIdentity)
+	if err := r.Stage([]string{rel}); err != nil {
+		t.Fatalf("stage %s: %v", rel, err)
+	}
+	h, err := r.CommitStaged(msg, DefaultIdentity)
 	if err != nil {
 		t.Fatalf("commit %s: %v", rel, err)
 	}
@@ -179,7 +182,10 @@ func TestCommit(t *testing.T) {
 	}
 
 	// No change → no new checkpoint.
-	h3, err := r.Commit([]string{"settings.json"}, "noop", DefaultIdentity)
+	if err := r.Stage([]string{"settings.json"}); err != nil {
+		t.Fatal(err)
+	}
+	h3, err := r.CommitStaged("noop", DefaultIdentity)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,6 +267,125 @@ func TestLogAndResolve(t *testing.T) {
 	}
 	if _, err := r.Resolve("deadbeefdeadbeef"); err == nil {
 		t.Fatal("Resolve of a bogus rev should error")
+	}
+}
+
+// inHead reports whether rel is present in the repo's HEAD tree.
+func inHead(t *testing.T, dir, rel string) bool {
+	t.Helper()
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree, err := c.Tree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tree.File(rel)
+	return err == nil
+}
+
+func TestSnapshotDirtyTrackedAndIsClean(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "v1", "first")
+
+	if clean, _ := r.IsClean(); !clean {
+		t.Fatal("freshly committed worktree should be clean")
+	}
+
+	// Hand-edit a tracked file + drop an untracked user file.
+	writeFile(t, dir, "a.txt", "hand-edited")
+	writeFile(t, dir, "user-scratch.txt", "mine")
+
+	if clean, _ := r.IsClean(); clean {
+		t.Fatal("a modified tracked file should make IsClean false")
+	}
+
+	snap, err := r.SnapshotDirtyTracked("snapshot", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap == "" {
+		t.Fatal("SnapshotDirtyTracked should have committed the tracked edit")
+	}
+	// The edit is now preserved in history (recoverable), worktree clean of TRACKED
+	// changes; the untracked user file is untouched and uncommitted.
+	if clean, _ := r.IsClean(); !clean {
+		t.Fatal("after snapshot, tracked changes should be clean")
+	}
+	if got := readFile(t, dir, "a.txt"); got != "hand-edited" {
+		t.Fatalf("snapshot lost the edit: a.txt = %q", got)
+	}
+	if inHead(t, dir, "user-scratch.txt") {
+		t.Fatal("untracked user file must NOT be committed by the snapshot")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "user-scratch.txt")); err != nil {
+		t.Fatalf("untracked user file disturbed: %v", err)
+	}
+
+	// Nothing dirty → no-op.
+	again, err := r.SnapshotDirtyTracked("noop", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != "" {
+		t.Fatalf("snapshot of a clean tree returned %q, want empty", again)
+	}
+	// An untracked-only worktree is still "clean" for our purposes.
+	writeFile(t, dir, "another-scratch.txt", "also mine")
+	if clean, _ := r.IsClean(); !clean {
+		t.Fatal("untracked-only changes should still count as clean")
+	}
+}
+
+func TestHasMultipleCheckpoints(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "1", "c1")
+	if multi, _ := r.HasMultipleCheckpoints(); multi {
+		t.Fatal("one commit should not be multiple checkpoints")
+	}
+	commitFile(t, r, dir, "a.txt", "2", "c2")
+	if multi, _ := r.HasMultipleCheckpoints(); !multi {
+		t.Fatal("two commits should be multiple checkpoints")
+	}
+}
+
+func TestNowSeamPinsCommitTime(t *testing.T) {
+	testenv.RequireContainer(t)
+	orig := now
+	defer func() { now = orig }()
+	fixed := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixed }
+
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "1", "c1")
+	repo, _ := gogit.PlainOpen(dir)
+	ref, _ := repo.Head()
+	c, _ := repo.CommitObject(ref.Hash())
+	if !c.Author.When.Equal(fixed) {
+		t.Fatalf("commit time = %v, want pinned %v", c.Author.When, fixed)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,337 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// writeFile writes content to <dir>/<rel>, creating parents.
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// readFile reads <dir>/<rel>.
+func readFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+// commitFile writes rel then commits it through the agentsync API, returning the
+// new hash.
+func commitFile(t *testing.T, r *Repo, dir, rel, content, msg string) string {
+	t.Helper()
+	writeFile(t, dir, rel, content)
+	h, err := r.Commit([]string{rel}, msg, DefaultIdentity)
+	if err != nil {
+		t.Fatalf("commit %s: %v", rel, err)
+	}
+	if h == "" {
+		t.Fatalf("commit %s returned empty hash", rel)
+	}
+	return h
+}
+
+func TestDetect(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	t.Run("untracked", func(t *testing.T) {
+		st, err := Detect(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st != StateUntracked {
+			t.Fatalf("got %v, want StateUntracked", st)
+		}
+	})
+
+	t.Run("agentsync-owned", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Init(dir); err != nil {
+			t.Fatal(err)
+		}
+		st, err := Detect(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st != StateAgentsyncOwned {
+			t.Fatalf("got %v, want StateAgentsyncOwned", st)
+		}
+	})
+
+	t.Run("foreign", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := gogit.PlainInit(dir, false); err != nil {
+			t.Fatal(err)
+		}
+		st, err := Detect(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st != StateForeign {
+			t.Fatalf("got %v, want StateForeign", st)
+		}
+	})
+
+	t.Run("nested in foreign repo", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := gogit.PlainInit(dir, false); err != nil {
+			t.Fatal(err)
+		}
+		child := filepath.Join(dir, "sub", "deep")
+		if err := os.MkdirAll(child, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		st, err := Detect(child)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st != StateForeign {
+			t.Fatalf("got %v, want StateForeign (DetectDotGit should find the parent repo)", st)
+		}
+	})
+}
+
+func TestInit(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Dir() != dir {
+		t.Fatalf("Dir()=%q want %q", r.Dir(), dir)
+	}
+	if fi, err := os.Stat(filepath.Join(dir, ".git")); err != nil || !fi.IsDir() {
+		t.Fatalf(".git not created: %v", err)
+	}
+	notice := filepath.Join(dir, NoticeFile)
+	fi, err := os.Stat(notice)
+	if err != nil {
+		t.Fatalf("%s not created: %v", NoticeFile, err)
+	}
+	if runtime.GOOS != "windows" {
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("%s mode = %o, want 600", NoticeFile, got)
+		}
+		if gi, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			if got := gi.Mode().Perm(); got != 0o700 {
+				t.Errorf(".git mode = %o, want 700", got)
+			}
+		}
+	}
+	st, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != StateAgentsyncOwned {
+		t.Fatalf("Detect after Init = %v, want StateAgentsyncOwned", st)
+	}
+}
+
+func TestCommit(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h1 := commitFile(t, r, dir, "settings.json", `{"a":1}`, "first")
+
+	// Author identity is the dedicated agentsync identity.
+	repo, _ := gogit.PlainOpen(dir)
+	ref, _ := repo.Head()
+	c, _ := repo.CommitObject(ref.Hash())
+	if c.Author.Name != "agentsync" || c.Author.Email != "agentsync@localhost" {
+		t.Errorf("author = %s <%s>, want agentsync <agentsync@localhost>", c.Author.Name, c.Author.Email)
+	}
+
+	// A second commit of a changed file gets a new hash whose parent is the first.
+	h2 := commitFile(t, r, dir, "settings.json", `{"a":2}`, "second")
+	if h2 == h1 {
+		t.Fatalf("second commit reused the first hash")
+	}
+	repo, _ = gogit.PlainOpen(dir)
+	ref, _ = repo.Head()
+	c2, _ := repo.CommitObject(ref.Hash())
+	if c2.NumParents() != 1 {
+		t.Fatalf("second commit has %d parents, want 1", c2.NumParents())
+	}
+	if p, _ := c2.Parent(0); p.Hash.String() != h1 {
+		t.Fatalf("second commit parent = %s, want %s", p.Hash.String(), h1)
+	}
+
+	// No change → no new checkpoint.
+	h3, err := r.Commit([]string{"settings.json"}, "noop", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h3 != "" {
+		t.Fatalf("commit with no change returned %q, want empty", h3)
+	}
+}
+
+func TestStageTrackedDeletions(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "mcp.json", `{}`, "add mcp.json")
+
+	// Remove the tracked file + drop an UNtracked user file alongside it.
+	if err := os.Remove(filepath.Join(dir, "mcp.json")); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "user-note.txt", "mine, do not touch")
+
+	staged, err := r.StageTrackedDeletions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(staged) != 1 || staged[0] != "mcp.json" {
+		t.Fatalf("staged deletions = %v, want [mcp.json]", staged)
+	}
+	if _, err := r.CommitStaged("remove mcp.json", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// The untracked user file is still present and was never committed.
+	if _, err := os.Stat(filepath.Join(dir, "user-note.txt")); err != nil {
+		t.Fatalf("untracked user file disturbed: %v", err)
+	}
+}
+
+func TestLogAndResolve(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "1", "c1")
+	commitFile(t, r, dir, "a.txt", "2", "c2")
+	h3 := commitFile(t, r, dir, "a.txt", "3", "c3")
+
+	all, err := r.Log(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("Log(0) len = %d, want 3", len(all))
+	}
+	if all[0].Subject != "c3" || all[2].Subject != "c1" {
+		t.Fatalf("Log not newest-first: %q … %q", all[0].Subject, all[2].Subject)
+	}
+	if all[0].Hash != h3 {
+		t.Fatalf("Log[0].Hash = %s, want %s", all[0].Hash, h3)
+	}
+
+	two, err := r.Log(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(two) != 2 {
+		t.Fatalf("Log(2) len = %d, want 2", len(two))
+	}
+
+	prev, err := r.Resolve("HEAD~1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev != all[1].Hash {
+		t.Fatalf("Resolve(HEAD~1) = %s, want %s", prev, all[1].Hash)
+	}
+	if _, err := r.Resolve("deadbeefdeadbeef"); err == nil {
+		t.Fatal("Resolve of a bogus rev should error")
+	}
+}
+
+func TestRestoreAppendOnly(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "v1", "apply 1")    // HEAD~2 target
+	commitFile(t, r, dir, "a.txt", "v2", "apply 2")    // HEAD~1
+	commitFile(t, r, dir, "b.txt", "added", "apply 3") // HEAD (a.txt still v2)
+
+	before, _ := r.Log(0)
+	if len(before) != 3 {
+		t.Fatalf("setup: want 3 commits, got %d", len(before))
+	}
+
+	// Dry-run plan: restoring HEAD~2 should restore a.txt and delete b.txt.
+	target, changes, err := r.Plan("HEAD~2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != before[2].Hash {
+		t.Fatalf("Plan target = %s, want %s", target, before[2].Hash)
+	}
+	kinds := map[string]string{}
+	for _, c := range changes {
+		kinds[c.Path] = c.Kind
+	}
+	if kinds["a.txt"] != "modify" || kinds["b.txt"] != "delete" {
+		t.Fatalf("Plan changes = %v, want a.txt:modify b.txt:delete", kinds)
+	}
+	// Plan must not have written anything.
+	if got := readFile(t, dir, "a.txt"); got != "v2" {
+		t.Fatalf("Plan mutated worktree: a.txt = %q", got)
+	}
+
+	h, err := r.Restore("HEAD~2", "agentsync revert: test", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h == "" {
+		t.Fatal("Restore returned empty hash")
+	}
+	// Worktree now matches the HEAD~2 checkpoint.
+	if got := readFile(t, dir, "a.txt"); got != "v1" {
+		t.Fatalf("after restore a.txt = %q, want v1", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "b.txt")); !os.IsNotExist(err) {
+		t.Fatalf("after restore b.txt should be gone, stat err = %v", err)
+	}
+	// Append-only: a new commit on top; all three originals still reachable.
+	after, _ := r.Log(0)
+	if len(after) != 4 {
+		t.Fatalf("after restore Log len = %d, want 4 (append-only)", len(after))
+	}
+	repo, _ := gogit.PlainOpen(dir)
+	ref, _ := repo.Head()
+	head, _ := repo.CommitObject(ref.Hash())
+	if p, _ := head.Parent(0); p.Hash.String() != before[0].Hash {
+		t.Fatalf("revert parent = %s, want prior HEAD %s", p.Hash.String(), before[0].Hash)
+	}
+
+	// Restoring to the current HEAD is a no-op.
+	noop, err := r.Restore("HEAD", "noop", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if noop != "" {
+		t.Fatalf("restore to HEAD returned %q, want empty (no-op)", noop)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -110,6 +110,99 @@ func TestDetect(t *testing.T) {
 	})
 }
 
+func TestOwnsExactly(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	t.Run("no repo", func(t *testing.T) {
+		got, err := OwnsExactly(t.TempDir())
+		if err != nil || got {
+			t.Fatalf("OwnsExactly(empty) = (%v, %v), want (false, nil)", got, err)
+		}
+	})
+	t.Run("agentsync repo at dir", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Init(dir); err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := OwnsExactly(dir); !got {
+			t.Fatal("OwnsExactly should be true at an agentsync repo root")
+		}
+	})
+	t.Run("foreign repo at dir", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := gogit.PlainInit(dir, false); err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := OwnsExactly(dir); got {
+			t.Fatal("OwnsExactly must be false for a foreign (unmarked) repo")
+		}
+	})
+	t.Run("child of an agentsync repo is NOT exact-owned", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Init(dir); err != nil {
+			t.Fatal(err)
+		}
+		child := filepath.Join(dir, "skills")
+		if err := os.MkdirAll(child, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		// Detect (upward) would call this Owned; OwnsExactly (exact) must not.
+		if got, _ := OwnsExactly(child); got {
+			t.Fatal("OwnsExactly must be false for a dir merely nested inside an agentsync repo")
+		}
+		if st, _ := Detect(child); st != StateAgentsyncOwned {
+			t.Fatal("precondition: Detect(child) should be Owned via DetectDotGit")
+		}
+	})
+}
+
+func TestHasNestedRepoBelow(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	t.Run("none", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "a/b/c.txt", "x")
+		if got, err := HasNestedRepoBelow(dir); err != nil || got {
+			t.Fatalf("HasNestedRepoBelow(no nested) = (%v,%v), want false", got, err)
+		}
+	})
+	t.Run("missing dir", func(t *testing.T) {
+		if got, err := HasNestedRepoBelow(filepath.Join(t.TempDir(), "nope")); err != nil || got {
+			t.Fatalf("HasNestedRepoBelow(missing) = (%v,%v), want (false,nil)", got, err)
+		}
+	})
+	t.Run("nested .git dir at depth", func(t *testing.T) {
+		dir := t.TempDir()
+		deep := filepath.Join(dir, "x", "y")
+		if _, err := gogit.PlainInit(deep, false); err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := HasNestedRepoBelow(dir); !got {
+			t.Fatal("should find a nested .git directory at depth")
+		}
+	})
+	t.Run("nested .git FILE (gitlink) is detected", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "sub/.git", "gitdir: /somewhere/else/.git\n")
+		if got, _ := HasNestedRepoBelow(dir); !got {
+			t.Fatal("should detect a nested .git gitlink FILE, not just a directory")
+		}
+	})
+	t.Run("does not match the dir's own .git", func(t *testing.T) {
+		// Init'd repo: its OWN .git must not count as "below". (In practice the guard
+		// only runs on untracked dirs, but pin the invariant anyway.)
+		dir := t.TempDir()
+		if _, err := Init(dir); err != nil {
+			t.Fatal(err)
+		}
+		// Remove the notice so the only entries are .git + nothing nested.
+		_ = os.Remove(filepath.Join(dir, NoticeFile))
+		if got, _ := HasNestedRepoBelow(dir); got {
+			t.Fatal("the dir's own .git must not count as a nested repo below it")
+		}
+	})
+}
+
 func TestInit(t *testing.T) {
 	testenv.RequireContainer(t)
 	dir := t.TempDir()

--- a/internal/git/init.go
+++ b/internal/git/init.go
@@ -1,0 +1,64 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	gogit "github.com/go-git/go-git/v5"
+)
+
+// NoticeFile is written at the repo root on init and committed in the first
+// checkpoint, so anyone browsing the history sees what it is and that it must not
+// be pushed.
+const NoticeFile = "AGENTSYNC_LOCAL_HISTORY.md"
+
+const noticeBody = `# agentsync local-only rollback history
+
+This git repository was created by **agentsync** (https://agentsync.cc) to version
+the rendered agent config in this directory, so a bad ` + "`agentsync apply`" + ` can be
+rolled back with ` + "`agentsync revert`" + ` (or plain ` + "`git revert` / `git checkout`" + `).
+
+## Do not push this repository
+
+- It is a **local-only** rollback history. agentsync never adds a remote and never
+  pushes it.
+- The files here are the *rendered* destination config, in which ` + "`${secret:…}`" + `
+  references have been **resolved to cleartext**. This history therefore may
+  contain secrets. Keeping it local is what makes that acceptable.
+- The thing you commit and push in normal use is the canonical ` + "`~/.agentsync/`" + `
+  source, which only ever holds secret *references* — not this directory.
+
+## Rolling back
+
+    agentsync revert <agent>           # undo the most recent apply to this dir
+    agentsync revert <agent> --to <ref>  # roll back to a specific checkpoint
+`
+
+// Init creates a new agentsync-owned git repo at dir: PlainInit, stamp the
+// [agentsync] managed=true marker into .git/config (so Detect recognizes it as
+// ours), tighten the .git dir to 0o700 (the history may carry cleartext secrets),
+// and write the local-only notice file. Callers MUST gate on Detect ==
+// StateUntracked first; Init errors if a repo already exists at dir.
+func Init(dir string) (*Repo, error) {
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		return nil, fmt.Errorf("git init %s: %w", dir, err)
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, fmt.Errorf("reading fresh git config at %s: %w", dir, err)
+	}
+	cfg.Raw.Section(markerSection).SetOption(markerOption, markerValue)
+	if err := repo.SetConfig(cfg); err != nil {
+		return nil, fmt.Errorf("writing agentsync marker to git config at %s: %w", dir, err)
+	}
+	// The history may carry cleartext secrets; keep .git readable only by the user.
+	// Best-effort: a chmod failure (e.g. Windows) must not abort the apply, but on
+	// POSIX it should normally succeed.
+	_ = os.Chmod(filepath.Join(dir, ".git"), 0o700)
+	if err := os.WriteFile(filepath.Join(dir, NoticeFile), []byte(noticeBody), 0o600); err != nil {
+		return nil, fmt.Errorf("writing %s in %s: %w", NoticeFile, dir, err)
+	}
+	return &Repo{dir: dir, repo: repo}, nil
+}

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -1,0 +1,92 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+)
+
+// Checkpoint is one commit in a destination repo's history.
+type Checkpoint struct {
+	Hash    string    // full hash
+	Short   string    // first 7 chars of Hash
+	Subject string    // first line of the commit message
+	When    time.Time // author time
+}
+
+// Log returns up to n checkpoints, newest first. n <= 0 returns the full history.
+func (r *Repo) Log(n int) ([]Checkpoint, error) {
+	iter, err := r.repo.Log(&gogit.LogOptions{})
+	if err != nil {
+		// A repo with no commits yet has no HEAD; report an empty history rather
+		// than an error so callers can say "nothing to revert to".
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("git log in %s: %w", r.dir, err)
+	}
+	defer iter.Close()
+	var out []Checkpoint
+	// ForEach returns nil when the callback returns storer.ErrStop, so this is the
+	// clean way to cap the walk at n without treating "done" as an error.
+	err = iter.ForEach(func(c *object.Commit) error {
+		out = append(out, Checkpoint{
+			Hash:    c.Hash.String(),
+			Short:   shortHash(c.Hash),
+			Subject: strings.SplitN(c.Message, "\n", 2)[0],
+			When:    c.Author.When,
+		})
+		if n > 0 && len(out) >= n {
+			return storer.ErrStop
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking git log in %s: %w", r.dir, err)
+	}
+	return out, nil
+}
+
+// Resolve turns a revision (e.g. "HEAD", "HEAD~1", a short or full hash) into a
+// full commit hash, erroring clearly when it does not resolve.
+func (r *Repo) Resolve(rev string) (string, error) {
+	h, err := r.repo.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return "", fmt.Errorf("no such checkpoint %q in %s: %w", rev, r.dir, err)
+	}
+	return h.String(), nil
+}
+
+// HasMultipleCheckpoints reports whether the repo has at least two commits, so a
+// default "undo the most recent apply" (HEAD~1) has somewhere to land.
+func (r *Repo) HasMultipleCheckpoints() (bool, error) {
+	cps, err := r.Log(2)
+	if err != nil {
+		return false, err
+	}
+	return len(cps) >= 2, nil
+}
+
+// headHash returns the current HEAD commit hash.
+func (r *Repo) headHash() (plumbing.Hash, error) {
+	ref, err := r.repo.Head()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("resolving HEAD in %s: %w", r.dir, err)
+	}
+	return ref.Hash(), nil
+}
+
+// shortHash renders the conventional 7-char abbreviation.
+func shortHash(h plumbing.Hash) string {
+	s := h.String()
+	if len(s) >= 7 {
+		return s[:7]
+	}
+	return s
+}

--- a/internal/git/nopush_test.go
+++ b/internal/git/nopush_test.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoPushSurface guards the load-bearing invariant of issue #118: these repos
+// are a LOCAL-ONLY rollback history that is never pushed. agentsync must never add
+// a remote or push, and the cheapest way to keep that true is to ensure this
+// package never even references the go-git remote/push API. If a future change
+// needs one of these tokens for a legitimate, non-pushing reason, narrow the guard
+// deliberately — do not just delete it.
+func TestNoPushSurface(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{"Push(", "PushContext", "CreateRemote", ".Remote(", "Remotes(", "RemoteAdd"}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, tok := range banned {
+			if bytes.Contains(b, []byte(tok)) {
+				t.Errorf("%s references %q — internal/git must never push or add a remote (issue #118)", f, tok)
+			}
+		}
+	}
+}

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -1,0 +1,123 @@
+package git
+
+import (
+	"fmt"
+	"sort"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/utils/merkletrie"
+)
+
+// FileChange describes one file a restore would touch, for `revert --dry-run`.
+type FileChange struct {
+	Path string
+	Kind string // "create" | "modify" | "delete"
+}
+
+// Plan computes what Restore(targetRev) would change in the worktree relative to
+// the current HEAD, WITHOUT writing anything. Returns the resolved target hash and
+// the file changes (sorted by path).
+func (r *Repo) Plan(targetRev string) (targetHash string, changes []FileChange, err error) {
+	targetStr, err := r.Resolve(targetRev)
+	if err != nil {
+		return "", nil, err
+	}
+	headH, err := r.headHash()
+	if err != nil {
+		return "", nil, err
+	}
+	headTree, err := r.commitTree(headH)
+	if err != nil {
+		return "", nil, err
+	}
+	targetTree, err := r.commitTree(plumbing.NewHash(targetStr))
+	if err != nil {
+		return "", nil, err
+	}
+	diff, err := headTree.Diff(targetTree)
+	if err != nil {
+		return "", nil, fmt.Errorf("diffing checkpoints in %s: %w", r.dir, err)
+	}
+	var out []FileChange
+	for _, ch := range diff {
+		action, aerr := ch.Action()
+		if aerr != nil {
+			return "", nil, fmt.Errorf("classifying change in %s: %w", r.dir, aerr)
+		}
+		switch action {
+		case merkletrie.Insert:
+			out = append(out, FileChange{Path: ch.To.Name, Kind: "create"})
+		case merkletrie.Delete:
+			out = append(out, FileChange{Path: ch.From.Name, Kind: "delete"})
+		default:
+			out = append(out, FileChange{Path: ch.To.Name, Kind: "modify"})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return targetStr, out, nil
+}
+
+// Restore makes the worktree match the targetRev checkpoint and records the result
+// as a NEW commit on top of the current HEAD. It is append-only: HEAD advances,
+// nothing is rewritten or lost, so the bad apply stays in history and the revert
+// is itself revertible. Returns the new commit hash, or ("", nil) when the worktree
+// already matches target (no checkpoint recorded).
+func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
+	targetStr, changes, err := r.Plan(targetRev)
+	if err != nil {
+		return "", err
+	}
+	if len(changes) == 0 {
+		return "", nil
+	}
+	orig, err := r.headHash()
+	if err != nil {
+		return "", err
+	}
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	// Append-only restore via two resets:
+	//   1. HARD reset to target  → index + worktree now hold target's content
+	//      (and the branch ref transiently points at target).
+	//   2. SOFT reset to orig    → moves the branch ref back to the original HEAD
+	//      WITHOUT touching the index/worktree (go-git SoftReset leaves both).
+	// Committing now records target's content as a new commit whose PARENT is the
+	// original HEAD — so the intervening commits (and the bad apply) stay reachable.
+	if err := wt.Reset(&gogit.ResetOptions{Commit: plumbing.NewHash(targetStr), Mode: gogit.HardReset}); err != nil {
+		return "", fmt.Errorf("reset worktree to checkpoint %s in %s: %w", shortStr(targetStr), r.dir, err)
+	}
+	if err := wt.Reset(&gogit.ResetOptions{Commit: orig, Mode: gogit.SoftReset}); err != nil {
+		return "", fmt.Errorf("restoring branch ref after revert in %s: %w", r.dir, err)
+	}
+	sig := signature(id)
+	h, err := wt.Commit(message, &gogit.CommitOptions{Author: sig, Committer: sig})
+	if err != nil {
+		return "", fmt.Errorf("recording revert commit in %s: %w", r.dir, err)
+	}
+	return h.String(), nil
+}
+
+// commitTree loads the tree of a commit hash.
+func (r *Repo) commitTree(h plumbing.Hash) (*object.Tree, error) {
+	c, err := r.repo.CommitObject(h)
+	if err != nil {
+		return nil, fmt.Errorf("loading commit %s in %s: %w", shortStr(h.String()), r.dir, err)
+	}
+	t, err := c.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("loading tree of %s in %s: %w", shortStr(h.String()), r.dir, err)
+	}
+	return t, nil
+}
+
+// shortStr abbreviates a hex hash string to 7 chars for messages.
+func shortStr(s string) string {
+	if len(s) >= 7 {
+		return s[:7]
+	}
+	return s
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -80,7 +80,9 @@ func Discover(start string) (root string, found bool, err error) {
 //   - Plugins / Marketplaces: project entries are not modeled at project scope in
 //     v1 and are inherited from base unchanged (see the migration note in
 //     docs/architecture.md). Config (Updates/Secrets/Memory) is inherited from
-//     base unless the project declares its own non-zero values; the effective
+//     base unless the project declares its own non-zero values (this also covers
+//     the [destination_directory_git_backup] table, though it is a user-scope
+//     concern in practice); the effective
 //     [memory] setting is also propagated onto the stored project overlay so
 //     project-scope render honours a user-level managed-banner opt-out.
 func Merge(base, proj source.Canonical) source.Canonical {
@@ -101,6 +103,9 @@ func Merge(base, proj source.Canonical) source.Canonical {
 	}
 	if proj.Config.Memory != (source.MemoryConfig{}) {
 		out.Config.Memory = proj.Config.Memory
+	}
+	if proj.Config.DestinationGitBackup != (source.DestinationGitBackupConfig{}) {
+		out.Config.DestinationGitBackup = proj.Config.DestinationGitBackup
 	}
 
 	out.MCPServers = overlayByKey(base.MCPServers, proj.MCPServers, func(m source.MCPServer) string { return m.ID })

--- a/internal/render/writer_lint_test.go
+++ b/internal/render/writer_lint_test.go
@@ -27,17 +27,18 @@ func TestNoDirectAtomicWriteOutsideAllowedFiles(t *testing.T) {
 	// canonical source (~/.agentsync/*), agentsync's own state, or the
 	// plugin cache — none of which are native destinations.
 	allowed := map[string]bool{
-		"internal/iox/atomic.go":         true,
-		"internal/render/writer.go":      true,
-		"internal/source/writer.go":      true,
-		"internal/state/store.go":        true,
-		"internal/secrets/age.go":        true, // writes secrets.age under ~/.agentsync/
-		"internal/cli/plugin.go":         true,
-		"internal/cli/marketplace.go":    true,
-		"internal/cli/agent.go":          true,
-		"internal/cli/reconcile.go":      true,
-		"internal/cli/update.go":         true,
-		"internal/adapter/testwriter.go": true,
+		"internal/iox/atomic.go":           true,
+		"internal/render/writer.go":        true,
+		"internal/source/writer.go":        true,
+		"internal/state/store.go":          true,
+		"internal/secrets/age.go":          true, // writes secrets.age under ~/.agentsync/
+		"internal/cli/plugin.go":           true,
+		"internal/cli/marketplace.go":      true,
+		"internal/cli/agent.go":            true,
+		"internal/cli/gitbackup_config.go": true, // writes agentsync.toml (canonical source)
+		"internal/cli/reconcile.go":        true,
+		"internal/cli/update.go":           true,
+		"internal/adapter/testwriter.go":   true,
 	}
 
 	var bad []string

--- a/internal/source/gitbackup_test.go
+++ b/internal/source/gitbackup_test.go
@@ -1,0 +1,38 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestDestinationGitBackupConfig(t *testing.T) {
+	t.Run("default mode is prompt", func(t *testing.T) {
+		var g DestinationGitBackupConfig
+		if got := g.EffectiveMode(); got != GitBackupModePrompt {
+			t.Fatalf("EffectiveMode() = %q, want %q", got, GitBackupModePrompt)
+		}
+	})
+
+	t.Run("parses the table", func(t *testing.T) {
+		var c Config
+		const in = `[destination_directory_git_backup]
+mode = "on"
+author_name = "agentsync"
+author_email = "bot@localhost"
+`
+		if err := toml.Unmarshal([]byte(in), &c); err != nil {
+			t.Fatal(err)
+		}
+		g := c.DestinationGitBackup
+		if g.Mode != GitBackupModeOn {
+			t.Errorf("Mode = %q, want on", g.Mode)
+		}
+		if g.AuthorName != "agentsync" || g.AuthorEmail != "bot@localhost" {
+			t.Errorf("author = %q <%q>, want agentsync <bot@localhost>", g.AuthorName, g.AuthorEmail)
+		}
+		if g.EffectiveMode() != GitBackupModeOn {
+			t.Errorf("EffectiveMode() = %q, want on", g.EffectiveMode())
+		}
+	})
+}

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -28,10 +28,39 @@ type Canonical struct {
 
 // Config mirrors agentsync.toml at the root of ~/.agentsync/.
 type Config struct {
-	Agents  map[string]Agent `toml:"agents"`
-	Updates UpdateDefaults   `toml:"updates"`
-	Secrets SecretsConfig    `toml:"secrets"`
-	Memory  MemoryConfig     `toml:"memory"`
+	Agents               map[string]Agent           `toml:"agents"`
+	Updates              UpdateDefaults             `toml:"updates"`
+	Secrets              SecretsConfig              `toml:"secrets"`
+	Memory               MemoryConfig               `toml:"memory"`
+	DestinationGitBackup DestinationGitBackupConfig `toml:"destination_directory_git_backup"`
+}
+
+// DestinationGitBackupConfig mirrors the [destination_directory_git_backup] table
+// in agentsync.toml. It controls whether `apply` git-versions the rendered
+// destination dirs (~/.claude, ~/.codex, …) so a bad apply is revertible — a
+// LOCAL-ONLY rollback history that is never pushed (issue #118; see the secret-
+// handling note in CLAUDE.md). The table name is deliberately explicit: these
+// repos back up the destination directories, not general git config. An empty Mode
+// means "prompt".
+type DestinationGitBackupConfig struct {
+	Mode        string `toml:"mode,omitempty"`         // "prompt" | "on" | "off"
+	AuthorName  string `toml:"author_name,omitempty"`  // commit author override
+	AuthorEmail string `toml:"author_email,omitempty"` // commit email override
+}
+
+// Destination-git-backup modes.
+const (
+	GitBackupModePrompt = "prompt" // default: ask on first write to an untracked dir
+	GitBackupModeOn     = "on"     // init + checkpoint silently
+	GitBackupModeOff    = "off"    // never init/commit/prompt
+)
+
+// EffectiveMode returns Mode, defaulting to GitBackupModePrompt when unset.
+func (g DestinationGitBackupConfig) EffectiveMode() string {
+	if g.Mode == "" {
+		return GitBackupModePrompt
+	}
+	return g.Mode
 }
 
 // MemoryConfig mirrors the [memory] table in agentsync.toml.

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -27,7 +27,8 @@ import { Aside } from '@astrojs/starlight/components';
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
 | `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
-| `apply` | Render source → write agent configs (offline). | `--dry-run --scope --project` |
+| `apply` | Render source → write agent configs (offline). Git-versions each destination dir (opt-out). | `--dry-run --scope --project --no-git-backup` |
+| `revert <agent>` | Roll a destination dir back to a prior apply checkpoint (local-only git history). | `--to --all --dry-run` |
 | `status` | Summarize drift / pending across agents (skill dirs collapse by default). | `--agents --verbose --json --scope --project` |
 | `diff [<path>]` | Show pending / drift changes; secrets redacted. | `--scope --project` |
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
@@ -142,6 +143,39 @@ as a no-op rather than a list of pending writes.
 ```bash
 agentsync apply --dry-run
 agentsync apply
+```
+
+**Destination git backup.** After a successful user-scope apply that changes
+managed files, `apply` keeps each agent's destination dir (`~/.claude`, `~/.codex`,
+…) in its own **local-only** git repo and records a checkpoint commit, so a bad
+apply is one `agentsync revert` away. The first apply to an untracked dir
+**prompts** to enable this (opt-out); answer once and it's remembered in
+`[destination_directory_git_backup]`. These repos are **never pushed** (the history
+may hold cleartext secrets, like the files it versions — which is why it stays
+local). A dir already under your own source control is left untouched. Pass
+`--no-git-backup` to skip it for one run (CI/scripting) without touching config.
+The `[destination_directory_git_backup]` table (`mode = "prompt" | "on" | "off"`,
+optional `author_name`/`author_email`) controls the default; `agentsync doctor`
+shows the current mode and per-dir status. See `agentsync revert` below.
+
+### `revert <agent>`
+Rolls an agent's destination dir back to a prior apply checkpoint from its
+local-only git history — recovering from a bad apply. It is **append-only**: it
+records a new commit, so the history is never rewritten and the revert is itself
+revertible. By default it undoes the most recent apply (restores the previous
+checkpoint); `--to <ref>` picks a specific one (a commit hash or `HEAD~2`), `--all`
+reverts every managed dir, and `--dry-run` previews the file changes without
+writing.
+
+revert moves only the **destination**. The next `apply` re-renders from the
+canonical source and would overwrite the reverted state, so revert prints a notice
+telling you to reconcile (`agentsync reconcile` / `import`) or fix the canonical
+source first. Only agentsync-managed (git-backed) user-scope dirs can be reverted.
+
+```bash
+agentsync revert claude              # undo the most recent apply to ~/.claude
+agentsync revert claude --to HEAD~3  # roll back further
+agentsync revert --all --dry-run     # preview reverting every managed dir
 ```
 
 ### `status`


### PR DESCRIPTION
## Summary

Implements **issue #118** — git-version the rendered destination agent dirs so a
bad `agentsync apply` is revertible.

Each user-scope destination dir (`~/.claude`, `~/.codex`, …) gets its **own
local-only git repo**; `apply` records a checkpoint commit after every run that
changes managed files there, and a new **`agentsync revert <agent>`** rolls a dir
back to a prior checkpoint (append-only). Governed by a new
`[destination_directory_git_backup]` table (`mode = "prompt" | "on" | "off"`);
opt-out prompt on first use, `apply --no-git-backup` bypass for CI. These repos are
**never pushed**.

This PR began as the design spec + plan (approved in the first two review rounds,
in `docs/superpowers/`) and now carries the full implementation on the same branch.

### What landed (by milestone / commit)

- **`feat(git)`** — `internal/git`: the entire go-git surface, isolated.
  `Detect`/`Init`/`Stage`/`CommitStaged`/`Log`/`Resolve`/`Plan`/`Restore`. Init
  stamps an `[agentsync] managed=true` marker into `.git/config`, writes a
  local-only `AGENTSYNC_LOCAL_HISTORY.md` notice, and chmods `.git` to `0o700`.
  Restore is **append-only** (hard-reset to target → soft-reset to HEAD → commit).
  `TestNoPushSurface` guards that the package exposes **no** remote/push API.
- **`feat(adapter,source)`** — `[destination_directory_git_backup]` schema
  (`EffectiveMode()`), project-overlay merge, and the optional `VersionedHome`
  adapter extension. The **nine deep adapters** implement it (each returns its
  single user-scope config dir); the **breadth tier abstains** — its targets are
  scattered/shared (`~/.agents/skills`) with no safe single dir to init.
  `TestVersionedHomeContract` pins this. `mode` persists via a comment-preserving
  line-splice (like `writeAgents`).
- **`feat(cli)` apply tail** — `runDestinationGitBackup`: group `written` by agent
  dir, detect (foreign → skip), init (`on`) or prompt (`prompt`, sticky), commit;
  captures managed-file deletions without sweeping in untracked user files;
  best-effort (never fails an apply). `apply --no-git-backup` flag.
- **`feat(cli)` revert** — `agentsync revert <agent>` (`--to`/`--all`/`--dry-run`),
  default undoes the most recent apply, prints the out-of-sync notice.
- **`feat(cli),docs`** — `doctor` status section + all docs (user-guide, README,
  website cli.mdx, concepts, architecture, the `init` scaffold, CHANGELOG).

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [ ] Tests / CI / tooling

## Test plan

- [x] New unit + integration tests throughout (all FS tests run in-container on
      `t.TempDir`, stdlib table-driven): `internal/git` (detect/init/commit/log/
      append-only restore + never-push guard), `VersionedHome` contract, config
      parse + mode persistence, apply-tail orchestration (on/off/`--no-git-backup`/
      empty/project/foreign/prompt-yes→on/prompt-never→off), an **end-to-end apply**
      that checkpoints once then no-ops on re-apply, and `revert`
      (default/`--to`/`--all`/`--dry-run`/errors + out-of-sync notice).
- [x] `go test ./...` green in-container (`AGENTSYNC_TEST_IN_CONTAINER=1`).
- [x] `golangci-lint` green (run with the pinned `GOTOOLCHAIN=go1.26.2`); `go mod
      tidy` is a no-op (no new deps — go-git was already vendored).
- [ ] `just test-release` — not runnable in this environment (`just` not installed);
      ran the equivalent `go test ./...` + lint by hand.

## Checklist

- [x] Conventional commit messages with scopes (`feat(git):`, `feat(adapter,source):`,
      `feat(cli):`, `docs:`).
- [x] Tests added/updated for the behavior changed.
- [x] Secret-handling invariants untouched: this adds **no** dest→source path and
      no `secrets.Resolved` unwrap; the new repos are local-only and never pushed
      (no remote/push API exists, guarded by a test). The accepted tradeoff
      (cleartext secrets in a never-pushed local history) is the issue's decision.
- [x] Docs updated in the same change (CLI surface + new config table), per the
      `CLAUDE.md` doc-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmpmxA4zbXNAxCnYdrHU9f