### PR TITLE
fix: refuse empty secrets set values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- `agentsync secrets set` now refuses empty or whitespace-only values by default
+  and exposes `--allow-empty` for the rare case where storing an empty string is
+  deliberate (issue #165).
 - **Destination dirs can be git-versioned for one-command rollback (issue #118).**
   `agentsync apply` now optionally keeps each rendered destination dir in its own
   **local-only** git repo, recording a checkpoint commit after every apply that

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -513,9 +513,14 @@ Store the value in the age-encrypted vault — three ways:
 ```bash
 agentsync secrets set github.token --stdin    # from stdin (best for scripts / 1Password CLI)
 agentsync secrets set github.token            # interactive prompt, echo off
+agentsync secrets set github.token --stdin --allow-empty  # deliberately store an empty value
 agentsync secrets edit                        # open the whole vault in $EDITOR
 agentsync secrets get github.token            # read one back (to verify)
 ```
+
+`secrets set` refuses empty or whitespace-only values by default so a failed
+paste does not silently store a broken secret; pass `--allow-empty` only when an
+empty string is intentional.
 
 `${secret:…}` is resolved at apply time and written into native config; `${env:…}`
 pulls from the environment. The resolved value is **never** captured back into
@@ -680,7 +685,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
-| `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
+| `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. `set` refuses empty/whitespace-only values unless `--allow-empty` is passed. | `set --stdin --allow-empty` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). Git-versions each user-scope destination dir into a local-only repo (opt-out) so a bad apply is revertible. | `--dry-run --scope --project --no-git-backup` |
 | `revert <agent>` | Roll a destination dir back to a prior apply checkpoint (append-only). Default undoes the most recent apply; prints an out-of-sync notice. | `--to --all --dry-run` |

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -54,6 +54,7 @@ func newSecretsCmd() *cobra.Command {
 // hanging on a non-interactive prompt.
 func newSecretsSetCmd() *cobra.Command {
 	var useStdin bool
+	var allowEmpty bool
 	cmd := &cobra.Command{
 		Use:   "set <key>[=<value>]",
 		Short: "set (or update) a secret key (prompts securely by default)",
@@ -61,11 +62,12 @@ func newSecretsSetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home := paths.AgentsyncHome(paths.OSEnv{})
 			return withGlobalLock(home, func() error {
-				return secretsSet(cmd, args[0], useStdin)
+				return secretsSet(cmd, args[0], useStdin, allowEmpty)
 			})
 		},
 	}
 	cmd.Flags().BoolVar(&useStdin, "stdin", false, "read the secret value from stdin (recommended for scripts)")
+	cmd.Flags().BoolVar(&allowEmpty, "allow-empty", false, "permit storing an empty-string secret (refused by default)")
 	return cmd
 }
 
@@ -333,7 +335,7 @@ func secretsGet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func secretsSet(cmd *cobra.Command, arg string, useStdin bool) error {
+func secretsSet(cmd *cobra.Command, arg string, useStdin, allowEmpty bool) error {
 	cfg, home, err := loadSecretsConfig()
 	if err != nil {
 		return err
@@ -351,6 +353,9 @@ func secretsSet(cmd *cobra.Command, arg string, useStdin bool) error {
 	key, value, err := resolveSecretKeyValue(cmd, arg, useStdin)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(value) == "" && !allowEmpty {
+		return fmt.Errorf("refusing to store an empty or whitespace-only value for secret %q; pass --allow-empty to store it deliberately", key)
 	}
 
 	m, err := decryptToMap(cfg, home)

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -235,6 +235,83 @@ func TestSecretsSet_StdinPath(t *testing.T) {
 	}
 }
 
+func TestSecretsSet_RefusesEmptyValue(t *testing.T) {
+	const sentinel = "ghp_SENTINEL_NEVER_ECHO_THIS_TOKEN"
+
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+	}{
+		{
+			name:  "stdin-empty",
+			stdin: "",
+			args:  []string{"secrets", "set", "github.token", "--stdin"},
+		},
+		{
+			name:  "stdin-newline-only",
+			stdin: "\n",
+			args:  []string{"secrets", "set", "github.token", "--stdin"},
+		},
+		{
+			name:  "stdin-whitespace-only",
+			stdin: "   ",
+			args:  []string{"secrets", "set", "github.token", "--stdin"},
+		},
+		{
+			name: "legacy-empty",
+			args: []string{"secrets", "set", "github.token="},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, _, _, _ := setupSecretsEnv(t)
+
+			var out string
+			var err error
+			if strings.HasPrefix(tt.name, "stdin-") {
+				out, err = runCLIWithStdin(t, env, tt.stdin, tt.args...)
+			} else {
+				out, err = runCLI(t, env, tt.args...)
+			}
+			if err == nil {
+				t.Fatalf("expected empty secret value to be refused, got success:\n%s", out)
+			}
+			if strings.Contains(out, "secret \"github.token\" set") {
+				t.Fatalf("refused empty value must not print success:\n%s", out)
+			}
+			if strings.Contains(out, sentinel) || strings.Contains(err.Error(), sentinel) {
+				t.Fatalf("SECURITY: refusal path echoed sentinel value: err=%v out=%q", err, out)
+			}
+
+			got, getErr := runCLI(t, env, "secrets", "get", "github.token")
+			if getErr == nil {
+				t.Fatalf("refused value should not have been stored; get succeeded with %q", got)
+			}
+			if !strings.Contains(got, "not found") && !strings.Contains(getErr.Error(), "not found") {
+				t.Fatalf("get after refusal should report not found: err=%v out=%q", getErr, got)
+			}
+		})
+	}
+}
+
+func TestSecretsSet_AllowEmptyStoresEmpty(t *testing.T) {
+	env, _, _, _ := setupSecretsEnv(t)
+	out, err := runCLIWithStdin(t, env, "", "secrets", "set", "github.token", "--stdin", "--allow-empty")
+	if err != nil {
+		t.Fatalf("secrets set --allow-empty: %v\n%s", err, out)
+	}
+
+	got, err := runCLI(t, env, "secrets", "get", "github.token")
+	if err != nil {
+		t.Fatalf("get after allow-empty set: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != "" {
+		t.Fatalf("expected empty secret value, got %q", got)
+	}
+}
+
 // TestSecretsSet_LegacyArgWarns proves the back-compat path still works
 // but warns the user that the value just hit argv.
 func TestSecretsSet_LegacyArgWarns(t *testing.T) {

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -25,7 +25,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
-| `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. | `set --stdin` |
+| `secrets set\|get\|edit <key>` | Manage age-encrypted secrets. `set` refuses empty/whitespace-only values unless `--allow-empty` is passed. | `set --stdin --allow-empty` |
 | `update` | **(network)** Refresh marketplace cache + pins. | `--apply --auto-safe --scope --project` |
 | `apply` | Render source → write agent configs (offline). Git-versions each destination dir (opt-out). | `--dry-run --scope --project --no-git-backup` |
 | `revert <agent>` | Roll a destination dir back to a prior apply checkpoint (local-only git history). | `--to --all --dry-run` |
@@ -125,9 +125,14 @@ Manage the age-encrypted vault. Full guide: [Secrets](/guides/secrets/).
 
 ```bash
 agentsync secrets set github.token --stdin
+agentsync secrets set github.token --stdin --allow-empty  # deliberately store an empty value
 agentsync secrets get github.token
 agentsync secrets edit
 ```
+
+`secrets set` refuses empty or whitespace-only values by default so a failed paste
+does not silently store a broken secret; pass `--allow-empty` only when an empty
+string is intentional.
 
 ---
 


### PR DESCRIPTION
## Summary
- refuse empty or whitespace-only `agentsync secrets set` values by default
- add `--allow-empty` for deliberate empty-string secrets
- cover stdin empty/newline/whitespace, legacy `key=`, and allow-empty vault round-trip
- document the new flag/refusal in the user guide, website CLI reference, and changelog

Fixes #165.

## Validation
```console
git diff --check
AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli -run 'TestSecrets(Set|Get|Edit)'
# ok  	github.com/spxrogers/agentsync/internal/cli	0.058s
AGENTSYNC_TEST_IN_CONTAINER=1 go test ./internal/cli
# ok  	github.com/spxrogers/agentsync/internal/cli	40.130s
```

Note: this runner does not have `just` installed, so I could not run `just lint`; `gofmt` was run on the touched Go files and `git diff --check` is clean.