### PR TITLE
epic #178 — Wave 1: blockers (Claude hooks, revert data-loss) + shared guards + website fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 .idea/
 *.swp
 .DS_Store
+
+# Transient per-agent git worktrees created by background workflow orchestration.
+# These are isolated checkouts managed (and cleaned up) by the harness — never
+# commit them.
+/.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **The capture cleartext backstop now refuses short and empty-edge moved secrets
+  (issue #135).** The fail-closed backstop (`secrets.ResidualSecretCleartext`)
+  reused the re-reference value set, which drops any resolved secret shorter than
+  4 characters — so a 1–3 character credential moved into a field whose source
+  counterpart is a literal was written verbatim into the committed canonical
+  source with no refusal. The backstop now builds its detection set without the
+  length floor (keeping 1–3 char values, excluding only truly-empty ones), closing
+  the leak while the re-reference fallback keeps its substring-safety floor
+  unchanged. Security hardening.
+
 - **`agentsync revert` no longer deletes your untracked or gitignored files
   (issue #128).** `Restore` used go-git's `HardReset`, which — unlike `git reset
   --hard` — enumerates and removes every untracked and gitignored file in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,14 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **An invalid `[destination_directory_git_backup]` `mode` now errors at config
+  load instead of being silently ignored (issue #137).** The strict TOML decoder
+  rejected unknown keys but accepted any value, so a typo like `mode = "On"`,
+  `"yes"`, or `"true"` silently disabled git backup for untracked dirs (while
+  still committing already-owned repos) — and only `doctor` warned. `source.Load`
+  now rejects any `mode` outside `{prompt, on, off}` (case-sensitive; empty
+  defaults to `prompt`) with a path-prefixed error, so `apply` and `doctor` agree.
+
 - **The capture cleartext backstop now refuses short and empty-edge moved secrets
   (issue #135).** The fail-closed backstop (`secrets.ResidualSecretCleartext`)
   reused the re-reference value set, which drops any resolved secret shorter than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **Claude hooks no longer drop unmodeled fields or corrupt non-command handlers
+  on `import`→`apply` (issue #124).** The canonical hook model represents only
+  command handlers, so an `import` that captured a `settings.json` hook event
+  carrying an unmodeled field (e.g. `timeout`) or a non-`command` handler, then
+  re-`apply`d it, silently rewrote the user's native `/hooks/<event>` array —
+  dropping the extra fields and emitting a structurally invalid
+  `{"type":"…","command":""}` entry. Ingest now leaves any hook event it cannot
+  fully represent **uncaptured** with a warning (matching the Gemini adapter), so
+  the next apply never owns or overwrites that event, and Render reports a dropped
+  `Skip` for a non-`command` handler instead of emitting an empty-command entry.
+
 - **Claude LSP capability corrected.** Claude Code reads LSP servers from plugin
   manifests, not `settings.json#/lspServers`; agentsync now reports canonical
   Claude LSP servers as skipped instead of writing or importing a key Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`agentsync revert` no longer deletes your untracked or gitignored files
+  (issue #128).** `Restore` used go-git's `HardReset`, which — unlike `git reset
+  --hard` — enumerates and removes every untracked and gitignored file in the
+  worktree, so a revert silently destroyed the user's own scratch files in the
+  managed destination dir during the operation sold as safe recovery. Restore now
+  applies only the tracked HEAD↔target delta file-by-file and never enumerates
+  untracked entries, so they (and gitignored files) survive byte-for-byte and stay
+  untracked. `revert --dry-run` now notes when untracked files are present (left
+  untouched).
+
 - **Claude hooks no longer drop unmodeled fields or corrupt non-command handlers
   on `import`→`apply` (issue #124).** The canonical hook model represents only
   command handlers, so an `import` that captured a `settings.json` hook event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **Corrected two copy-paste-wrong docs examples (issue #129).** The onboarding
+  and daily-loop pages told users to run `agentsync diff claude`, but `diff`'s
+  argument is a filesystem path, not an agent name — `diff claude` matched nothing
+  and silently printed "no diff"; the example is now bare `agentsync diff`. The
+  configuration reference showed an `[[agents]]` array-of-tables snippet with
+  `name = "…"`, but the loader unmarshals `agents` as a table keyed by name, so the
+  documented TOML registered zero agents; it now shows the correct `[agents.<name>]`
+  form. Also documented the previously-undocumented `[updates]` block and
+  `[secrets].file` key.
+
 - **An invalid `[destination_directory_git_backup]` `mode` now errors at config
   load instead of being silently ignored (issue #137).** The strict TOML decoder
   rejected unknown keys but accepted any value, so a typo like `mode = "On"`,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ configs quietly drift apart. agentsync fixes the fan-out:
   back into your (committable) source.
 - **A bad apply is revertible.** `apply` keeps each destination dir (`~/.claude`,
   …) in a **local-only** git history (opt-out, never pushed), so `agentsync revert`
-  rolls back to a prior checkpoint.
+  rolls back to a prior checkpoint — while leaving any untracked/gitignored files
+  you put in the dir untouched.
 
 New here? The **[User guide](docs/user-guide.md)** takes you 0→100.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -434,6 +434,10 @@ secret from a deliberate non-secret edit. As a **fail-closed backstop**,
 written verbatim, or a `${secret:K}` the source referenced has vanished from the
 captured group (rotated/edited away), it **refuses the write** rather than risk
 persisting cleartext — directing the user to update the vault or edit the source.
+The backstop detects live secret values regardless of length: it does **not**
+inherit the re-reference value-based fallback's length floor (which skips 1–3
+char values to avoid substring-rewriting unrelated text), because refusing to
+persist a leak is not a rewrite — so even a 1–3 char credential trips it.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -111,6 +111,12 @@ Claude's native paths (`~/.claude/skills/<name>/`, `mcpServers` in
 `.claude.json`, …) and deliberately leaves the enablement keys themselves
 untouched. The asymmetry is the cross-adapter rule, not a Claude quirk — see
 [architecture.md § PluginIngester (read-only)](architecture.md#pluginingester-read-only).
+Hook fidelity: the canonical `Hook` models only command handlers, so (like
+Gemini) Ingest leaves a `settings.json` hook event uncaptured with a warning if
+it carries an unmodeled definition/handler field (e.g. `timeout`) or a
+non-command handler, and Render reports a dropped `Skip` for any non-command
+hook rather than emitting an empty-command entry — an import→apply round-trip
+never rewrites the user's native `/hooks/<event>` array lossily.
 - **Key:** `New(Options) *Adapter`; the `Adapter` + `PluginIngester` methods;
   `ParseFrontmatter`/`EncodeFrontmatter`; `MergeKeys`.
 - **Depends on:** adapter, secrets, source, paths, iox, jsonkeys.

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -339,7 +339,8 @@ Behavior:
    go-git's `HardReset`, which (unlike `git reset --hard`) enumerates and deletes
    every untracked/gitignored worktree file. Touching only the diffed paths leaves
    the user's own untracked/gitignored files intact (issue #128); `--dry-run` notes
-   when such files are present.
+   when untracked files are present (gitignored files are also preserved, but
+   git status can't enumerate them, so they aren't listed).
 4. Print the **out-of-sync notice** (decision #4):
 
    > `agentsync revert` completed. The destination directory `<dir>` is now out

--- a/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-28-destination-git-versioning-design.md
@@ -334,7 +334,12 @@ Behavior:
    agentsync-managed repo (no marker / never inited).
 2. Resolve the target checkpoint (`--to` or the previous checkpoint by default).
 3. Restore the worktree files to that checkpoint's content and record a new commit
-   `agentsync revert: <agent> → <short-ref>`. Append-only (decision #8).
+   `agentsync revert: <agent> → <short-ref>`. Append-only (decision #8). This
+   applies **only the tracked HEAD↔target delta** file-by-file — it must NOT use
+   go-git's `HardReset`, which (unlike `git reset --hard`) enumerates and deletes
+   every untracked/gitignored worktree file. Touching only the diffed paths leaves
+   the user's own untracked/gitignored files intact (issue #128); `--dry-run` notes
+   when such files are present.
 4. Print the **out-of-sync notice** (decision #4):
 
    > `agentsync revert` completed. The destination directory `<dir>` is now out

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -258,8 +258,12 @@ agentsync revert --all --dry-run     # preview reverting every managed dir
 history, so the bad apply stays in the log and the revert is itself revertible. If
 you hand-edited a tracked file after the last apply, revert snapshots that edit
 into history first, so **nothing is lost** (recover it with `revert --to <snapshot>`).
-It moves only the *destination*, so afterwards it reminds you to **reconcile** (or
-fix the canonical source) before the next `apply` re-renders over it.
+Any **untracked files** you dropped into the dir (and gitignored files) are **left
+untouched** — revert only rewinds the files agentsync itself versions, so your own
+scratch files are never deleted. `revert --dry-run` notes when such files are
+present. It moves only the *destination*, so afterwards it reminds you to
+**reconcile** (or fix the canonical source) before the next `apply` re-renders over
+it.
 
 The first apply to an untracked dir **asks** before initializing the repo
 (opt-out). Answer once and it's remembered in `agentsync.toml`:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -275,6 +275,12 @@ mode = "on"          # "prompt" (default) | "on" | "off"
 # author_email = "agentsync@localhost"
 ```
 
+`mode` accepts exactly `prompt`, `on`, or `off` (case-sensitive; an omitted
+`mode` defaults to `prompt`). Any other value — a typo like `"On"`, `"yes"`, or
+`"true"` — is now **rejected at load** with a path-prefixed error, so every
+command that reads the config (`apply`, `doctor`, …) agrees. (Previously an
+invalid value was silently ignored and only `doctor` warned about it.)
+
 `apply --no-git-backup` skips it for one run (CI/scripting) without touching
 config, and `agentsync doctor` shows the current mode and per-dir status.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -218,7 +218,7 @@ A typical session after an agent edited a file out from under you:
 
 ```bash
 agentsync status              # spot the drift
-agentsync diff claude         # inspect it (resolved secrets are masked)
+agentsync diff                # inspect it (resolved secrets are masked)
 agentsync reconcile           # interactively resolve
 ```
 

--- a/internal/adapter/claude/hook.go
+++ b/internal/adapter/claude/hook.go
@@ -115,6 +115,7 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 		for _, rawEntry := range entries {
 			entry, ok := rawEntry.(map[string]any)
 			if !ok {
+				fmt.Fprintf(warn, "warning: hook event %q has a malformed definition (not an object); event not captured\n", event)
 				representable = false
 				break
 			}
@@ -128,6 +129,7 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 			for _, rawH := range hooksArr {
 				h, ok := rawH.(map[string]any)
 				if !ok {
+					fmt.Fprintf(warn, "warning: hook event %q has a malformed handler (not an object); event not captured\n", event)
 					representable = false
 					break defs
 				}

--- a/internal/adapter/claude/hook.go
+++ b/internal/adapter/claude/hook.go
@@ -98,6 +98,11 @@ var (
 // entry without the dropped fields; Render is the last line of defense (it skips
 // non-command handlers), and this ingest guard keeps unrepresentable events out
 // of the canonical source in the first place.
+//
+// This is intentionally MORE diagnostic than Gemini's twin: it also warns on the
+// structurally-malformed shapes (non-object def/handler, non-array event value or
+// "hooks" value) that Gemini's ingestHooks drops silently. Bringing Gemini to
+// parity is a separate follow-up (out of this issue's scope).
 func ingestHooks(raw any, warn io.Writer) []source.Hook {
 	hooks, ok := raw.(map[string]any)
 	if !ok {
@@ -107,6 +112,7 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 	for event, rawEntries := range hooks {
 		entries, ok := rawEntries.([]any)
 		if !ok {
+			fmt.Fprintf(warn, "warning: hook event %q value is not an array; event not captured\n", event)
 			continue
 		}
 		var captured []source.Hook
@@ -125,14 +131,14 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 				break
 			}
 			matcher := asStr(entry["matcher"])
-			// A present-but-non-array "hooks" value (e.g. an object) can't be
-			// captured; leave the whole event uncaptured rather than silently
-			// contribute zero handlers while a sibling def keeps the event alive
-			// (which the next apply would then own and clobber this def).
-			rawHooks, hasHooks := entry["hooks"]
-			hooksArr, isArr := rawHooks.([]any)
-			if hasHooks && !isArr {
-				fmt.Fprintf(warn, "warning: hook event %q has a definition whose \"hooks\" value is not an array; event not captured\n", event)
+			// A definition must carry a "hooks" ARRAY of handlers. An absent, null,
+			// or non-array "hooks" value can't be captured, so leave the whole event
+			// uncaptured rather than silently contribute zero handlers while a
+			// sibling def keeps the event alive (which the next apply would then own
+			// and clobber this def). An empty array is fine — a def with no handlers.
+			hooksArr, isArr := entry["hooks"].([]any)
+			if !isArr {
+				fmt.Fprintf(warn, "warning: hook event %q has a definition without a valid \"hooks\" array; event not captured\n", event)
 				representable = false
 				break
 			}

--- a/internal/adapter/claude/hook.go
+++ b/internal/adapter/claude/hook.go
@@ -3,6 +3,9 @@ package claude
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
+	"strings"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -12,13 +15,33 @@ import (
 // entries. Per-event ownership: agentsync owns the entire array under its
 // event key. Foreign event keys (e.g. PreToolUse if user has authored
 // directly) are NOT touched if they're not in canonical.
-func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, error) {
+//
+// Render is the last line of defense against corrupting the user's real
+// settings.json: the canonical Hook models only command handlers, so any hook
+// whose Type is a non-empty non-"command" value is reported as a dropped Skip
+// and never emitted — emitting a {type:"...",command:""} handler would let the
+// owned-array overwrite clobber the user's native handler. An empty Type is
+// treated as command-compatible (mirrors Gemini's `h.Type != "" && h.Type !=
+// "command"` guard).
+func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, []adapter.Skip, error) {
 	if len(c.Hooks) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	byEvent := map[string][]map[string]any{}
-	var ownedKeys []string
+	var skips []adapter.Skip
 	for _, h := range c.Hooks {
+		// agentsync models only command hooks (the only kind the canonical Hook
+		// represents). Skip any other type with a report rather than emitting an
+		// entry with an empty command that would overwrite the user's handler.
+		if h.Type != "" && h.Type != "command" {
+			skips = append(skips, adapter.Skip{
+				Component: "hook",
+				Name:      h.Event,
+				Reason:    fmt.Sprintf("agentsync models only command hooks; type %q is not projected", h.Type),
+				Kind:      adapter.SkipDropped,
+			})
+			continue
+		}
 		entry := map[string]any{
 			"matcher": h.Matcher,
 			"hooks": []map[string]any{{
@@ -28,13 +51,17 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, er
 		}
 		byEvent[h.Event] = append(byEvent[h.Event], entry)
 	}
+	if len(byEvent) == 0 {
+		return nil, skips, nil
+	}
+	var ownedKeys []string
 	for event := range byEvent {
 		ownedKeys = append(ownedKeys, "/hooks/"+event)
 	}
 	obj := map[string]any{"hooks": byEvent}
 	body, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("marshal hooks: %w", err)
+		return nil, nil, fmt.Errorf("marshal hooks: %w", err)
 	}
 	return []adapter.FileOp{{
 		Action:        "write",
@@ -44,5 +71,99 @@ func (a *Adapter) renderHooks(c source.Canonical, p Paths) ([]adapter.FileOp, er
 		SourceID:      "hooks/* (multiple)",
 		MergeStrategy: "merge-json-keys",
 		OwnedKeys:     ownedKeys,
-	}}, nil
+	}}, skips, nil
+}
+
+// Claude's documented hook schema is wider than the canonical source.Hook: a
+// per-event definition can carry keys beyond {matcher, hooks} and an individual
+// handler keys beyond {type, command} (e.g. `timeout`). These enumerate the
+// fields the canonical model CAN represent; anything else in an event makes that
+// event unrepresentable — see ingestHooks.
+var (
+	claudeHookDefModeledKeys   = map[string]bool{"matcher": true, "hooks": true}
+	claudeHookEntryModeledKeys = map[string]bool{"type": true, "command": true}
+)
+
+// ingestHooks decodes settings.json's `hooks` object into canonical hooks,
+// warning on anything it cannot capture. Inverse of renderHooks: each
+// {type, command} handler becomes a source.Hook sharing the group's matcher.
+// Unlike Gemini there is NO event-name remapping — every Claude event name is
+// canonical. Per event, if ANY definition carries an unmodeled key, or ANY
+// handler is a non-empty non-"command" type, or ANY handler carries an unmodeled
+// key (e.g. `timeout`), the WHOLE event is left uncaptured with a warning.
+//
+// APPROACH A (no schema change): mirror the Gemini adapter's guard-and-warn
+// posture rather than widen source.Hook. Capturing a lossy subset would let the
+// next apply — which owns the whole per-event array — rewrite the user's native
+// entry without the dropped fields; Render is the last line of defense (it skips
+// non-command handlers), and this ingest guard keeps unrepresentable events out
+// of the canonical source in the first place.
+func ingestHooks(raw any, warn io.Writer) []source.Hook {
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []source.Hook
+	for event, rawEntries := range hooks {
+		entries, ok := rawEntries.([]any)
+		if !ok {
+			continue
+		}
+		var captured []source.Hook
+		representable := true
+	defs:
+		for _, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				representable = false
+				break
+			}
+			if extra := unmodeledKeys(entry, claudeHookDefModeledKeys); len(extra) > 0 {
+				fmt.Fprintf(warn, "warning: hook event %q has a definition with unmodeled fields (%s); event not captured\n", event, strings.Join(extra, ", "))
+				representable = false
+				break
+			}
+			matcher := asStr(entry["matcher"])
+			hooksArr, _ := entry["hooks"].([]any)
+			for _, rawH := range hooksArr {
+				h, ok := rawH.(map[string]any)
+				if !ok {
+					representable = false
+					break defs
+				}
+				if typ := asStr(h["type"]); typ != "" && typ != "command" {
+					fmt.Fprintf(warn, "warning: hook event %q has a %q-type handler agentsync cannot represent; event not captured\n", event, typ)
+					representable = false
+					break defs
+				}
+				if extra := unmodeledKeys(h, claudeHookEntryModeledKeys); len(extra) > 0 {
+					fmt.Fprintf(warn, "warning: hook event %q has a handler with unmodeled fields (%s); event not captured\n", event, strings.Join(extra, ", "))
+					representable = false
+					break defs
+				}
+				captured = append(captured, source.Hook{
+					Event:   event,
+					Matcher: matcher,
+					Type:    asStr(h["type"]),
+					Command: asStr(h["command"]),
+				})
+			}
+		}
+		if representable {
+			out = append(out, captured...)
+		}
+	}
+	return out
+}
+
+// unmodeledKeys returns the sorted keys of m that are not in modeled.
+func unmodeledKeys(m map[string]any, modeled map[string]bool) []string {
+	var out []string
+	for k := range m {
+		if !modeled[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/adapter/claude/hook.go
+++ b/internal/adapter/claude/hook.go
@@ -130,6 +130,15 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 				representable = false
 				break
 			}
+			// A non-string matcher would be coerced to "" by asStr and captured as a
+			// match-all — refuse the event rather than silently rewrite it.
+			if rawMatcher, present := entry["matcher"]; present {
+				if _, isStr := rawMatcher.(string); !isStr {
+					fmt.Fprintf(warn, "warning: hook event %q has a definition whose \"matcher\" is not a string; event not captured\n", event)
+					representable = false
+					break
+				}
+			}
 			matcher := asStr(entry["matcher"])
 			// A definition must carry a "hooks" ARRAY of handlers. An absent, null,
 			// or non-array "hooks" value can't be captured, so leave the whole event
@@ -148,6 +157,15 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 					fmt.Fprintf(warn, "warning: hook event %q has a malformed handler (not an object); event not captured\n", event)
 					representable = false
 					break defs
+				}
+				// A non-string type would be coerced to "" by asStr and captured as a
+				// command handler; refuse the malformed shape instead.
+				if rawType, present := h["type"]; present {
+					if _, isStr := rawType.(string); !isStr {
+						fmt.Fprintf(warn, "warning: hook event %q has a handler whose \"type\" is not a string; event not captured\n", event)
+						representable = false
+						break defs
+					}
 				}
 				if typ := asStr(h["type"]); typ != "" && typ != "command" {
 					fmt.Fprintf(warn, "warning: hook event %q has a %q-type handler agentsync cannot represent; event not captured\n", event, typ)

--- a/internal/adapter/claude/hook.go
+++ b/internal/adapter/claude/hook.go
@@ -125,7 +125,17 @@ func ingestHooks(raw any, warn io.Writer) []source.Hook {
 				break
 			}
 			matcher := asStr(entry["matcher"])
-			hooksArr, _ := entry["hooks"].([]any)
+			// A present-but-non-array "hooks" value (e.g. an object) can't be
+			// captured; leave the whole event uncaptured rather than silently
+			// contribute zero handlers while a sibling def keeps the event alive
+			// (which the next apply would then own and clobber this def).
+			rawHooks, hasHooks := entry["hooks"]
+			hooksArr, isArr := rawHooks.([]any)
+			if hasHooks && !isArr {
+				fmt.Fprintf(warn, "warning: hook event %q has a definition whose \"hooks\" value is not an array; event not captured\n", event)
+				representable = false
+				break
+			}
 			for _, rawH := range hooksArr {
 				h, ok := rawH.(map[string]any)
 				if !ok {

--- a/internal/adapter/claude/hook_test.go
+++ b/internal/adapter/claude/hook_test.go
@@ -288,6 +288,16 @@ func TestIngest_HookGuardWarnsAndSkips(t *testing.T) {
 			hooks:     `{ "PreToolUse": { "matcher": "Bash" } }`,
 			wantWarns: []string{"value is not an array", "event not captured"},
 		},
+		{
+			name:      "handler type is not a string",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": 5, "command": "x" } ] } ] }`,
+			wantWarns: []string{`"type" is not a string`, "event not captured"},
+		},
+		{
+			name:      "matcher is not a string",
+			hooks:     `{ "PreToolUse": [ { "matcher": 5, "hooks": [ { "type": "command", "command": "x" } ] } ] }`,
+			wantWarns: []string{`"matcher" is not a string`, "event not captured"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/adapter/claude/hook_test.go
+++ b/internal/adapter/claude/hook_test.go
@@ -190,17 +190,34 @@ func TestRenderHooks_SkipsNonCommandHandler(t *testing.T) {
 				t.Errorf("got hook skip = %v, want %v (skips=%+v)", gotHookSkip, tt.wantSkip, skips)
 			}
 
-			// A settings.json op must never carry an empty-command handler.
+			// A settings.json op must never carry an empty-command handler. Parse
+			// the op payload and walk it (not a spacing-coupled byte substring) so
+			// the negative assertion can't pass vacuously if the encoder changes.
 			var renderedHooks bool
 			for _, op := range ops {
 				if !strings.HasSuffix(op.Path, "settings.json") {
 					continue
 				}
-				if bytes.Contains(op.Content, []byte(`"hooks"`)) {
+				var payload map[string]any
+				if err := json.Unmarshal(op.Content, &payload); err != nil {
+					t.Fatalf("parse settings.json op: %v\n%s", err, op.Content)
+				}
+				hooksObj, _ := payload["hooks"].(map[string]any)
+				if len(hooksObj) > 0 {
 					renderedHooks = true
 				}
-				if bytes.Contains(op.Content, []byte(`"command": ""`)) {
-					t.Errorf("settings.json op emitted an empty-command handler:\n%s", op.Content)
+				for event, raw := range hooksObj {
+					defs, _ := raw.([]any)
+					for _, rawDef := range defs {
+						def, _ := rawDef.(map[string]any)
+						hs, _ := def["hooks"].([]any)
+						for _, rawH := range hs {
+							h, _ := rawH.(map[string]any)
+							if cmd, ok := h["command"].(string); ok && cmd == "" {
+								t.Errorf("event %q op emitted an empty-command handler: %+v", event, h)
+							}
+						}
+					}
 				}
 			}
 			if renderedHooks != tt.wantRender {
@@ -242,6 +259,11 @@ func TestIngest_HookGuardWarnsAndSkips(t *testing.T) {
 			name:      "malformed handler (not an object)",
 			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": [ "echo hi" ] } ] }`,
 			wantWarns: []string{"malformed handler", "event not captured"},
+		},
+		{
+			name:      "hooks value is not an array",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": { "not": "an array" } } ] }`,
+			wantWarns: []string{`"hooks" value is not an array`, "event not captured"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/adapter/claude/hook_test.go
+++ b/internal/adapter/claude/hook_test.go
@@ -53,6 +53,12 @@ func TestIngest_HookArtifactRoundTrip(t *testing.T) {
 	if len(out.Hooks) != 1 || out.Hooks[0].Event != "PostToolUse" {
 		t.Fatalf("expected only the clean PostToolUse event captured, got %+v", out.Hooks)
 	}
+	// Modify the captured command so the rendered PostToolUse DIFFERS from the
+	// native fixture. Otherwise a no-op Apply (or a stubbed Render) would leave
+	// "echo after" in place and the round-trip assertion below would pass
+	// vacuously — a correct Apply must materialize this new value through the
+	// owned-key merge while leaving the guarded foreign events untouched.
+	out.Hooks[0].Command = "echo after (rerendered)"
 
 	ops, _, err := a.Render(secrets.ForRender(out), adapter.ScopeUser, "")
 	if err != nil {
@@ -117,10 +123,12 @@ func TestIngest_HookArtifactRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("clean hook round-trips", func(t *testing.T) {
+	t.Run("clean hook round-trips through a real merge", func(t *testing.T) {
 		h := handler(t, "PostToolUse")
-		if h["type"] != "command" || h["command"] != "echo after" {
-			t.Errorf("PostToolUse did not round-trip: %+v", h)
+		// The rerendered value proves Apply actually wrote via the owned-key merge
+		// (a no-op Apply would leave the native "echo after").
+		if h["type"] != "command" || h["command"] != "echo after (rerendered)" {
+			t.Errorf("PostToolUse did not round-trip through a real render/merge: %+v", h)
 		}
 	})
 
@@ -263,7 +271,22 @@ func TestIngest_HookGuardWarnsAndSkips(t *testing.T) {
 		{
 			name:      "hooks value is not an array",
 			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": { "not": "an array" } } ] }`,
-			wantWarns: []string{`"hooks" value is not an array`, "event not captured"},
+			wantWarns: []string{`without a valid "hooks" array`, "event not captured"},
+		},
+		{
+			name:      "hooks value is null",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": null } ] }`,
+			wantWarns: []string{`without a valid "hooks" array`, "event not captured"},
+		},
+		{
+			name:      "hooks key absent",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash" } ] }`,
+			wantWarns: []string{`without a valid "hooks" array`, "event not captured"},
+		},
+		{
+			name:      "event value is not an array",
+			hooks:     `{ "PreToolUse": { "matcher": "Bash" } }`,
+			wantWarns: []string{"value is not an array", "event not captured"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/adapter/claude/hook_test.go
+++ b/internal/adapter/claude/hook_test.go
@@ -126,9 +126,20 @@ func TestIngest_HookArtifactRoundTrip(t *testing.T) {
 
 	t.Run("no empty-command handler emitted", func(t *testing.T) {
 		// A regression would emit {"type":"prompt","command":""} (or any
-		// command:"") for a guarded handler. Assert none appears anywhere.
-		if bytes.Contains(finalRaw, []byte(`"command": ""`)) || bytes.Contains(finalRaw, []byte(`"command":""`)) {
-			t.Errorf("final settings.json contains an empty-command handler:\n%s", finalRaw)
+		// command:"") for a guarded handler. Walk the PARSED object (not the
+		// formatted bytes) so the check is independent of the encoder's spacing.
+		for event, raw := range hooks {
+			defs, _ := raw.([]any)
+			for _, rawDef := range defs {
+				def, _ := rawDef.(map[string]any)
+				hs, _ := def["hooks"].([]any)
+				for _, rawH := range hs {
+					h, _ := rawH.(map[string]any)
+					if cmd, ok := h["command"].(string); ok && cmd == "" {
+						t.Errorf("event %q has a handler with an empty command: %+v", event, h)
+					}
+				}
+			}
 		}
 	})
 }
@@ -200,37 +211,65 @@ func TestRenderHooks_SkipsNonCommandHandler(t *testing.T) {
 }
 
 // TestIngest_HookGuardWarnsAndSkips captures the adapter's stderr and asserts
-// that an event with an unmodeled handler field is absent from the ingested
-// model and produces an "event not captured" warning.
+// that EVERY kind of unrepresentable hook event — an unmodeled field, a
+// non-command handler, and a structurally malformed (non-object) definition or
+// handler — is left out of the ingested model AND produces an "event not
+// captured" warning, honouring the "warn on anything it cannot capture"
+// contract.
 func TestIngest_HookGuardWarnsAndSkips(t *testing.T) {
 	testenv.RequireContainer(t)
-	tmp := t.TempDir()
-	settings := filepath.Join(tmp, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name      string
+		hooks     string // the JSON value of the settings.json "hooks" object
+		wantWarns []string
+	}{
+		{
+			name:      "unmodeled handler field",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo before", "timeout": 30 } ] } ] }`,
+			wantWarns: []string{"unmodeled fields (timeout)", "event not captured"},
+		},
+		{
+			name:      "non-command handler",
+			hooks:     `{ "Notification": [ { "matcher": "", "hooks": [ { "type": "prompt", "command": "notify me" } ] } ] }`,
+			wantWarns: []string{`"prompt"-type handler`, "event not captured"},
+		},
+		{
+			name:      "malformed definition (not an object)",
+			hooks:     `{ "PreToolUse": [ "echo hi" ] }`,
+			wantWarns: []string{"malformed definition", "event not captured"},
+		},
+		{
+			name:      "malformed handler (not an object)",
+			hooks:     `{ "PreToolUse": [ { "matcher": "Bash", "hooks": [ "echo hi" ] } ] }`,
+			wantWarns: []string{"malformed handler", "event not captured"},
+		},
 	}
-	native := `{
-  "hooks": {
-    "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo before", "timeout": 30 } ] } ]
-  }
-}`
-	if err := os.WriteFile(settings, []byte(native), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			settings := filepath.Join(tmp, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(settings, []byte(`{ "hooks": `+tt.hooks+` }`), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	var warn bytes.Buffer
-	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: &warn})
-	out, err := a.Ingest(adapter.ScopeUser, "")
-	if err != nil {
-		t.Fatalf("Ingest: %v", err)
-	}
-	if len(out.Hooks) != 0 {
-		t.Fatalf("guarded event should be absent from ingested hooks, got %+v", out.Hooks)
-	}
-	got := warn.String()
-	for _, want := range []string{`unmodeled fields (timeout)`, `event not captured`} {
-		if !strings.Contains(got, want) {
-			t.Errorf("missing warning %q in:\n%s", want, got)
-		}
+			var warn bytes.Buffer
+			a := claude.New(claude.Options{TargetRoot: tmp, Stderr: &warn})
+			out, err := a.Ingest(adapter.ScopeUser, "")
+			if err != nil {
+				t.Fatalf("Ingest: %v", err)
+			}
+			if len(out.Hooks) != 0 {
+				t.Fatalf("guarded event should be absent from ingested hooks, got %+v", out.Hooks)
+			}
+			got := warn.String()
+			for _, want := range tt.wantWarns {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing warning %q in:\n%s", want, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/adapter/claude/hook_test.go
+++ b/internal/adapter/claude/hook_test.go
@@ -1,0 +1,236 @@
+package claude_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/adapter/claude"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// TestIngest_HookArtifactRoundTrip is artifact-anchored: it seeds a
+// spec-complete settings.json on disk (with hook events the canonical model
+// cannot fully represent) and asserts the ON-DISK result of a full
+// import→apply round-trip. Approach A leaves unrepresentable events entirely
+// uncaptured, so the render pipeline never owns their /hooks/<event> array and
+// the user's native entries survive byte-for-byte. Only the clean
+// command-only event round-trips, and no {type,command:""} handler is ever
+// emitted.
+func TestIngest_HookArtifactRoundTrip(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	settings := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// (a) PreToolUse: a command handler carrying an unmodeled field (timeout).
+	// (b) Notification: a non-command ("prompt") handler.
+	// (c) PostToolUse: a clean command-only event.
+	native := `{
+  "hooks": {
+    "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo before", "timeout": 30 } ] } ],
+    "Notification": [ { "matcher": "", "hooks": [ { "type": "prompt", "command": "notify me" } ] } ],
+    "PostToolUse": [ { "matcher": "Write", "hooks": [ { "type": "command", "command": "echo after" } ] } ]
+  }
+}`
+	if err := os.WriteFile(settings, []byte(native), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := claude.New(claude.Options{TargetRoot: tmp})
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	// Only the clean command-only event is captured.
+	if len(out.Hooks) != 1 || out.Hooks[0].Event != "PostToolUse" {
+		t.Fatalf("expected only the clean PostToolUse event captured, got %+v", out.Hooks)
+	}
+
+	ops, _, err := a.Render(secrets.ForRender(out), adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := a.Apply(ops, adapter.PassThroughWriter{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	finalRaw, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatalf("re-read settings.json: %v", err)
+	}
+	var final map[string]any
+	if err := json.Unmarshal(finalRaw, &final); err != nil {
+		t.Fatalf("parse final settings.json: %v\n%s", err, finalRaw)
+	}
+	hooks, ok := final["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("final settings.json has no hooks object:\n%s", finalRaw)
+	}
+
+	// handler navigates to hooks[event][0].hooks[0], the only handler in each
+	// fixture event.
+	handler := func(t *testing.T, event string) map[string]any {
+		t.Helper()
+		defs, ok := hooks[event].([]any)
+		if !ok || len(defs) == 0 {
+			t.Fatalf("event %q missing from final file:\n%s", event, finalRaw)
+		}
+		def, ok := defs[0].(map[string]any)
+		if !ok {
+			t.Fatalf("event %q def[0] not an object", event)
+		}
+		hs, ok := def["hooks"].([]any)
+		if !ok || len(hs) == 0 {
+			t.Fatalf("event %q has no handlers", event)
+		}
+		h, ok := hs[0].(map[string]any)
+		if !ok {
+			t.Fatalf("event %q handler[0] not an object", event)
+		}
+		return h
+	}
+
+	t.Run("extra-field hook left untouched", func(t *testing.T) {
+		h := handler(t, "PreToolUse")
+		if h["command"] != "echo before" {
+			t.Errorf("PreToolUse command corrupted: %+v", h)
+		}
+		// The unmodeled timeout field must survive verbatim (it was never
+		// captured, so the array was never owned/overwritten).
+		if _, ok := h["timeout"]; !ok {
+			t.Errorf("PreToolUse lost its unmodeled timeout field: %+v", h)
+		}
+	})
+
+	t.Run("non-command handler left untouched", func(t *testing.T) {
+		h := handler(t, "Notification")
+		if h["type"] != "prompt" || h["command"] != "notify me" {
+			t.Errorf("Notification prompt handler corrupted: %+v", h)
+		}
+	})
+
+	t.Run("clean hook round-trips", func(t *testing.T) {
+		h := handler(t, "PostToolUse")
+		if h["type"] != "command" || h["command"] != "echo after" {
+			t.Errorf("PostToolUse did not round-trip: %+v", h)
+		}
+	})
+
+	t.Run("no empty-command handler emitted", func(t *testing.T) {
+		// A regression would emit {"type":"prompt","command":""} (or any
+		// command:"") for a guarded handler. Assert none appears anywhere.
+		if bytes.Contains(finalRaw, []byte(`"command": ""`)) || bytes.Contains(finalRaw, []byte(`"command":""`)) {
+			t.Errorf("final settings.json contains an empty-command handler:\n%s", finalRaw)
+		}
+	})
+}
+
+// TestRenderHooks_SkipsNonCommandHandler asserts Render reports a dropped Skip
+// for a non-command handler and never emits an empty-command entry, while
+// command and empty-type handlers render normally (empty type is
+// command-compatible, per the Gemini precedent).
+func TestRenderHooks_SkipsNonCommandHandler(t *testing.T) {
+	testenv.RequireContainer(t)
+	tests := []struct {
+		name       string
+		hookType   string
+		wantSkip   bool
+		wantRender bool
+	}{
+		{name: "command handler renders", hookType: "command", wantSkip: false, wantRender: true},
+		{name: "empty type renders", hookType: "", wantSkip: false, wantRender: true},
+		{name: "prompt handler skipped", hookType: "prompt", wantSkip: true, wantRender: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			in := source.Canonical{
+				Hooks: []source.Hook{{
+					Event:   "PreToolUse",
+					Matcher: "Bash",
+					Type:    tt.hookType,
+					Command: "echo hi",
+				}},
+			}
+			a := claude.New(claude.Options{TargetRoot: tmp})
+			ops, skips, err := a.Render(secrets.ForRender(in), adapter.ScopeUser, "")
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+
+			var gotHookSkip bool
+			for _, s := range skips {
+				if s.Component == "hook" && s.Name == "PreToolUse" {
+					gotHookSkip = true
+					if s.Kind != adapter.SkipDropped {
+						t.Errorf("hook skip kind = %v, want SkipDropped", s.Kind)
+					}
+				}
+			}
+			if gotHookSkip != tt.wantSkip {
+				t.Errorf("got hook skip = %v, want %v (skips=%+v)", gotHookSkip, tt.wantSkip, skips)
+			}
+
+			// A settings.json op must never carry an empty-command handler.
+			var renderedHooks bool
+			for _, op := range ops {
+				if !strings.HasSuffix(op.Path, "settings.json") {
+					continue
+				}
+				if bytes.Contains(op.Content, []byte(`"hooks"`)) {
+					renderedHooks = true
+				}
+				if bytes.Contains(op.Content, []byte(`"command": ""`)) {
+					t.Errorf("settings.json op emitted an empty-command handler:\n%s", op.Content)
+				}
+			}
+			if renderedHooks != tt.wantRender {
+				t.Errorf("rendered hooks op = %v, want %v", renderedHooks, tt.wantRender)
+			}
+		})
+	}
+}
+
+// TestIngest_HookGuardWarnsAndSkips captures the adapter's stderr and asserts
+// that an event with an unmodeled handler field is absent from the ingested
+// model and produces an "event not captured" warning.
+func TestIngest_HookGuardWarnsAndSkips(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	settings := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	native := `{
+  "hooks": {
+    "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "echo before", "timeout": 30 } ] } ]
+  }
+}`
+	if err := os.WriteFile(settings, []byte(native), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	a := claude.New(claude.Options{TargetRoot: tmp, Stderr: &warn})
+	out, err := a.Ingest(adapter.ScopeUser, "")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(out.Hooks) != 0 {
+		t.Fatalf("guarded event should be absent from ingested hooks, got %+v", out.Hooks)
+	}
+	got := warn.String()
+	for _, want := range []string{`unmodeled fields (timeout)`, `event not captured`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing warning %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -138,9 +138,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	if data, err := os.ReadFile(p.Settings); err == nil {
 		var top map[string]any
 		if json.Unmarshal(data, &top) == nil {
-			if hooks, ok := top["hooks"].(map[string]any); ok {
-				c.Hooks = append(c.Hooks, ingestHooks(hooks, warn)...)
-			}
+			// ingestHooks takes any and does its own map assertion (mirroring the
+			// gemini adapter's call site), so pass the raw value straight through.
+			c.Hooks = append(c.Hooks, ingestHooks(top["hooks"], warn)...)
 		}
 	}
 

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -14,7 +14,12 @@ import (
 
 // Ingest reads native Claude config files and returns a partial source.Canonical.
 // It is the inverse of Render: Ingest(Apply(Render(c))) round-trips to c
-// for the components agentsync manages.
+// for the components agentsync manages. Hook events settings.json holds that the
+// canonical model cannot fully represent — an unmodeled definition/handler field
+// (e.g. `timeout`) or a non-command handler type — are left uncaptured with a
+// warning rather than captured as a lossy subset, matching the Gemini adapter:
+// the next apply owns the whole per-event array, so capturing a subset would let
+// it rewrite the user's native entry without those fields.
 func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical, error) {
 	if err := adapter.RequireProjectRoot(scope, project); err != nil {
 		return source.Canonical{}, err
@@ -134,32 +139,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 		var top map[string]any
 		if json.Unmarshal(data, &top) == nil {
 			if hooks, ok := top["hooks"].(map[string]any); ok {
-				for event, rawEntries := range hooks {
-					entries, ok := rawEntries.([]any)
-					if !ok {
-						continue
-					}
-					for _, rawEntry := range entries {
-						entry, ok := rawEntry.(map[string]any)
-						if !ok {
-							continue
-						}
-						matcher := asStr(entry["matcher"])
-						hooksArr, _ := entry["hooks"].([]any)
-						for _, rawH := range hooksArr {
-							h, ok := rawH.(map[string]any)
-							if !ok {
-								continue
-							}
-							c.Hooks = append(c.Hooks, source.Hook{
-								Event:   event,
-								Matcher: matcher,
-								Type:    asStr(h["type"]),
-								Command: asStr(h["command"]),
-							})
-						}
-					}
-				}
+				c.Hooks = append(c.Hooks, ingestHooks(hooks, warn)...)
 			}
 		}
 	}

--- a/internal/adapter/claude/render.go
+++ b/internal/adapter/claude/render.go
@@ -66,10 +66,11 @@ func (a *Adapter) Render(r secrets.Resolved, scope adapter.Scope, project string
 	}
 
 	// 6. Hooks -> settings.json /hooks/<event>
-	if hookOps, err := a.renderHooks(renderC, paths); err != nil {
+	if hookOps, hookSkips, err := a.renderHooks(renderC, paths); err != nil {
 		return nil, nil, err
 	} else {
 		ops = append(ops, hookOps...)
+		skips = append(skips, hookSkips...)
 	}
 
 	// 7. LSP servers: Claude Code only reads LSP servers from plugin

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -139,6 +139,70 @@ func TestCapture_RefusesMovedSecretIntoLiteralField(t *testing.T) {
 	}
 }
 
+// TestCapture_RefusesShortSecretMovedIntoLiteralField is the analog of
+// TestCapture_RefusesMovedSecretIntoLiteralField for a SHORT (1–3 char) secret.
+// The re-reference value-based fallback intentionally skips values shorter than
+// minReReferenceLen (=4), but the fail-closed backstop must NOT inherit that
+// floor: a short credential moved onto a field whose source counterpart is a
+// literal (so re-reference leaves it as cleartext) must still be refused rather
+// than persisted into the committed canonical source. This fails on main (the
+// backstop reused sourceSecretValues, which dropped the short value) and passes
+// after decoupling the backstop onto backstopSecretValues.
+func TestCapture_RefusesShortSecretMovedIntoLiteralField(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "1char", value: "a"},
+		{name: "2char", value: "ab"},
+		{name: "3char", value: "abc"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("TOK", tc.value)
+			writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+			writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+				"[server]\ntype = \"stdio\"\ncommand = \"run-server\"\n[server.env]\nAUTH = \"${secret:TOK}\"\n")
+
+			ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+				ID:     "srv",
+				Server: source.MCPServerSpec{Type: "stdio", Command: "run-server --token=" + tc.value},
+			}}}
+			if _, err := capture.Capture(home, ingested, capture.Opts{}); err == nil {
+				t.Fatal("capture must REFUSE a short secret moved into a literal-counterpart field, got nil")
+			}
+			if raw, _ := os.ReadFile(filepath.Join(home, "mcp", "srv.toml")); strings.Contains(string(raw), "--token="+tc.value) {
+				t.Fatalf("LEAK: short cleartext persisted despite refusal:\n%s", raw)
+			}
+		})
+	}
+}
+
+// TestCapture_EmptySecretNotFalseRefused proves the backstop does not
+// false-refuse when a ${secret:K} resolves to the EMPTY string: an empty value
+// has nothing to leak, and strings.Contains(field, "") is always true, so an
+// unguarded detection set would refuse every benign write-back. A benign,
+// unchanged write must succeed.
+func TestCapture_EmptySecretNotFalseRefused(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("K", "")
+	writeFile(t, filepath.Join(home, "agentsync.toml"), "[secrets]\nbackend = \"env\"\n")
+	writeFile(t, filepath.Join(home, "mcp", "srv.toml"), ""+
+		"[server]\ntype = \"stdio\"\ncommand = \"npx\"\n[server.env]\nAUTH = \"${secret:K}\"\n")
+
+	// Unchanged write-back: apply resolved ${secret:K} to "" in the dest env.
+	ingested := &source.Canonical{MCPServers: []source.MCPServer{{
+		ID: "srv",
+		Server: source.MCPServerSpec{
+			Type: "stdio", Command: "npx",
+			Env: map[string]string{"AUTH": ""},
+		},
+	}}}
+	if _, err := capture.Capture(home, ingested, capture.Opts{}); err != nil {
+		t.Fatalf("empty-resolving secret must not be false-refused: %v", err)
+	}
+}
+
 // TestCapture_RefusesRotatedSecret is the fail-closed backstop for a ROTATED
 // secret: the source field is ${secret:}-templated, but the user changed the
 // dest value to a NEW token the vault doesn't know. Re-reference can't match it,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -235,6 +235,9 @@ func checkDestinationGitBackup(p *ui.Printer, cfg source.DestinationGitBackupCon
 	case source.GitBackupModePrompt:
 		okCheck(p, "mode       ", "prompt (asks on first apply to an untracked dir)")
 	default:
+		// Defensive: source.Load now rejects an invalid mode at load time
+		// (validateMode), so doctor should never reach here on a loaded config.
+		// Kept as a belt-and-suspenders guard.
 		warnCheck(p, "mode       ", fmt.Sprintf("unknown value %q — use \"prompt\", \"on\", or \"off\"", cfg.Mode))
 	}
 

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -255,7 +255,11 @@ func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mo
 			return nil, nil
 		}
 	}
-	return nil, nil // mode "off" reached here only if flipped mid-run
+	// Defensive fallback: load-time validation (source.loadConfig →
+	// validateMode) now rejects any mode outside {"", prompt, on, off}, so an
+	// invalid value never reaches here; "off" is the only remaining case,
+	// reachable only if flipped mid-run.
+	return nil, nil
 }
 
 // initGuarded inits an agentsync repo at dir UNLESS dir already contains a nested

--- a/internal/cli/gitbackup_apply_test.go
+++ b/internal/cli/gitbackup_apply_test.go
@@ -434,8 +434,12 @@ func TestApply_GitBackupSkipsDirNestedInForeignRepo(t *testing.T) {
 	assertSkippedNotInited(t, out, claude)
 }
 
-// TestDoctor_WarnsUnknownGitBackupMode checks doctor flags a typo'd mode value.
-func TestDoctor_WarnsUnknownGitBackupMode(t *testing.T) {
+// TestDoctor_RejectsUnknownGitBackupModeAtLoad checks that a typo'd git-backup
+// mode is now caught at source.Load (via validateMode), so doctor surfaces it as
+// an invalid schema and returns an error rather than reaching the git-backup
+// section's defensive warn arm. (Previously the value slipped past strict
+// key-decoding and only the git-backup section warned about it — see issue #137.)
+func TestDoctor_RejectsUnknownGitBackupModeAtLoad(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	mustRun(t, env, "init")
@@ -443,11 +447,13 @@ func TestDoctor_WarnsUnknownGitBackupMode(t *testing.T) {
 	_, _ = f.WriteString("\n[destination_directory_git_backup]\nmode = \"bogus\"\n")
 	_ = f.Close()
 	out, err := runCLI(t, env, "doctor")
-	if err != nil {
-		t.Fatalf("doctor: %v\n%s", err, out)
+	if err == nil {
+		t.Fatalf("doctor should fail on the invalid mode; got no error\n%s", out)
 	}
-	if !strings.Contains(out, "unknown value") || !strings.Contains(out, "bogus") {
-		t.Fatalf("doctor should warn on the unknown mode; got:\n%s", out)
+	// The schema check reports the load error, which names the offending value
+	// and the valid set.
+	if !strings.Contains(out, "invalid") || !strings.Contains(out, "bogus") {
+		t.Fatalf("doctor should report the invalid mode at schema load; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/requireprojectroot_guard_test.go
+++ b/internal/cli/requireprojectroot_guard_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestEveryAdapterGuardsProjectRoot is the registry-wide behavioral guard that
+// every registered adapter honors the (ScopeProject, "") boundary contract:
+// Render, Ingest, and — for adapters implementing PluginIngester — IngestPlugins
+// MUST return adapter.ErrProjectRootRequired when a project-scope call supplies
+// no project root, rather than silently falling through to user-scope
+// destinations. The per-adapter TestProjectScope_EmptyProjectErrors tests and
+// the adapter-boundary TestRequireProjectRoot helper test each pin a piece; this
+// closes the "a new adapter forgets to call RequireProjectRoot in one of its
+// scope-resolving methods" gap by exhaustively driving the SAME registered set
+// apply uses (via registryFactory).
+//
+// It mirrors the sibling TestEveryAdapterClassifiesSkips guard, including its
+// non-vacuity backstop: the test fails if no adapters were checked at all, or if
+// no PluginIngester was exercised — so the guard can't pass because the loop
+// found nothing to assert against (e.g. a broken registry, or every
+// PluginIngester having been removed).
+func TestEveryAdapterGuardsProjectRoot(t *testing.T) {
+	reg := registryFactory()
+
+	var (
+		offenders       []string
+		adaptersChecked int
+		pluginIngesters int
+	)
+
+	for _, name := range reg.Names() {
+		a := reg.Lookup(name)
+		adaptersChecked++
+
+		if _, _, err := a.Render(secrets.ForRender(source.Canonical{}), adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+			offenders = append(offenders, name+".Render did not return ErrProjectRootRequired at (ScopeProject, \"\"), got: "+errString(err))
+		}
+		if _, err := a.Ingest(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+			offenders = append(offenders, name+".Ingest did not return ErrProjectRootRequired at (ScopeProject, \"\"), got: "+errString(err))
+		}
+		if pi, ok := a.(adapter.PluginIngester); ok {
+			pluginIngesters++
+			if _, _, err := pi.IngestPlugins(adapter.ScopeProject, ""); !errors.Is(err, adapter.ErrProjectRootRequired) {
+				offenders = append(offenders, name+".IngestPlugins did not return ErrProjectRootRequired at (ScopeProject, \"\"), got: "+errString(err))
+			}
+		}
+	}
+
+	for _, o := range offenders {
+		t.Errorf("project-root guard: %s", o)
+	}
+	// Guard against a vacuous pass: if no adapter (or no PluginIngester) was
+	// exercised, the assertions above would be meaningless.
+	if adaptersChecked == 0 {
+		t.Fatal("no adapters registered — registryFactory produced an empty registry")
+	}
+	if pluginIngesters == 0 {
+		t.Fatal("no PluginIngester exercised — the IngestPlugins branch of the guard is not covered")
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
+}

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -28,8 +28,10 @@ apply checkpoint from its local-only git history, recovering from a bad apply.
 
 It is append-only: revert records a NEW commit, so the history is never rewritten
 and the revert is itself revertible. Uncommitted hand-edits to tracked files are
-preserved as a snapshot commit first, so nothing is lost. By default it undoes the
-most recent apply (restores the previous checkpoint); --to picks a specific one.
+preserved as a snapshot commit first, so nothing is lost. Untracked files you
+dropped into the dir (and gitignored files) are left untouched — revert only
+rewinds the files agentsync itself versions. By default it undoes the most recent
+apply (restores the previous checkpoint); --to picks a specific one.
 
 revert only moves the DESTINATION. The next 'agentsync apply' re-renders from the
 canonical config and would overwrite the reverted state, so revert prints a notice
@@ -224,7 +226,8 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 		return true, err
 	}
 	// Preserve any uncommitted hand-edits to tracked files as a snapshot commit so
-	// the hard reset inside Restore can't lose them (untracked files are untouched).
+	// Restore's delta-apply can't lose them. Untracked files are untouched: Restore
+	// only rewrites the tracked HEAD↔target delta and never enumerates them.
 	snap, err := repo.SnapshotDirtyTracked("agentsync revert: snapshot uncommitted changes before revert", id)
 	if err != nil {
 		return true, err
@@ -263,6 +266,9 @@ func previewRevert(p *ui.Printer, repo *agit.Repo, root, target string) error {
 		p.Bold("dry-run:"), root, p.Cyan(shortRef(targetHash)), subject)
 	if clean, _ := repo.IsClean(); !clean {
 		fmt.Fprintf(p.Out, "  (uncommitted changes to tracked files would be snapshotted first, then preserved in history)\n")
+	}
+	if untracked, _ := repo.UntrackedPaths(); len(untracked) > 0 {
+		fmt.Fprintf(p.Out, "  (%d untracked file(s) in this dir are left untouched)\n", len(untracked))
 	}
 	if len(changes) == 0 {
 		fmt.Fprintf(p.Out, "  (already matches; nothing to change)\n")

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -225,6 +225,85 @@ func TestRevert_FoldedSharedDirNoted(t *testing.T) {
 	}
 }
 
+// TestRevert_PreservesUntrackedUserFiles is the CLI-level regression for issue
+// #128: a file the user dropped into a managed dest dir (untracked by agentsync's
+// backup) must survive a revert byte-for-byte and never be swept into any
+// checkpoint. The old go-git HardReset would have deleted it.
+func TestRevert_PreservesUntrackedUserFiles(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+
+	// The user drops a scratch file into ~/.claude that agentsync never wrote.
+	const userBody = "personal scratch — keep me\n"
+	userFile := filepath.Join(claude, "MY-NOTES.txt")
+	if err := os.WriteFile(userFile, []byte(userBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "revert", "claude")
+	if err != nil {
+		t.Fatalf("revert: %v\n%s", err, out)
+	}
+	// The revert otherwise succeeded: dest skill back to v1.
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v1") || strings.Contains(string(b), "v2") {
+		t.Fatalf("after revert dest skill should hold v1:\n%s", b)
+	}
+	// The user's untracked file survives byte-for-byte.
+	if b, _ := os.ReadFile(userFile); string(b) != userBody {
+		t.Fatalf("untracked user file was destroyed/mutated by revert: %q", b)
+	}
+	// It is in NO checkpoint tree — revert never versioned it, so it is still
+	// reported untracked after the revert commit.
+	repo, _ := agit.Open(claude)
+	if untracked, err := repo.UntrackedPaths(); err != nil || !contains(untracked, "MY-NOTES.txt") {
+		t.Fatalf("MY-NOTES.txt should still be untracked; UntrackedPaths=%v err=%v", untracked, err)
+	}
+}
+
+// TestRevert_DryRunWarnsUntracked verifies --dry-run notes the presence of
+// untracked files (left untouched) and writes nothing.
+func TestRevert_DryRunWarnsUntracked(t *testing.T) {
+	tmp, env, destSkill := setupGitBackedClaude(t)
+	claude := filepath.Join(tmp, ".claude")
+	repo, _ := agit.Open(claude)
+	before, _ := repo.Log(0)
+
+	const userBody = "keep me\n"
+	userFile := filepath.Join(claude, "SCRATCH.txt")
+	if err := os.WriteFile(userFile, []byte(userBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "revert", "claude", "--dry-run")
+	if err != nil {
+		t.Fatalf("revert --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "untracked file(s) in this dir are left untouched") {
+		t.Errorf("expected the untracked-present note, got:\n%s", out)
+	}
+	// Nothing changed on disk or in history.
+	if b, _ := os.ReadFile(destSkill); !strings.Contains(string(b), "v2") {
+		t.Fatalf("dry-run mutated the dest skill:\n%s", b)
+	}
+	if b, _ := os.ReadFile(userFile); string(b) != userBody {
+		t.Fatalf("dry-run mutated the untracked file: %q", b)
+	}
+	after, _ := repo.Log(0)
+	if len(after) != len(before) {
+		t.Fatalf("dry-run recorded a commit: %d -> %d", len(before), len(after))
+	}
+}
+
+// contains reports whether s is in xs.
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
 // TestRevert_SharedDirWarnsBlastRadius asserts the user-facing warning that
 // reverting a shared dir (~/.agents/skills, owned by codex + warp) rolls back the
 // other agent's files too.

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -255,7 +256,7 @@ func TestRevert_PreservesUntrackedUserFiles(t *testing.T) {
 	// It is in NO checkpoint tree — revert never versioned it, so it is still
 	// reported untracked after the revert commit.
 	repo, _ := agit.Open(claude)
-	if untracked, err := repo.UntrackedPaths(); err != nil || !contains(untracked, "MY-NOTES.txt") {
+	if untracked, err := repo.UntrackedPaths(); err != nil || !slices.Contains(untracked, "MY-NOTES.txt") {
 		t.Fatalf("MY-NOTES.txt should still be untracked; UntrackedPaths=%v err=%v", untracked, err)
 	}
 }
@@ -292,16 +293,6 @@ func TestRevert_DryRunWarnsUntracked(t *testing.T) {
 	if len(after) != len(before) {
 		t.Fatalf("dry-run recorded a commit: %d -> %d", len(before), len(after))
 	}
-}
-
-// contains reports whether s is in xs.
-func contains(xs []string, s string) bool {
-	for _, x := range xs {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 // TestRevert_SharedDirWarnsBlastRadius asserts the user-facing warning that

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -81,7 +81,7 @@ func (r *Repo) CommitStaged(message string, id Identity) (string, error) {
 
 // SnapshotDirtyTracked commits any uncommitted changes to already-TRACKED files
 // (modifications and deletions) as a safety checkpoint, so a subsequent
-// destructive operation (notably revert's hard reset) cannot lose them. Untracked
+// destructive operation (notably revert's restore) cannot lose them. Untracked
 // files — the user's own scratch files — are never touched. Returns the snapshot
 // commit hash, or ("", nil) when the worktree has no tracked changes. This is what
 // keeps the append-only promise true of the WORKTREE, not just of history.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -992,3 +992,41 @@ func TestRestore_ParentFileCollisionBlocked(t *testing.T) {
 		t.Fatalf("untracked file 'a' must survive the refused revert, got %q", got)
 	}
 }
+
+// TestRestore_CreatePathCollidesWithUntrackedFile pins the untouched-files promise
+// for a create-path collision: agentsync manages X, a later apply removes X, the
+// user drops their own untracked file at path X. Reverting to a checkpoint that has
+// X must refuse rather than silently overwrite + commit over the user's file.
+func TestRestore_CreatePathCollidesWithUntrackedFile(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "keep", "k", "c1")
+	commitFile(t, r, dir, "X", "managed-content", "c2: add managed X") // HEAD~1 has X
+	if err := os.Remove(filepath.Join(dir, "X")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c3: remove X", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// The user drops their OWN untracked file at path X.
+	const user = "my own notes at X\n"
+	writeFile(t, dir, "X", user)
+
+	// Reverting to c2 (has managed X) is a create of X — but X is now the user's
+	// untracked file. Restore must refuse, not overwrite it.
+	if _, err := r.Restore("HEAD~1", "agentsync revert: create collision", DefaultIdentity); err == nil {
+		t.Fatal("Restore should refuse to overwrite an untracked file at a create path")
+	} else if !strings.Contains(err.Error(), "a file agentsync does not manage already exists") {
+		t.Fatalf("error should name the create-collision; got: %v", err)
+	}
+	if got := readFile(t, dir, "X"); got != user {
+		t.Fatalf("user's untracked file at X must survive, got %q", got)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -693,3 +693,111 @@ func headTreePaths(t *testing.T, r *Repo) map[string]bool {
 	})
 	return out
 }
+
+// commitExecFile writes rel at 0o755, stages it, and commits, returning the hash.
+// Used to exercise restoreFileFromTree's exec-bit preservation.
+func commitExecFile(t *testing.T, r *Repo, dir, rel, content, msg string) string {
+	t.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+	if err := r.Stage([]string{rel}); err != nil {
+		t.Fatalf("stage %s: %v", rel, err)
+	}
+	h, err := r.CommitStaged(msg, DefaultIdentity)
+	if err != nil {
+		t.Fatalf("commit %s: %v", rel, err)
+	}
+	return h
+}
+
+// assertPerm fails unless <dir>/<rel> has exactly the given permission bits.
+func assertPerm(t *testing.T, dir, rel string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("stat %s: %v", rel, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s perm = %04o, want %04o", rel, got, want)
+	}
+}
+
+// TestRestore_PreservesFileMode backs restoreFileFromTree's documented
+// mode-preservation contract (notably the exec bit): a revert that re-creates a
+// tracked 0o755 script must restore it executable, not as 0o644. Without an
+// enforcing test, a refactor that dropped the mode handling would silently strip
+// +x from restored skill scripts on every revert while the suite stayed green.
+func TestRestore_PreservesFileMode(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitExecFile(t, r, dir, "run.sh", "#!/bin/sh\necho v1\n", "add script") // HEAD~1
+	// Remove the script in a second checkpoint so reverting exercises the CREATE
+	// path of restoreFileFromTree (a fresh OpenFile, where the mode must be set).
+	if err := os.Remove(filepath.Join(dir, "run.sh")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("remove script", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Restore("HEAD~1", "agentsync revert: restore script", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, dir, "run.sh"); got != "#!/bin/sh\necho v1\n" {
+		t.Fatalf("run.sh content = %q, want v1", got)
+	}
+	assertPerm(t, dir, "run.sh", 0o755)
+}
+
+// TestRestore_FileDirTransition exercises a path that is a FILE in the target
+// checkpoint but a DIRECTORY prefix in HEAD (foo vs foo/bar). Restore must apply
+// the delete (foo/bar) before the create (foo) so the now-empty dir can be
+// replaced by the file; the pre-fix single-pass sorted order created "foo" first
+// and aborted with "directory not empty".
+func TestRestore_FileDirTransition(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// c1 (target, HEAD~1): foo is a regular file.
+	commitFile(t, r, dir, "foo", "iamfile", "c1: foo is a file")
+	// c2 (HEAD): foo becomes a directory (remove the file, add foo/bar).
+	if err := os.Remove(filepath.Join(dir, "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "foo/bar", "iamdir")
+	if err := r.Stage([]string{"foo/bar"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c2: foo is a dir", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// Revert to c1: delete foo/bar, then create the file foo over the empty dir.
+	if _, err := r.Restore("HEAD~1", "agentsync revert: dir->file", DefaultIdentity); err != nil {
+		t.Fatalf("Restore across a file<->dir transition should not error: %v", err)
+	}
+	if got := readFile(t, dir, "foo"); got != "iamfile" {
+		t.Fatalf("foo = %q, want the restored file content", got)
+	}
+	// foo is now a regular file, so foo/bar cannot exist (stat yields ENOENT or
+	// ENOTDIR); either way a nil error would mean the dir entry survived.
+	if _, err := os.Stat(filepath.Join(dir, "foo", "bar")); err == nil {
+		t.Fatal("foo/bar should be gone after reverting to the file checkpoint")
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -686,16 +686,21 @@ func headTreePaths(t *testing.T, r *Repo) map[string]bool {
 	return out
 }
 
-// commitExecFile writes rel at 0o755, stages it, and commits, returning the hash.
-// Used to exercise restoreFileFromTree's exec-bit preservation.
-func commitExecFile(t *testing.T, r *Repo, dir, rel, content, msg string) string {
+// commitFileMode writes rel with the given mode, stages it, and commits, returning
+// the hash. Used to exercise restoreFileFromTree's mode preservation (notably the
+// exec bit). An explicit Chmod pins the mode even when rel already exists (a
+// content edit) — os.WriteFile only honors perms when it creates the file.
+func commitFileMode(t *testing.T, r *Repo, dir, rel, content string, mode os.FileMode, msg string) string {
 	t.Helper()
 	abs := filepath.Join(dir, filepath.FromSlash(rel))
 	if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
 		t.Fatalf("mkdir for %s: %v", rel, err)
 	}
-	if err := os.WriteFile(abs, []byte(content), 0o755); err != nil {
+	if err := os.WriteFile(abs, []byte(content), mode); err != nil {
 		t.Fatalf("write %s: %v", rel, err)
+	}
+	if err := os.Chmod(abs, mode); err != nil {
+		t.Fatalf("chmod %s: %v", rel, err)
 	}
 	if err := r.Stage([]string{rel}); err != nil {
 		t.Fatalf("stage %s: %v", rel, err)
@@ -726,30 +731,54 @@ func assertPerm(t *testing.T, dir, rel string, want os.FileMode) {
 // +x from restored skill scripts on every revert while the suite stayed green.
 func TestRestore_PreservesFileMode(t *testing.T) {
 	testenv.RequireContainer(t)
-	dir := t.TempDir()
-	r, err := Init(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	commitExecFile(t, r, dir, "run.sh", "#!/bin/sh\necho v1\n", "add script") // HEAD~1
-	// Remove the script in a second checkpoint so reverting exercises the CREATE
-	// path of restoreFileFromTree (a fresh OpenFile, where the mode must be set).
-	if err := os.Remove(filepath.Join(dir, "run.sh")); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := r.StageTrackedDeletions(); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := r.CommitStaged("remove script", DefaultIdentity); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := r.Restore("HEAD~1", "agentsync revert: restore script", DefaultIdentity); err != nil {
-		t.Fatal(err)
-	}
-	if got := readFile(t, dir, "run.sh"); got != "#!/bin/sh\necho v1\n" {
-		t.Fatalf("run.sh content = %q, want v1", got)
-	}
-	assertPerm(t, dir, "run.sh", 0o755)
+
+	t.Run("create path", func(t *testing.T) {
+		dir := t.TempDir()
+		r, err := Init(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitFileMode(t, r, dir, "run.sh", "#!/bin/sh\necho v1\n", 0o755, "add script") // HEAD~1
+		// Remove the script in a second checkpoint so reverting RE-CREATES it fresh
+		// (a fresh OpenFile, where the target mode must be set).
+		if err := os.Remove(filepath.Join(dir, "run.sh")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.StageTrackedDeletions(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.CommitStaged("remove script", DefaultIdentity); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.Restore("HEAD~1", "agentsync revert: restore script", DefaultIdentity); err != nil {
+			t.Fatal(err)
+		}
+		if got := readFile(t, dir, "run.sh"); got != "#!/bin/sh\necho v1\n" {
+			t.Fatalf("run.sh content = %q, want v1", got)
+		}
+		assertPerm(t, dir, "run.sh", 0o755)
+	})
+
+	t.Run("modify path", func(t *testing.T) {
+		dir := t.TempDir()
+		r, err := Init(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// run.sh stays a file across both checkpoints but flips 0o755 -> 0o644, so
+		// reverting exercises the MODIFY path: restoreFileFromTree must Remove the
+		// existing 0o644 file before OpenFile so the target 0o755 mode takes hold
+		// (OpenFile only honors perm on creation).
+		commitFileMode(t, r, dir, "run.sh", "#!/bin/sh\necho v1\n", 0o755, "exec v1") // HEAD~1
+		commitFileMode(t, r, dir, "run.sh", "#!/bin/sh\necho v2\n", 0o644, "nonexec v2")
+		if _, err := r.Restore("HEAD~1", "agentsync revert: restore exec bit", DefaultIdentity); err != nil {
+			t.Fatal(err)
+		}
+		if got := readFile(t, dir, "run.sh"); got != "#!/bin/sh\necho v1\n" {
+			t.Fatalf("run.sh content = %q, want v1", got)
+		}
+		assertPerm(t, dir, "run.sh", 0o755)
+	})
 }
 
 // TestRestore_FileDirTransition exercises a path that is a FILE in the target
@@ -874,5 +903,10 @@ func TestRestore_UntrackedSiblingBlocksFileReplacement(t *testing.T) {
 	}
 	if got := readFile(t, dir, "foo/scratch.txt"); got != scratch {
 		t.Fatalf("untracked scratch file must survive the refused revert, got %q", got)
+	}
+	// All-or-nothing: the pre-flight refuses BEFORE any delete, so the tracked
+	// foo/bar must still be present (no half-applied worktree mutation).
+	if got := readFile(t, dir, "foo/bar"); got != "iamdir" {
+		t.Fatalf("refusal must be all-or-nothing: tracked foo/bar was mutated, got %q", got)
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
@@ -584,4 +586,110 @@ func TestRestoreAppendOnly(t *testing.T) {
 	if noop != "" {
 		t.Fatalf("restore to HEAD returned %q, want empty (no-op)", noop)
 	}
+}
+
+// TestRestore_PreservesUntrackedFiles is the regression guard for issue #128:
+// Restore must NOT delete the user's own untracked/gitignored files (go-git's
+// HardReset would have; the delta-apply must not). Fails against the old
+// HardReset implementation, which enumerates and removes them.
+func TestRestore_PreservesUntrackedFiles(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a.txt", "v1", "apply 1") // HEAD~1 target
+	commitFile(t, r, dir, "a.txt", "v2", "apply 2") // HEAD
+
+	// Drop files the user owns that git is NOT versioning: a plain untracked file,
+	// plus a .gitignore and a matching ignored file (invisible to go-git status).
+	const notesBody = "my personal notes — do not delete\n"
+	const scratchBody = "ephemeral scratch log line\n"
+	writeFile(t, dir, "MY-PERSONAL-NOTES.txt", notesBody)
+	writeFile(t, dir, ".gitignore", "scratch.log\n")
+	writeFile(t, dir, "scratch.log", scratchBody)
+
+	// UntrackedPaths should surface the plain untracked files (not the ignored one).
+	untracked, err := r.UntrackedPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsStr(untracked, "MY-PERSONAL-NOTES.txt") {
+		t.Fatalf("UntrackedPaths = %v, want it to include MY-PERSONAL-NOTES.txt", untracked)
+	}
+	if containsStr(untracked, "scratch.log") {
+		t.Fatalf("UntrackedPaths = %v, should NOT list the gitignored scratch.log", untracked)
+	}
+
+	h, err := r.Restore("HEAD~1", "agentsync revert: preserve untracked", DefaultIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h == "" {
+		t.Fatal("Restore returned empty hash")
+	}
+
+	// The tracked restore still happened.
+	if got := readFile(t, dir, "a.txt"); got != "v1" {
+		t.Fatalf("after restore a.txt = %q, want v1", got)
+	}
+	// Both of the user's own files survive byte-for-byte.
+	if got := readFile(t, dir, "MY-PERSONAL-NOTES.txt"); got != notesBody {
+		t.Fatalf("untracked file was mutated/deleted: got %q", got)
+	}
+	if got := readFile(t, dir, "scratch.log"); got != scratchBody {
+		t.Fatalf("gitignored file was mutated/deleted: got %q", got)
+	}
+
+	// Neither user file was swept into the revert commit's tree — they stay untracked.
+	tree := headTreePaths(t, r)
+	for _, p := range []string{"MY-PERSONAL-NOTES.txt", "scratch.log"} {
+		if _, ok := tree[p]; ok {
+			t.Fatalf("revert commit tree unexpectedly contains %s: %v", p, tree)
+		}
+	}
+	if _, ok := tree["a.txt"]; !ok {
+		t.Fatalf("revert commit tree missing the tracked a.txt: %v", tree)
+	}
+}
+
+// containsStr reports whether s is in xs.
+func containsStr(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// headTreePaths returns the set of file paths in the repo's current HEAD tree.
+func headTreePaths(t *testing.T, r *Repo) map[string]bool {
+	t.Helper()
+	log, err := r.Log(0)
+	if err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	if len(log) == 0 {
+		t.Fatalf("Log returned no commits")
+	}
+	repo, err := gogit.PlainOpen(r.Dir())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	c, err := repo.CommitObject(plumbing.NewHash(log[0].Hash))
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+	tree, err := c.Tree()
+	if err != nil {
+		t.Fatalf("tree: %v", err)
+	}
+	out := map[string]bool{}
+	_ = tree.Files().ForEach(func(f *object.File) error {
+		out[f.Name] = true
+		return nil
+	})
+	return out
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -910,3 +910,85 @@ func TestRestore_UntrackedSiblingBlocksFileReplacement(t *testing.T) {
 		t.Fatalf("refusal must be all-or-nothing: tracked foo/bar was mutated, got %q", got)
 	}
 }
+
+// TestRestore_GitignoredSiblingBlocksFileReplacement proves the pre-flight is
+// filesystem-based, not git-status-based: a GITIGNORED file (which git status
+// omits) inside a dir being replaced by a file must still block the revert
+// all-or-nothing, since #128 preserves gitignored files equally.
+func TestRestore_GitignoredSiblingBlocksFileReplacement(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "foo", "iamfile", "c1: foo is a file") // target
+	// c2: foo becomes a dir (foo/bar tracked) with a .gitignore for *.log under it.
+	if err := os.Remove(filepath.Join(dir, "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "foo/bar", "iamdir")
+	writeFile(t, dir, ".gitignore", "foo/*.log\n")
+	if err := r.Stage([]string{"foo/bar", ".gitignore"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c2: foo is a dir", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	const scratch = "gitignored — keep me\n"
+	writeFile(t, dir, "foo/debug.log", scratch) // gitignored; git status omits it
+
+	if _, err := r.Restore("HEAD~1", "agentsync revert: blocked by gitignored", DefaultIdentity); err == nil {
+		t.Fatal("Restore should refuse when a gitignored file blocks a dir->file replacement")
+	} else if !strings.Contains(err.Error(), "agentsync does not manage") {
+		t.Fatalf("error should point at the unmanaged files; got: %v", err)
+	}
+	if got := readFile(t, dir, "foo/debug.log"); got != scratch {
+		t.Fatalf("gitignored file must survive the refused revert, got %q", got)
+	}
+	if got := readFile(t, dir, "foo/bar"); got != "iamdir" {
+		t.Fatalf("refusal must be all-or-nothing: tracked foo/bar was mutated, got %q", got)
+	}
+}
+
+// TestRestore_ParentFileCollisionBlocked covers the reverse structural conflict:
+// creating a target path whose ancestor is an existing untracked FILE (MkdirAll
+// would fail over it). The pre-flight must refuse before mutating and preserve the
+// untracked file.
+func TestRestore_ParentFileCollisionBlocked(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, r, dir, "a/b", "iamdir", "c1: a is a dir")
+	commitFile(t, r, dir, "keep", "k", "c2: add keep")
+	// c3 (HEAD): remove a/b so "a" no longer exists in the tree.
+	if err := os.RemoveAll(filepath.Join(dir, "a")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c3: remove a/b", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// The user drops an untracked FILE named exactly "a".
+	const scratch = "untracked file named a\n"
+	writeFile(t, dir, "a", scratch)
+
+	// Revert to c2 (has a/b): creating a/b needs MkdirAll("a") over the untracked
+	// file "a" — the pre-flight must refuse before mutating, preserving "a".
+	if _, err := r.Restore("HEAD~1", "agentsync revert: parent collision", DefaultIdentity); err == nil {
+		t.Fatal("Restore should refuse when an untracked file blocks creating a parent dir")
+	} else if !strings.Contains(err.Error(), "does not manage") {
+		t.Fatalf("error should point at the unmanaged parent; got: %v", err)
+	}
+	if got := readFile(t, dir, "a"); got != scratch {
+		t.Fatalf("untracked file 'a' must survive the refused revert, got %q", got)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -615,10 +617,10 @@ func TestRestore_PreservesUntrackedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !containsStr(untracked, "MY-PERSONAL-NOTES.txt") {
+	if !slices.Contains(untracked, "MY-PERSONAL-NOTES.txt") {
 		t.Fatalf("UntrackedPaths = %v, want it to include MY-PERSONAL-NOTES.txt", untracked)
 	}
-	if containsStr(untracked, "scratch.log") {
+	if slices.Contains(untracked, "scratch.log") {
 		t.Fatalf("UntrackedPaths = %v, should NOT list the gitignored scratch.log", untracked)
 	}
 
@@ -652,16 +654,6 @@ func TestRestore_PreservesUntrackedFiles(t *testing.T) {
 	if _, ok := tree["a.txt"]; !ok {
 		t.Fatalf("revert commit tree missing the tracked a.txt: %v", tree)
 	}
-}
-
-// containsStr reports whether s is in xs.
-func containsStr(xs []string, s string) bool {
-	for _, x := range xs {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 // headTreePaths returns the set of file paths in the repo's current HEAD tree.
@@ -799,5 +791,88 @@ func TestRestore_FileDirTransition(t *testing.T) {
 	// ENOTDIR); either way a nil error would mean the dir entry survived.
 	if _, err := os.Stat(filepath.Join(dir, "foo", "bar")); err == nil {
 		t.Fatal("foo/bar should be gone after reverting to the file checkpoint")
+	}
+}
+
+// TestRestore_FileToDirTransition is the reverse of TestRestore_FileDirTransition:
+// the target checkpoint has foo as a DIRECTORY (foo/bar) while HEAD has foo as a
+// regular file. The delete of the file foo must run before restoreFileFromTree's
+// MkdirAll("foo"), which would otherwise fail over the still-present file. It
+// fails against the pre-fix single-pass sorted order (create foo/bar first).
+func TestRestore_FileToDirTransition(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// c1 (target, HEAD~1): foo is a directory containing foo/bar.
+	commitFile(t, r, dir, "foo/bar", "iamdir", "c1: foo is a dir")
+	// c2 (HEAD): foo becomes a regular file (remove the dir, add the file foo).
+	if err := os.RemoveAll(filepath.Join(dir, "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "foo", "iamfile")
+	if err := r.Stage([]string{"foo"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c2: foo is a file", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// Revert to c1: delete the file foo, then MkdirAll("foo") + create foo/bar.
+	if _, err := r.Restore("HEAD~1", "agentsync revert: file->dir", DefaultIdentity); err != nil {
+		t.Fatalf("Restore across a file->dir transition should not error: %v", err)
+	}
+	if got := readFile(t, dir, "foo/bar"); got != "iamdir" {
+		t.Fatalf("foo/bar = %q, want the restored dir content", got)
+	}
+}
+
+// TestRestore_UntrackedSiblingBlocksFileReplacement pins the fail-safe contract
+// for the one case Restore genuinely cannot complete: the target turns a directory
+// into a file, but the user left an UNTRACKED file inside that directory. Restore
+// must refuse (never delete the untracked file) with an actionable error, and the
+// untracked file must survive.
+func TestRestore_UntrackedSiblingBlocksFileReplacement(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// c1 (target): foo is a regular file.
+	commitFile(t, r, dir, "foo", "iamfile", "c1: foo is a file")
+	// c2 (HEAD): foo becomes a directory (foo/bar tracked).
+	if err := os.Remove(filepath.Join(dir, "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.StageTrackedDeletions(); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "foo/bar", "iamdir")
+	if err := r.Stage([]string{"foo/bar"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.CommitStaged("c2: foo is a dir", DefaultIdentity); err != nil {
+		t.Fatal(err)
+	}
+	// The user drops an untracked scratch file inside dir foo.
+	const scratch = "keep me — untracked\n"
+	writeFile(t, dir, "foo/scratch.txt", scratch)
+
+	// Reverting to c1 would need to replace dir foo with a file, but foo still
+	// holds the untracked scratch file — Restore must refuse, not delete it.
+	_, err = r.Restore("HEAD~1", "agentsync revert: blocked", DefaultIdentity)
+	if err == nil {
+		t.Fatal("Restore should refuse when an untracked file blocks a dir->file replacement")
+	}
+	if !strings.Contains(err.Error(), "agentsync does not manage") {
+		t.Fatalf("error should point at the unmanaged files; got: %v", err)
+	}
+	if got := readFile(t, dir, "foo/scratch.txt"); got != scratch {
+		t.Fatalf("untracked scratch file must survive the refused revert, got %q", got)
 	}
 }

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -102,6 +102,10 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	//   (1) a path that is a file in the target but CURRENTLY a directory whose
 	//       contents aren't all being deleted (it holds untracked/gitignored files)
 	//       — replacing it with a file would delete them;
+	//  (1b) a CREATE path that is currently a regular file — since a create means
+	//       HEAD doesn't track this path, that file is the user's own
+	//       (untracked/gitignored); overwriting + committing it would violate the
+	//       untouched-files promise;
 	//   (2) a create whose ancestor is an existing unmanaged FILE — MkdirAll would
 	//       fail over it.
 	// A non-transactional restore can't guarantee zero partial state for every
@@ -119,7 +123,9 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 			continue
 		}
 		abs := filepath.Join(r.dir, filepath.FromSlash(ch.Path))
-		if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+		info, statErr := os.Stat(abs)
+		switch {
+		case statErr == nil && info.IsDir():
 			blocker, werr := firstUnmanagedFileUnder(r.dir, abs, deleting)
 			if werr != nil {
 				return "", fmt.Errorf("scanning %s during revert in %s: %w", ch.Path, r.dir, werr)
@@ -127,6 +133,11 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 			if blocker != "" {
 				return "", fmt.Errorf("cannot restore %q to a file: the directory holds files agentsync does not manage (e.g. %q); move or remove them, then re-run revert", ch.Path, blocker)
 			}
+		case statErr == nil && ch.Kind == "create":
+			// (1b) a create over an existing regular file: it is the user's own
+			// untracked/gitignored file (HEAD doesn't track this path) — refuse
+			// rather than overwrite and commit it.
+			return "", fmt.Errorf("cannot restore %q: a file agentsync does not manage already exists there; move or remove it, then re-run revert", ch.Path)
 		}
 		for parent := path.Dir(ch.Path); parent != "." && parent != "/"; parent = path.Dir(parent) {
 			pinfo, statErr := os.Stat(filepath.Join(r.dir, filepath.FromSlash(parent)))
@@ -240,14 +251,15 @@ func restoreFileFromTree(wt *gogit.Worktree, tree *object.Tree, p string) error 
 			return fmt.Errorf("creating parent dir of %s: %w", p, err)
 		}
 	}
-	// Drop any existing file so the target mode takes effect on (re)create. When p
-	// was a DIRECTORY in HEAD and is a file in the target, the delete pass already
-	// removed p's tracked contents; if the user left untracked files under p the
-	// dir is still non-empty, and we must NOT delete them — so surface a clear,
-	// actionable error rather than a raw "directory not empty".
+	// Drop any existing file so the target mode takes effect on (re)create. Restore's
+	// up-front pre-flight already refuses a dir->file replacement that would destroy
+	// unmanaged files, so reaching here with p still a non-empty directory means the
+	// filesystem changed AFTER that scan (a concurrent write) — a TOCTOU backstop.
+	// Distinct wording ("still holds ... after the pre-flight") so a test can tell it
+	// apart from the pre-flight's refusal; we still never delete the unmanaged files.
 	if err := fs.Remove(p); err != nil && !os.IsNotExist(err) {
 		if info, statErr := fs.Stat(p); statErr == nil && info.IsDir() {
-			return fmt.Errorf("cannot restore %q to a file: the directory still holds files agentsync does not manage; move or remove your own files under %q, then re-run revert", p, p)
+			return fmt.Errorf("cannot restore %q to a file: its directory still holds unmanaged files after the pre-flight (a concurrent change?); move or remove your own files under %q, then re-run revert", p, p)
 		}
 		return fmt.Errorf("replacing %s: %w", p, err)
 	}

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -96,20 +96,34 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	// Apply the delta path-by-path and stage each change. HEAD never moves, so the
 	// commit below is parented on the original HEAD automatically — the intervening
 	// commits (and the bad apply) stay reachable, keeping revert append-only.
+	//
+	// Deletes are applied in a FIRST pass, before any create/modify, so a path that
+	// swaps between a file and a directory across the two checkpoints cannot abort
+	// mid-restore. E.g. going back to a target where "a" is a file while HEAD has
+	// "a/b": the diff is {delete "a/b", create "a"}; removing "a/b" first empties
+	// dir "a" so restoreFileFromTree can replace it with the file "a". The reverse
+	// (delete file "a", then create "a/b") likewise needs the delete first so
+	// MkdirAll("a") succeeds. Delete and create paths are otherwise disjoint (a tree
+	// diff never both deletes and creates the same path), so the two passes are
+	// order-independent within themselves.
 	for _, ch := range changes {
-		switch ch.Kind {
-		case "delete":
-			// wt.Remove both deletes the worktree file and stages the deletion.
-			if _, err := wt.Remove(ch.Path); err != nil {
-				return "", fmt.Errorf("removing %s during revert in %s: %w", ch.Path, r.dir, err)
-			}
-		default: // "create" | "modify"
-			if err := restoreFileFromTree(wt, targetTree, ch.Path); err != nil {
-				return "", fmt.Errorf("restoring %s during revert in %s: %w", ch.Path, r.dir, err)
-			}
-			if _, err := wt.Add(ch.Path); err != nil {
-				return "", fmt.Errorf("staging %s during revert in %s: %w", ch.Path, r.dir, err)
-			}
+		if ch.Kind != "delete" {
+			continue
+		}
+		// wt.Remove both deletes the worktree file and stages the deletion.
+		if _, err := wt.Remove(ch.Path); err != nil {
+			return "", fmt.Errorf("removing %s during revert in %s: %w", ch.Path, r.dir, err)
+		}
+	}
+	for _, ch := range changes {
+		if ch.Kind == "delete" {
+			continue // "create" | "modify"
+		}
+		if err := restoreFileFromTree(wt, targetTree, ch.Path); err != nil {
+			return "", fmt.Errorf("restoring %s during revert in %s: %w", ch.Path, r.dir, err)
+		}
+		if _, err := wt.Add(ch.Path); err != nil {
+			return "", fmt.Errorf("staging %s during revert in %s: %w", ch.Path, r.dir, err)
 		}
 	}
 	sig := signature(id)

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -92,6 +93,30 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	wt, err := r.repo.Worktree()
 	if err != nil {
 		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	// Pre-flight the one conflict Restore cannot resolve without data loss: a path
+	// that is a file in the target but is CURRENTLY a directory still holding
+	// untracked files (which we must never delete). Detect it BEFORE mutating the
+	// worktree so the refusal is all-or-nothing — no half-applied deletes — and
+	// name the offending file. restoreFileFromTree keeps a defensive backstop for
+	// the same case, but this makes the common one fail cleanly up front.
+	untracked, err := r.UntrackedPaths()
+	if err != nil {
+		return "", err
+	}
+	for _, ch := range changes {
+		if ch.Kind == "delete" {
+			continue
+		}
+		info, statErr := wt.Filesystem.Stat(ch.Path)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		for _, u := range untracked {
+			if u == ch.Path || strings.HasPrefix(u, ch.Path+"/") {
+				return "", fmt.Errorf("cannot restore %q to a file: the directory holds files agentsync does not manage (e.g. %q); move or remove them, then re-run revert", ch.Path, u)
+			}
+		}
 	}
 	// Apply the delta path-by-path and stage each change. HEAD never moves, so the
 	// commit below is parented on the original HEAD automatically — the intervening

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
-	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -94,28 +94,52 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
 	}
-	// Pre-flight the one conflict Restore cannot resolve without data loss: a path
-	// that is a file in the target but is CURRENTLY a directory still holding
-	// untracked files (which we must never delete). Detect it BEFORE mutating the
-	// worktree so the refusal is all-or-nothing — no half-applied deletes — and
-	// name the offending file. restoreFileFromTree keeps a defensive backstop for
-	// the same case, but this makes the common one fail cleanly up front.
-	untracked, err := r.UntrackedPaths()
-	if err != nil {
-		return "", err
+	// Pre-flight the STRUCTURAL conflicts a create/modify can't resolve without
+	// destroying a file agentsync doesn't manage, and refuse BEFORE mutating the
+	// worktree — so no unmanaged file is ever deleted and these conflicts fail up
+	// front rather than half-way through the delete pass. We inspect the worktree
+	// filesystem directly (NOT git status, which omits gitignored files):
+	//   (1) a path that is a file in the target but CURRENTLY a directory whose
+	//       contents aren't all being deleted (it holds untracked/gitignored files)
+	//       — replacing it with a file would delete them;
+	//   (2) a create whose ancestor is an existing unmanaged FILE — MkdirAll would
+	//       fail over it.
+	// A non-transactional restore can't guarantee zero partial state for every
+	// possible I/O error, but any staged-but-uncommitted delete is git-recoverable
+	// and no unmanaged file is ever lost. restoreFileFromTree keeps a defensive
+	// backstop for the same dir->file case.
+	deleting := make(map[string]bool, len(changes))
+	for _, ch := range changes {
+		if ch.Kind == "delete" {
+			deleting[ch.Path] = true
+		}
 	}
 	for _, ch := range changes {
 		if ch.Kind == "delete" {
 			continue
 		}
-		info, statErr := wt.Filesystem.Stat(ch.Path)
-		if statErr != nil || !info.IsDir() {
-			continue
-		}
-		for _, u := range untracked {
-			if u == ch.Path || strings.HasPrefix(u, ch.Path+"/") {
-				return "", fmt.Errorf("cannot restore %q to a file: the directory holds files agentsync does not manage (e.g. %q); move or remove them, then re-run revert", ch.Path, u)
+		abs := filepath.Join(r.dir, filepath.FromSlash(ch.Path))
+		if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+			blocker, werr := firstUnmanagedFileUnder(r.dir, abs, deleting)
+			if werr != nil {
+				return "", fmt.Errorf("scanning %s during revert in %s: %w", ch.Path, r.dir, werr)
 			}
+			if blocker != "" {
+				return "", fmt.Errorf("cannot restore %q to a file: the directory holds files agentsync does not manage (e.g. %q); move or remove them, then re-run revert", ch.Path, blocker)
+			}
+		}
+		for parent := path.Dir(ch.Path); parent != "." && parent != "/"; parent = path.Dir(parent) {
+			pinfo, statErr := os.Stat(filepath.Join(r.dir, filepath.FromSlash(parent)))
+			if statErr != nil {
+				continue // doesn't exist yet — MkdirAll will create it
+			}
+			if pinfo.IsDir() {
+				break // a real directory — fine
+			}
+			if !deleting[parent] {
+				return "", fmt.Errorf("cannot restore %q: its parent %q is a file agentsync does not manage; move or remove it, then re-run revert", ch.Path, parent)
+			}
+			break // parent is a file being deleted — the delete pass clears it first
 		}
 	}
 	// Apply the delta path-by-path and stage each change. HEAD never moves, so the
@@ -157,6 +181,32 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 		return "", fmt.Errorf("recording revert commit in %s: %w", r.dir, err)
 	}
 	return h.String(), nil
+}
+
+// firstUnmanagedFileUnder walks absDir and returns the first regular file — as a
+// repoDir-relative slash path — that is NOT in the `deleting` set: an untracked or
+// gitignored file that replacing this directory with a file would have to destroy.
+// It returns "" when the directory holds nothing agentsync isn't already removing.
+func firstUnmanagedFileUnder(repoDir, absDir string, deleting map[string]bool) (string, error) {
+	var found string
+	err := filepath.WalkDir(absDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(repoDir, p)
+		if rerr != nil {
+			return rerr
+		}
+		if slash := filepath.ToSlash(rel); !deleting[slash] {
+			found = slash
+			return filepath.SkipAll // stop at the first unmanaged file
+		}
+		return nil
+	})
+	return found, err
 }
 
 // restoreFileFromTree writes the target tree's blob for slash-path p into the

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -2,6 +2,9 @@ package git
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path"
 	"sort"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -59,11 +62,21 @@ func (r *Repo) Plan(targetRev string) (targetHash string, changes []FileChange, 
 	return targetStr, out, nil
 }
 
-// Restore makes the worktree match the targetRev checkpoint and records the result
-// as a NEW commit on top of the current HEAD. It is append-only: HEAD advances,
-// nothing is rewritten or lost, so the bad apply stays in history and the revert
-// is itself revertible. Returns the new commit hash, or ("", nil) when the worktree
-// already matches target (no checkpoint recorded).
+// Restore makes the worktree's TRACKED files match the targetRev checkpoint and
+// records the result as a NEW commit on top of the current HEAD. It is append-only:
+// HEAD advances, nothing is rewritten or lost, so the bad apply stays in history
+// and the revert is itself revertible. Returns the new commit hash, or ("", nil)
+// when the worktree already matches target (no checkpoint recorded).
+//
+// It applies ONLY the tracked HEAD↔target delta (the FileChanges from Plan) to the
+// worktree — it deliberately does NOT use go-git's HardReset. Unlike `git reset
+// --hard`, go-git's HardReset enumerates and DELETES every untracked and gitignored
+// worktree file; a revert sold as safe rollback must never destroy the user's own
+// scratch files. Because only the diffed paths are touched, any untracked or
+// gitignored file the user dropped into the dir survives byte-for-byte and stays
+// untracked. (Callers snapshot uncommitted TRACKED edits first — see revert's
+// SnapshotDirtyTracked — so at entry tracked worktree == HEAD and applying the
+// delta reproduces target's tracked content exactly.)
 func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	targetStr, changes, err := r.Plan(targetRev)
 	if err != nil {
@@ -72,7 +85,7 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	if len(changes) == 0 {
 		return "", nil
 	}
-	orig, err := r.headHash()
+	targetTree, err := r.commitTree(plumbing.NewHash(targetStr))
 	if err != nil {
 		return "", err
 	}
@@ -80,18 +93,24 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("worktree for %s: %w", r.dir, err)
 	}
-	// Append-only restore via two resets:
-	//   1. HARD reset to target  → index + worktree now hold target's content
-	//      (and the branch ref transiently points at target).
-	//   2. SOFT reset to orig    → moves the branch ref back to the original HEAD
-	//      WITHOUT touching the index/worktree (go-git SoftReset leaves both).
-	// Committing now records target's content as a new commit whose PARENT is the
-	// original HEAD — so the intervening commits (and the bad apply) stay reachable.
-	if err := wt.Reset(&gogit.ResetOptions{Commit: plumbing.NewHash(targetStr), Mode: gogit.HardReset}); err != nil {
-		return "", fmt.Errorf("reset worktree to checkpoint %s in %s: %w", shortStr(targetStr), r.dir, err)
-	}
-	if err := wt.Reset(&gogit.ResetOptions{Commit: orig, Mode: gogit.SoftReset}); err != nil {
-		return "", fmt.Errorf("restoring branch ref after revert in %s: %w", r.dir, err)
+	// Apply the delta path-by-path and stage each change. HEAD never moves, so the
+	// commit below is parented on the original HEAD automatically — the intervening
+	// commits (and the bad apply) stay reachable, keeping revert append-only.
+	for _, ch := range changes {
+		switch ch.Kind {
+		case "delete":
+			// wt.Remove both deletes the worktree file and stages the deletion.
+			if _, err := wt.Remove(ch.Path); err != nil {
+				return "", fmt.Errorf("removing %s during revert in %s: %w", ch.Path, r.dir, err)
+			}
+		default: // "create" | "modify"
+			if err := restoreFileFromTree(wt, targetTree, ch.Path); err != nil {
+				return "", fmt.Errorf("restoring %s during revert in %s: %w", ch.Path, r.dir, err)
+			}
+			if _, err := wt.Add(ch.Path); err != nil {
+				return "", fmt.Errorf("staging %s during revert in %s: %w", ch.Path, r.dir, err)
+			}
+		}
 	}
 	sig := signature(id)
 	h, err := wt.Commit(message, &gogit.CommitOptions{Author: sig, Committer: sig})
@@ -99,6 +118,78 @@ func (r *Repo) Restore(targetRev, message string, id Identity) (string, error) {
 		return "", fmt.Errorf("recording revert commit in %s: %w", r.dir, err)
 	}
 	return h.String(), nil
+}
+
+// restoreFileFromTree writes the target tree's blob for slash-path p into the
+// worktree filesystem, preserving the blob's file mode (notably the exec bit).
+// It writes through wt.Filesystem so paths resolve under the worktree root even
+// for folded/rerooted repos. The file is removed first so OpenFile's perm applies
+// even when p already exists (a "modify"), since OpenFile only honors perm on
+// creation.
+//
+// A symlink-mode blob (git mode 120000) is written as a regular file here, not
+// recreated as a symlink; agentsync writes only regular files into the versioned
+// dirs, so a tracked symlink blob does not arise in practice.
+func restoreFileFromTree(wt *gogit.Worktree, tree *object.Tree, p string) error {
+	fs := wt.Filesystem
+	f, err := tree.File(p)
+	if err != nil {
+		return fmt.Errorf("loading blob %s from target checkpoint: %w", p, err)
+	}
+	mode, err := f.Mode.ToOSFileMode()
+	if err != nil {
+		return fmt.Errorf("resolving file mode of %s: %w", p, err)
+	}
+	reader, err := f.Reader()
+	if err != nil {
+		return fmt.Errorf("reading blob %s: %w", p, err)
+	}
+	defer reader.Close()
+
+	if dir := path.Dir(p); dir != "." && dir != "/" {
+		if err := fs.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("creating parent dir of %s: %w", p, err)
+		}
+	}
+	// Drop any existing file so the target mode takes effect on (re)create.
+	if err := fs.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("replacing %s: %w", p, err)
+	}
+	dst, err := fs.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("opening %s for write: %w", p, err)
+	}
+	if _, err := io.Copy(dst, reader); err != nil {
+		_ = dst.Close()
+		return fmt.Errorf("writing %s: %w", p, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", p, err)
+	}
+	return nil
+}
+
+// UntrackedPaths returns the sorted slash-relative paths of files in the worktree
+// that git is not tracking (a `?` status) — the user's own scratch files that a
+// revert leaves untouched. Note go-git's status does not enumerate gitignored
+// files, so those (also preserved by revert) do not appear here.
+func (r *Repo) UntrackedPaths() ([]string, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("worktree for %s: %w", r.dir, err)
+	}
+	st, err := wt.Status()
+	if err != nil {
+		return nil, fmt.Errorf("git status in %s: %w", r.dir, err)
+	}
+	var out []string
+	for p, fs := range st {
+		if isUntracked(fs) {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // commitTree loads the tree of a commit hash.

--- a/internal/git/restore.go
+++ b/internal/git/restore.go
@@ -165,8 +165,15 @@ func restoreFileFromTree(wt *gogit.Worktree, tree *object.Tree, p string) error 
 			return fmt.Errorf("creating parent dir of %s: %w", p, err)
 		}
 	}
-	// Drop any existing file so the target mode takes effect on (re)create.
+	// Drop any existing file so the target mode takes effect on (re)create. When p
+	// was a DIRECTORY in HEAD and is a file in the target, the delete pass already
+	// removed p's tracked contents; if the user left untracked files under p the
+	// dir is still non-empty, and we must NOT delete them — so surface a clear,
+	// actionable error rather than a raw "directory not empty".
 	if err := fs.Remove(p); err != nil && !os.IsNotExist(err) {
+		if info, statErr := fs.Stat(p); statErr == nil && info.IsDir() {
+			return fmt.Errorf("cannot restore %q to a file: the directory still holds files agentsync does not manage; move or remove your own files under %q, then re-run revert", p, p)
+		}
 		return fmt.Errorf("replacing %s: %w", p, err)
 	}
 	dst, err := fs.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)

--- a/internal/secrets/leakscan.go
+++ b/internal/secrets/leakscan.go
@@ -48,7 +48,10 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 	if ingested == nil || against == nil {
 		return nil
 	}
-	secretVals := sourceSecretValues(against, sec) // resolved value -> placeholder
+	// backstopSecretValues (NOT sourceSecretValues) is the detection set: the
+	// backstop must trip on short (1–3 char) live secrets too, since refusing a
+	// leak is not the substring rewrite the re-reference length floor guards.
+	secretVals := backstopSecretValues(against, sec) // resolved value -> placeholder
 	srcByLoc := make(map[secretFieldLoc]string)
 	walkSecretFields(against, func(loc secretFieldLoc, s string) string {
 		srcByLoc[loc] = s
@@ -81,6 +84,13 @@ func ResidualSecretCleartext(ingested, against *source.Canonical, sec, env Resol
 		// in source (even one that coincidentally equals another secret's value)
 		// is pre-existing, not a new leak, so it must not be refused.
 		for v := range secretVals {
+			// belt-and-suspenders: strings.Contains(s, "") is always true, so an
+			// empty resolved value would false-flag every field. backstopSecretValues
+			// already excludes "" at build time; this guards against any future
+			// detection-set change.
+			if v == "" {
+				continue
+			}
 			if strings.Contains(s, v) && !strings.Contains(src, v) {
 				flag(g)
 				return s

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -108,15 +108,23 @@ func rereferenceHookByValue(against *source.Canonical, event, ingested string, s
 }
 
 // minReReferenceLen is the shortest resolved secret value the value-based
-// fallback will invert. A 1–3 char "secret" is not a credential worth the risk
-// of substring-rewriting unrelated text (a flag, a path segment); the
-// field-positional pass still restores it when the dest field is unchanged.
+// re-reference fallback will invert. A 1–3 char "secret" is not a credential
+// worth the risk of substring-rewriting unrelated text (a flag, a path segment);
+// the field-positional pass still restores it when the dest field is unchanged.
+//
+// This floor governs ONLY the re-reference value-based fallback
+// (sourceSecretValues). The fail-closed cleartext backstop deliberately does NOT
+// inherit it — refusing to persist a leak is not a substring rewrite, so it uses
+// backstopSecretValues (no length floor) and still trips on a 1–3 char credential.
 const minReReferenceLen = 4
 
 // sourceSecretValues resolves every ${secret:…} reference in against and returns
 // a map from the resolved cleartext to its placeholder. ${env:…} is excluded:
 // an env value is not a credential-at-rest concern and is never inverted (see
-// restoreField). Values shorter than minReReferenceLen are skipped.
+// restoreField). This is the RE-REFERENCE fallback's detection set, so values
+// shorter than minReReferenceLen are skipped (the field-positional pass still
+// restores an unchanged short-secret field). The backstop uses
+// backstopSecretValues instead, which keeps those short values.
 func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]string {
 	out := map[string]string{}
 	if against == nil || sec == nil {
@@ -129,6 +137,38 @@ func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]stri
 			}
 			v, err := sec.Resolve(m[2])
 			if err != nil || len(v) < minReReferenceLen {
+				continue
+			}
+			out[v] = m[0]
+		}
+		return s
+	})
+	return out
+}
+
+// backstopSecretValues resolves every ${secret:…} reference in against and
+// returns a map from the resolved cleartext to its placeholder, for the
+// fail-closed cleartext backstop (ResidualSecretCleartext). ${env:…} is excluded
+// (same rationale as sourceSecretValues).
+//
+// Unlike sourceSecretValues it does NOT apply minReReferenceLen: refusing to
+// persist a leak is not a substring rewrite of unrelated text, so a 1–3 char
+// credential moved into a literal-counterpart field must still trip the backstop
+// rather than be silently written to the committed canonical source. Only
+// truly-empty values are excluded — there is nothing to leak — which also folds
+// in the empty-secret (e.g. blank age/env value) blind spot.
+func backstopSecretValues(against *source.Canonical, sec Resolver) map[string]string {
+	out := map[string]string{}
+	if against == nil || sec == nil {
+		return out
+	}
+	walkSecretFields(against, func(_ secretFieldLoc, s string) string {
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			if len(m) < 3 || m[1] != "secret" {
+				continue
+			}
+			v, err := sec.Resolve(m[2])
+			if err != nil || v == "" {
 				continue
 			}
 			out[v] = m[0]

--- a/internal/secrets/rereference.go
+++ b/internal/secrets/rereference.go
@@ -118,14 +118,16 @@ func rereferenceHookByValue(against *source.Canonical, event, ingested string, s
 // backstopSecretValues (no length floor) and still trips on a 1–3 char credential.
 const minReReferenceLen = 4
 
-// sourceSecretValues resolves every ${secret:…} reference in against and returns
-// a map from the resolved cleartext to its placeholder. ${env:…} is excluded:
-// an env value is not a credential-at-rest concern and is never inverted (see
-// restoreField). This is the RE-REFERENCE fallback's detection set, so values
-// shorter than minReReferenceLen are skipped (the field-positional pass still
-// restores an unchanged short-secret field). The backstop uses
-// backstopSecretValues instead, which keeps those short values.
-func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]string {
+// resolvedSecretValues resolves every ${secret:…} reference in against to a map
+// from resolved cleartext -> its placeholder, skipping any value shorter than
+// minLen (which also excludes empty values, len 0). ${env:…} is excluded: an env
+// value is not a credential-at-rest concern and is never inverted (see
+// restoreField). It is the single body behind BOTH sourceSecretValues (the
+// re-reference fallback set) and backstopSecretValues (the fail-closed backstop
+// set) so a future change to the regex, the env/secret discrimination, or the
+// walkSecretFields closure can't silently desync the two security-sensitive
+// detection sets — the drift hazard two independent copies would create.
+func resolvedSecretValues(against *source.Canonical, sec Resolver, minLen int) map[string]string {
 	out := map[string]string{}
 	if against == nil || sec == nil {
 		return out
@@ -136,7 +138,7 @@ func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]stri
 				continue
 			}
 			v, err := sec.Resolve(m[2])
-			if err != nil || len(v) < minReReferenceLen {
+			if err != nil || len(v) < minLen {
 				continue
 			}
 			out[v] = m[0]
@@ -146,36 +148,23 @@ func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]stri
 	return out
 }
 
-// backstopSecretValues resolves every ${secret:…} reference in against and
-// returns a map from the resolved cleartext to its placeholder, for the
-// fail-closed cleartext backstop (ResidualSecretCleartext). ${env:…} is excluded
-// (same rationale as sourceSecretValues).
-//
-// Unlike sourceSecretValues it does NOT apply minReReferenceLen: refusing to
-// persist a leak is not a substring rewrite of unrelated text, so a 1–3 char
-// credential moved into a literal-counterpart field must still trip the backstop
-// rather than be silently written to the committed canonical source. Only
-// truly-empty values are excluded — there is nothing to leak — which also folds
-// in the empty-secret (e.g. blank age/env value) blind spot.
+// sourceSecretValues is the RE-REFERENCE fallback's detection set: values shorter
+// than minReReferenceLen are skipped (the field-positional pass still restores an
+// unchanged short-secret field, and inverting a 1–3 char value risks
+// substring-rewriting unrelated text). The backstop uses backstopSecretValues.
+func sourceSecretValues(against *source.Canonical, sec Resolver) map[string]string {
+	return resolvedSecretValues(against, sec, minReReferenceLen)
+}
+
+// backstopSecretValues is the fail-closed cleartext backstop's detection set
+// (ResidualSecretCleartext). Unlike sourceSecretValues it does NOT apply
+// minReReferenceLen: refusing to persist a leak is not a substring rewrite, so a
+// 1–3 char credential moved into a literal-counterpart field must still trip the
+// backstop rather than be silently written to the committed canonical source. Only
+// truly-empty values (len 0) are excluded — nothing to leak — which also folds in
+// the empty-secret (blank age/env value) blind spot.
 func backstopSecretValues(against *source.Canonical, sec Resolver) map[string]string {
-	out := map[string]string{}
-	if against == nil || sec == nil {
-		return out
-	}
-	walkSecretFields(against, func(_ secretFieldLoc, s string) string {
-		for _, m := range re.FindAllStringSubmatch(s, -1) {
-			if len(m) < 3 || m[1] != "secret" {
-				continue
-			}
-			v, err := sec.Resolve(m[2])
-			if err != nil || v == "" {
-				continue
-			}
-			out[v] = m[0]
-		}
-		return s
-	})
-	return out
+	return resolvedSecretValues(against, sec, 1)
 }
 
 // restoreField returns the source field's templated value when it referenced a

--- a/internal/secrets/rereference_test.go
+++ b/internal/secrets/rereference_test.go
@@ -410,3 +410,55 @@ func TestResidualSecretCleartext_ExtraValue(t *testing.T) {
 		t.Fatalf("pre-existing source Extra literal must not be flagged, got %v", leaks)
 	}
 }
+
+// TestBackstopVsSourceSecretValues pins the decoupling: the re-reference
+// fallback set (sourceSecretValues) applies the minReReferenceLen floor and so
+// drops 1–3 char values, while the backstop set (backstopSecretValues) keeps
+// them — it only drops truly-empty values.
+func TestBackstopVsSourceSecretValues(t *testing.T) {
+	sec := fakeResolver{
+		"ONE":   "a",
+		"TWO":   "ab",
+		"THREE": "abc",
+		"FOUR":  "abcd",
+		"EMPTY": "",
+	}
+	against := &source.Canonical{
+		MCPServers: []source.MCPServer{{
+			ID: "srv",
+			Server: source.MCPServerSpec{
+				Type: "stdio",
+				Env: map[string]string{
+					"A": "${secret:ONE}",
+					"B": "${secret:TWO}",
+					"C": "${secret:THREE}",
+					"D": "${secret:FOUR}",
+					"E": "${secret:EMPTY}",
+				},
+			},
+		}},
+	}
+
+	backstop := backstopSecretValues(against, sec)
+	for _, v := range []string{"a", "ab", "abc", "abcd"} {
+		if _, ok := backstop[v]; !ok {
+			t.Errorf("backstopSecretValues must include %q", v)
+		}
+	}
+	if _, ok := backstop[""]; ok {
+		t.Errorf("backstopSecretValues must exclude the empty value")
+	}
+
+	reref := sourceSecretValues(against, sec)
+	for _, v := range []string{"a", "ab", "abc"} {
+		if _, ok := reref[v]; ok {
+			t.Errorf("sourceSecretValues must exclude short value %q (< minReReferenceLen)", v)
+		}
+	}
+	if _, ok := reref["abcd"]; !ok {
+		t.Errorf("sourceSecretValues must include >=4-char value %q", "abcd")
+	}
+	if _, ok := reref[""]; ok {
+		t.Errorf("sourceSecretValues must exclude the empty value")
+	}
+}

--- a/internal/source/loader.go
+++ b/internal/source/loader.go
@@ -89,6 +89,14 @@ func loadConfig(fs afero.Fs, home string, cfg *Config) error {
 		}
 		return fmt.Errorf("parse %s: %w", p, err)
 	}
+	// Validate enumerated values the strict decoder can't catch: it rejects
+	// unknown KEYS but accepts any VALUE, so a typo'd git-backup mode
+	// (mode = "On"/"yes"/"true") would otherwise slip through and silently
+	// change behavior. Reject it here so every source.Load caller (apply,
+	// doctor) agrees at load time.
+	if err := cfg.DestinationGitBackup.validateMode(); err != nil {
+		return fmt.Errorf("parse %s: %w", p, err)
+	}
 	return nil
 }
 

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -27,6 +27,76 @@ defauls_mode = "track"
 	}
 }
 
+// TestLoadRejectsInvalidGitBackupMode confirms that an out-of-set
+// [destination_directory_git_backup] mode value is rejected at source.Load
+// (previously the strict decoder caught unknown KEYS but accepted any VALUE, so
+// a typo like mode = "On"/"yes" silently disabled backup). The error must
+// surface from the top-level Load call and name the file path, the offending
+// value, and the valid set. Valid values (including the empty default) must
+// load cleanly, with EffectiveMode() defaulting "" → "prompt".
+func TestLoadRejectsInvalidGitBackupMode(t *testing.T) {
+	const home = "/home/.agentsync"
+	const path = home + "/agentsync.toml"
+
+	invalid := []struct {
+		name string
+		mode string
+	}{
+		{"yes", "yes"},
+		{"true", "true"},
+		{"capital On", "On"},
+		{"numeric zero", "0"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid "+tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			_ = afero.WriteFile(fs, path, []byte(
+				"[destination_directory_git_backup]\nmode = \""+tc.mode+"\"\n"), 0o644)
+			_, err := source.Load(fs, home)
+			if err == nil {
+				t.Fatalf("Load accepted invalid mode %q; want error", tc.mode)
+			}
+			got := err.Error()
+			// Path prefix, offending value, and valid set must all appear.
+			if !contains(got, path) {
+				t.Errorf("error %q does not name the file path %q", got, path)
+			}
+			if !contains(got, tc.mode) {
+				t.Errorf("error %q does not mention the offending value %q", got, tc.mode)
+			}
+			for _, want := range []string{source.GitBackupModePrompt, source.GitBackupModeOn, source.GitBackupModeOff} {
+				if !contains(got, want) {
+					t.Errorf("error %q does not mention valid value %q", got, want)
+				}
+			}
+		})
+	}
+
+	valid := []struct {
+		name    string
+		body    string
+		wantEff string
+	}{
+		{"omitted defaults to prompt", "", source.GitBackupModePrompt},
+		{"prompt", "[destination_directory_git_backup]\nmode = \"prompt\"\n", source.GitBackupModePrompt},
+		{"on", "[destination_directory_git_backup]\nmode = \"on\"\n", source.GitBackupModeOn},
+		{"off", "[destination_directory_git_backup]\nmode = \"off\"\n", source.GitBackupModeOff},
+	}
+	for _, tc := range valid {
+		t.Run("valid "+tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			_ = afero.WriteFile(fs, path, []byte(tc.body), 0o644)
+			c, err := source.Load(fs, home)
+			if err != nil {
+				t.Fatalf("Load(%q) = error %v; want success", tc.body, err)
+			}
+			if got := c.Config.DestinationGitBackup.EffectiveMode(); got != tc.wantEff {
+				t.Errorf("EffectiveMode() = %q, want %q", got, tc.wantEff)
+			}
+		})
+	}
+}
+
 // TestParseFrontmatter_ClosingFenceAtEOF guards the parser against two common
 // real-world shapes that previously returned "unterminated frontmatter":
 // a closing "---" at end-of-file with no trailing newline (editors strip it),

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -51,7 +51,8 @@ func TestLoadRejectsInvalidGitBackupMode(t *testing.T) {
 		t.Run("invalid "+tc.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			_ = afero.WriteFile(fs, path, []byte(
-				"[destination_directory_git_backup]\nmode = \""+tc.mode+"\"\n"), 0o644)
+				"[destination_directory_git_backup]\nmode = \""+tc.mode+"\"\n",
+			), 0o644)
 			_, err := source.Load(fs, home)
 			if err == nil {
 				t.Fatalf("Load accepted invalid mode %q; want error", tc.mode)
@@ -94,6 +95,64 @@ func TestLoadRejectsInvalidGitBackupMode(t *testing.T) {
 				t.Errorf("EffectiveMode() = %q, want %q", got, tc.wantEff)
 			}
 		})
+	}
+}
+
+// TestConfigurationDocExampleParses is artifact-anchored on the exact
+// agentsync.toml snippet published in
+// website/src/content/docs/reference/configuration.mdx. It guards against the
+// doc regressing back to the invalid [[agents]] array-of-tables form (which
+// registers ZERO agents): the [agents.<name>] sub-table form must load a
+// non-empty, correctly-keyed Agents map, and the [updates]/[secrets] sections
+// the same snippet documents must parse under strict decoding.
+func TestConfigurationDocExampleParses(t *testing.T) {
+	// Kept byte-identical (minus the `age1…`/`…` placeholders that are just
+	// opaque strings) to the fenced ```toml block in configuration.mdx.
+	const doc = `
+[agents.claude]
+enabled = true
+scope   = "user"
+
+[agents.opencode]
+enabled = true
+
+[updates]
+default_mode     = "track"
+default_interval = "24h"
+
+[secrets]
+backend       = "age"
+file          = "secrets/secrets.age"
+recipient     = "age1example"
+identity_file = "${env:HOME}/.config/agentsync/age.key"
+
+[memory]
+banner = true
+`
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(doc), 0o644)
+	c, err := source.Load(fs, "/home/.agentsync")
+	if err != nil {
+		t.Fatalf("source.Load of documented snippet: %v", err)
+	}
+	if len(c.Config.Agents) != 2 {
+		t.Fatalf("Agents map = %d entries, want 2 (the [[agents]] form would give 0): %#v",
+			len(c.Config.Agents), c.Config.Agents)
+	}
+	for _, name := range []string{"claude", "opencode"} {
+		ag, ok := c.Config.Agents[name]
+		if !ok {
+			t.Fatalf("agent %q missing from parsed Agents map", name)
+		}
+		if !ag.Enabled {
+			t.Errorf("agent %q parsed as disabled; want enabled", name)
+		}
+	}
+	if got := c.Config.Updates.DefaultMode; got != "track" {
+		t.Errorf("[updates] default_mode = %q, want %q", got, "track")
+	}
+	if got := c.Config.Secrets.File; got != "secrets/secrets.age" {
+		t.Errorf("[secrets] file = %q, want %q", got, "secrets/secrets.age")
 	}
 }
 

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -1,11 +1,14 @@
 package source_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
 // TestLoad_AgentsyncTOMLRejectsTypos guards against the silent-drop bug
@@ -107,34 +110,22 @@ func TestLoadRejectsInvalidGitBackupMode(t *testing.T) {
 // non-empty, correctly-keyed Agents map, and the [updates]/[secrets] sections
 // the same snippet documents must parse under strict decoding.
 func TestConfigurationDocExampleParses(t *testing.T) {
-	// Kept byte-identical (minus the `age1…`/`…` placeholders that are just
-	// opaque strings) to the fenced ```toml block in configuration.mdx.
-	const doc = `
-[agents.claude]
-enabled = true
-scope   = "user"
+	testenv.RequireContainer(t)
+	// Read the LIVE published snippet, not a copy: extract the fenced ```toml block
+	// from configuration.mdx and load THAT, so a doc edit back to [[agents]] (or a
+	// dropped/renamed section) fails this test instead of shipping undetected.
+	mdxPath := filepath.Join("..", "..", "website", "src", "content", "docs", "reference", "configuration.mdx")
+	raw, err := os.ReadFile(mdxPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mdxPath, err)
+	}
+	doc := extractFencedBlock(t, string(raw), "```toml", `title="~/.agentsync/agentsync.toml"`)
 
-[agents.opencode]
-enabled = true
-
-[updates]
-default_mode     = "track"
-default_interval = "24h"
-
-[secrets]
-backend       = "age"
-file          = "secrets/secrets.age"
-recipient     = "age1example"
-identity_file = "${env:HOME}/.config/agentsync/age.key"
-
-[memory]
-banner = true
-`
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "/home/.agentsync/agentsync.toml", []byte(doc), 0o644)
 	c, err := source.Load(fs, "/home/.agentsync")
 	if err != nil {
-		t.Fatalf("source.Load of documented snippet: %v", err)
+		t.Fatalf("source.Load of the documented agentsync.toml snippet: %v\n---\n%s", err, doc)
 	}
 	if len(c.Config.Agents) != 2 {
 		t.Fatalf("Agents map = %d entries, want 2 (the [[agents]] form would give 0): %#v",
@@ -152,9 +143,32 @@ banner = true
 	if got := c.Config.Updates.DefaultMode; got != "track" {
 		t.Errorf("[updates] default_mode = %q, want %q", got, "track")
 	}
-	if got := c.Config.Secrets.File; got != "secrets/secrets.age" {
-		t.Errorf("[secrets] file = %q, want %q", got, "secrets/secrets.age")
+	if got := c.Config.Secrets.File; got == "" {
+		t.Error("[secrets] file should be documented and parse to a non-empty value")
 	}
+}
+
+// extractFencedBlock returns the body of the first ```<lang> fence whose opening
+// line contains marker, from markdown src. It fails the test if none is found, so
+// a doc restructure that removes the block is caught rather than silently skipped.
+func extractFencedBlock(t *testing.T, src, fence, marker string) string {
+	t.Helper()
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), fence) || !strings.Contains(line, marker) {
+			continue
+		}
+		var body []string
+		for _, l := range lines[i+1:] {
+			if strings.TrimSpace(l) == "```" {
+				return strings.Join(body, "\n")
+			}
+			body = append(body, l)
+		}
+		t.Fatalf("unterminated %s fence in doc", fence)
+	}
+	t.Fatalf("no %s fence containing %q found in the doc", fence, marker)
+	return ""
 }
 
 // TestParseFrontmatter_ClosingFenceAtEOF guards the parser against two common

--- a/internal/source/loader_test.go
+++ b/internal/source/loader_test.go
@@ -1,6 +1,7 @@
 package source_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -22,7 +23,7 @@ defauls_mode = "track"
 	}
 	// We don't pin on the exact pelletier message; just confirm the bad
 	// key surfaces.
-	if got := err.Error(); !contains(got, "defauls_mode") {
+	if got := err.Error(); !strings.Contains(got, "defauls_mode") {
 		t.Fatalf("error %q does not mention the typo'd key", got)
 	}
 }
@@ -59,14 +60,14 @@ func TestLoadRejectsInvalidGitBackupMode(t *testing.T) {
 			}
 			got := err.Error()
 			// Path prefix, offending value, and valid set must all appear.
-			if !contains(got, path) {
+			if !strings.Contains(got, path) {
 				t.Errorf("error %q does not name the file path %q", got, path)
 			}
-			if !contains(got, tc.mode) {
+			if !strings.Contains(got, tc.mode) {
 				t.Errorf("error %q does not mention the offending value %q", got, tc.mode)
 			}
 			for _, want := range []string{source.GitBackupModePrompt, source.GitBackupModeOn, source.GitBackupModeOff} {
-				if !contains(got, want) {
+				if !strings.Contains(got, want) {
 					t.Errorf("error %q does not mention valid value %q", got, want)
 				}
 			}
@@ -219,10 +220,10 @@ body
 	if !ok {
 		t.Fatalf("description not a string: %T %v", fm["description"], fm["description"])
 	}
-	if !contains(desc, "Triggers on: optimize GLB") {
+	if !strings.Contains(desc, "Triggers on: optimize GLB") {
 		t.Fatalf("lenient description truncated at colon-space: %q", desc)
 	}
-	if !contains(desc, "model optimization.") {
+	if !strings.Contains(desc, "model optimization.") {
 		t.Fatalf("lenient description missing tail: %q", desc)
 	}
 	if body != "body\n" {
@@ -252,7 +253,7 @@ body
 		t.Fatalf("skill silently dropped: %+v", c.Skills)
 	}
 	desc, _ := c.Skills[0].Frontmatter["description"].(string)
-	if !contains(desc, "Triggers on: optimize GLB") {
+	if !strings.Contains(desc, "Triggers on: optimize GLB") {
 		t.Fatalf("description truncated: %q", desc)
 	}
 }
@@ -297,17 +298,6 @@ func TestLoad_NestedMemoryFragments(t *testing.T) {
 	if got, ok := c.Memory.Fragments["top.md"]; !ok || got != "top body" {
 		t.Fatalf("flat fragment regressed: %#v", c.Memory.Fragments)
 	}
-}
-
-// contains is a small substring helper so the new test reads cleanly
-// without bringing in strings.Contains for one call.
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }
 
 func TestLoad_EmptyHome(t *testing.T) {

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -4,7 +4,11 @@
 // types directly.
 package source
 
-import "github.com/spxrogers/agentsync/internal/untrusted"
+import (
+	"fmt"
+
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
 
 // Canonical is the in-memory image of a fully-loaded ~/.agentsync/ tree.
 type Canonical struct {
@@ -61,6 +65,23 @@ func (g DestinationGitBackupConfig) EffectiveMode() string {
 		return GitBackupModePrompt
 	}
 	return g.Mode
+}
+
+// validateMode rejects any Mode value outside the allowed set
+// {"", "prompt", "on", "off"}. The empty string is accepted (EffectiveMode
+// defaults it to "prompt"); every other value must match a mode constant
+// case-SENSITIVELY — "On"/"true"/"yes" are invalid by design, so a typo can no
+// longer silently disable backup for untracked dirs while owned repos still
+// commit. Called from loadConfig after a successful decode so every source.Load
+// caller (apply, doctor, …) inherits the rejection.
+func (g DestinationGitBackupConfig) validateMode() error {
+	switch g.Mode {
+	case "", GitBackupModePrompt, GitBackupModeOn, GitBackupModeOff:
+		return nil
+	default:
+		return fmt.Errorf("[destination_directory_git_backup] mode: invalid value %q (want %q, %q, or %q)",
+			g.Mode, GitBackupModePrompt, GitBackupModeOn, GitBackupModeOff)
+	}
 }
 
 // MemoryConfig mirrors the [memory] table in agentsync.toml.

--- a/website/src/content/docs/getting-started/mental-model.mdx
+++ b/website/src/content/docs/getting-started/mental-model.mdx
@@ -65,7 +65,7 @@ agentsync apply
 
 # An agent edited its own config  →  bring the edit home
 agentsync status              # spot the drift
-agentsync diff claude         # inspect it (resolved secrets masked)
+agentsync diff                # inspect it (resolved secrets masked)
 agentsync reconcile           # interactively resolve
 ```
 

--- a/website/src/content/docs/guides/daily-loop.mdx
+++ b/website/src/content/docs/guides/daily-loop.mdx
@@ -22,7 +22,7 @@ After an agent (or you) edited a native file out from under agentsync:
 
 ```bash frame="terminal"
 agentsync status              # spot the drift
-agentsync diff claude         # inspect it (resolved secrets are masked)
+agentsync diff                # inspect it (resolved secrets are masked)
 agentsync reconcile           # interactively resolve
 ```
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -168,7 +168,10 @@ local). A dir already under your own source control is left untouched. Pass
 `--no-git-backup` to skip it for one run (CI/scripting) without touching config.
 The `[destination_directory_git_backup]` table (`mode = "prompt" | "on" | "off"`,
 optional `author_name`/`author_email`) controls the default; `agentsync doctor`
-shows the current mode and per-dir status. See `agentsync revert` below.
+shows the current mode and per-dir status. `mode` is validated at load — it must
+be exactly `prompt`, `on`, or `off` (case-sensitive; omit it for the `prompt`
+default). Any other value now **errors at load** with a path-prefixed message,
+rather than being silently ignored. See `agentsync revert` below.
 
 ### `revert <agent>`
 Rolls an agent's destination dir back to a prior apply checkpoint from its

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -174,10 +174,12 @@ shows the current mode and per-dir status. See `agentsync revert` below.
 Rolls an agent's destination dir back to a prior apply checkpoint from its
 local-only git history — recovering from a bad apply. It is **append-only**: it
 records a new commit, so the history is never rewritten and the revert is itself
-revertible. By default it undoes the most recent apply (restores the previous
-checkpoint); `--to <ref>` picks a specific one (a commit hash or `HEAD~2`), `--all`
-reverts every managed dir, and `--dry-run` previews the file changes without
-writing.
+revertible. Untracked files you dropped into the dir (and gitignored files) are
+**left untouched** — revert only rewinds the files agentsync versions, so your own
+scratch files are never deleted. By default it undoes the most recent apply
+(restores the previous checkpoint); `--to <ref>` picks a specific one (a commit
+hash or `HEAD~2`), `--all` reverts every managed dir, and `--dry-run` previews the
+file changes without writing (noting when untracked files are present).
 
 revert moves only the **destination**. The next `apply` re-renders from the
 canonical source and would overwrite the reverted state, so revert prints a notice

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -55,18 +55,29 @@ The top-level config: which agents are registered, update defaults, and the
 secrets backend.
 
 ```toml title="~/.agentsync/agentsync.toml"
-# Registered agents and whether each is enabled.
-[[agents]]
-name    = "claude"
+# Registered agents and whether each is enabled. Each agent is its own
+# [agents.<name>] sub-table (a TOML table keyed by agent name), not an
+# array-of-tables.
+[agents.claude]
+enabled = true
+scope   = "user"   # display-only; the file an entry lives in is the scope of record
+
+[agents.opencode]
 enabled = true
 
-[[agents]]
-name    = "opencode"
-enabled = true
+# Plugin update defaults (used by `agentsync update`).
+[updates]
+default_mode     = "track"   # pinned | track | manual — a plugin's own `update`
+                             # wins; this is the fallback. Only "track" plugins are
+                             # auto-bumped; "pinned"/"manual" need explicit action.
+                             # Unset behaves as "track".
+default_interval = "24h"     # configured update cadence
 
 # Secrets backend — see the Secrets guide.
 [secrets]
 backend       = "age"
+file          = "secrets/secrets.age"                # vault path; relative → under
+                                                     # ~/.agentsync, default shown
 recipient     = "age1…"                              # public key, safe to commit
 identity_file = "${env:HOME}/.config/agentsync/age.key"  # private key, per-machine
 
@@ -75,6 +86,19 @@ identity_file = "${env:HOME}/.config/agentsync/age.key"  # private key, per-mach
 banner = true   # default; set false to omit the managed-file banner from
                 # rendered memory files (CLAUDE.md, AGENTS.md, …)
 ```
+
+`[updates]` sets the default plugin-update policy for `agentsync update`.
+`default_mode` is `pinned` (never auto-bump), `track` (auto-bump to the latest
+marketplace version), or `manual` (bump only on explicit action); a plugin's own
+`update` key overrides it, and an unset `default_mode` behaves as `track`.
+`default_interval` (e.g. `"24h"`) is the configured update cadence for plugins
+that opt in to periodic updates.
+
+`[secrets].file` is the path to the age-encrypted vault. A relative path is
+resolved under `~/.agentsync/` (honouring `AGENTSYNC_HOME`); an absolute path or
+one with a leading `~` / `${env:HOME}` is expanded as written. When omitted it
+defaults to `secrets/secrets.age`, so most configs can leave it out. See the
+[Secrets guide](/guides/secrets/).
 
 The `[memory] banner` notice that agentsync prepends to each rendered memory file
 points edits back at `.agentsync/memory/AGENTS.md` + `agentsync apply`. It lives


### PR DESCRIPTION
## Summary

Implements **Wave 1** of the agentsync v1.0 remediation epic (#178) — the foundation wave: the two release-gating **blockers**, the shared registry/secret/git guards downstream waves consume, and the pure-docs website correctness fixes. Six issues, each landed as its own commit with same-commit docs + a `CHANGELOG [Unreleased]` entry.

Closes #124 · Closes #128 · Closes #131 · Closes #135 · Closes #137 · Closes #129.

| Issue | Sev | What it fixes |
| --- | --- | --- |
| **#124** | blocker | **Claude hook model.** Ingest captured a lossy subset of a `settings.json` hook event (dropping unmodeled fields like `timeout`, turning a non-`command` handler into `{type:…,command:""}`), and `renderHooks` owned/overwrote the whole per-event `/hooks/<event>` array — so `import`→`apply` silently corrupted the user's real config. Now: Ingest leaves any event it can't fully represent **uncaptured with a warning** (Gemini's guard-and-warn posture, approach A — no schema change), and Render reports a dropped `Skip` for a non-`command` handler instead of emitting an empty-command entry. |
| **#128** | blocker | **`revert` deleted untracked files.** `Restore` used go-git `HardReset`, which (unlike `git reset --hard`) enumerates and deletes every untracked/gitignored worktree file. `Restore` now applies **only the tracked HEAD↔target delta** file-by-file and never enumerates untracked entries, so they (and gitignored files) survive byte-for-byte and stay untracked. `revert --dry-run` notes their presence. |
| **#131** | high | **Registry-wide `RequireProjectRoot` guard.** New `TestEveryAdapterGuardsProjectRoot` asserts every registered adapter's `Render`/`Ingest` (and `IngestPlugins` for `PluginIngester`s) reject `(ScopeProject, "")` — closing the "a new adapter forgets the call" gap. Test-only. |
| **#135** | medium | **Secret backstop ⟂ len<4 floor.** The fail-closed cleartext backstop reused the re-reference value set, which drops secrets shorter than 4 chars — so a 1–3 char secret moved into a literal-counterpart field leaked into the committed source with no refusal. The backstop now builds its detection set without the length floor (excluding only empty values); re-reference keeps its substring-safety floor unchanged. |
| **#137** | medium | **Git-backup mode load validation.** A typo (`mode = "On"/"yes"/"true"`) silently disabled backup and only `doctor` warned. `source.Load` now rejects any `mode` outside `{prompt,on,off}` (case-sensitive) with a path-prefixed error, so every command agrees. |
| **#129** | high | **Website/docs correctness.** `agentsync diff claude` (arg is a path, not an agent name → silently "no diff") corrected to bare `agentsync diff` in 3 places; the `[[agents]]` config snippet (registered zero agents) corrected to `[agents.<name>]`; documented `[updates]` and `[secrets].file`. |

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

Every fix is backed by an **artifact-anchored** test where the issue requires it, and the local gate is green.

- **#124** — `TestIngest_HookArtifactRoundTrip` seeds a spec-complete on-disk `settings.json` (a `command` hook with `timeout`, a `prompt` handler, a clean event), runs Ingest→Render→Apply→re-read, and asserts the guarded events survive byte-for-byte (`applyWrite` genuinely merges `merge-json-keys` + `OwnedKeys`) and **no** `{command:""}` handler is ever written; plus `TestRenderHooks_SkipsNonCommandHandler`, `TestIngest_HookGuardWarnsAndSkips`. Pre-existing `TestIngest_RoundTripsHooksButIgnoresSettingsLSP` still passes.
- **#128** — `TestRestore_PreservesUntrackedFiles` (engine) drops an untracked **and** a gitignored file, reverts, asserts both survive + are absent from the commit tree; `TestRevert_PreservesUntrackedUserFiles` + `TestRevert_DryRunWarnsUntracked` (CLI). The engine test also confirms `UntrackedPaths` excludes gitignored files — the reason the delta approach (not a Status-based snapshot) is correct.
- **#131** — `TestEveryAdapterGuardsProjectRoot` (31 adapters + 2 `PluginIngester`s; non-vacuity backstop).
- **#135** — `TestCapture_RefusesShortSecretMovedIntoLiteralField` (1/2/3-char, fails on pre-fix code), `TestCapture_EmptySecretNotFalseRefused`, `TestBackstopVsSourceSecretValues`; all existing false-refusal regressions stay green.
- **#137** — `TestLoadRejectsInvalidGitBackupMode` (Load-anchored, on-disk fixture); driven end-to-end via the built binary (`doctor` rejects `On`/`yes`/`true`, accepts `on`/`off`/`prompt`/empty).
- **#129** — `TestConfigurationDocExampleParses` loads the literal documented snippet and asserts a non-empty `Agents` map (would fail if the doc regressed to `[[agents]]`); `grep 'diff claude'` / `[[agents]]` over `website/` + `docs/` return 0.

An adversarial per-issue review drove every acceptance criterion end-to-end (including a real binary drive of `revert` for #128 and `doctor` for #137): **all criteria CONFIRMED across all six issues, zero FAILED**. Two `#128` comment nits it surfaced (a stale "hard reset" reference in `commit.go`; symlink-mode blobs in `restoreFileFromTree`) were folded back into the #128 commit. Two other flagged items are **intended behavior**, not defects: the #135 backstop's fail-closed over-refusal of a short-value edit is the documented "err toward refusing" design, and the symlink case is practically unreachable (agentsync writes only regular files into versioned dirs).

Local gate (in-container equivalents, since this environment runs the hermetic guard directly):

- [x] `AGENTSYNC_TEST_IN_CONTAINER=1 go test -race -count=1 ./...` — **all 30 packages green**.
- [x] `golangci-lint run ./...` (forced `GOTOOLCHAIN=go1.26.2`) — **0 issues**; `gofmt -s`/`gofumpt` clean; `go mod tidy` no-op.
- [ ] `just test-release` — not run here (no nested container engine); the underlying `go test -race ./...` layer is green.

## Checklist

- [x] Conventional commit messages with a scope (one commit per issue, blockers first).
- [x] Tests added/updated for the behavior changed (artifact-anchored where required).
- [x] Touches `internal/secrets`/`internal/capture` (#135): re-read the secret-handling invariants — the change only **strengthens** the fail-closed backstop, `walkSecretFields` is untouched, no new secret-bearing field, no new dest→source write path, the re-reference floor is preserved.
- [x] Docs updated in the same commit as each behavior change (`docs/*.md`, `README.md`, `website/`, `CHANGELOG [Unreleased]`); the capability-matrix `◐` downgrade is deliberately left to #147 per #124's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGtuCxCBpVHDPjked46q7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGtuCxCBpVHDPjked46q7H)_