### PR TITLE
test: re-home LSP sibling-section regressions + #73 review follow-ups

### DIFF
--- a/docs/superpowers/specs/2026-05-04-agentsync-design.md
+++ b/docs/superpowers/specs/2026-05-04-agentsync-design.md
@@ -258,7 +258,7 @@ A plugin is a bag of components. Each component is translated independently per 
 | Subagent | ✓ `~/.claude/agents/X.md` | ◐ projected — `.opencode/agents/X.md` w/ frontmatter munging (`tools` → `permission`, `color` drops, `mode: subagent` added) | ◐ projected — `.codex/agents/X.toml` (markdown→TOML; body→`developer_instructions`) | ✗ skip |
 | Slash command | ✓ `~/.claude/commands/X.md` | ◐ projected — `.opencode/commands/X.md`; body preserved as template, frontmatter fields don't all map (`argument-hint` drops, OpenCode-specific fields not added) | ✗ skip — no custom slash commands | ◐ projected — `.cursor/rules/X.mdc` Manual rule, body=template |
 | Hook | ✓ JSON in settings | ✗ skip(warn) — OpenCode hooks are JS/TS plugins (shim generation deferred) | ◐ projected — `hooks.json`, 5/9 events overlap, requires `[features] codex_hooks = true` | ◐ projected — `hooks.json`, ~6/9 events overlap (Tab hooks unique to Cursor) |
