### PR TITLE
ci: stop running CI on merges to main; gate releases on it instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: ci
+# CI runs on PRs (the gate that keeps a red commit from merging) and as a
+# reusable workflow called at the top of the release pipeline (release.yml), so a
+# release can never publish from a commit that wouldn't pass CI. It deliberately
+# does NOT run on `push: branches: [main]`: a PR can't merge while its checks are
+# red, so a post-merge run on main only re-proves what the PR already proved —
+# wasted compute. The release path re-runs the suite via `workflow_call` exactly
+# because there's no longer a merge-to-main run for it to lean on.
 on:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
 
 # Single source of truth for the Go version: go.mod's `go` directive.
 # setup-go reads it via go-version-file below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Re-run the full CI suite (test-fast matrix, hermetic test-release gate, lint,
+  # goreleaser snapshot) against the exact commit being released, as the gate the
+  # rest of this workflow depends on. CI no longer runs on push-to-main, so there
+  # is no merge-time run to lean on; this `workflow_call` is how a release proves
+  # the commit is green before goreleaser publishes anything irreversible. On a
+  # `push: tags` trigger it runs against the tagged commit; on workflow_dispatch,
+  # against the dispatched ref's HEAD (the same commit the tag step below tags).
+  ci:
+    name: ci (pre-release gate)
+    uses: ./.github/workflows/ci.yml
+
   goreleaser:
     name: goreleaser (publish)
+    # Gate publication on the CI suite above: nothing ships from a red commit.
+    needs: ci
     # ubuntu-22.04: the Chocolatey step below runs `choco` under Mono, and
     # mono-complete installs cleanly from this image's apt repos (jammy). The whole
     # release — every channel — is produced in this one job. (This image is on


### PR DESCRIPTION
## Summary

CI (`ci.yml`) ran on both `pull_request` and `push: branches: [main]`. Because a PR can't merge while its required checks are red, the post-merge run on `main` only re-proved what the PR already proved — wasted Actions minutes on every merge.

This change:

- **`ci.yml`** — drops the `push: branches: [main]` trigger so CI runs **only on PRs**, and adds `workflow_call` so the suite can be invoked as a reusable workflow.
- **`release.yml`** — adds a `ci` job (`uses: ./.github/workflows/ci.yml`) that `goreleaser` now `needs:`, so the **full CI suite runs at the top of the release pipeline** against the exact commit being released. Nothing publishes from a commit that wouldn't pass CI — restoring the green-commit guarantee the merge-to-main run used to provide incidentally.

Works for both release entry points: `push: tags` runs CI against the tagged commit; `workflow_dispatch` runs it against the dispatched ref's HEAD (the same commit the tag step then tags).

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [x] Tests / CI / tooling

## Test plan

Workflow-only change (no Go code touched). Verified:

- [x] Both workflows parse as valid YAML; `ci.yml` triggers resolve to `pull_request` + `workflow_call` (no `push`), and `release.yml` jobs are `ci` → `goreleaser` (`needs: ci`) → `docs` (`needs: goreleaser`).
- [ ] `just test-release` is green (the release bar) — unchanged; this PR only alters when/how the suite is triggered, not what it runs.
- [ ] `just lint` is clean — unchanged; no Go sources modified.

## Checklist

- [x] Conventional commit messages with a scope (`ci: …`).
- [ ] Tests added/updated for the behavior changed. — N/A; CI config only, behavior is validated by the workflows running on this very PR.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path… — N/A; no such paths touched.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — No doc describes agentsync's own CI triggers (the lone `on: [push, pull_request]` in `website/.../ci-verification.mdx` is end-user guidance for *their* `agentsync verify`, not this repo's CI).

## Notes

- The release gate runs the **whole** CI suite, including `goreleaser-snapshot` — slightly redundant with the real publish build, but the simplest correct "run CI at the top of release" gate. Easy to trim to just `test-release`/`lint` later if preferred.
- Minor cache trade-off: without `main` runs, `setup-go`'s build cache won't be pre-warmed on the default branch for PRs to restore from — a small first-run efficiency hit per branch, not a correctness issue, and net-positive on the compute-savings goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEtZMLPHH7WhWzYSmZ8Jxs)_