### PR TITLE
feat(cli): add `version` subcommand as alias for `--version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `status --json` is
   unchanged and **never collapsed** — it still carries every tracked file, so the
   machine contract is stable.
+- **`agentsync version` is now a subcommand alias for `agentsync --version`.**
+  It renders the same version template as the `--version` flag, so the two
+  outputs can never drift.
 
 ### Fixed
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -689,6 +689,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source; drop parts to import a whole component or the agent's full config. Includes `plugin` (Claude), which re-fetches installed plugins + marketplaces **(network)**. `--scope project` reads the agent's *native project-scope* config (e.g. `<root>/.claude/`) and captures it into the project tree `<root>/.agentsync/`, seeding central state with the project scope + root. Plugin import is user-scope only. | `--dry-run --scope --project` |
 | `explain [<plugin>...]` | Show per-agent translation coverage for one or more plugins. | `--all --list --json` |
+| `version` | Print version information (alias for `--version`). | |
 
 Global: `-v/--verbose` for verbose logging on any command (in `status` it also
 expands each collapsed skill directory back to one row per bundled file).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,7 @@ func NewRoot() *cobra.Command {
 		newSecretsCmd(),
 		newExplainCmd(),
 		newImportCmd(),
+		newVersionCmd(),
 	)
 	return cmd
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -15,6 +15,20 @@ func TestRoot_VersionFlag(t *testing.T) {
 	}
 }
 
+func TestRoot_VersionCommandAliasesFlag(t *testing.T) {
+	cmdOut, err := runCLI(t, nil, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flagOut, err := runCLI(t, nil, "--version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmdOut != flagOut {
+		t.Fatalf("`version` output %q != `--version` output %q", cmdOut, flagOut)
+	}
+}
+
 func TestRoot_HelpListsSubcommands(t *testing.T) {
 	out, _ := runCLI(t, nil, "--help")
 	for _, sub := range []string{"init", "agent", "doctor", "verify", "apply"} {

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+// newVersionCmd registers `agentsync version` as an alias for the root
+// `--version` flag. It renders the root's version template (set via
+// SetVersionTemplate in NewRoot), so the two outputs can never drift.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information (alias for --version)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root := cmd.Root()
+			t, err := template.New("version").Parse(root.VersionTemplate())
+			if err != nil {
+				return err
+			}
+			return t.Execute(cmd.OutOrStdout(), root)
+		},
+	}
+}

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -34,6 +34,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `reconcile` | Interactively merge drift back into source. | `--auto-writeback --auto-override --auto-safe --scope --project` |
 | `import <agent>[:<component>[:<name>]]` | Capture native config into source. `--scope project` captures the agent's native project-scope config into the project tree. | `--dry-run --scope --project` |
 | `explain [<plugin>...]` | Show per-agent translation coverage for one or more plugins. | `--all --list --json` |
+| `version` | Print version information (alias for `--version`). | |
 
 ---
 
@@ -280,3 +281,4 @@ agentsync explain --list
 | `--agents <list>` | status | Scope the report to a comma-separated agent allowlist (`*` = all enabled; matches `mcp add --agents`). |
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. In `status`, also expands each collapsed skill directory back to one row per bundled file. |
+| `--version` | root | Print version information and exit. The `agentsync version` subcommand is an alias. |


### PR DESCRIPTION
## Summary

Adds `agentsync version` as a subcommand alias for `agentsync --version`.

The new command renders the **root's** version template — the same one set via `SetVersionTemplate` in `NewRoot` — by reading `cmd.Root().VersionTemplate()`. Because both forms render the identical template (commit/date metadata included), their output can never drift. The subcommand takes no args of its own (`cobra.NoArgs`); it's a pure print-and-exit alias.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [ ] Tests / CI / tooling

## Test plan

- Added `TestRoot_VersionCommandAliasesFlag`, which asserts `version` and `--version` produce **byte-identical** output (not merely "contains agentsync").
- Built with real ldflags and confirmed both forms print identically, e.g. `agentsync 1.2.3 (commit abc123, built 2026-06-29)`.
- `go test ./internal/cli/` passes (incl. the new test).
- `golangci-lint` reports 0 issues; `gofmt` clean.

- [ ] `just test-release` is green (the release bar)
- [x] `just lint` is clean

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. _(N/A — no secret/capture/source-writer paths touched.)_
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. _(Command tables in `docs/user-guide.md` and `website/.../reference/cli.mdx`, a `--version` global-flags row noting the alias, and a `[Unreleased]` CHANGELOG entry.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeLgyK5mpmXU2jM7DV5biw)_