-| LSP server | ✓ native | ✗ skip(warn) — LSP projection deferred to v1.x | ✗ skip(warn) — no LSP concept | ✗ skip(warn) — Cursor inherits VSCode LSP but projection deferred |
+| LSP server | ✗ skip — corrected post-design: Claude Code reads LSP only from plugin manifests, not `settings.json` (see #66/#73) | ✗ skip(warn) — LSP projection deferred to v1.x | ✗ skip(warn) — no LSP concept | ✗ skip(warn) — Cursor inherits VSCode LSP but projection deferred |
 
 **Skill-write strategy**: when a skill must reach multiple agents that read different paths, agentsync writes the same `SKILL.md` content to each path directly. **No symlinks ever.** Two file ops per skill, both tracked in state. Robustness over disk-cost.
 
@@ -440,7 +440,7 @@ State is schema-versioned; future bumps add migrators in `internal/state/`.
 | Milestone | Scope |
 |---|---|
 | **M0** Skeleton | cobra root, `AGENTSYNC_HOME` / `AGENTSYNC_TARGET_ROOT` resolution, adapter interface + registry, source loader (TOML→Go structs), state manager (`targets.json` with fsync+rename), atomic write + flock, slog. |
-| **M1** Claude adapter (full) | Detect/Read/Plan/Apply for all 7 components incl. LSP. `~/.claude/settings.json` and `~/.claude.json` key-level merge with `applied_keys`; foreign keys preserved. Skill frontmatter passthrough. |
+| **M1** Claude adapter (full) | Detect/Read/Plan/Apply for the six supported components (memory, MCP, skill, subagent, command, hook; LSP was scoped here but downgraded to a documented skip post-design — Claude loads LSP only from plugin manifests, see #66/#73). `~/.claude/settings.json` and `~/.claude.json` key-level merge with `applied_keys`; foreign keys preserved. Skill frontmatter passthrough. |
 | **M2** OpenCode adapter | MCP, AGENTS.md, skills (write to `.claude/skills/`), agents (`.opencode/agents/`), commands (`.opencode/commands/`). Hooks: ✗ skip(warn). LSP: ✗ skip(warn). JSONC round-trip via `tailscale/hujson`. |
 | **M3** Drift / status / diff / reconcile | 3-way classifier, file + key levels, prompt loop, bulk hotkeys, `--auto-*` flags, foreign-key reporting. |
 | **M4** Marketplaces + plugins | All 5 plugin sources (relative, github, url, git-subdir, npm). go-git fetch + sparse for git-subdir. npm tarball fetch via registry HTTP. `strict` mode handling. `${CLAUDE_PLUGIN_ROOT}` substitution. Per-component projection, translation report, sha pinning, update modes. |

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -99,11 +99,11 @@ func Plan(r secrets.Resolved, reg *adapter.Registry, agents []string, scope adap
 				if IsKeyMerge(op.MergeStrategy) {
 					owned := ownedKeysFor(s, name, scope, project, op.Path, userHome)
 					// Scope each op's OwnedKeys to the top-level sections THIS op
-					// writes. Several ops can target one file (claude writes
-					// mcpServers, hooks, AND lspServers to settings.json); without
-					// scoping, every op carried the union of owned pointers and
-					// MergeKeys' removal step deleted the OTHER ops' sections —
-					// last op wins, earlier sections wiped on the next apply.
+					// writes. Several ops can target one file (codex writes
+					// mcp_servers AND hooks to config.toml); without scoping, every
+					// op carried the union of owned pointers and MergeKeys' removal
+					// step deleted the OTHER ops' sections — last op wins, earlier
+					// sections wiped on the next apply.
 					ops[i].OwnedKeys = scopeOwnedToSections(owned, op.Content)
 				}
 			}

--- a/internal/render/sibling_section_test.go
+++ b/internal/render/sibling_section_test.go
@@ -108,6 +108,12 @@ func codexTwoSection() source.Canonical {
 // other section is wiped. scopeOwnedToSections (pipeline.go) fixes it; this
 // proves it stays fixed. (Re-homed from Claude hooks+lspServers to Codex
 // mcp_servers+hooks after #73 dropped Claude's settings.json LSP write.)
+//
+// This guards the interaction at the render-pipeline layer. The same
+// no-sibling-wipe property is also covered end-to-end through the CLI by
+// TestApply_Codex_MCPAndHooks_Converge (internal/cli), and for the single-apply
+// case with a fake adapter by TestRenderApply_MultipleMergeOpsSamePathAllApplied
+// (writer_test.go) — three altitudes, one property.
 func TestApply_MultiSectionSameFile_NoSiblingWipe(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, ".agentsync")
@@ -131,7 +137,10 @@ func TestApply_MultiSectionSameFile_NoSiblingWipe(t *testing.T) {
 // TestApply_WholeSectionRemoval_StillCleansUp guards the removal case that the
 // per-op-section scoping must not regress: removing ALL hooks (while keeping the
 // MCP server) must still delete the orphaned [hooks.*] section from config.toml,
-// even though another section's op still writes that file.
+// even though another section's op still writes that file. Unlike the
+// convergence tests cross-referenced above, this is the only coverage for
+// per-section orphan cleanup while a sibling section stays live (it exercises
+// orphanCleanupOps, a different pipeline path than scopeOwnedToSections).
 func TestApply_WholeSectionRemoval_StillCleansUp(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, ".agentsync")

--- a/internal/render/sibling_section_test.go
+++ b/internal/render/sibling_section_test.go
@@ -6,18 +6,22 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
+
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/adapter/codex"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
-// applyOnce runs the real plan→apply→prune→record cycle the apply command uses.
-func applyOnce(t *testing.T, reg *adapter.Registry, c source.Canonical, st *state.Targets, home, userHome string) {
+// applyOnce runs the real plan→apply→prune→record cycle the apply command uses
+// for the given agents.
+func applyOnce(t *testing.T, reg *adapter.Registry, agents []string, c source.Canonical, st *state.Targets, home, userHome string) {
 	t.Helper()
-	plan, err := render.Plan(secrets.ForRender(c), reg, []string{"claude"}, adapter.ScopeUser, "", st, userHome)
+	plan, err := render.Plan(secrets.ForRender(c), reg, agents, adapter.ScopeUser, "", st, userHome)
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -47,6 +51,19 @@ func readSettings(t *testing.T, tmp string) map[string]any {
 	return m
 }
 
+func readCodexConfig(t *testing.T, tmp string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(tmp, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	var m map[string]any
+	if err := toml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse config.toml: %v", err)
+	}
+	return m
+}
+
 func TestApply_ClaudeLSPSkipsSettingsJSON(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, ".agentsync")
@@ -59,7 +76,7 @@ func TestApply_ClaudeLSPSkipsSettingsJSON(t *testing.T) {
 		LSPServers: []source.LSPServer{{ID: "gopls", Spec: source.LSPServerSpec{Command: "gopls"}}},
 	}
 	st := state.New()
-	applyOnce(t, reg, c, st, home, tmp)
+	applyOnce(t, reg, []string{"claude"}, c, st, home, tmp)
 
 	m := readSettings(t, tmp)
 	hooks, _ := m["hooks"].(map[string]any)
@@ -68,5 +85,74 @@ func TestApply_ClaudeLSPSkipsSettingsJSON(t *testing.T) {
 	}
 	if _, ok := m["lspServers"]; ok {
 		t.Fatalf("Claude LSP must be skipped instead of written to ignored settings.json key: %+v", m)
+	}
+}
+
+// codexTwoSection is the multi-section canonical the two regressions below drive
+// through the real pipeline: Codex renders MCP servers AND hooks as two separate
+// merge-toml-keys ops to the SAME ~/.codex/config.toml (`[mcp_servers.*]` +
+// `[[hooks.*]]`). This is the shape Claude used to have with settings.json
+// hooks+lspServers; #66/#73 removed Claude's ignored LSP write, so Codex is now
+// the live vehicle for the pipeline's per-op OwnedKeys section-scoping.
+func codexTwoSection() source.Canonical {
+	return source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github", Server: source.MCPServerSpec{Type: "stdio", Command: "npx"}}},
+		Hooks:      []source.Hook{{Event: "Stop", Type: "command", Command: "echo x"}},
+	}
+}
+
+// TestApply_MultiSectionSameFile_NoSiblingWipe is the regression for the
+// showstopper: two key-merge ops target one file as separate sections. Each op
+// received ALL owned pointers for the file, so on the second apply the
+// mcp_servers op deleted the hooks pointer and vice versa — last op wins, the
+// other section is wiped. scopeOwnedToSections (pipeline.go) fixes it; this
+// proves it stays fixed. (Re-homed from Claude hooks+lspServers to Codex
+// mcp_servers+hooks after #73 dropped Claude's settings.json LSP write.)
+func TestApply_MultiSectionSameFile_NoSiblingWipe(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	reg := adapter.NewRegistry()
+	if err := reg.Register(codex.New(codex.Options{TargetRoot: tmp})); err != nil {
+		t.Fatal(err)
+	}
+	st := state.New()
+	applyOnce(t, reg, []string{"codex"}, codexTwoSection(), st, home, tmp)
+	applyOnce(t, reg, []string{"codex"}, codexTwoSection(), st, home, tmp) // second apply is where the wipe happened
+
+	m := readCodexConfig(t, tmp)
+	if servers, _ := m["mcp_servers"].(map[string]any); len(servers) == 0 {
+		t.Fatalf("mcp_servers section was wiped on re-apply: %+v", m)
+	}
+	if hooks, _ := m["hooks"].(map[string]any); len(hooks) == 0 {
+		t.Fatalf("hooks section was wiped on re-apply: %+v", m)
+	}
+}
+
+// TestApply_WholeSectionRemoval_StillCleansUp guards the removal case that the
+// per-op-section scoping must not regress: removing ALL hooks (while keeping the
+// MCP server) must still delete the orphaned [hooks.*] section from config.toml,
+// even though another section's op still writes that file.
+func TestApply_WholeSectionRemoval_StillCleansUp(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	reg := adapter.NewRegistry()
+	if err := reg.Register(codex.New(codex.Options{TargetRoot: tmp})); err != nil {
+		t.Fatal(err)
+	}
+	st := state.New()
+	applyOnce(t, reg, []string{"codex"}, codexTwoSection(), st, home, tmp)
+
+	// Remove hooks entirely; keep the MCP server.
+	noHooks := source.Canonical{
+		MCPServers: []source.MCPServer{{ID: "github", Server: source.MCPServerSpec{Type: "stdio", Command: "npx"}}},
+	}
+	applyOnce(t, reg, []string{"codex"}, noHooks, st, home, tmp)
+
+	m := readCodexConfig(t, tmp)
+	if hooks, _ := m["hooks"].(map[string]any); len(hooks) != 0 {
+		t.Fatalf("removed hook section was not cleaned up: %+v", m["hooks"])
+	}
+	if servers, _ := m["mcp_servers"].(map[string]any); len(servers) == 0 {
+		t.Fatalf("mcp_servers wrongly removed when only hooks were dropped: %+v", m)
 	}
 }

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/source"
@@ -136,24 +137,11 @@ func TestReReferenceCanonical_LSPSecretFields(t *testing.T) {
 	}
 
 	walkSecretFields(ingested, func(loc secretFieldLoc, s string) string {
-		if s == live || containsString(s, live) {
+		if strings.Contains(s, live) {
 			t.Errorf("LSP re-reference residual leak at %+v: %q", loc, s)
 		}
 		return s
 	})
-}
-
-func containsString(s, substr string) bool {
-	return len(substr) > 0 && len(s) >= len(substr) && (s == substr || containsStringAt(s, substr))
-}
-
-func containsStringAt(s, substr string) bool {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 // TestReReferenceCanonical_ValueFallbackOnStructuralShift is the regression for


### PR DESCRIPTION
## Summary

Three review follow-ups to #73 (skip unsupported Claude LSP settings). #73 is correct as merged; these address coverage/quality gaps it left behind. No production behavior changes — tests, one code comment, and a historical doc.

**1. Re-home the deleted sibling-section regressions onto Codex.** #73 dropped Claude's ignored `settings.json#/lspServers` write, which was the *vehicle* for two render-pipeline regressions in `internal/render/sibling_section_test.go`:
- `TestApply_MultiSectionSameFile_NoSiblingWipe` — the showstopper where two key-merge ops to one file each carried the *union* of owned pointers, so the second apply wiped a sibling section.
- `TestApply_WholeSectionRemoval_StillCleansUp` — removing one section must still prune its orphaned keys while another op keeps writing the file.

Claude now writes a single key-merge section to `settings.json`, so those tests could no longer exercise the bug and were removed/gutted in #73. But the pipeline bug they guard (`scopeOwnedToSections`) is still reachable by **any** adapter that writes 2+ key-merge sections to one file — **Codex** is exactly that shape today (`mcp_servers` + `hooks` → `~/.codex/config.toml`). Re-homed both regressions onto Codex so the coverage is preserved rather than silently dropped (per CLAUDE.md's "capture it or acknowledge it — never drop it silently"). Also refreshed the load-bearing `scopeOwnedToSections` comment in `pipeline.go`, which still cited Claude's removed `lspServers` case.

**2. Drop the hand-rolled `strings.Contains`.** The LSP residual-leak scan in `internal/secrets/rereference_test.go` reimplemented `strings.Contains` as `containsString`/`containsStringAt`; replaced with the stdlib call.

**3. Correct the historical v1 design spec.** `docs/superpowers/specs/2026-05-04-agentsync-design.md` still listed Claude LSP as `✓ native`; annotated the component table and the M1 milestone as corrected post-design (see #66/#73), kept as a point-in-time annotation rather than a rewrite.

## Type of change

- [x] Bug fix (test-coverage restoration)
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

- `go test ./internal/render/ ./internal/secrets/ ./internal/adapter/codex/ ./internal/adapter/claude/` (with the `AGENTSYNC_TEST_IN_CONTAINER=1` guard) — all green.
- **Verified the re-homed regression has teeth**: reintroduced the sibling-wipe bug (`OwnedKeys = owned` instead of `scopeOwnedToSections(owned, op.Content)`) and confirmed `TestApply_MultiSectionSameFile_NoSiblingWipe` fails with `mcp_servers section was wiped on re-apply`, then restored the fix.
- `gofmt`/`gofumpt` clean, `go build ./...` clean, `go mod tidy` produces no `go.mod`/`go.sum` drift.
- `golangci-lint run ./internal/render/... ./internal/secrets/...` → **0 issues**.
- [ ] `just test-release` is green (the release bar) — not run: no `just`/container harness in this environment; ran the focused package set with the container guard instead.
- [ ] `just lint` is clean — ran the equivalent container-safe invocation (`GOTOOLCHAIN=go1.26.2 golangci-lint@v2.12.2`) → 0 issues; gofmt/gofumpt/`go mod tidy` clean.

## Checklist

- [x] Conventional commit messages with a scope (`test(render):`, `test(secrets):`, `docs(spec):`).
- [x] Tests added/updated for the behavior changed (regressions re-homed onto Codex).
- [x] Touches `internal/secrets` — change is test-only (swaps a hand-rolled substring helper for `strings.Contains`); re-read the secret-handling invariants and did not weaken them.
- [x] Docs updated (historical design spec corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDVCzWy5ARfp9N3TFEKeH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDVCzWy5ARfp9N3TFEKeH5)_