### PR TITLE
feat(project)!: project scope requires explicitly declared agents

### DIFF
--- a/.agentsync/agentsync.toml
+++ b/.agentsync/agentsync.toml
@@ -4,10 +4,11 @@
 # share project-scoped agent config with collaborators.
 
 [agents]
-# Leave this empty to inherit the agents you enabled at user scope, or pin a
-# subset for this project:
-# claude   = { enabled = true }
-# opencode = { enabled = true }
+# Project scope renders ONLY to the agents declared here — this committed table
+# is authoritative, and user-scope agents are never inherited, so every
+# collaborator gets the same render from the same source.
+claude = { enabled = true }
+codex  = { enabled = true }
 
 # Author project components by adding files under this tree (mcp/<id>.toml,
 # skills/<name>/SKILL.md, agents/<name>.md, commands/<name>.md, hooks/<event>.toml,

--- a/.agentsync/agentsync.toml
+++ b/.agentsync/agentsync.toml
@@ -2,15 +2,16 @@
 # Rendered into <repo>/.claude/, <repo>/.opencode/, <repo>/.codex/, … by
 # 'agentsync apply' when run inside this repo. Commit this .agentsync/ tree to
 # share project-scoped agent config with collaborators.
-
-[agents]
-# Project scope renders ONLY to the agents declared here — this committed table
-# is authoritative, and user-scope agents are never inherited, so every
-# collaborator gets the same render from the same source.
-claude = { enabled = true }
-codex  = { enabled = true }
-
+#
 # Author project components by adding files under this tree (mcp/<id>.toml,
 # skills/<name>/SKILL.md, agents/<name>.md, commands/<name>.md, hooks/<event>.toml,
 # lsp/<id>.toml, memory/AGENTS.md) or capture existing native config with
 # 'agentsync import <agent> --scope project'.
+#
+# Project scope renders ONLY to the agents declared in [agents] below — the
+# committed table is authoritative, and user-scope agents are never inherited,
+# so every collaborator gets the same render from the same source.
+
+[agents]
+claude = { enabled = true }
+codex  = { enabled = true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   (issue #183).** A project tree's `[agents]` table in
   `<root>/.agentsync/agentsync.toml` is now **authoritative**: project-scope
   rendering targets exactly the agents the project declares, and an empty or
-  missing table is a **hard error** on `apply`/`status`/`diff`/`reconcile`/
-  `verify` instead of silently inheriting the current user's enabled agents.
+  missing table is a **hard error** on every scope-aware render path —
+  `apply`/`status`/`diff`/`reconcile`/`update --apply`/`verify` — instead of
+  silently inheriting the current user's enabled agents.
   Inheritance made the committed project tree render differently on each
   collaborator's machine (whoever ran apply decided which `.claude/`, `.codex/`,
   … trees existed); now identical source always produces an identical render.
@@ -30,7 +31,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   <path>` and edit the project tree's own `[agents]` declaration (project
   entries are written without the redundant `scope` key). At project scope,
   `agent disable --purge` removes only that project's rendered files and state
-  — never the user's machine-wide destinations or another repo's files.
+  — never the user's machine-wide destinations or another repo's files. (At
+  user scope, `--purge` keeps its historical semantics: it cleans up that
+  agent's rendered files across every scope and project.) `agent add/enable/…`
+  rewrites of the `[agents]` table are now also validated fail-closed: if the
+  regenerated file would not re-parse (e.g. an exotic TOML construct the
+  rewriter cannot splice), the command refuses and leaves the file untouched.
 
 - **Docs website: new "drafting table" visual identity.** agentsync.cc gets its
   own look instead of stock Starlight: Space Grotesk / JetBrains Mono

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **BREAKING: project scope now requires the project to declare its own agents
+  (issue #183).** A project tree's `[agents]` table in
+  `<root>/.agentsync/agentsync.toml` is now **authoritative**: project-scope
+  rendering targets exactly the agents the project declares, and an empty or
+  missing table is a **hard error** on `apply`/`status`/`diff`/`reconcile`/
+  `verify` instead of silently inheriting the current user's enabled agents.
+  Inheritance made the committed project tree render differently on each
+  collaborator's machine (whoever ran apply decided which `.claude/`, `.codex/`,
+  … trees existed); now identical source always produces an identical render.
+  `import --scope project` is deliberately exempt so a tree can still be
+  bootstrapped from native config before agents are declared. **Migration:**
+  projects that relied on an empty `[agents]` must now declare their agents —
+  run `agentsync agent add <name> --scope project` (or edit the `[agents]`
+  table) for each agent the project should render to.
+- **All `agent` subcommands are scope-aware.** `agent
+  add|remove|list|enable|disable` now take `--scope project` / `--project
+  <path>` and edit the project tree's own `[agents]` declaration (project
+  entries are written without the redundant `scope` key). At project scope,
+  `agent disable --purge` removes only that project's rendered files and state
+  — never the user's machine-wide destinations or another repo's files.
+
 - **Docs website: new "drafting table" visual identity.** agentsync.cc gets its
   own look instead of stock Starlight: Space Grotesk / JetBrains Mono
   (self-hosted), a warm graphite + amber palette (manila drafting-paper light

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   user scope, `--purge` keeps its historical semantics: it cleans up that
   agent's rendered files across every scope and project.) `agent add/enable/…`
   rewrites of the `[agents]` table are now also validated fail-closed: if the
-  regenerated file would not re-parse (e.g. an exotic TOML construct the
-  rewriter cannot splice), the command refuses and leaves the file untouched.
+  regenerated file would not re-parse, or would alter ANY data outside the
+  `[agents]` table (e.g. an exotic TOML construct the rewriter cannot splice,
+  like a multi-line string containing an `[agents]`-shaped line), the command
+  refuses and leaves the file untouched.
 
 - **Docs website: new "drafting table" visual identity.** agentsync.cc gets its
   own look instead of stock Starlight: Space Grotesk / JetBrains Mono

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,9 +60,15 @@ source.Canonical
 At **project scope** the same canonical is loaded a second time from the repo's
 `<root>/.agentsync/` tree (identical layout) and overlaid onto the user canonical
 by `project.Merge`: entries are merged by id/name (project wins), project memory
-is appended, an empty project `[agents]` inherits the user's enabled agents, and
-a project `plugins/<id>.toml` with `disabled = true` is excluded from projection
-in that repo. The retired M5 single-file `.agentsync.toml` marker is no longer
+is appended, and a project `plugins/<id>.toml` with `disabled = true` is excluded
+from projection in that repo. The project's `[agents]` table is **authoritative**
+— `project.Merge` never inherits the user's enabled agents, so identical
+committed source renders identically for every collaborator. An empty or absent
+project `[agents]` is rejected before render by `requireProjectAgents`
+(`internal/cli`), which every scope-aware command reaches via
+`loadProjectedForScope` (`verify` calls it on its own load path); the error
+points at `agentsync agent add <name> --scope project`. `import --scope project`
+is deliberately exempt: it is the capture path used to bootstrap a tree. The retired M5 single-file `.agentsync.toml` marker is no longer
 read — `project.Discover` surfaces a migration error if it finds one.
 
 **Managed memory banner.** Every rendered memory file (`CLAUDE.md`, `AGENTS.md`,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -120,8 +120,14 @@ project tree is ambiguous, so agentsync **prompts** for project-vs-user (or, whe
 non-interactive / `--no-input`, errors rather than guessing). It never silently
 acts on a tree it merely detected. The project tree is **overlaid** onto the
 user canonical: a project entry replaces a user entry with the same id/name, new
-entries are added, project memory is appended, and an empty `[agents]` inherits
-the user's enabled agents. A project `plugins/<id>.toml` with `disabled = true`
+entries are added, and project memory is appended. The project's `[agents]`
+table is **authoritative**: project scope renders only to the agents the project
+itself declares, never the user's enabled agents — so a committed tree produces
+the same render on every collaborator's machine. A project that declares no
+agents is a hard error on `apply`/`status`/`diff`/`reconcile`/`verify` (declare
+them with `agentsync agent add <name> --scope project`); `import --scope
+project` stays available for bootstrapping the tree from native config first. A
+project `plugins/<id>.toml` with `disabled = true`
 suppresses that plugin's components in the repo. (The retired M5 single-file
 `.agentsync.toml` marker is no longer read; `agentsync init --scope project`
 prints how to migrate.)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -124,9 +124,10 @@ entries are added, and project memory is appended. The project's `[agents]`
 table is **authoritative**: project scope renders only to the agents the project
 itself declares, never the user's enabled agents — so a committed tree produces
 the same render on every collaborator's machine. A project that declares no
-agents is a hard error on `apply`/`status`/`diff`/`reconcile`/`verify` (declare
-them with `agentsync agent add <name> --scope project`); `import --scope
-project` stays available for bootstrapping the tree from native config first. A
+agents is a hard error on every scope-aware render path —
+`apply`/`status`/`diff`/`reconcile`/`update --apply`/`verify` (declare agents
+with `agentsync agent add <name> --scope project`); `import --scope project`
+stays available for bootstrapping the tree from native config first. A
 project `plugins/<id>.toml` with `disabled = true`
 suppresses that plugin's components in the repo. (The retired M5 single-file
 `.agentsync.toml` marker is no longer read; `agentsync init --scope project`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -335,7 +335,9 @@ Every agent command also takes `--scope project` / `--project <path>` to manage
 the **project's own** `[agents]` declaration in `<root>/.agentsync/agentsync.toml`
 instead of the user registry — project scope renders only to agents declared
 there (see [Project-local config](#project-local-config)). At project scope,
-`disable --purge` removes only that project's rendered files.
+`disable --purge` removes only that project's rendered files; at user scope,
+`--purge` cleans up that agent's rendered files across every scope and project
+(the historical behavior).
 
 > All nine deep adapters (`claude`, `opencode`, `codex`, `cursor`, `gemini`,
 > `continue`, `windsurf`, `roo`, `cline`) plus 22 breadth-tier agents work with
@@ -591,9 +593,10 @@ replaces a user entry with the same id/name, new entries are appended, and
 project memory is appended after user memory. The project's `[agents]` table is
 **authoritative** — project scope renders only to the agents the project itself
 declares, never your user-scope agents. A project that declares none is a hard
-error on `apply`/`status`/`diff`/`reconcile`/`verify` (run `agentsync agent add
-<name> --scope project` to fix); `import --scope project` still works before any
-agents are declared, so you can bootstrap the tree from native config first.
+error on every scope-aware render path — `apply`/`status`/`diff`/`reconcile`/
+`update --apply`/`verify` (run `agentsync agent add <name> --scope project` to
+fix); `import --scope project` still works before any agents are declared, so
+you can bootstrap the tree from native config first.
 
 Apply at project scope (an explicit opt-in) and the overlay merges onto your
 user config:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -331,6 +331,12 @@ agentsync agent disable opencode  # stop applying to it (keeps source)
 agentsync agent disable opencode --purge   # also remove what it wrote
 ```
 
+Every agent command also takes `--scope project` / `--project <path>` to manage
+the **project's own** `[agents]` declaration in `<root>/.agentsync/agentsync.toml`
+instead of the user registry — project scope renders only to agents declared
+there (see [Project-local config](#project-local-config)). At project scope,
+`disable --purge` removes only that project's rendered files.
+
 > All nine deep adapters (`claude`, `opencode`, `codex`, `cursor`, `gemini`,
 > `continue`, `windsurf`, `roo`, `cline`) plus 22 breadth-tier agents work with
 > `agent add` — run `agentsync agent list --all` for the full set, or see the
@@ -549,9 +555,18 @@ this tree:
 ```toml
 # myrepo/.agentsync/agentsync.toml
 [agents]
-claude = { enabled = true }       # subset for this project;
-                                  # leave [agents] empty to inherit the user's
-                                  # enabled agents
+claude = { enabled = true }       # the agents THIS project renders to —
+                                  # required; user-scope agents are never
+                                  # inherited, so every collaborator gets the
+                                  # same render
+```
+
+Declare agents with the project-scope agent commands instead of hand-editing:
+
+```bash
+agentsync agent add claude --scope project     # or --project <path>
+agentsync agent list --scope project
+agentsync agent disable claude --scope project
 ```
 
 ```toml
@@ -572,9 +587,13 @@ Author project memory directly in `<root>/.agentsync/memory/AGENTS.md` (compose
 it from `fragments/` just like the user tree).
 
 The project tree is **overlaid** onto your user canonical: a project entry
-replaces a user entry with the same id/name, new entries are appended, project
-memory is appended after user memory, and an empty project `[agents]` inherits
-the user's enabled agents.
+replaces a user entry with the same id/name, new entries are appended, and
+project memory is appended after user memory. The project's `[agents]` table is
+**authoritative** — project scope renders only to the agents the project itself
+declares, never your user-scope agents. A project that declares none is a hard
+error on `apply`/`status`/`diff`/`reconcile`/`verify` (run `agentsync agent add
+<name> --scope project` to fix); `import --scope project` still works before any
+agents are declared, so you can bootstrap the tree from native config first.
 
 Apply at project scope (an explicit opt-in) and the overlay merges onto your
 user config:
@@ -676,7 +695,7 @@ Beta surface. `agentsync <command> --help` is always authoritative.
 | `init [<git-url>]` | Create `~/.agentsync/` (user scope); optionally clone a bootstrap repo. `--scope project` scaffolds a project tree at `<cwd>/.agentsync/` instead; `--project <path>` targets `<path>/.agentsync/` (implies project scope). A git-URL clone is user-scope only. | `--scope --project` |
 | `doctor` | Diagnose setup: PATH, home/state writability, config schema, secrets backend; flags natively-installed plugins missing from source. | |
 | `verify` | Validate config and surface every unresolved `${secret:}`/`${env:}` ref. `--scope project`/`--project <path>` schema-lints the project tree and validates its references against the inherited user secrets backend. | `--scope --project` |
-| `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
+| `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry — the user's, or with `--scope project`/`--project <path>` the project tree's own `[agents]` declaration (which project scope renders from; never inherited). At project scope `disable --purge` touches only that project's rendered files. | `disable --purge --scope --project` |
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter/generic"
 	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -94,8 +95,8 @@ func boolStr(b bool) string {
 func newAgentCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "agent", Short: "manage which agents agentsync targets"}
 	cmd.AddCommand(
-		&cobra.Command{Use: "add <name>", Short: "register an agent (any supported agent; see `agent list --all`)", Args: cobra.ExactArgs(1), RunE: lockedRun(agentAddRun)},
-		&cobra.Command{Use: "remove <name>", Short: "unregister an agent", Args: cobra.ExactArgs(1), RunE: lockedRun(agentRemoveRun)},
+		newAgentAddCmd(),
+		newAgentRemoveCmd(),
 		newAgentListCmd(),
 		newAgentEnableCmd(),
 		newAgentDisableCmd(),
@@ -103,26 +104,73 @@ func newAgentCmd() *cobra.Command {
 	return cmd
 }
 
+// addAgentScopeFlags registers the shared --scope/--project pair on an agent
+// subcommand. Every agent command is scope-aware: at project scope it edits the
+// [agents] table in <root>/.agentsync/agentsync.toml — the declaration project
+// scope renders from (project.Merge never inherits user-scope agents).
+func addAgentScopeFlags(cmd *cobra.Command, scopeFlag, projectFlag *string) {
+	cmd.Flags().StringVar(scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
+	cmd.Flags().StringVar(projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+}
+
+func newAgentAddCmd() *cobra.Command {
+	var scopeFlag, projectFlag string
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "register an agent (any supported agent; see `agent list --all`)",
+		Args:  cobra.ExactArgs(1),
+		RunE: lockedRun(func(cmd *cobra.Command, args []string) error {
+			return agentAddRun(cmd, args, scopeFlag, projectFlag)
+		}),
+	}
+	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	return cmd
+}
+
+func newAgentRemoveCmd() *cobra.Command {
+	var scopeFlag, projectFlag string
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "unregister an agent",
+		Args:  cobra.ExactArgs(1),
+		RunE: lockedRun(func(cmd *cobra.Command, args []string) error {
+			return agentRemoveRun(cmd, args, scopeFlag, projectFlag)
+		}),
+	}
+	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	return cmd
+}
+
 func newAgentEnableCmd() *cobra.Command {
-	return &cobra.Command{
+	var scopeFlag, projectFlag string
+	cmd := &cobra.Command{
 		Use:   "enable <name>",
 		Args:  cobra.ExactArgs(1),
 		Short: "enable a registered agent",
-		RunE:  lockedRun(agentEnableRun),
+		RunE: lockedRun(func(cmd *cobra.Command, args []string) error {
+			return agentEnableRun(cmd, args, scopeFlag, projectFlag)
+		}),
 	}
+	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	return cmd
 }
 
 func newAgentDisableCmd() *cobra.Command {
-	var purge bool
+	var (
+		purge       bool
+		scopeFlag   string
+		projectFlag string
+	)
 	cmd := &cobra.Command{
 		Use:   "disable <name>",
 		Args:  cobra.ExactArgs(1),
 		Short: "disable a registered agent (optionally purging its destination files)",
 		RunE: lockedRun(func(cmd *cobra.Command, args []string) error {
-			return agentDisableRun(cmd, args, purge)
+			return agentDisableRun(cmd, args, purge, scopeFlag, projectFlag)
 		}),
 	}
 	cmd.Flags().BoolVar(&purge, "purge", false, "remove agent destination files that agentsync owns")
+	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -141,14 +189,36 @@ func validateAgent(name string) error {
 	return fmt.Errorf("unknown agent %q; valid: %s", name, validAgentsList())
 }
 
-// readAgentsyncTOML returns the file path + raw bytes + parsed `agents` section.
-func readAgentsyncTOML() (string, []byte, map[string]map[string]any, error) {
-	home := paths.AgentsyncHome(paths.OSEnv{})
+// agentScopeHome resolves the effective scope for an agent command and the
+// agentsync home whose agentsync.toml it edits: ~/.agentsync at user scope, the
+// <root>/.agentsync project tree at project scope. Scope resolution is shared
+// with apply/status/diff (resolveScope), so the same explicit-opt-in rules hold:
+// --project implies project scope, --scope project walks up from cwd, and a bare
+// invocation inside a project tree prompts (or fails closed when non-interactive).
+func agentScopeHome(cmd *cobra.Command, scopeFlag, projectFlag string) (home string, sc adapter.Scope, projectRoot string, err error) {
+	sc, projectRoot, err = resolveScope(cmd, scopeFlag, projectFlag, noInputFlag(cmd))
+	if err != nil {
+		return "", sc, projectRoot, err
+	}
+	if sc == adapter.ScopeProject {
+		return project.Home(projectRoot), sc, projectRoot, nil
+	}
+	return paths.AgentsyncHome(paths.OSEnv{}), sc, "", nil
+}
+
+// readAgentsyncTOMLAt returns the file path + raw bytes + parsed `agents`
+// section of the agentsync.toml under home. The missing-file hint points at the
+// scope-appropriate init.
+func readAgentsyncTOMLAt(home string, sc adapter.Scope) (string, []byte, map[string]map[string]any, error) {
 	p := filepath.Join(home, "agentsync.toml")
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return p, nil, nil, fmt.Errorf("no agentsync config at %s; run `agentsync init` first", p)
+			hint := "run `agentsync init` first"
+			if sc == adapter.ScopeProject {
+				hint = "run `agentsync init --scope project` first"
+			}
+			return p, nil, nil, fmt.Errorf("no agentsync config at %s; %s", p, hint)
 		}
 		return p, nil, nil, fmt.Errorf("read %s: %w", p, err)
 	}
@@ -176,8 +246,14 @@ func buildAgentsSection(agents map[string]map[string]any) string {
 	for _, n := range names {
 		v := agents[n]
 		enabled, _ := v["enabled"].(bool)
-		scope, _ := v["scope"].(string)
-		fmt.Fprintf(&sb, "%s = { enabled = %s, scope = %q }\n", n, boolStr(enabled), scope)
+		// The scope field is omitted when empty: project-scope entries carry no
+		// scope key (the file's location already IS the scope), and regenerating
+		// `scope = ""` for them would add noise the loader never reads.
+		if scope, _ := v["scope"].(string); scope != "" {
+			fmt.Fprintf(&sb, "%s = { enabled = %s, scope = %q }\n", n, boolStr(enabled), scope)
+		} else {
+			fmt.Fprintf(&sb, "%s = { enabled = %s }\n", n, boolStr(enabled))
+		}
 	}
 	return sb.String()
 }
@@ -239,7 +315,7 @@ func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
 	return iox.AtomicWrite(p, []byte(strings.Join(out, "\n")), 0o644)
 }
 
-func agentAddRun(cmd *cobra.Command, args []string) error {
+func agentAddRun(cmd *cobra.Command, args []string, scopeFlag, projectFlag string) error {
 	name := args[0]
 	if err := validateAgent(name); err != nil {
 		return err
@@ -248,7 +324,11 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent %q has no implemented adapter yet; "+
 			"set AGENTSYNC_ALLOW_UNIMPLEMENTED=1 to register anyway and accept a no-op apply", name)
 	}
-	p, raw, agents, err := readAgentsyncTOML()
+	home, sc, _, err := agentScopeHome(cmd, scopeFlag, projectFlag)
+	if err != nil {
+		return err
+	}
+	p, raw, agents, err := readAgentsyncTOMLAt(home, sc)
 	if err != nil {
 		return err
 	}
@@ -256,7 +336,13 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "agent %s already registered\n", name)
 		return nil
 	}
-	agents[name] = map[string]any{"enabled": true, "scope": "user"}
+	entry := map[string]any{"enabled": true}
+	if sc != adapter.ScopeProject {
+		// The user-scope entry keeps its historical scope marker; project-scope
+		// entries carry none — the project file's location already is the scope.
+		entry["scope"] = "user"
+	}
+	agents[name] = entry
 	if err := writeAgents(p, raw, agents); err != nil {
 		return err
 	}
@@ -279,9 +365,13 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func agentRemoveRun(cmd *cobra.Command, args []string) error {
+func agentRemoveRun(cmd *cobra.Command, args []string, scopeFlag, projectFlag string) error {
 	name := args[0]
-	p, raw, agents, err := readAgentsyncTOML()
+	home, sc, _, err := agentScopeHome(cmd, scopeFlag, projectFlag)
+	if err != nil {
+		return err
+	}
+	p, raw, agents, err := readAgentsyncTOMLAt(home, sc)
 	if err != nil {
 		return err
 	}
@@ -298,21 +388,41 @@ func agentRemoveRun(cmd *cobra.Command, args []string) error {
 }
 
 func newAgentListCmd() *cobra.Command {
-	var all bool
+	var (
+		all         bool
+		scopeFlag   string
+		projectFlag string
+	)
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list registered agents (--all to list every supported agent)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return agentListRun(cmd, all)
+			return agentListRun(cmd, all, scopeFlag, projectFlag)
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "list every agent agentsync supports, marking which are registered")
+	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
-func agentListRun(cmd *cobra.Command, all bool) error {
-	_, _, agents, err := readAgentsyncTOML()
+// agentEntrySuffix renders the trailing detail of one `agent list` line. The
+// scope field is shown only when the entry carries one (project-scope entries
+// don't — the file's location is the scope).
+func agentEntrySuffix(v map[string]any) string {
+	enabled, _ := v["enabled"].(bool)
+	if scope, _ := v["scope"].(string); scope != "" {
+		return fmt.Sprintf("enabled=%t scope=%s", enabled, scope)
+	}
+	return fmt.Sprintf("enabled=%t", enabled)
+}
+
+func agentListRun(cmd *cobra.Command, all bool, scopeFlag, projectFlag string) error {
+	home, sc, _, err := agentScopeHome(cmd, scopeFlag, projectFlag)
+	if err != nil {
+		return err
+	}
+	_, _, agents, err := readAgentsyncTOMLAt(home, sc)
 	if err != nil {
 		return err
 	}
@@ -322,9 +432,7 @@ func agentListRun(cmd *cobra.Command, all bool) error {
 		// points at.
 		for _, n := range allAgentNames() {
 			if v, ok := agents[n]; ok {
-				enabled, _ := v["enabled"].(bool)
-				scope, _ := v["scope"].(string)
-				fmt.Fprintf(cmd.OutOrStdout(), "%-12s registered enabled=%t scope=%s\n", n, enabled, scope)
+				fmt.Fprintf(cmd.OutOrStdout(), "%-12s registered %s\n", n, agentEntrySuffix(v))
 			} else {
 				fmt.Fprintf(cmd.OutOrStdout(), "%-12s available\n", n)
 			}
@@ -337,27 +445,41 @@ func agentListRun(cmd *cobra.Command, all bool) error {
 	}
 	sort.Strings(names)
 	if len(names) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "(no agents registered; try: agentsync agent add claude, or agentsync agent list --all)")
+		if sc == adapter.ScopeProject {
+			fmt.Fprintln(cmd.OutOrStdout(), "(no agents declared for this project; project scope renders only to declared agents — try: agentsync agent add claude --scope project)")
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "(no agents registered; try: agentsync agent add claude, or agentsync agent list --all)")
+		}
 		return nil
 	}
 	for _, n := range names {
-		v := agents[n]
-		enabled, _ := v["enabled"].(bool)
-		scope, _ := v["scope"].(string)
-		fmt.Fprintf(cmd.OutOrStdout(), "%-10s enabled=%t scope=%s\n", n, enabled, scope)
+		fmt.Fprintf(cmd.OutOrStdout(), "%-10s %s\n", n, agentEntrySuffix(agents[n]))
 	}
 	return nil
 }
 
-func agentEnableRun(cmd *cobra.Command, args []string) error {
+// agentRegisterHint is the scope-appropriate "register it first" suffix for
+// enable/disable errors on an unregistered agent.
+func agentRegisterHint(name string, sc adapter.Scope) string {
+	if sc == adapter.ScopeProject {
+		return fmt.Sprintf("use 'agentsync agent add %s --scope project' first", name)
+	}
+	return fmt.Sprintf("use 'agentsync agent add %s' first", name)
+}
+
+func agentEnableRun(cmd *cobra.Command, args []string, scopeFlag, projectFlag string) error {
 	name := args[0]
-	p, raw, agents, err := readAgentsyncTOML()
+	home, sc, _, err := agentScopeHome(cmd, scopeFlag, projectFlag)
+	if err != nil {
+		return err
+	}
+	p, raw, agents, err := readAgentsyncTOMLAt(home, sc)
 	if err != nil {
 		return err
 	}
 	v, ok := agents[name]
 	if !ok {
-		return fmt.Errorf("agent %q not registered; use 'agentsync agent add %s' first", name, name)
+		return fmt.Errorf("agent %q not registered; %s", name, agentRegisterHint(name, sc))
 	}
 	v["enabled"] = true
 	agents[name] = v
@@ -368,12 +490,19 @@ func agentEnableRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
+func agentDisableRun(cmd *cobra.Command, args []string, purge bool, scopeFlag, projectFlag string) error {
 	name := args[0]
-	p, raw, agents, err := readAgentsyncTOML()
+	cfgHome, sc, projectRoot, err := agentScopeHome(cmd, scopeFlag, projectFlag)
 	if err != nil {
 		return err
 	}
+	p, raw, agents, err := readAgentsyncTOMLAt(cfgHome, sc)
+	if err != nil {
+		return err
+	}
+	// State (and therefore purge bookkeeping) always lives in the USER agentsync
+	// home — project trees carry no .state/ (apply records project-scope state
+	// centrally, keyed by project root).
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	v, ok := agents[name]
 	if !ok {
@@ -385,7 +514,7 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 			if err := validateAgent(name); err != nil {
 				return err
 			}
-			return purgeAgentDests(cmd, name, home)
+			return purgeAgentDests(cmd, name, home, sc, projectRoot)
 		}
 		return fmt.Errorf("agent %q not registered (pass --purge to clean up an already-removed agent's leftover files)", name)
 	}
@@ -403,12 +532,30 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	// The whole disable command (including this purge) already runs under the
 	// global lock via lockedRun, so call purge directly — re-acquiring here
 	// would deadlock on the re-entrant flock.
-	return purgeAgentDests(cmd, name, home)
+	return purgeAgentDests(cmd, name, home, sc, projectRoot)
+}
+
+// purgeKeyMatch reports whether a state key ("agent:scope:project:…") belongs
+// to the purge set. At user scope the purge keeps its historical cleanup-
+// everything semantics: every entry of the named agent, across all scopes and
+// projects. At project scope it matches only the agent's entries for THAT
+// project root — purging a project must not delete the user's machine-wide
+// destinations or another repo's rendered files.
+func purgeKeyMatch(key, agent string, sc adapter.Scope, portableProject string) bool {
+	parts := strings.SplitN(key, ":", 4)
+	if len(parts) < 4 || parts[0] != agent {
+		return false
+	}
+	if sc != adapter.ScopeProject {
+		return true
+	}
+	return parts[1] == adapter.ScopeProject.String() && parts[2] == portableProject
 }
 
 // purgeAgentDests deletes the destination files owned solely by the named
-// agent and removes its state entries. Must be called under withGlobalLock.
-func purgeAgentDests(cmd *cobra.Command, name, home string) error {
+// agent (at project scope: only within that project) and removes the matching
+// state entries. Must be called under withGlobalLock.
+func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, projectRoot string) error {
 	// State keys store dest paths HOME-relative ("${HOME}/.claude.json").
 	// Expand them back to absolute via the user's $HOME before deleting —
 	// otherwise os.Remove would target the literal "${HOME}/..." string,
@@ -420,7 +567,9 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 		return fmt.Errorf("load state: %w", err)
 	}
 
-	prefix := name + ":"
+	// The project segment of state keys is HOME-relative (matching
+	// render.RecordOpsState), so portabilize before comparing.
+	portableProject := paths.HomeRelative(userHome, projectRoot)
 
 	// File-owned dests (whole-file replace ops, e.g. ~/.claude/skills/<n>/
 	// SKILL.md): the whole file is agentsync's, so a whole-file delete is
@@ -433,7 +582,7 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 		if len(parts) < 4 || parts[3] == "" {
 			continue
 		}
-		if strings.HasPrefix(key, prefix) {
+		if purgeKeyMatch(key, name, sc, portableProject) {
 			purgedFilePaths[parts[3]] = true
 		} else {
 			otherFilePaths[parts[3]] = true
@@ -447,7 +596,7 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 	// this agent's owned pointers per path so we can remove ONLY them.
 	purgedKeyPtrs := map[string][]string{}
 	for key := range s.Keys {
-		if !strings.HasPrefix(key, prefix) {
+		if !purgeKeyMatch(key, name, sc, portableProject) {
 			continue
 		}
 		parts := strings.SplitN(key, ":", 5)
@@ -497,20 +646,20 @@ func purgeAgentDests(cmd *cobra.Command, name, home string) error {
 				prunedFiles++
 			}
 		}
-		rw := render.NewWriter(s, home, userHome, adapter.ScopeUser, "", name)
+		rw := render.NewWriter(s, home, userHome, sc, projectRoot, name)
 		if err := a.Apply(ops, rw); err != nil {
 			return fmt.Errorf("purge apply %s: %w", name, err)
 		}
 	}
 
-	// Remove state entries for this agent.
+	// Remove the matching state entries for this agent.
 	for key := range s.Files {
-		if strings.HasPrefix(key, prefix) {
+		if purgeKeyMatch(key, name, sc, portableProject) {
 			delete(s.Files, key)
 		}
 	}
 	for key := range s.Keys {
-		if strings.HasPrefix(key, prefix) {
+		if purgeKeyMatch(key, name, sc, portableProject) {
 			delete(s.Keys, key)
 		}
 	}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -104,15 +104,6 @@ func newAgentCmd() *cobra.Command {
 	return cmd
 }
 
-// addAgentScopeFlags registers the shared --scope/--project pair on an agent
-// subcommand. Every agent command is scope-aware: at project scope it edits the
-// [agents] table in <root>/.agentsync/agentsync.toml — the declaration project
-// scope renders from (project.Merge never inherits user-scope agents).
-func addAgentScopeFlags(cmd *cobra.Command, scopeFlag, projectFlag *string) {
-	cmd.Flags().StringVar(scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(projectFlag, "project", "", "explicit path to project root (implies --scope project)")
-}
-
 func newAgentAddCmd() *cobra.Command {
 	var scopeFlag, projectFlag string
 	cmd := &cobra.Command{
@@ -123,7 +114,7 @@ func newAgentAddCmd() *cobra.Command {
 			return agentAddRun(cmd, args, scopeFlag, projectFlag)
 		}),
 	}
-	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -137,7 +128,7 @@ func newAgentRemoveCmd() *cobra.Command {
 			return agentRemoveRun(cmd, args, scopeFlag, projectFlag)
 		}),
 	}
-	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -151,7 +142,7 @@ func newAgentEnableCmd() *cobra.Command {
 			return agentEnableRun(cmd, args, scopeFlag, projectFlag)
 		}),
 	}
-	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -170,7 +161,7 @@ func newAgentDisableCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().BoolVar(&purge, "purge", false, "remove agent destination files that agentsync owns")
-	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -312,7 +303,50 @@ func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
 		}
 		out = append(out, tail...)
 	}
-	return iox.AtomicWrite(p, []byte(strings.Join(out, "\n")), 0o644)
+
+	// Fail-closed backstop: the splicer above is line-based, not a TOML parser,
+	// so a construct it cannot see (e.g. a multi-line string whose CONTENT
+	// contains an "[agents]" line) would corrupt the file — bricking every
+	// subsequent command that loads it. Before writing, re-parse the spliced
+	// result and require the agents table to round-trip exactly; refuse the
+	// write (leaving the on-disk file untouched) rather than persist a config
+	// the loader can no longer read.
+	content := []byte(strings.Join(out, "\n"))
+	var check agentsyncCfg
+	if err := toml.Unmarshal(content, &check); err != nil {
+		return fmt.Errorf("refusing to rewrite %s: the regenerated config does not parse (%v); "+
+			"the file likely uses a TOML construct the [agents] rewriter cannot splice "+
+			"(e.g. a multi-line string containing an \"[agents]\" line) — edit the [agents] table by hand", p, err)
+	}
+	if !agentsTablesEqual(check.Agents, agents) {
+		return fmt.Errorf("refusing to rewrite %s: the regenerated [agents] table does not round-trip; "+
+			"edit the [agents] table by hand", p)
+	}
+	return iox.AtomicWrite(p, content, 0o644)
+}
+
+// agentsTablesEqual reports whether a re-parsed agents table carries exactly
+// the intended entries (same names, enabled bits, and scope markers). It is
+// the writeAgents backstop's oracle, so it compares only the fields
+// buildAgentsSection emits.
+func agentsTablesEqual(got, want map[string]map[string]any) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for name, w := range want {
+		g, ok := got[name]
+		if !ok {
+			return false
+		}
+		ge, _ := g["enabled"].(bool)
+		we, _ := w["enabled"].(bool)
+		gs, _ := g["scope"].(string)
+		ws, _ := w["scope"].(string)
+		if ge != we || gs != ws {
+			return false
+		}
+	}
+	return true
 }
 
 func agentAddRun(cmd *cobra.Command, args []string, scopeFlag, projectFlag string) error {
@@ -402,7 +436,7 @@ func newAgentListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "list every agent agentsync supports, marking which are registered")
-	addAgentScopeFlags(cmd, &scopeFlag, &projectFlag)
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 
@@ -535,21 +569,35 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool, scopeFlag, p
 	return purgeAgentDests(cmd, name, home, sc, projectRoot)
 }
 
-// purgeKeyMatch reports whether a state key ("agent:scope:project:…") belongs
-// to the purge set. At user scope the purge keeps its historical cleanup-
-// everything semantics: every entry of the named agent, across all scopes and
-// projects. At project scope it matches only the agent's entries for THAT
-// project root — purging a project must not delete the user's machine-wide
-// destinations or another repo's rendered files.
-func purgeKeyMatch(key, agent string, sc adapter.Scope, portableProject string) bool {
+// purgeKeyRest reports whether a state key ("agent:scope:project:path[:ptr]")
+// belongs to the purge set and, if so, returns the key's remainder after the
+// dest-identifying prefix (the path, or "path:ptr" for a Keys entry). At user
+// scope the purge keeps its historical cleanup-everything semantics: every
+// entry of the named agent, across all scopes and projects. At project scope it
+// matches only the agent's entries for THAT project root — purging a project
+// must not delete the user's machine-wide destinations or another repo's
+// rendered files. The project-scope match compares the full literal prefix
+// (like render.PruneStaleState's key prefixes) instead of colon-split fields:
+// a portable project root is not guaranteed colon-free (a root outside $HOME
+// stays an absolute path), and field-splitting would silently mismatch it.
+func purgeKeyRest(key, agent string, sc adapter.Scope, portableProject string) (rest string, ok bool) {
+	if sc == adapter.ScopeProject {
+		prefix := agent + ":" + adapter.ScopeProject.String() + ":" + portableProject + ":"
+		if !strings.HasPrefix(key, prefix) {
+			return "", false
+		}
+		return key[len(prefix):], true
+	}
+	if !strings.HasPrefix(key, agent+":") {
+		return "", false
+	}
+	// User scope spans every scope:project pair, so the remainder is the 4th
+	// colon field (exact for the colon-free segments user-scope keys carry).
 	parts := strings.SplitN(key, ":", 4)
-	if len(parts) < 4 || parts[0] != agent {
-		return false
+	if len(parts) < 4 {
+		return "", false
 	}
-	if sc != adapter.ScopeProject {
-		return true
-	}
-	return parts[1] == adapter.ScopeProject.String() && parts[2] == portableProject
+	return parts[3], true
 }
 
 // purgeAgentDests deletes the destination files owned solely by the named
@@ -578,13 +626,15 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 	purgedFilePaths := map[string]bool{}
 	otherFilePaths := map[string]bool{}
 	for key := range s.Files {
-		parts := strings.SplitN(key, ":", 4)
-		if len(parts) < 4 || parts[3] == "" {
+		if path, ok := purgeKeyRest(key, name, sc, portableProject); ok {
+			if path != "" {
+				purgedFilePaths[path] = true
+			}
 			continue
 		}
-		if purgeKeyMatch(key, name, sc, portableProject) {
-			purgedFilePaths[parts[3]] = true
-		} else {
+		// Not ours: record the path so shared files stay protected below. The
+		// 4th colon field is exact for the colon-free segments these keys carry.
+		if parts := strings.SplitN(key, ":", 4); len(parts) == 4 && parts[3] != "" {
 			otherFilePaths[parts[3]] = true
 		}
 	}
@@ -596,14 +646,16 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 	// this agent's owned pointers per path so we can remove ONLY them.
 	purgedKeyPtrs := map[string][]string{}
 	for key := range s.Keys {
-		if !purgeKeyMatch(key, name, sc, portableProject) {
+		rest, ok := purgeKeyRest(key, name, sc, portableProject)
+		if !ok {
 			continue
 		}
-		parts := strings.SplitN(key, ":", 5)
-		if len(parts) < 5 || parts[3] == "" {
+		// rest is "path:ptr" for a Keys entry.
+		parts := strings.SplitN(rest, ":", 2)
+		if len(parts) < 2 || parts[0] == "" {
 			continue
 		}
-		purgedKeyPtrs[parts[3]] = append(purgedKeyPtrs[parts[3]], parts[4])
+		purgedKeyPtrs[parts[0]] = append(purgedKeyPtrs[parts[0]], parts[1])
 	}
 
 	reg := registryFactory()
@@ -654,12 +706,12 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 
 	// Remove the matching state entries for this agent.
 	for key := range s.Files {
-		if purgeKeyMatch(key, name, sc, portableProject) {
+		if _, ok := purgeKeyRest(key, name, sc, portableProject); ok {
 			delete(s.Files, key)
 		}
 	}
 	for key := range s.Keys {
-		if purgeKeyMatch(key, name, sc, portableProject) {
+		if _, ok := purgeKeyRest(key, name, sc, portableProject); ok {
 			delete(s.Keys, key)
 		}
 	}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -224,7 +225,10 @@ func readAgentsyncTOMLAt(home string, sc adapter.Scope) (string, []byte, map[str
 }
 
 // buildAgentsSection returns a TOML [agents] block with inline table values,
-// preserving comment header context. Agents are sorted alphabetically.
+// preserving comment header context. Agents are sorted alphabetically. It
+// emits ONLY the fields the canonical model reads (enabled + scope) — any
+// extra key a user hand-added inside an agent entry is deliberately dropped,
+// matching source.Agent, which never loads such keys either.
 func buildAgentsSection(agents map[string]map[string]any) string {
 	names := make([]string, 0, len(agents))
 	for n := range agents {
@@ -306,11 +310,12 @@ func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
 
 	// Fail-closed backstop: the splicer above is line-based, not a TOML parser,
 	// so a construct it cannot see (e.g. a multi-line string whose CONTENT
-	// contains an "[agents]" line) would corrupt the file — bricking every
-	// subsequent command that loads it. Before writing, re-parse the spliced
-	// result and require the agents table to round-trip exactly; refuse the
-	// write (leaving the on-disk file untouched) rather than persist a config
-	// the loader can no longer read.
+	// contains an "[agents]" line) could corrupt the file — either bricking
+	// every subsequent load, or worse, silently mangling ANOTHER table's data
+	// while still parsing. Before writing, re-parse the spliced result and
+	// require BOTH that the agents table matches the intended entries AND that
+	// everything outside [agents] is semantically unchanged from the original;
+	// refuse the write (leaving the on-disk file untouched) otherwise.
 	content := []byte(strings.Join(out, "\n"))
 	var check agentsyncCfg
 	if err := toml.Unmarshal(content, &check); err != nil {
@@ -322,7 +327,34 @@ func writeAgents(p string, raw []byte, agents map[string]map[string]any) error {
 		return fmt.Errorf("refusing to rewrite %s: the regenerated [agents] table does not round-trip; "+
 			"edit the [agents] table by hand", p)
 	}
+	same, err := nonAgentsUnchanged(raw, content)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: %w; edit the [agents] table by hand", p, err)
+	}
+	if !same {
+		return fmt.Errorf("refusing to rewrite %s: the rewrite would alter content outside the [agents] table "+
+			"(the file likely uses a TOML construct the rewriter cannot splice, e.g. a multi-line string "+
+			"containing an \"[agents]\" line) — edit the [agents] table by hand", p)
+	}
 	return iox.AtomicWrite(p, content, 0o644)
+}
+
+// nonAgentsUnchanged reports whether every table EXCEPT [agents] decodes to
+// the same value in the original and the spliced config. Comments and
+// whitespace are free to differ; data outside the section the rewriter owns is
+// not — a splice that still parses but changed another table's values is
+// silent corruption and must be refused.
+func nonAgentsUnchanged(oldRaw, newRaw []byte) (bool, error) {
+	var oldDoc, newDoc map[string]any
+	if err := toml.Unmarshal(oldRaw, &oldDoc); err != nil {
+		return false, fmt.Errorf("re-parse original config: %w", err)
+	}
+	if err := toml.Unmarshal(newRaw, &newDoc); err != nil {
+		return false, fmt.Errorf("re-parse regenerated config: %w", err)
+	}
+	delete(oldDoc, "agents")
+	delete(newDoc, "agents")
+	return reflect.DeepEqual(oldDoc, newDoc), nil
 }
 
 // agentsTablesEqual reports whether a re-parsed agents table carries exactly
@@ -592,12 +624,40 @@ func purgeKeyRest(key, agent string, sc adapter.Scope, portableProject string) (
 		return "", false
 	}
 	// User scope spans every scope:project pair, so the remainder is the 4th
-	// colon field (exact for the colon-free segments user-scope keys carry).
+	// colon field. That is exact for user-scope keys (empty project segment)
+	// and colon-free project roots; a colon-bearing root mangles it — an
+	// accepted residual of the historical cross-scope user purge, and safe
+	// because otherFilesKeyPath mangles identically, keeping the shared-file
+	// guard aligned.
 	parts := strings.SplitN(key, ":", 4)
 	if len(parts) < 4 {
 		return "", false
 	}
 	return parts[3], true
+}
+
+// otherFilesKeyPath extracts the dest path from a Files key that is NOT part
+// of the purge set, for the shared-file guard. A key whose project segment
+// matches the purge's own portableProject is stripped colon-safely by literal
+// prefix — a co-owned dest under the same project root is exactly the case the
+// guard protects, and the root is not guaranteed colon-free. Every other key
+// falls back to the 4th colon field: user-scope keys carry an empty (colon-
+// free) project segment there, and a DIFFERENT project's dest can never
+// collide with this purge's paths, so a mangled extraction cannot cause a
+// false unprotected delete (it can only fail to match, which is the status
+// quo for keys that were never candidates).
+func otherFilesKeyPath(key, portableProject string) string {
+	if i := strings.Index(key, ":"); i >= 0 {
+		marker := ":" + adapter.ScopeProject.String() + ":" + portableProject + ":"
+		if tail := key[i:]; strings.HasPrefix(tail, marker) {
+			return tail[len(marker):]
+		}
+	}
+	parts := strings.SplitN(key, ":", 4)
+	if len(parts) < 4 {
+		return ""
+	}
+	return parts[3]
 }
 
 // purgeAgentDests deletes the destination files owned solely by the named
@@ -632,10 +692,9 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 			}
 			continue
 		}
-		// Not ours: record the path so shared files stay protected below. The
-		// 4th colon field is exact for the colon-free segments these keys carry.
-		if parts := strings.SplitN(key, ":", 4); len(parts) == 4 && parts[3] != "" {
-			otherFilePaths[parts[3]] = true
+		// Not ours: record the path so shared files stay protected below.
+		if path := otherFilesKeyPath(key, portableProject); path != "" {
+			otherFilePaths[path] = true
 		}
 	}
 

--- a/internal/cli/agent_disable_test.go
+++ b/internal/cli/agent_disable_test.go
@@ -197,6 +197,79 @@ func TestAgentDisable_Purge_KeepsSharedFileOwnedByOtherAgent(t *testing.T) {
 	}
 }
 
+// TestAgentDisable_Purge_ProjectScopeOnlyTouchesProject verifies the scope
+// filter on purge (#183): `agent disable claude --purge --project <root>`
+// removes only claude's PROJECT-scope destinations for that root — the user's
+// machine-wide destinations (also owned by claude) must survive untouched.
+func TestAgentDisable_Purge_ProjectScopeOnlyTouchesProject(t *testing.T) {
+	tmp := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	// A user-scope MCP server → ~/.claude.json keys owned by claude:user.
+	userMCP := filepath.Join(tmp, ".agentsync", "mcp", "usersrv.toml")
+	if err := os.MkdirAll(filepath.Dir(userMCP), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userMCP, []byte("[server]\ntype = \"stdio\"\ncommand = \"npx\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A project tree with its own claude declaration + MCP → <proj>/.mcp.json
+	// keys owned by claude:project:<proj>.
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	scaffoldProjectMCP(t, proj, "projsrv", "node", "s.js")
+	if _, err := runCLI(t, env, "apply", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+
+	projMCPPath := filepath.Join(proj, ".mcp.json")
+	if body, err := os.ReadFile(projMCPPath); err != nil || !strings.Contains(string(body), "projsrv") {
+		t.Fatalf("fixture: project .mcp.json missing projsrv (err=%v):\n%s", err, body)
+	}
+
+	out, err := runCLI(t, env, "agent", "disable", "claude", "--purge", "--project", proj)
+	if err != nil {
+		t.Fatalf("agent disable --purge --project: %v\n%s", err, out)
+	}
+
+	// Project dest: claude's owned key pruned.
+	if body, _ := os.ReadFile(projMCPPath); strings.Contains(string(body), "projsrv") {
+		t.Fatalf("project purge did not prune the project-owned key:\n%s", body)
+	}
+	// User dest: untouched — the purge was scoped to the project.
+	userBody, err := os.ReadFile(filepath.Join(tmp, ".claude.json"))
+	if err != nil {
+		t.Fatalf("user .claude.json must survive a project-scoped purge: %v", err)
+	}
+	if !strings.Contains(string(userBody), "usersrv") {
+		t.Fatalf("project-scoped purge deleted user-scope keys:\n%s", userBody)
+	}
+	// And the project declaration was flipped to disabled, not the user's.
+	projCfg, _ := os.ReadFile(filepath.Join(proj, ".agentsync", "agentsync.toml"))
+	if !strings.Contains(string(projCfg), "claude = { enabled = false }") {
+		t.Fatalf("project entry not disabled:\n%s", projCfg)
+	}
+	userCfg, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"))
+	if !strings.Contains(string(userCfg), `claude = { enabled = true, scope = "user" }`) {
+		t.Fatalf("user entry must stay enabled:\n%s", userCfg)
+	}
+}
+
 // TestAgentDisable_Purge_NoPurge verifies that without --purge, destination
 // files are NOT removed.
 func TestAgentDisable_Purge_NoPurge(t *testing.T) {

--- a/internal/cli/agent_disable_test.go
+++ b/internal/cli/agent_disable_test.go
@@ -229,9 +229,7 @@ func TestAgentDisable_Purge_ProjectScopeOnlyTouchesProject(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, proj, "claude")
 	scaffoldProjectMCP(t, proj, "projsrv", "node", "s.js")
 	if _, err := runCLI(t, env, "apply", "--project", proj); err != nil {
 		t.Fatal(err)

--- a/internal/cli/agent_internal_test.go
+++ b/internal/cli/agent_internal_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// TestPurgeKeyRest pins the purge state-key matcher, in particular the
+// colon-safety of the project-scope match: a portable project root is not
+// guaranteed colon-free (a root outside $HOME stays an absolute path), so the
+// matcher compares a full literal prefix instead of colon-split fields.
+func TestPurgeKeyRest(t *testing.T) {
+	testenv.RequireContainer(t)
+	cases := []struct {
+		name            string
+		key             string
+		agent           string
+		sc              adapter.Scope
+		portableProject string
+		wantOK          bool
+		wantRest        string
+	}{
+		{
+			name:  "user scope matches every scope and project of the agent",
+			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			agent: "claude", sc: adapter.ScopeUser,
+			wantOK: true, wantRest: "${HOME}/proj/.mcp.json",
+		},
+		{
+			name:  "user scope binds the agent name exactly, not as a sub-prefix",
+			key:   "claude2:user::${HOME}/.claude.json",
+			agent: "claude", sc: adapter.ScopeUser,
+			wantOK: false,
+		},
+		{
+			name:  "project scope matches only that project root",
+			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
+			wantOK: true, wantRest: "${HOME}/proj/.mcp.json",
+		},
+		{
+			name:  "project scope rejects another project's keys",
+			key:   "claude:project:${HOME}/other:${HOME}/other/.mcp.json",
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
+			wantOK: false,
+		},
+		{
+			name:  "project scope rejects the agent's user-scope keys",
+			key:   "claude:user::${HOME}/.claude.json",
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
+			wantOK: false,
+		},
+		{
+			name:  "project scope survives a colon-bearing project root",
+			key:   "claude:project:/mnt/we:ird/proj:/mnt/we:ird/proj/.mcp.json",
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "/mnt/we:ird/proj",
+			wantOK: true, wantRest: "/mnt/we:ird/proj/.mcp.json",
+		},
+		{
+			name:  "keys entry remainder keeps the path:ptr tail",
+			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json:/mcpServers/x",
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
+			wantOK: true, wantRest: "${HOME}/proj/.mcp.json:/mcpServers/x",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rest, ok := purgeKeyRest(tc.key, tc.agent, tc.sc, tc.portableProject)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && rest != tc.wantRest {
+				t.Fatalf("rest = %q, want %q", rest, tc.wantRest)
+			}
+		})
+	}
+}

--- a/internal/cli/agent_internal_test.go
+++ b/internal/cli/agent_internal_test.go
@@ -64,6 +64,12 @@ func TestPurgeKeyRest(t *testing.T) {
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
 			wantOK: true, wantRest: "${HOME}/proj/.mcp.json:/mcpServers/x",
 		},
+		{
+			name:  "user-scope keys entry remainder keeps the path:ptr tail",
+			key:   "claude:user::${HOME}/.claude.json:/mcpServers/x",
+			agent: "claude", sc: adapter.ScopeUser,
+			wantOK: true, wantRest: "${HOME}/.claude.json:/mcpServers/x",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -73,6 +79,54 @@ func TestPurgeKeyRest(t *testing.T) {
 			}
 			if ok && rest != tc.wantRest {
 				t.Fatalf("rest = %q, want %q", rest, tc.wantRest)
+			}
+		})
+	}
+}
+
+// TestOtherFilesKeyPath pins the shared-file guard's path extraction: keys
+// under the purge's OWN project root are stripped colon-safely (they are the
+// candidates for a co-owned dest), everything else falls back to the 4th colon
+// field. Both sides of the guard must extract a same-root dest identically, or
+// a co-owned file under a colon-bearing root would lose its protection and be
+// deleted without backup.
+func TestOtherFilesKeyPath(t *testing.T) {
+	testenv.RequireContainer(t)
+	cases := []struct {
+		name            string
+		key             string
+		portableProject string
+		want            string
+	}{
+		{
+			name:            "same project root, colon-bearing, extracts the exact path",
+			key:             "opencode:project:/mnt/we:ird/proj:/mnt/we:ird/proj/x/SKILL.md",
+			portableProject: "/mnt/we:ird/proj",
+			want:            "/mnt/we:ird/proj/x/SKILL.md",
+		},
+		{
+			name:            "same project root, plain, extracts the path",
+			key:             "opencode:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			portableProject: "${HOME}/proj",
+			want:            "${HOME}/proj/.mcp.json",
+		},
+		{
+			name:            "user-scope key falls back to the exact 4th field",
+			key:             "opencode:user::${HOME}/.claude.json",
+			portableProject: "${HOME}/proj",
+			want:            "${HOME}/.claude.json",
+		},
+		{
+			name:            "malformed short key yields nothing",
+			key:             "opencode:user",
+			portableProject: "${HOME}/proj",
+			want:            "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := otherFilesKeyPath(tc.key, tc.portableProject); got != tc.want {
+				t.Fatalf("otherFilesKeyPath(%q) = %q, want %q", tc.key, got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -79,6 +79,44 @@ func TestAgent_AddPreservesSubtableForm(t *testing.T) {
 	}
 }
 
+// TestAgent_AddRefusesUnsplicableTOML pins the writeAgents fail-closed
+// backstop: the [agents] rewriter is line-based, so a multi-line string whose
+// CONTENT contains an "[agents.…]" line would be mangled by the splice —
+// previously bricking the config (the spliced file no longer parsed, so every
+// later command failed to load the home). The rewrite must now be validated by
+// re-parsing before the write, refusing and leaving the file untouched.
+func TestAgent_AddRefusesUnsplicableTOML(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	// Valid TOML the line splicer cannot handle: a multi-line string carrying
+	// an [agents.evil] line as CONTENT.
+	body := "[agents]\nclaude = { enabled = true }\n\n[updates]\ndefault_mode = \"track\"\ndefault_interval = \"\"\"\n[agents.evil]\n\"\"\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runCLI(t, env, "agent", "add", "opencode")
+	if err == nil {
+		t.Fatal("agent add on an unsplicable config must refuse, not corrupt the file")
+	}
+	if !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("error should say the rewrite was refused; got: %v", err)
+	}
+	// The on-disk file must be byte-identical (still parseable) and later
+	// commands must still work.
+	after, _ := os.ReadFile(cfgPath)
+	if string(after) != body {
+		t.Fatalf("refused rewrite still modified the file:\n%s", after)
+	}
+	if out, lerr := runCLI(t, env, "agent", "list"); lerr != nil || !strings.Contains(out, "claude") {
+		t.Fatalf("config unusable after refused add: %v\n%s", lerr, out)
+	}
+}
+
 // TestAgent_ProjectScope_Lifecycle exercises the #183 project-scope agent
 // commands end-to-end: add/list/disable/enable/remove against a project tree's
 // agentsync.toml, leaving the user-scope config untouched throughout.
@@ -108,6 +146,11 @@ func TestAgent_ProjectScope_Lifecycle(t *testing.T) {
 	}
 	if strings.Contains(string(projCfg), `scope = "user"`) {
 		t.Fatalf("project config must not carry a user scope marker:\n%s", projCfg)
+	}
+	// The scaffold's guidance comments sit ABOVE the [agents] header precisely
+	// so the section rewrite cannot swallow them — pin that.
+	if !strings.Contains(string(projCfg), "# Author project components") {
+		t.Fatalf("first project agent add dropped the scaffold guidance comments:\n%s", projCfg)
 	}
 	if after, _ := os.ReadFile(userCfgPath); string(after) != string(userCfgBefore) {
 		t.Fatalf("project-scope agent add modified the USER config:\n%s", after)

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -78,3 +78,106 @@ func TestAgent_AddPreservesSubtableForm(t *testing.T) {
 		t.Errorf("comment outside agents section was dropped:\n%s", cfg)
 	}
 }
+
+// TestAgent_ProjectScope_Lifecycle exercises the #183 project-scope agent
+// commands end-to-end: add/list/disable/enable/remove against a project tree's
+// agentsync.toml, leaving the user-scope config untouched throughout.
+func TestAgent_ProjectScope_Lifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	userCfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	projCfgPath := filepath.Join(proj, ".agentsync", "agentsync.toml")
+	userCfgBefore, _ := os.ReadFile(userCfgPath)
+
+	// add writes the PROJECT toml — with no scope key (the file's location is
+	// the scope) — and leaves the user config byte-identical.
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("agent add --scope project: %v", err)
+	}
+	projCfg, _ := os.ReadFile(projCfgPath)
+	if !strings.Contains(string(projCfg), "claude = { enabled = true }") {
+		t.Fatalf("project config missing scope-less claude entry:\n%s", projCfg)
+	}
+	if strings.Contains(string(projCfg), `scope = "user"`) {
+		t.Fatalf("project config must not carry a user scope marker:\n%s", projCfg)
+	}
+	if after, _ := os.ReadFile(userCfgPath); string(after) != string(userCfgBefore) {
+		t.Fatalf("project-scope agent add modified the USER config:\n%s", after)
+	}
+
+	// list reads the project declaration.
+	out, err := runCLI(t, env, "agent", "list", "--project", proj)
+	if err != nil {
+		t.Fatalf("agent list --project: %v", err)
+	}
+	if !strings.Contains(out, "claude") || !strings.Contains(out, "enabled=true") {
+		t.Fatalf("project list missing claude: %s", out)
+	}
+
+	// disable/enable flip the project entry.
+	if _, err := runCLI(t, env, "agent", "disable", "claude", "--project", proj); err != nil {
+		t.Fatalf("agent disable --project: %v", err)
+	}
+	projCfg, _ = os.ReadFile(projCfgPath)
+	if !strings.Contains(string(projCfg), "claude = { enabled = false }") {
+		t.Fatalf("disable did not flip the project entry:\n%s", projCfg)
+	}
+	if _, err := runCLI(t, env, "agent", "enable", "claude", "--project", proj); err != nil {
+		t.Fatalf("agent enable --project: %v", err)
+	}
+	projCfg, _ = os.ReadFile(projCfgPath)
+	if !strings.Contains(string(projCfg), "claude = { enabled = true }") {
+		t.Fatalf("enable did not flip the project entry back:\n%s", projCfg)
+	}
+
+	// enable of an agent the project never declared points at the project add.
+	if _, err := runCLI(t, env, "agent", "enable", "codex", "--project", proj); err == nil ||
+		!strings.Contains(err.Error(), "--scope project") {
+		t.Fatalf("expected project-scope registration hint; got: %v", err)
+	}
+
+	// remove deletes the project entry; user config still untouched.
+	if _, err := runCLI(t, env, "agent", "remove", "claude", "--project", proj); err != nil {
+		t.Fatalf("agent remove --project: %v", err)
+	}
+	projCfg, _ = os.ReadFile(projCfgPath)
+	if strings.Contains(string(projCfg), "claude = {") {
+		t.Fatalf("remove left the project entry behind:\n%s", projCfg)
+	}
+	if after, _ := os.ReadFile(userCfgPath); string(after) != string(userCfgBefore) {
+		t.Fatalf("project-scope lifecycle modified the USER config:\n%s", after)
+	}
+}
+
+// TestAgent_ProjectScope_RequiresTree pins the shared scope-resolution rule for
+// agent commands: --project at a path with no .agentsync/ tree is a hard error
+// pointing at project init, never a silent user-scope write.
+func TestAgent_ProjectScope_RequiresTree(t *testing.T) {
+	tmp := t.TempDir()
+	bare := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCLI(t, env, "agent", "add", "claude", "--project", bare)
+	if err == nil {
+		t.Fatal("expected agent add --project at a treeless path to error")
+	}
+	if !strings.Contains(err.Error(), "init --scope project") {
+		t.Fatalf("error should point at project init; got: %v", err)
+	}
+	// Nothing may have been registered at user scope as a fallback.
+	cfg, _ := os.ReadFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"))
+	if strings.Contains(string(cfg), "claude = {") {
+		t.Fatalf("failed project add fell back to a user-scope write:\n%s", cfg)
+	}
+}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -117,6 +117,38 @@ func TestAgent_AddRefusesUnsplicableTOML(t *testing.T) {
 	}
 }
 
+// TestAgent_AddRefusesSilentNonAgentsCorruption pins the second half of the
+// writeAgents backstop: a splice that still PARSES but silently altered
+// another table's data must also be refused. The fixture's [custom] multi-line
+// string contains an "[agents.injected]" line followed by a "["-opening line —
+// the line splicer drops the former and un-strings the latter, so the result
+// parses cleanly and the agents table round-trips, yet [custom].note changed.
+// Only the whole-document non-agents comparison catches it.
+func TestAgent_AddRefusesSilentNonAgentsCorruption(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(tmp, ".agentsync", "agentsync.toml")
+	body := "[agents]\nclaude = { enabled = true }\n\n[custom]\nnote = \"\"\"\n[agents.injected]\n[whatever]\n\"\"\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runCLI(t, env, "agent", "add", "opencode")
+	if err == nil {
+		t.Fatal("agent add must refuse a splice that silently corrupts non-agents content")
+	}
+	if !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("error should say the rewrite was refused; got: %v", err)
+	}
+	after, _ := os.ReadFile(cfgPath)
+	if string(after) != body {
+		t.Fatalf("refused rewrite still modified the file:\n%s", after)
+	}
+}
+
 // TestAgent_ProjectScope_Lifecycle exercises the #183 project-scope agent
 // commands end-to-end: add/list/disable/enable/remove against a project tree's
 // agentsync.toml, leaving the user-scope config untouched throughout.

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -68,7 +68,7 @@ func addScopeFlags(cmd *cobra.Command, scopeFlag, projectFlag *string) {
 // to edit the wrong file.
 func noAgentsEnabledHint(sc adapter.Scope, projectRoot string) string {
 	if sc == adapter.ScopeProject {
-		return fmt.Sprintf("no agents enabled at project scope (%s); check the [agents] table in %s or run `agentsync agent enable <name> --scope project`",
+		return fmt.Sprintf("no agents are enabled at project scope (%s); check the [agents] table in %s or run `agentsync agent enable <name> --scope project`",
 			projectRoot, filepath.Join(project.Home(projectRoot), "agentsync.toml"))
 	}
 	return "no agents enabled; run `agentsync agent add claude` (or opencode)"

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -48,10 +48,30 @@ func newApplyCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "compute plan without writing destinations")
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	cmd.Flags().BoolVar(&noGitBackup, "no-git-backup", false, "skip destination git versioning/checkpoint for this run (CI/scripting); does not modify agentsync.toml")
 	return cmd
+}
+
+// addScopeFlags registers the standard --scope/--project pair every
+// scope-aware command shares (apply, status, diff, reconcile, verify, import,
+// and the agent subcommands). init and update register their own variants with
+// scope-specific help text.
+func addScopeFlags(cmd *cobra.Command, scopeFlag, projectFlag *string) {
+	cmd.Flags().StringVar(scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
+	cmd.Flags().StringVar(projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+}
+
+// noAgentsEnabledHint is the shared "nothing is enabled" notice for read-only
+// commands (status/diff). At project scope it must point at the PROJECT's
+// [agents] declaration — the user-scope `agent add` hint would send the user
+// to edit the wrong file.
+func noAgentsEnabledHint(sc adapter.Scope, projectRoot string) string {
+	if sc == adapter.ScopeProject {
+		return fmt.Sprintf("no agents enabled at project scope (%s); check the [agents] table in %s or run `agentsync agent enable <name> --scope project`",
+			projectRoot, filepath.Join(project.Home(projectRoot), "agentsync.toml"))
+	}
+	return "no agents enabled; run `agentsync agent add claude` (or opencode)"
 }
 
 // applyRun is the lock-protected body of the apply command. It is split

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -373,9 +373,29 @@ func loadProjectedForScope(cmd *cobra.Command, fs afero.Fs, home, scopeFlag, pro
 		if perr != nil {
 			return source.Canonical{}, sc, projectRoot, fmt.Errorf("load project source %s: %w", projHome, perr)
 		}
+		if err := requireProjectAgents(pc, projHome); err != nil {
+			return source.Canonical{}, sc, projectRoot, err
+		}
 		c = project.Merge(c, pc)
 	}
 	return c, sc, projectRoot, nil
+}
+
+// requireProjectAgents rejects a project tree whose [agents] table is empty or
+// absent. A project's agent declaration is authoritative for project scope
+// (project.Merge never inherits the user's enabled agents), so an undeclared
+// set can only mean "render to nothing" — which reads as a silent no-op, or
+// worse, as per-machine behavior to a user expecting the old inheritance. Fail
+// with the fix instead. A declared-but-all-disabled table is a deliberate
+// state and passes; the enabled-agent extraction downstream reports it softly.
+func requireProjectAgents(pc source.Canonical, projHome string) error {
+	if len(pc.Config.Agents) > 0 {
+		return nil
+	}
+	cfgPath := filepath.Join(projHome, "agentsync.toml")
+	return fmt.Errorf("this project declares no agents: the [agents] table in %s is empty or missing, "+
+		"and project scope renders only to agents the project itself declares (user-scope agents are not inherited); "+
+		"run `agentsync agent add <name> --scope project` or add them to %s", cfgPath, cfgPath)
 }
 
 // projectDisabledPlugins returns the plugin ids a project tree marks disabled

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -70,7 +70,7 @@ func TestApply_AnnouncesScope(t *testing.T) {
 
 	proj := filepath.Join(tmp, "proj")
 	mustRun(t, env, "init", "--scope", "project", "--project", proj)
-	mustRun(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj)
+	declareProjectAgent(t, env, proj, "claude")
 	out2, err := runCLI(t, env, "apply", "--project", proj)
 	if err != nil {
 		t.Fatalf("apply --project: %v\n%s", err, out2)

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -70,6 +70,7 @@ func TestApply_AnnouncesScope(t *testing.T) {
 
 	proj := filepath.Join(tmp, "proj")
 	mustRun(t, env, "init", "--scope", "project", "--project", proj)
+	mustRun(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj)
 	out2, err := runCLI(t, env, "apply", "--project", proj)
 	if err != nil {
 		t.Fatalf("apply --project: %v\n%s", err, out2)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -82,7 +82,7 @@ func newDiffCmd() *cobra.Command {
 				if jsonOut {
 					return emitJSON(p.Out, diffModel{Hunks: []diffHunk{}})
 				}
-				fmt.Fprintln(p.Out, "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				fmt.Fprintln(p.Out, noAgentsEnabledHint(sc, projectRoot))
 				return nil
 			}
 			// diff renders the TEMPLATED canonical (it masks the destination's
@@ -195,8 +195,7 @@ func newDiffCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted diff")
 	return cmd
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -197,8 +197,7 @@ Examples:
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview which source files would be written, without writing")
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 

--- a/internal/cli/import_project_test.go
+++ b/internal/cli/import_project_test.go
@@ -47,6 +47,12 @@ func TestIntegration_Import_ProjectScope(t *testing.T) {
 		t.Fatalf("import --scope project: %v\n%s", err, out)
 	}
 
+	// Declare the project's agent so the round-trip apply below passes the
+	// #183 undeclared-agents guard (import itself deliberately doesn't need it).
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+
 	// Captured config must land in the PROJECT tree, not the user home.
 	if _, err := os.Stat(filepath.Join(proj, ".agentsync", "agents", "rev.md")); err != nil {
 		t.Fatalf("project subagent not captured into project tree: %v", err)

--- a/internal/cli/import_project_test.go
+++ b/internal/cli/import_project_test.go
@@ -49,9 +49,7 @@ func TestIntegration_Import_ProjectScope(t *testing.T) {
 
 	// Declare the project's agent so the round-trip apply below passes the
 	// #183 undeclared-agents guard (import itself deliberately doesn't need it).
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, proj, "claude")
 
 	// Captured config must land in the PROJECT tree, not the user home.
 	if _, err := os.Stat(filepath.Join(proj, ".agentsync", "agents", "rev.md")); err != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -185,8 +185,12 @@ const initialProjectAgentsyncTOML = `# agentsync project-scope config
 # share project-scoped agent config with collaborators.
 
 [agents]
-# Leave this empty to inherit the agents you enabled at user scope, or pin a
-# subset for this project:
+# Project scope renders ONLY to the agents declared here — this committed table
+# is authoritative, and user-scope agents are never inherited, so every
+# collaborator gets the same render from the same source. Declare at least one
+# (apply/status/diff refuse to run against a project that declares none):
+#   agentsync agent add <name> --scope project
+# or uncomment/edit directly:
 # claude   = { enabled = true }
 # opencode = { enabled = true }
 
@@ -232,10 +236,12 @@ func scaffoldProjectHome(cmd *cobra.Command, root string) error {
 	}
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Next steps:")
-	fmt.Fprintln(w, "  1. add project components under", home)
+	fmt.Fprintf(w, "  1. agentsync agent add claude --scope project --project %s\n", root)
+	fmt.Fprintln(w, "     (declare every agent this project renders to; user-scope agents are not inherited)")
+	fmt.Fprintln(w, "  2. add project components under", home)
 	fmt.Fprintf(w, "     (or: agentsync import claude --scope project --project %s)\n", root)
-	fmt.Fprintf(w, "  2. agentsync apply --project %s --dry-run   # preview\n", root)
-	fmt.Fprintf(w, "  3. agentsync apply --project %s             # write project destinations\n", root)
+	fmt.Fprintf(w, "  3. agentsync apply --project %s --dry-run   # preview\n", root)
+	fmt.Fprintf(w, "  4. agentsync apply --project %s             # write project destinations\n", root)
 	return nil
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -179,25 +179,31 @@ func scaffoldHome(cmd *cobra.Command, home string) error {
 	return nil
 }
 
+// initialProjectAgentsyncTOML is the project-scope scaffold stub. The guidance
+// comments live ABOVE the [agents] header on purpose: `agent add --scope
+// project` regenerates the [agents] section (dropping every line inside it,
+// comments included), and with [agents] as the file's last section a trailing
+// guidance block would be swallowed by the very first add.
 const initialProjectAgentsyncTOML = `# agentsync project-scope config
 # Rendered into <repo>/.claude/, <repo>/.opencode/, <repo>/.codex/, … by
 # 'agentsync apply' when run inside this repo. Commit this .agentsync/ tree to
 # share project-scoped agent config with collaborators.
-
-[agents]
-# Project scope renders ONLY to the agents declared here — this committed table
-# is authoritative, and user-scope agents are never inherited, so every
-# collaborator gets the same render from the same source. Declare at least one
-# (apply/status/diff refuse to run against a project that declares none):
-#   agentsync agent add <name> --scope project
-# or uncomment/edit directly:
-# claude   = { enabled = true }
-# opencode = { enabled = true }
-
+#
 # Author project components by adding files under this tree (mcp/<id>.toml,
 # skills/<name>/SKILL.md, agents/<name>.md, commands/<name>.md, hooks/<event>.toml,
 # lsp/<id>.toml, memory/AGENTS.md) or capture existing native config with
 # 'agentsync import <agent> --scope project'.
+#
+# Project scope renders ONLY to the agents declared in [agents] below — the
+# committed table is authoritative, and user-scope agents are never inherited,
+# so every collaborator gets the same render from the same source. Declare at
+# least one (apply/status/diff refuse to run against a project that declares
+# none):
+#   agentsync agent add <name> --scope project
+
+[agents]
+# claude   = { enabled = true }
+# opencode = { enabled = true }
 `
 
 // scaffoldProjectHome populates an empty <root>/.agentsync/ project source tree

--- a/internal/cli/m5_integration_test.go
+++ b/internal/cli/m5_integration_test.go
@@ -50,6 +50,11 @@ func TestIntegration_Project_Overlay(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
+	// Project scope renders only to agents the project itself declares (#183) —
+	// declare claude via the project-scope agent command.
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
 	scaffoldProjectMCP(t, projectDir, "proj-mcp", "npx", "-y", "@proj/mcp")
 
 	// chdir into project dir so auto-detect kicks in.
@@ -205,6 +210,9 @@ func TestIntegration_Project_ExplicitFlag(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
 	scaffoldProjectMCP(t, projectDir, "api-mcp", "node", "server.js")
 
 	out, err := runCLI(t, env, "apply", "--project", projectDir)
@@ -275,6 +283,9 @@ func TestIntegration_Project_Memory(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
 	mem := "# Project Rules\nAlways write tests first."
 	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync", "memory", "AGENTS.md"), []byte(mem), 0o644); err != nil {
 		t.Fatal(err)
@@ -310,6 +321,9 @@ func TestIntegration_Project_OpenCode_MCP(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "opencode", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
 	scaffoldProjectMCP(t, projectDir, "oc-mcp", "node", "server.js")
@@ -349,6 +363,9 @@ func TestIntegration_Project_MCPJsonDriftDetected(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
 	// Server id deliberately free of the substring "drift" so the drift
 	// assertion below can only match the drift *class*, never the id in the path.
 	scaffoldProjectMCP(t, projectDir, "apisrv", "npx", "-y", "@x/mcp")
@@ -377,5 +394,69 @@ func TestIntegration_Project_MCPJsonDriftDetected(t *testing.T) {
 	}
 	if !strings.Contains(out, "drift") {
 		t.Fatalf("status did not report drift on project .mcp.json:\n%s", out)
+	}
+}
+
+// TestIntegration_Project_UndeclaredAgentsError pins the #183 contract: a
+// project tree whose [agents] table is empty or missing is a hard error for
+// every scope-aware read/render command — never a silent no-op, and never an
+// inherit of the user's enabled agents. The message must be actionable (point
+// at `agent add --scope project`). `import --scope project` stays exempt: it
+// is the capture path a user may need BEFORE declaring agents.
+func TestIntegration_Project_UndeclaredAgentsError(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	// User scope has claude enabled — precisely the agent set that must NOT
+	// leak into project scope.
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"apply", "--project", projectDir, "--dry-run"},
+		{"apply", "--project", projectDir},
+		{"status", "--project", projectDir},
+		{"diff", "--project", projectDir},
+		{"reconcile", "--project", projectDir, "--auto-safe"},
+		{"verify", "--project", projectDir},
+	} {
+		out, err := runCLI(t, env, args...)
+		if err == nil {
+			t.Fatalf("%v: expected undeclared-project-agents error, got success:\n%s", args, out)
+		}
+		if !strings.Contains(err.Error(), "declares no agents") {
+			t.Fatalf("%v: error should say the project declares no agents; got: %v", args, err)
+		}
+		if !strings.Contains(err.Error(), "agent add") {
+			t.Fatalf("%v: error should point at `agentsync agent add --scope project`; got: %v", args, err)
+		}
+	}
+
+	// No project destination may have been written, and nothing may have been
+	// inherited from user scope.
+	if _, err := os.Stat(filepath.Join(projectDir, "CLAUDE.md")); err == nil {
+		t.Fatal("apply against an undeclared project wrote CLAUDE.md (inherited user agents?)")
+	}
+
+	// The capture path stays available before declaration: import is how a user
+	// may bootstrap the project tree from native config in the first place.
+	if out, err := runCLI(t, env, "import", "claude", "--scope", "project", "--project", projectDir, "--dry-run"); err != nil {
+		t.Fatalf("import --scope project must not require declared agents: %v\n%s", err, out)
+	}
+
+	// Declaring an agent clears the error.
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply", "--project", projectDir, "--dry-run"); err != nil {
+		t.Fatalf("apply after declaring agents: %v\n%s", err, out)
 	}
 }

--- a/internal/cli/m5_integration_test.go
+++ b/internal/cli/m5_integration_test.go
@@ -7,6 +7,16 @@ import (
 	"testing"
 )
 
+// declareProjectAgent declares an agent in a project tree's [agents] table via
+// the project-scope agent command — the #183 contract: project scope renders
+// only to agents the project itself declares, never the user's enabled agents.
+func declareProjectAgent(t *testing.T, env map[string]string, projectDir, name string) {
+	t.Helper()
+	if out, err := runCLI(t, env, "agent", "add", name, "--scope", "project", "--project", projectDir); err != nil {
+		t.Fatalf("agent add %s --scope project: %v\n%s", name, err, out)
+	}
+}
+
 // scaffoldProjectMCP writes a project-scope MCP server into an already-created
 // project tree (<projectDir>/.agentsync/mcp/<id>.toml).
 func scaffoldProjectMCP(t *testing.T, projectDir, id, command string, args ...string) {
@@ -50,11 +60,7 @@ func TestIntegration_Project_Overlay(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
-	// Project scope renders only to agents the project itself declares (#183) —
-	// declare claude via the project-scope agent command.
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "claude")
 	scaffoldProjectMCP(t, projectDir, "proj-mcp", "npx", "-y", "@proj/mcp")
 
 	// chdir into project dir so auto-detect kicks in.
@@ -210,9 +216,7 @@ func TestIntegration_Project_ExplicitFlag(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "claude")
 	scaffoldProjectMCP(t, projectDir, "api-mcp", "node", "server.js")
 
 	out, err := runCLI(t, env, "apply", "--project", projectDir)
@@ -283,9 +287,7 @@ func TestIntegration_Project_Memory(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "claude")
 	mem := "# Project Rules\nAlways write tests first."
 	if err := os.WriteFile(filepath.Join(projectDir, ".agentsync", "memory", "AGENTS.md"), []byte(mem), 0o644); err != nil {
 		t.Fatal(err)
@@ -323,9 +325,7 @@ func TestIntegration_Project_OpenCode_MCP(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "opencode", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "opencode")
 	scaffoldProjectMCP(t, projectDir, "oc-mcp", "node", "server.js")
 
 	if out, err := runCLI(t, env, "apply", "--project", projectDir); err != nil {
@@ -363,9 +363,7 @@ func TestIntegration_Project_MCPJsonDriftDetected(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", projectDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "claude")
 	// Server id deliberately free of the substring "drift" so the drift
 	// assertion below can only match the drift *class*, never the id in the path.
 	scaffoldProjectMCP(t, projectDir, "apisrv", "npx", "-y", "@x/mcp")
@@ -446,6 +444,32 @@ func TestIntegration_Project_UndeclaredAgentsError(t *testing.T) {
 		t.Fatal("apply against an undeclared project wrote CLAUDE.md (inherited user agents?)")
 	}
 
+	// A DECLARED-but-all-disabled table is a different state: it passes the
+	// guard (a deliberate declaration) and the command reports softly instead
+	// of erroring — pin that boundary before declaring for real below.
+	allDisabled := t.TempDir()
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", allDisabled); err != nil {
+		t.Fatal(err)
+	}
+	declareProjectAgent(t, env, allDisabled, "claude")
+	if _, err := runCLI(t, env, "agent", "disable", "claude", "--scope", "project", "--project", allDisabled); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "apply", "--project", allDisabled)
+	if err != nil {
+		t.Fatalf("apply against an all-disabled project must soft-noop, not error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "no agents are enabled at project scope") {
+		t.Fatalf("apply should explain the all-disabled state with the project-scope hint; got:\n%s", out)
+	}
+	out, err = runCLI(t, env, "status", "--project", allDisabled)
+	if err != nil {
+		t.Fatalf("status against an all-disabled project must soft-noop: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "project scope") {
+		t.Fatalf("status hint should be project-scoped, not point at the user registry; got:\n%s", out)
+	}
+
 	// The capture path stays available before declaration: import is how a user
 	// may bootstrap the project tree from native config in the first place.
 	if out, err := runCLI(t, env, "import", "claude", "--scope", "project", "--project", projectDir, "--dry-run"); err != nil {
@@ -453,9 +477,7 @@ func TestIntegration_Project_UndeclaredAgentsError(t *testing.T) {
 	}
 
 	// Declaring an agent clears the error.
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", projectDir); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, projectDir, "claude")
 	if out, err := runCLI(t, env, "apply", "--project", projectDir, "--dry-run"); err != nil {
 		t.Fatalf("apply after declaring agents: %v\n%s", err, out)
 	}

--- a/internal/cli/preview_plugin_test.go
+++ b/internal/cli/preview_plugin_test.go
@@ -97,7 +97,7 @@ func TestProjectTree_DisablesPluginProjection(t *testing.T) {
 	// A project tree that disables the demo plugin.
 	proj := filepath.Join(tmp, "proj")
 	mustRun(t, env, "init", "--scope", "project", "--project", proj)
-	mustRun(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj)
+	declareProjectAgent(t, env, proj, "claude")
 	if err := os.MkdirAll(filepath.Join(proj, ".agentsync", "plugins"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/preview_plugin_test.go
+++ b/internal/cli/preview_plugin_test.go
@@ -97,6 +97,7 @@ func TestProjectTree_DisablesPluginProjection(t *testing.T) {
 	// A project tree that disables the demo plugin.
 	proj := filepath.Join(tmp, "proj")
 	mustRun(t, env, "init", "--scope", "project", "--project", proj)
+	mustRun(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj)
 	if err := os.MkdirAll(filepath.Join(proj, ".agentsync", "plugins"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -58,8 +58,7 @@ func newReconcileCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&autoWB, "auto-writeback", false, "auto-resolve drift by writing dest back to source")
 	cmd.Flags().BoolVar(&autoOR, "auto-override", false, "auto-resolve drift by re-applying source to dest")
 	cmd.Flags().BoolVar(&autoSafe, "auto-safe", false, "auto-resolve only converged/pending/new (no-op)")
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -110,7 +110,7 @@ func newStatusCmd() *cobra.Command {
 					emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 					return emitJSON(p.Out, statusModel{Agents: []statusAgent{}, Summary: map[string]int{}})
 				}
-				fmt.Fprintln(p.Out, "no agents enabled; run `agentsync agent add claude` (or opencode)")
+				fmt.Fprintln(p.Out, noAgentsEnabledHint(sc, projectRoot))
 				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
 				return nil
 			}
@@ -146,8 +146,7 @@ func newStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the formatted report")
 	cmd.Flags().StringVar(&agentsCSV, "agents", "", `limit the report to a comma-separated agent allowlist ("*" = all enabled; default: all enabled)`)
 	return cmd

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -52,6 +52,39 @@ func TestUpdate_ApplyRecordsFreshManifestSHA(t *testing.T) {
 	}
 }
 
+// TestUpdate_ApplyProjectScope_RequiresDeclaredAgents pins the #183 guard on
+// update's re-apply path: `update --apply --project <root>` reloads the source
+// via loadProjectedForScope once a bump lands, so a project that declares no
+// agents must fail there with the same actionable error apply gives — never
+// silently re-render with inherited user-scope agents.
+func TestUpdate_ApplyProjectScope_RequiresDeclaredAgents(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	proj := t.TempDir()
+
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	// A pending bump so the re-apply (and therefore the reload) actually runs.
+	mpDir := makeVersionedMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "install", "demo@test-mp-v")
+	mustRun(t, env, "apply")
+	_ = makeVersionedMarketplace(t, base, "1.0.1")
+
+	// A project tree with NO declared agents.
+	mustRun(t, env, "init", "--scope", "project", "--project", proj)
+
+	_, err := runCLI(t, env, "update", "--apply", "--project", proj)
+	if err == nil {
+		t.Fatal("update --apply --project against an undeclared project must error")
+	}
+	if !strings.Contains(err.Error(), "declares no agents") {
+		t.Fatalf("error should say the project declares no agents; got: %v", err)
+	}
+}
+
 // TestUpdate_ApplyBumpFailureLeavesCacheConsistent is the regression for the
 // applyPluginBump fetch-then-write window. It overwrote the LIVE plugin cache
 // before writing plugins/<id>.toml, so a TOML-write failure left the cache new

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -101,8 +101,7 @@ func newVerifyCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&scopeFlag, "scope", "", "user | project (default: user; prompts when run inside a project tree)")
-	cmd.Flags().StringVar(&projectFlag, "project", "", "explicit path to project root (implies --scope project)")
+	addScopeFlags(cmd, &scopeFlag, &projectFlag)
 	return cmd
 }
 

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -68,6 +68,11 @@ func newVerifyCmd() *cobra.Command {
 				if perr != nil {
 					return fmt.Errorf("verify: load project source %s: %w", sourceRoot, perr)
 				}
+				// verify lints the source a project-scope apply would consume, so
+				// it must reject the same undeclared-agents state apply rejects.
+				if err := requireProjectAgents(pc, sourceRoot); err != nil {
+					return err
+				}
 				c = project.Merge(c, pc)
 			}
 			for name := range c.Config.Agents {

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -167,6 +167,9 @@ func TestVerify_ProjectScope_OK(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
 	// A valid project-scope MCP server referencing an env var that is set, so
 	// the ${env:} resolution pass succeeds.
 	mcp := filepath.Join(proj, ".agentsync", "mcp", "projapi.toml")

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -167,9 +167,7 @@ func TestVerify_ProjectScope_OK(t *testing.T) {
 	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
-		t.Fatal(err)
-	}
+	declareProjectAgent(t, env, proj, "claude")
 	// A valid project-scope MCP server referencing an env var that is set, so
 	// the ${env:} resolution pass succeeds.
 	mcp := filepath.Join(proj, ".agentsync", "mcp", "projapi.toml")

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -68,8 +68,12 @@ func Discover(start string) (root string, found bool, err error) {
 // returning a new Canonical. It never mutates base.
 //
 // Semantics (documented in docs/architecture.md §project overlay):
-//   - Agents: if proj declares any agents, its agent map REPLACES base's (the
-//     project picks its own agent set); an empty project agent map inherits base.
+//   - Agents: the project's agent map is AUTHORITATIVE — project scope renders
+//     only to agents the project itself declares, so the committed tree produces
+//     the same render on every collaborator's machine. Base (user-scope) agents
+//     are never inherited; an empty project agent map merges to an empty agent
+//     set (scope-aware commands reject it before rendering — see
+//     requireProjectAgents in internal/cli).
 //   - MCP / LSP / Skills / Subagents / Commands: overlaid by identity (ID or
 //     Name) — a project entry replaces a base entry with the same key, and a new
 //     key is appended. Order is base-first, then appended project entries.
@@ -88,13 +92,15 @@ func Discover(start string) (root string, found bool, err error) {
 func Merge(base, proj source.Canonical) source.Canonical {
 	out := base // shallow copy; every slice/map we touch is replaced, not mutated
 
-	if len(proj.Config.Agents) > 0 {
-		agents := make(map[string]source.Agent, len(proj.Config.Agents))
-		for k, v := range proj.Config.Agents {
-			agents[k] = v
-		}
-		out.Config.Agents = agents
+	// The project's agent declaration is authoritative — never fall back to
+	// base's agents when it is empty. Inheriting made the project render depend
+	// on each collaborator's personal user-scope config, so identical committed
+	// source produced different .claude/.cursor/.codex/… trees per machine.
+	agents := make(map[string]source.Agent, len(proj.Config.Agents))
+	for k, v := range proj.Config.Agents {
+		agents[k] = v
 	}
+	out.Config.Agents = agents
 	if proj.Config.Updates != (source.UpdateDefaults{}) {
 		out.Config.Updates = proj.Config.Updates
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -146,6 +146,10 @@ func TestMerge_AgentsReplaceWhenDeclared(t *testing.T) {
 	if _, ok := out.Config.Agents["claude"]; !ok {
 		t.Fatal("claude should be retained")
 	}
+	// base must be left untouched (Merge never mutates its inputs).
+	if len(base.Config.Agents) != 3 {
+		t.Fatalf("base agents mutated by Merge: %v", base.Config.Agents)
+	}
 }
 
 // TestMerge_AgentsNotInheritedWhenProjectEmpty pins the #183 contract flip: the

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -148,14 +148,23 @@ func TestMerge_AgentsReplaceWhenDeclared(t *testing.T) {
 	}
 }
 
-func TestMerge_AgentsInheritWhenProjectEmpty(t *testing.T) {
+// TestMerge_AgentsNotInheritedWhenProjectEmpty pins the #183 contract flip: the
+// project's [agents] declaration is authoritative, so a project that declares
+// none merges to an EMPTY agent set — never the user's enabled agents. (The
+// pre-#183 behavior inherited base here, which made a committed project tree
+// render differently per collaborator.)
+func TestMerge_AgentsNotInheritedWhenProjectEmpty(t *testing.T) {
 	base := source.Canonical{Config: source.Config{Agents: map[string]source.Agent{
 		"claude": {Enabled: true}, "codex": {Enabled: true},
 	}}}
 	proj := source.Canonical{} // no agents declared
 	out := project.Merge(base, proj)
-	if len(out.Config.Agents) != 2 {
-		t.Fatalf("empty project agents should inherit base; got %v", out.Config.Agents)
+	if len(out.Config.Agents) != 0 {
+		t.Fatalf("empty project agents must NOT inherit base; got %v", out.Config.Agents)
+	}
+	// base must be left untouched (Merge never mutates its inputs).
+	if len(base.Config.Agents) != 2 {
+		t.Fatalf("base agents mutated by Merge: %v", base.Config.Agents)
 	}
 }
 

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -75,8 +75,12 @@ type MemoryConfig struct {
 }
 
 type Agent struct {
-	Enabled bool   `toml:"enabled"`
-	Scope   string `toml:"scope,omitempty"` // "user" | "project"
+	Enabled bool `toml:"enabled"`
+	// Scope is display-only and never drives behavior: the scope of record is
+	// which file the entry lives in (~/.agentsync/agentsync.toml vs a project
+	// tree's). `agent add` writes "user" at user scope for continuity and omits
+	// the key entirely in project files; no render/plan path reads it.
+	Scope string `toml:"scope,omitempty"`
 }
 
 type UpdateDefaults struct {

--- a/website/src/content/docs/guides/projects.mdx
+++ b/website/src/content/docs/guides/projects.mdx
@@ -39,7 +39,7 @@ That writes a tree with the same files as the user tree — `agentsync.toml` plu
 
 - myrepo/
   - .agentsync/
-    - agentsync.toml `[agents]` table (subset / inherit)
+    - agentsync.toml `[agents]` table (the project's own agent set — required)
     - mcp/
       - **company-api.toml** project-only MCP servers
     - plugins/
@@ -60,13 +60,23 @@ state centrally under `~/.agentsync/.state/`, keyed by the project root.
 
 ## Author the tree
 
-The project's enabled agents go in an `[agents]` table — leave it empty to inherit
-the user's enabled agents:
+The project's enabled agents go in an `[agents]` table. This declaration is
+**authoritative**: project scope renders only to the agents declared here —
+never your user-scope agents — so every collaborator gets the same render from
+the same committed source. Declaring at least one agent is **required**;
+`apply`/`status`/`diff` refuse to run against a project that declares none.
 
 ```toml title="myrepo/.agentsync/agentsync.toml"
 [agents]
-claude = { enabled = true }       # subset for this project
-# (empty [agents] inherits the user's enabled agents)
+claude = { enabled = true }       # the agents THIS project renders to
+```
+
+The ergonomic way to manage it is the agent commands at project scope:
+
+```bash
+agentsync agent add claude --scope project      # or --project <path>
+agentsync agent list --scope project
+agentsync agent disable claude --scope project
 ```
 
 A project-only MCP server is just an `mcp/<id>.toml` file, identical in format to
@@ -102,7 +112,11 @@ The project tree is **overlaid** onto your user canonical:
 - a project entry **replaces** a user entry with the same id/name,
 - new project entries are **appended**,
 - project memory is **appended after** user memory,
-- an empty project `[agents]` **inherits** the user's enabled agents.
+- the project's `[agents]` table is **authoritative** — user-scope agents are
+  never inherited, and a project that declares none is a hard error (fix it with
+  `agentsync agent add <name> --scope project`). `import --scope project` stays
+  available before any agents are declared, so you can bootstrap the tree from
+  native config first.
 
 User-level servers and plugins still apply unless the project replaces or disables
 them.
@@ -159,8 +173,9 @@ user scope.
 
 <Aside type="note">
 	`--scope` and `--project` work on `init`, `import`, `apply`, `status`, `diff`,
-	`reconcile`, and `update` — anywhere the active config set matters. The global
-	`--no-input` flag makes any of them fail closed instead of prompting.
+	`reconcile`, `update`, `verify`, and every `agent` subcommand — anywhere the
+	active config set matters. The global `--no-input` flag makes any of them fail
+	closed instead of prompting.
 </Aside>
 
 <Aside type="caution" title="Upgrading from the old marker?">

--- a/website/src/content/docs/guides/projects.mdx
+++ b/website/src/content/docs/guides/projects.mdx
@@ -63,8 +63,9 @@ state centrally under `~/.agentsync/.state/`, keyed by the project root.
 The project's enabled agents go in an `[agents]` table. This declaration is
 **authoritative**: project scope renders only to the agents declared here —
 never your user-scope agents — so every collaborator gets the same render from
-the same committed source. Declaring at least one agent is **required**;
-`apply`/`status`/`diff` refuse to run against a project that declares none.
+the same committed source. Declaring at least one agent is **required**; every
+scope-aware render path (`apply`, `status`, `diff`, `reconcile`,
+`update --apply`, `verify`) refuses to run against a project that declares none.
 
 ```toml title="myrepo/.agentsync/agentsync.toml"
 [agents]

--- a/website/src/content/docs/recipes/team-onboarding.mdx
+++ b/website/src/content/docs/recipes/team-onboarding.mdx
@@ -23,8 +23,14 @@ directory committed at the repo root, with the same layout as your user
    agentsync init --scope project    # creates ./.agentsync/
    ```
 
-2. **Set the project's agents** — an `[agents]` table (leave it empty to inherit
-   each teammate's enabled agents):
+2. **Declare the project's agents** — required. Project scope renders only to
+   the agents declared here, never each teammate's user-scope agents, so
+   everyone gets the same render from the committed tree:
+
+   ```bash
+   agentsync agent add claude --scope project
+   agentsync agent add opencode --scope project
+   ```
 
    ```toml title="myrepo/.agentsync/agentsync.toml"
    [agents]
@@ -79,9 +85,11 @@ directory committed at the repo root, with the same layout as your user
 
 </Steps>
 
-<Aside type="note" title="The overlay is additive">
+<Aside type="note" title="The overlay is additive — except agents">
 	The project tree merges *onto* each teammate's user-level config — it doesn't
 	wipe their personal servers or plugins. A project entry replaces a user entry
-	with the same id/name, new entries are appended, and an empty project `[agents]`
-	inherits each teammate's own enabled agents.
+	with the same id/name and new entries are appended. Agents are the exception:
+	the project's `[agents]` table is authoritative, and a project that declares
+	none is a hard error (never an inherit of the teammate's own agents), which is
+	what keeps the render identical across the team.
 </Aside>

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -21,7 +21,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `init [<git-url>]` | Create `~/.agentsync/`; optionally clone a bootstrap repo. `--scope project` / `--project <path>` scaffolds a project tree instead. | `--scope --project` |
 | `doctor` | Diagnose setup: PATH, home/state writability, schema, secrets backend. | |
 | `verify` | Validate config; surface unresolved `${secret:}` / `${env:}` refs. `--scope project` / `--project <path>` lints the project tree instead. | `--scope --project` |
-| `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry. | `disable --purge` |
+| `agent add\|remove\|list\|enable\|disable <name>` | Manage the agent registry — the user's, or a project tree's own `[agents]` declaration with `--scope project` / `--project <path>`. | `disable --purge --scope --project` |
 | `mcp add\|remove\|list <name>` | Manage MCP servers. | `--type --command --args --url --env --agents` |
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
 | `plugin install\|upgrade\|enable\|disable\|remove\|list <id>` | Manage plugins. | `install <id[@marketplace]>` |
@@ -87,6 +87,17 @@ agentsync agent list              # registry + enabled state
 agentsync agent list --all        # every supported agent (registered or not)
 agentsync agent disable opencode  # stop applying (keeps source)
 agentsync agent disable opencode --purge   # also remove what it wrote
+```
+
+Every subcommand also takes `--scope project` / `--project <path>` to manage the
+**project's own** `[agents]` declaration in `<root>/.agentsync/agentsync.toml` —
+the set project scope renders to (user-scope agents are never inherited; see
+[Project-local config](/guides/projects/)):
+
+```bash
+agentsync agent add claude --scope project     # declare a project agent
+agentsync agent list --project ~/code/myrepo   # read a project's declaration
+agentsync agent disable claude --purge --scope project  # purge only this project's rendered files
 ```
 
 <Aside type="note">

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -109,10 +109,12 @@ source) and is on unless you set `banner = false`. See the
 A repo can carry a **project source tree** — a `.agentsync/` directory at its root
 with the *same* layout as the user tree above (scaffolded by `agentsync init
 --scope project`), minus `.state/`. It overlays onto your user config: a project
-entry replaces a user entry with the same id/name, new entries are appended,
-project memory is appended after user memory, and an empty project `[agents]`
-inherits the user's enabled agents. Commit the `.agentsync/` tree to share it with
-collaborators. See [Project-local config](/guides/projects/).
+entry replaces a user entry with the same id/name, new entries are appended, and
+project memory is appended after user memory. The project's `[agents]` table is
+authoritative — project scope renders only to the agents the project declares
+(`agentsync agent add <name> --scope project`), never the user's enabled agents,
+and a project that declares none is a hard error. Commit the `.agentsync/` tree
+to share it with collaborators. See [Project-local config](/guides/projects/).
 
 ## State
 


### PR DESCRIPTION
## Summary

Closes #183.

**BREAKING:** a project tree's `[agents]` table in `<root>/.agentsync/agentsync.toml` is now **authoritative** for project scope. `project.Merge` no longer inherits the user's enabled agents when the project declares none — inheritance made identical committed source render differently on each collaborator's machine (`.claude/`, `.codex/`, … drifted per-machine and churned in git). Now:

- **Empty/absent project `[agents]` is a hard, actionable error** on every scope-aware render path — `apply`/`status`/`diff`/`reconcile`/`update --apply`/`verify` — enforced by `requireProjectAgents` on the shared `loadProjectedForScope` path (and `verify`'s own load path). `import --scope project` is deliberately exempt so a tree can be bootstrapped from native config before agents are declared. A declared-but-all-disabled table passes the guard and soft-noops with a project-scoped hint.
- **Every `agent` subcommand is scope-aware:** `add`/`remove`/`list`/`enable`/`disable` take `--scope project` / `--project <path>` and edit the project tree's own `[agents]` declaration. Project entries are written without the redundant `scope` key (the file's location is the scope of record; the dormant `source.Agent.Scope` field stays display-only). At project scope, `disable --purge` filters state by scope + project root so it removes only that project's rendered files; user-scope `--purge` keeps its historical cross-scope cleanup semantics (now documented).
- **Hardened `[agents]` rewriter:** `writeAgents` is now fail-closed — the spliced result must re-parse, the agents table must round-trip, and nothing outside `[agents]` may change (`nonAgentsUnchanged`), otherwise the command refuses and leaves the file untouched. Purge state-key matching is colon-safe (literal-prefix, mirroring `render.PruneStaleState`) on both the purge side and the shared-file-protection side.
- **Init scaffold + dogfood:** the project scaffold teaches declaration (guidance comments moved above `[agents]` so the section rewrite can't swallow them), and this repo's own `.agentsync/agentsync.toml` declares `claude` + `codex` explicitly (verified byte-identical to the currently rendered `CLAUDE.md`/`AGENTS.md`/skills via `apply --scope project --dry-run`: 4 ops, all synced).

**Migration:** projects that relied on an empty `[agents]` to inherit must now declare their agents — `agentsync agent add <name> --scope project` for each agent the project renders to (see the CHANGELOG entry).

Reviewed via a 3-round, four-lens adversarial review loop (correctness, adversarial, API design, test rigor) that reached unanimous `CLEAN — ship it` in round 3; each round's findings were fixed and break-verified in commits `5ad3b1c` and `4ed3c56`. Suggested follow-ups (not blocking, happy to file as issues): scope-filter the user-scope `--purge` blast radius; move state keys off colon-joined strings to a structured encoding.

## Type of change

- [x] New feature / enhancement (breaking change to the documented v1 project-scope contract)

## Test plan

- New/updated tests: `TestMerge_AgentsNotInheritedWhenProjectEmpty` (contract flip), `TestIntegration_Project_UndeclaredAgentsError` (hard error across apply/status/diff/reconcile/verify + import exemption + all-disabled soft path), `TestUpdate_ApplyProjectScope_RequiresDeclaredAgents` (update's re-apply path), `TestAgent_ProjectScope_Lifecycle` / `TestAgent_ProjectScope_RequiresTree` (scope-aware agent CLI), `TestAgentDisable_Purge_ProjectScopeOnlyTouchesProject` (scoped purge), `TestPurgeKeyRest` / `TestOtherFilesKeyPath` (colon-safe key matching, break-verified), `TestAgent_AddRefusesUnsplicableTOML` / `TestAgent_AddRefusesSilentNonAgentsCorruption` (fail-closed rewriter, break-verified).
- Full suite green in the hermetic container: `go test -race ./...`, `go test -tags=e2e ./test/e2e/...`, `go test -tags=bdd ./test/bdd/...`.

- [x] `just test-release` is green (the release bar) — run as its container steps (race tests + e2e + bdd) inside this sandboxed session
- [x] `just lint` is clean (golangci-lint v2.12.2 under `GOTOOLCHAIN=go1.26.2`: 0 issues; gofmt/gofumpt/tidy no-ops)

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [ ] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. *(N/A — this change does not touch those paths.)*
- [x] Docs updated if behavior, CLI surface, or capability coverage changed — `docs/concepts.md`, `docs/architecture.md`, `docs/user-guide.md` (+ command reference), `CHANGELOG.md` breaking-change + migration note, init scaffold copy, and the website's `projects`/`team-onboarding`/`configuration`/`cli` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvJgEF5PZwMWWr9y9a11rL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvJgEF5PZwMWWr9y9a11rL)_