### PR TITLE
ci(release): temporarily disable the chocolatey pipe pending community review

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -161,31 +161,39 @@ scoops:
 # NOTE: the chocolatey pipe packages the Windows amd64 binary only — goreleaser's
 # own arch filter selects amd64/386 and excludes arm64 — so the windows/arm64
 # build is intentionally absent from the package.
+#
+# TEMPORARILY DISABLED — the agentsync package is still in Chocolatey's community
+# moderation queue, so `choco push` returns 403 and fails the whole release job
+# (it sank the v0.10.0 publish after every other channel had shipped). The block
+# below is preserved verbatim; uncomment it once the package passes community
+# review. Tracked in issue #188. The workflow-side gating (release.yml's
+# CHOCOLATEY_API_KEY detect step + Mono choco CLI setup) stays in place, so
+# re-enabling is exactly this uncomment.
 # --------------------------------------------------------------------------
-chocolateys:
-  - name: agentsync
-    ids: [default]
-    title: agentsync
-    authors: spxrogers
-    owners: spxrogers
-    summary: Centrally manage AI coding-agent configurations.
-    description: |
-      agentsync centrally manages AI coding-agent configurations from one
-      canonical source and renders them into each agent's native config.
-    project_url: https://github.com/spxrogers/agentsync
-    project_source_url: https://github.com/spxrogers/agentsync
-    package_source_url: https://github.com/spxrogers/agentsync
-    docs_url: https://agentsync.cc/
-    bug_tracker_url: https://github.com/spxrogers/agentsync/issues
-    license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
-    require_license_acceptance: false
-    copyright: 2026 spxrogers
-    tags: "agentsync cli ai coding agents configuration claude codex cursor dotfiles"
-    release_notes: "https://github.com/spxrogers/agentsync/releases/tag/{{ .Tag }}"
-    url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
-    source_repo: "https://push.chocolatey.org/"
-    goamd64: v1
+# chocolateys:
+#   - name: agentsync
+#     ids: [default]
+#     title: agentsync
+#     authors: spxrogers
+#     owners: spxrogers
+#     summary: Centrally manage AI coding-agent configurations.
+#     description: |
+#       agentsync centrally manages AI coding-agent configurations from one
+#       canonical source and renders them into each agent's native config.
+#     project_url: https://github.com/spxrogers/agentsync
+#     project_source_url: https://github.com/spxrogers/agentsync
+#     package_source_url: https://github.com/spxrogers/agentsync
+#     docs_url: https://agentsync.cc/
+#     bug_tracker_url: https://github.com/spxrogers/agentsync/issues
+#     license_url: https://github.com/spxrogers/agentsync/blob/main/LICENSE
+#     require_license_acceptance: false
+#     copyright: 2026 spxrogers
+#     tags: "agentsync cli ai coding agents configuration claude codex cursor dotfiles"
+#     release_notes: "https://github.com/spxrogers/agentsync/releases/tag/{{ .Tag }}"
+#     url_template: "https://github.com/spxrogers/agentsync/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+#     source_repo: "https://push.chocolatey.org/"
+#     goamd64: v1
 
 # --------------------------------------------------------------------------
 # AUR (Arch) — deliberately NOT enabled yet. Uncomment once its companion repo /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **Chocolatey publishing is temporarily paused (issue #188).** The `chocolateys`
+  block in `.goreleaser.yaml` is commented out while the `agentsync` package
+  waits in Chocolatey's community moderation queue — `choco push` returns 403
+  until it clears review, and that failure sank the tail of the v0.10.0 publish
+  after every other channel had shipped. Homebrew, Scoop, deb/rpm, and the
+  GitHub Release archives are unaffected. The block will be re-enabled verbatim
+  once the package is approved.
 - **BREAKING: project scope now requires the project to declare its own agents
   (issue #183).** A project tree's `[agents]` table in
   `<root>/.agentsync/agentsync.toml` is now **authoritative**: project-scope

--- a/README.md
+++ b/README.md
@@ -124,13 +124,11 @@ Scoop:
     scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
     scoop install agentsync
 
-Chocolatey:
+Chocolatey (pending — the package is in the community moderation queue and not
+yet installable; publishing is paused until it clears review, see
+[issue #188](https://github.com/spxrogers/agentsync/issues/188)):
 
     choco install agentsync
-
-Chocolatey packages pass through the community moderation queue before they're
-publicly installable, so a freshly published version can lag the other channels
-by a day or two.
 
 ### Any platform — prebuilt binary
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -87,9 +87,11 @@ brew install agentsync
 ```bash
 scoop bucket add spxrogers https://github.com/spxrogers/scoop-bucket
 scoop install agentsync
-# or:
-choco install agentsync
 ```
+
+(Chocolatey — `choco install agentsync` — is pending the community moderation
+queue and not yet installable; publishing is paused until it clears review, see
+[issue #188](https://github.com/spxrogers/agentsync/issues/188).)
 
 **Linux** — `.deb`/`.rpm` on the [Releases page](https://github.com/spxrogers/agentsync/releases).
 (AUR packaging is wired but not published yet — [issue #13](https://github.com/spxrogers/agentsync/issues/13).)

--- a/website/src/content/docs/getting-started/install.mdx
+++ b/website/src/content/docs/getting-started/install.mdx
@@ -34,7 +34,9 @@ import { Tabs, TabItem, Aside, Steps } from '@astrojs/starlight/components';
 		scoop install agentsync
 		```
 
-		Chocolatey:
+		Chocolatey — pending: the package is in the community moderation queue and
+		not yet installable (publishing is paused until it clears review — see
+		[issue #188](https://github.com/spxrogers/agentsync/issues/188)):
 
 		```powershell
 		choco install agentsync


### PR DESCRIPTION
## Summary

Temporarily comments out the `chocolateys` block in `.goreleaser.yaml` while the `agentsync` package waits in Chocolatey's community moderation queue. Until it clears review, `choco push` returns 403 — which failed the tail of the v0.10.0 publish ([run 29426826853](https://github.com/spxrogers/agentsync/actions/runs/29426826853)) after every other channel had shipped, and skipped the release's docs deploy. Re-enabling is tracked in #188 (this PR does not close it — the issue closes when the block is uncommented after approval).

- The block is preserved verbatim as comments, following the dormant-AUR precedent right below it, with a header pointing at #188.
- `release.yml` is untouched: the `CHOCOLATEY_API_KEY` detect gate and Mono choco CLI setup stay in place, so re-enabling is exactly the uncomment.
- Docs updated in the same commit per the docs-sync rule: the `choco install agentsync` instructions in `README.md`, `docs/user-guide.md`, and the website install page now say the package is pending moderation (linking #188), and `CHANGELOG.md` notes the pause under `[Unreleased]`.

Refs #188.

## Type of change

- [x] Tests / CI / tooling
- [x] Docs

## Test plan

- `.goreleaser.yaml` re-parses as valid YAML with `chocolateys` absent from the active document (verified locally).
- CI's `goreleaser-snapshot` job on this PR is the real config check (it runs the full cross-build against this config).

- [ ] `just test-release` is green (the release bar) — no Go code changed; PR CI runs the full gate
- [x] `just lint` is clean — no Go sources touched

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [ ] Tests added/updated for the behavior changed. *(N/A — config/docs only; CI's goreleaser-snapshot validates the config.)*
- [ ] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. *(N/A.)*
- [x] Docs updated if behavior, CLI surface, or capability coverage changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvJgEF5PZwMWWr9y9a11rL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvJgEF5PZwMWWr9y9a11rL)_