### PR TITLE
Print a one-time upgrade notice on the first run of a new release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,10 +116,7 @@ linters:
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # CLI files writing to ~/.agentsync/* (canonical source).
-      # init.go's ensureStateGitignore is atomic on purpose: the lock-free
-      # first-run upgrade notice also calls it, and a plain O_TRUNC write can
-      # truncate a user's hand-maintained .gitignore under concurrent runs.
-      - path: '(^|/)internal/cli/(init|plugin|marketplace|agent|gitbackup_config|reconcile|plugin_poll)\.go$'
+      - path: '(^|/)internal/cli/(plugin|marketplace|agent|gitbackup_config|reconcile|plugin_poll)\.go$'
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # The PassThroughWriter test helper deliberately delegates to

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,7 +116,10 @@ linters:
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # CLI files writing to ~/.agentsync/* (canonical source).
-      - path: '(^|/)internal/cli/(plugin|marketplace|agent|gitbackup_config|reconcile|plugin_poll)\.go$'
+      # init.go's ensureStateGitignore is atomic on purpose: the lock-free
+      # first-run upgrade notice also calls it, and a plain O_TRUNC write can
+      # truncate a user's hand-maintained .gitignore under concurrent runs.
+      - path: '(^|/)internal/cli/(init|plugin|marketplace|agent|gitbackup_config|reconcile|plugin_poll)\.go$'
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
       # The PassThroughWriter test helper deliberately delegates to

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,12 @@ linters:
       - path: '(^|/)internal/state/store\.go$'
         linters: [forbidigo]
         text: 'iox\.AtomicWrite is reserved'
+      # state/lastrun.go writes .state/last-run.json (agentsync's own per-machine
+      # run record for the upgrade notice) — same non-destination category as
+      # store.go, never a native agent file.
+      - path: '(^|/)internal/state/lastrun\.go$'
+        linters: [forbidigo]
+        text: 'iox\.AtomicWrite is reserved'
       # secrets/age.go writes secrets.age under ~/.agentsync/ via the
       # atomic path so a Ctrl-C during re-encrypt can't truncate the file.
       # Same canonical-source category, not a native destination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **Shell completion no longer consumes the upgrade notice.** Cobra runs the
+  root pre-run hook for its hidden `__complete` request too, and the generated
+  bash/zsh scripts invoke it with stderr discarded — so a single TAB after
+  `agentsync ` printed the banner into `/dev/null`, recorded it as seen, and the
+  user's next real command said nothing. Anyone with completions installed
+  would have hit that before ever seeing the notice, which is the one outcome
+  the feature exists to prevent. Completion requests now return before the
+  notice is considered.
+
 - **The upgrade notice no longer fires at a brand-new project-scope user.** It
   treated "the user home exists but has no run record" as an upgrade — but a
   project-scope user never runs `agentsync init` at user scope, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,35 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **The first-run-after-upgrade notice no longer silently disables the
+  `--scope` / `--project` refusal.** Wiring the notice assigned the root
+  command's `PersistentPreRunE` a SECOND time, and cobra's hook is a plain
+  field — so the assignment discarded the one calling `enforceScopeStance`, and
+  every scope-unaware command went back to accepting the flags and ignoring
+  them (exactly the bug #200 F6 shipped to kill). Nothing failed: the three
+  scope tests all read annotations, so none of them ever executed the hook. The
+  root now composes both concerns in one closure, and two guards cover the
+  shape — `TestRootDeclaresExactlyOnePersistentPreRun` (a second assignment
+  fails the build) and a behavioral table asserting scope-unaware commands
+  really do refuse.
+
+- **A corrupt run record no longer suppresses the upgrade notice forever.** Any
+  parse failure was treated like an I/O error: the notice was skipped and the
+  file was never rewritten, so one truncated or empty `last-run.json` — the
+  classic crash-mid-write or full-disk artifact — meant the user *never* learned
+  their canonical layout had moved. That directly contradicted the documented
+  contract. A record that cannot be parsed carries no information, so it is now
+  read as "this machine has shown nothing": the notice prints and the record is
+  repaired. `state.LoadLastRun` distinguishes `ErrCorruptLastRun` from a real
+  I/O error and always returns a usable record.
+
+- **The run record is gitignored on the path that creates it.** The notice is a
+  second place that can create `.state/` (`init` is the other) and it fires
+  precisely for pre-existing homes — which may predate the `.gitignore`
+  scaffolding — so in a dotfiles repo one `git add -A` committed one machine's
+  run marker and carried it to every other machine, silently suppressing the
+  notice there.
+
 - **`agentsync explain` no longer prints a resolved secret through an adapter
   skip reason.** `explain` renders from the secret-RESOLVED canonical (it must,
   to hash the same bytes `apply` writes), and the Continue adapter interpolated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,27 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **The upgrade notice no longer fires at a brand-new project-scope user.** It
+  treated "the user home exists but has no run record" as an upgrade — but a
+  project-scope user never runs `agentsync init` at user scope, and
+  `~/.agentsync/` gets materialized anyway the first time any mutating command
+  takes the global lock or records central state. A 0.11.0-native user was
+  therefore told to run `agentsync migrate subagents` against a tree that never
+  had an `agents/` directory, and that `verify` is now `check` having never
+  seen `verify`. The trigger is now `agentsync.toml` — written by `init`, never
+  by the state path — and a home without one is seeded silently instead. A
+  project-scope-only user upgrading from an older release still gets the
+  retired layout reported per tree by the fail-closed load gate, which names
+  the same command.
+
+- **`ensureStateGitignore` writes atomically.** The upgrade notice calls it
+  from a deliberately lock-free path, and it was a plain read-modify-write with
+  `os.WriteFile(O_TRUNC)` — so a reader landing inside another process's
+  truncate window wrote back its short read. Observed under concurrent first
+  runs: a 4000-line `~/.agentsync/.gitignore` reduced to one line, the user's
+  own rules gone. It also no longer appends a duplicate rule to a home that
+  already ignores `.state/` in one of its equivalent spellings.
+
 - **The first-run-after-upgrade notice no longer silently disables the
   `--scope` / `--project` refusal.** Wiring the notice assigned the root
   command's `PersistentPreRunE` a SECOND time, and cobra's hook is a plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **The upgrade notice no longer describes a removed command as deprecated.**
+  After the top-level `update` was cut outright, the banner's action line still
+  read "`agentsync update` is deprecated". Every guard stayed green: the notice
+  source is exempt from the stale-renamed-command scan (naming old spellings is
+  its job), and that exemption is whole-file, so it can catch a *missing*
+  mention but never a *wrong* one. Telling a user their cron line has a grace
+  period it does not have is the worst thing this banner can say, to the exact
+  audience it exists for. `TestUpgradeNoticeNamesEveryRetiredCommand` now pins
+  both directions — every retired top-level spelling must be named, and no
+  action line may call anything deprecated.
+
 - **Shell completion no longer consumes the upgrade notice.** Cobra runs the
   root pre-run hook for its hidden `__complete` request too, and the generated
   bash/zsh scripts invoke it with stderr discarded — so a single TAB after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,18 +241,30 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   therefore told to run `agentsync migrate subagents` against a tree that never
   had an `agents/` directory, and that `verify` is now `check` having never
   seen `verify`. The trigger is now `agentsync.toml` — written by `init`, never
-  by the state path — and a home without one is seeded silently instead. A
+  by the state path — and a home without one is passed over without recording
+  anything, so a machine that later gains a user config (a dotfiles restore, or
+  `agentsync init` run afterwards) still hears about the changes rather than
+  being silenced forever. A
   project-scope-only user upgrading from an older release still gets the
   retired layout reported per tree by the fail-closed load gate, which names
   the same command.
 
-- **`ensureStateGitignore` writes atomically.** The upgrade notice calls it
-  from a deliberately lock-free path, and it was a plain read-modify-write with
-  `os.WriteFile(O_TRUNC)` — so a reader landing inside another process's
-  truncate window wrote back its short read. Observed under concurrent first
-  runs: a 4000-line `~/.agentsync/.gitignore` reduced to one line, the user's
-  own rules gone. It also no longer appends a duplicate rule to a home that
-  already ignores `.state/` in one of its equivalent spellings.
+- **`ensureStateGitignore` appends instead of rewriting.** The upgrade notice
+  calls it from a deliberately lock-free path — the only write in the tool that
+  can run concurrently with itself — and it was a read-modify-write with
+  `os.WriteFile(O_TRUNC)`, so a reader landing inside another writer's truncate
+  window wrote back its short read. Measured under concurrent first runs: a
+  4000-line `~/.agentsync/.gitignore` collapsed to a single line, the user's own
+  rules gone. `iox.AtomicWrite` does **not** fix this — it uses a fixed sibling
+  temp name, so N concurrent writers share one temp inode and the same collapse
+  reproduces. The rule is now appended with `O_APPEND`, which additionally
+  restores two behaviors an atomic rewrite had broken: it writes **through** a
+  symlinked `.gitignore` (chezmoi / GNU Stow manage dotfiles that way, and
+  `iox.AtomicWrite` refuses a symlinked destination outright — silently leaving
+  `.state/` unignored for exactly those users), and it preserves the file's
+  existing mode rather than chmod-ing it to 0644. It also no longer appends a
+  duplicate rule to a home that already ignores `.state/` in an equivalent
+  spelling.
 
 - **The first-run-after-upgrade notice no longer silently disables the
   `--scope` / `--project` refusal.** Wiring the notice assigned the root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,29 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Added
 
+- **A one-time upgrade notice, printed by the CLI itself.** agentsync ships
+  through channels with no usable post-install hook — `go install` has none at
+  all, a Homebrew cask's caveats print only at install time, Scoop has nothing,
+  and only deb/rpm have real scripts — so the binary is the only thing that
+  reliably reaches an upgrading user. The first time you run a release carrying
+  a notice you have not seen, it prints what changed, the exact command to run,
+  and a link to <https://agentsync.cc/reference/upgrading/>.
+  - **Once per machine**, recorded in `~/.agentsync/.state/last-run.json` (a
+    separate file from `targets.json` on purpose: a read-only `status` must be
+    able to record that it showed the notice, and a UX marker has no business
+    gating on the drift state's `SchemaVersion`). `.state/` is gitignored, so
+    the record never travels with a dotfiles repo.
+  - **On stderr, always** — `status --json` / `diff --json` / `explain --json`
+    pipe their payload on stdout and must stay clean.
+  - **Never on a fresh install**: nothing can have broken under a user with no
+    config, so `init` seeds the record as already-seen. It is also silent for
+    an unversioned (`dev`) build, which keeps it out of local builds and the
+    whole test suite.
+  - **Best-effort**: a corrupt, missing, or unwritable record only means the
+    notice shows again later. It can never fail a command.
+  - Opt out permanently with `AGENTSYNC_NO_UPGRADE_NOTICE=1`.
+
+
 - **`agentsync explain <path>[#<pointer>]` — provenance for a destination
   file.** `diff` answers "what changed"; this answers "where did this come
   from", which is exactly the question a *converged* file (where `diff` is

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you lose your age private key, you lose access to all encrypted secrets. Reco
 | `AGENTSYNC_ALLOW_UNIMPLEMENTED=1` | Register an agent that has no implemented adapter yet (none today — every valid agent is real). |
 | `AGENTSYNC_ALLOW_PLUGIN_DRIFT=1` | Bypass the plugin-cache manifest-SHA check (after hand-editing). |
 | `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` | Skip `${secret:…}` resolution in `agentsync check`; reference *shape* is still validated (CI without an age key). |
+| `AGENTSYNC_NO_UPGRADE_NOTICE=1` | Never show the one-time first-run-after-upgrade notice. |
 | `AGENTSYNC_AGE_SKIP_PERM_CHECK=1` | Skip the 0600 mode check on the age identity file (ACL'd NFS). |
 | `AGENTSYNC_MAX_TARBALL_MB=<N>` | Override the per-tarball decompressed-bytes cap (default 512). 0 disables. |
 | `AGENTSYNC_TEST_IN_CONTAINER=1` | Bypass the host test guard (use only with `go test -run` for a single case). |

--- a/docs/components.md
+++ b/docs/components.md
@@ -382,10 +382,16 @@ Pure 3-way classifier — no IO.
 
 ### `internal/state`
 Persists last-applied hashes and plugin/marketplace pins to
-`.state/targets.json`; schema-versioned with migrators.
+`.state/targets.json`; schema-versioned with migrators. Also owns the
+per-machine run record `.state/last-run.json`, which backs the one-time
+first-run-after-upgrade notice — a SEPARATE file on purpose: it must be
+writable by read-only commands and must never gate on (or bump) the drift
+state's `SchemaVersion`.
 - **Key:** `SchemaVersion`; `Targets` (`Files`, `Keys`, `Marketplaces`,
-  `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`.
-- **Depends on:** iox. **Files:** `schema.go`, `store.go`, `migrate.go`.
+  `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`;
+  `LastRun`/`LoadLastRun`/`SaveLastRun`.
+- **Depends on:** iox. **Files:** `schema.go`, `store.go`, `migrate.go`,
+  `lastrun.go`.
 
 ### `internal/marketplace`
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin

--- a/internal/cli/gitignore_internal_test.go
+++ b/internal/cli/gitignore_internal_test.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
@@ -15,8 +17,39 @@ import (
 // concurrently with itself. The file it touches is a user's own .gitignore in a
 // repo they commit, which makes silent data loss here expensive.
 
+// gitignoreHelperEnv marks a re-exec of this test binary as the concurrency
+// helper: it runs ensureStateGitignore once against the named home and exits.
+const (
+	gitignoreHelperEnv     = "AGENTSYNC_TEST_GITIGNORE_HELPER"
+	gitignoreHelperHome    = "AGENTSYNC_TEST_GITIGNORE_HOME"
+	gitignoreHelperBarrier = "AGENTSYNC_TEST_GITIGNORE_BARRIER"
+)
+
+// TestEnsureStateGitignoreHelperProcess is not a test. It is the child process
+// spawned by the concurrency test below (the standard Go helper-process
+// pattern); it is inert unless the marker env var is set.
+func TestEnsureStateGitignoreHelperProcess(t *testing.T) {
+	if os.Getenv(gitignoreHelperEnv) != "1" {
+		t.Skip("helper process; runs only when re-executed by the concurrency test")
+	}
+	// Spin on the barrier so every child enters the critical section at the same
+	// moment. Without it the first writer wins the race, adds the rule, and
+	// every other process short-circuits on "already ignored" — leaving exactly
+	// one unsynchronized write and no race at all.
+	if barrier := os.Getenv(gitignoreHelperBarrier); barrier != "" {
+		for i := 0; i < 20000; i++ {
+			if _, err := os.Stat(barrier); err == nil {
+				break
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+	}
+	_ = ensureStateGitignore(os.Getenv(gitignoreHelperHome))
+	os.Exit(0)
+}
+
 // TestEnsureStateGitignore_ConcurrentWritersPreserveUserRules is the regression
-// for that loss.
+// for silent data loss in a user's own .gitignore.
 //
 // The first fix used a plain read-modify-write, and a reader landing inside
 // another writer's O_TRUNC window wrote back its short read. The SECOND fix
@@ -24,40 +57,78 @@ import (
 // name, so N concurrent writers share one temp inode and the same collapse
 // reproduces (measured: 4000 lines to 1). Appending with O_APPEND is what
 // actually holds.
+//
+// THIS IS A SMOKE TEST, NOT THE REGRESSION GUARD — read
+// TestEnsureStateGitignoreDoesNotUseATruncatingWrite below for that, and this
+// comment for why.
+//
+// The first version used goroutines and passed 10/10 against the KNOWN-BROKEN
+// implementation: under -race, which is what CI runs, the detector's
+// serialization closes the window entirely. Re-executing this binary (the real
+// shape: many short-lived invocations racing on one home) does catch it — but
+// only about 1 run in 5 even with a start barrier, because after the first
+// writer adds the rule every other process short-circuits on "already
+// ignored", so only the very first write ever races.
+//
+// A 1-in-5 detector is not something to gate a release on. What IS reliable is
+// the structural property: O_APPEND cannot truncate, so the bug is impossible
+// by construction rather than improbable. That is what the guard below asserts.
+// This test stays because exercising the concurrent path end-to-end is still
+// worth something, and it is cheap at these numbers.
 func TestEnsureStateGitignore_ConcurrentWritersPreserveUserRules(t *testing.T) {
 	testenv.RequireContainer(t)
-	home := t.TempDir()
 
-	var want strings.Builder
-	for i := 0; i < 2000; i++ {
-		want.WriteString("user-rule-" + strings.Repeat("x", 20) + "-" + itoa(i) + "\n")
-	}
-	path := filepath.Join(home, ".gitignore")
-	if err := os.WriteFile(path, []byte(want.String()), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	const (
+		rules    = 2000
+		writers  = 12
+		attempts = 2
+	)
 
-	var wg sync.WaitGroup
-	for i := 0; i < 16; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_ = ensureStateGitignore(home)
-		}()
-	}
-	wg.Wait()
+	for attempt := 1; attempt <= attempts; attempt++ {
+		home := t.TempDir()
+		var seed strings.Builder
+		for i := 0; i < rules; i++ {
+			seed.WriteString("user-rule-" + strings.Repeat("x", 20) + "-" + itoa(i) + "\n")
+		}
+		path := filepath.Join(home, ".gitignore")
+		if err := os.WriteFile(path, []byte(seed.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
 
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	kept := strings.Count(string(got), "user-rule-")
-	if kept != 2000 {
-		t.Fatalf("concurrent ensureStateGitignore destroyed the user's rules: %d of 2000 survived "+
-			"(a truncating write lost them)", kept)
-	}
-	if !strings.Contains(string(got), "/.state/") {
-		t.Fatalf(".state/ is not ignored after the concurrent run:\n%s", tail(string(got)))
+		barrier := filepath.Join(t.TempDir(), "go")
+		var wg sync.WaitGroup
+		for i := 0; i < writers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				cmd := exec.Command(os.Args[0], "-test.run=TestEnsureStateGitignoreHelperProcess")
+				cmd.Env = append(os.Environ(),
+					gitignoreHelperEnv+"=1",
+					gitignoreHelperHome+"="+home,
+					gitignoreHelperBarrier+"="+barrier,
+					"AGENTSYNC_TEST_IN_CONTAINER=1",
+				)
+				_ = cmd.Run()
+			}()
+		}
+		// Give every child time to reach the barrier, then release them at once.
+		time.Sleep(400 * time.Millisecond)
+		if err := os.WriteFile(barrier, []byte("go"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		wg.Wait()
+
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if kept := strings.Count(string(got), "user-rule-"); kept != rules {
+			t.Fatalf("attempt %d: concurrent ensureStateGitignore destroyed the user's rules: "+
+				"%d of %d survived — a truncating write lost them", attempt, kept, rules)
+		}
+		if !strings.Contains(string(got), "/.state/") {
+			t.Fatalf("attempt %d: .state/ is not ignored after the concurrent run:\n%s", attempt, tail(string(got)))
+		}
 	}
 }
 
@@ -199,4 +270,41 @@ func tail(s string) string {
 		return s[len(s)-400:]
 	}
 	return s
+}
+
+// TestEnsureStateGitignoreDoesNotUseATruncatingWrite is the real regression
+// guard for the .gitignore data loss, and it is deterministic where a
+// concurrency test is not.
+//
+// Two implementations have already lost a user's rules here. Both failed the
+// same way: they replaced the file's contents from a value read earlier, so a
+// reader inside another writer's window wrote back a short read.
+// os.WriteFile(O_TRUNC) does it directly; iox.AtomicWrite does it too, because
+// its temp file has a FIXED name that concurrent writers share. Appending is
+// the property that makes the failure impossible rather than unlikely — a
+// POSIX O_APPEND write cannot truncate and cannot interleave with another
+// append of this size.
+//
+// So assert the property, not the symptom: this function must open with
+// O_APPEND and must not route through a whole-file writer.
+func TestEnsureStateGitignoreDoesNotUseATruncatingWrite(t *testing.T) {
+	src := readFileForGuard(t, repoRootFromCaller(t), "internal/cli/init.go")
+	body := funcBody(src, "func ensureStateGitignore(")
+	if body == "" {
+		t.Fatal("ensureStateGitignore not found in init.go — update this guard")
+	}
+
+	if !strings.Contains(body, "os.O_APPEND") {
+		t.Error("ensureStateGitignore no longer opens with os.O_APPEND. It is reachable from the " +
+			"LOCK-FREE upgrade-notice path, so a whole-file write can truncate a user's .gitignore " +
+			"under concurrent runs (measured: 4000 rules to 1). Append instead.")
+	}
+	for _, banned := range []string{"os.WriteFile(", "iox.AtomicWrite("} {
+		if strings.Contains(body, banned) {
+			t.Errorf("ensureStateGitignore uses %s, which REPLACES the file from a previously-read "+
+				"value — the exact shape that lost a user's rules twice. iox.AtomicWrite is not a fix "+
+				"here either: its temp file has a fixed name, so concurrent writers share one inode.",
+				strings.TrimSuffix(banned, "("))
+		}
+	}
 }

--- a/internal/cli/gitignore_internal_test.go
+++ b/internal/cli/gitignore_internal_test.go
@@ -102,7 +102,8 @@ func TestEnsureStateGitignore_ConcurrentWritersPreserveUserRules(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				cmd := exec.Command(os.Args[0], "-test.run=TestEnsureStateGitignoreHelperProcess")
-				cmd.Env = append(os.Environ(),
+				cmd.Env = append(
+					os.Environ(),
 					gitignoreHelperEnv+"=1",
 					gitignoreHelperHome+"="+home,
 					gitignoreHelperBarrier+"="+barrier,

--- a/internal/cli/gitignore_internal_test.go
+++ b/internal/cli/gitignore_internal_test.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// ensureStateGitignore is reachable from the first-run upgrade notice, which is
+// deliberately LOCK-FREE — so unlike every other write in the tool it can run
+// concurrently with itself. The file it touches is a user's own .gitignore in a
+// repo they commit, which makes silent data loss here expensive.
+
+// TestEnsureStateGitignore_ConcurrentWritersPreserveUserRules is the regression
+// for that loss.
+//
+// The first fix used a plain read-modify-write, and a reader landing inside
+// another writer's O_TRUNC window wrote back its short read. The SECOND fix
+// reached for iox.AtomicWrite and did not help: it uses a fixed sibling temp
+// name, so N concurrent writers share one temp inode and the same collapse
+// reproduces (measured: 4000 lines to 1). Appending with O_APPEND is what
+// actually holds.
+func TestEnsureStateGitignore_ConcurrentWritersPreserveUserRules(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+
+	var want strings.Builder
+	for i := 0; i < 2000; i++ {
+		want.WriteString("user-rule-" + strings.Repeat("x", 20) + "-" + itoa(i) + "\n")
+	}
+	path := filepath.Join(home, ".gitignore")
+	if err := os.WriteFile(path, []byte(want.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = ensureStateGitignore(home)
+		}()
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept := strings.Count(string(got), "user-rule-")
+	if kept != 2000 {
+		t.Fatalf("concurrent ensureStateGitignore destroyed the user's rules: %d of 2000 survived "+
+			"(a truncating write lost them)", kept)
+	}
+	if !strings.Contains(string(got), "/.state/") {
+		t.Fatalf(".state/ is not ignored after the concurrent run:\n%s", tail(string(got)))
+	}
+}
+
+// TestEnsureStateGitignore_WritesThroughSymlink pins the chezmoi / GNU Stow
+// case: those tools symlink dotfiles into place, so replacing the link with a
+// regular file detaches the user's managed copy. An earlier fix used
+// iox.AtomicWrite, which REFUSES a symlinked destination — leaving .state/
+// unignored for exactly those users, silently, on the best-effort notice path.
+func TestEnsureStateGitignore_WritesThroughSymlink(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+	real := filepath.Join(t.TempDir(), "managed-gitignore")
+	if err := os.WriteFile(real, []byte("managed-rule\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(home, ".gitignore")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureStateGitignore(home); err != nil {
+		t.Fatalf("a symlinked .gitignore must still be updated: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("the symlink was REPLACED by a regular file, detaching the user's managed copy")
+	}
+	body, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "/.state/") {
+		t.Fatalf("the rule did not reach the symlink target:\n%s", body)
+	}
+	if !strings.Contains(string(body), "managed-rule") {
+		t.Fatalf("the managed file's own content was lost:\n%s", body)
+	}
+}
+
+// TestEnsureStateGitignore_PreservesModeAndIsIdempotent covers the two quieter
+// regressions: a rewrite-based implementation chmods the file (600 -> 644), and
+// a rule already present in an equivalent spelling must not gain a duplicate.
+func TestEnsureStateGitignore_PreservesModeAndIsIdempotent(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	t.Run("preserves an existing restrictive mode", func(t *testing.T) {
+		home := t.TempDir()
+		path := filepath.Join(home, ".gitignore")
+		if err := os.WriteFile(path, []byte("secret-ish\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureStateGitignore(home); err != nil {
+			t.Fatal(err)
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("mode changed from 0600 to %04o", fi.Mode().Perm())
+		}
+	})
+
+	for _, spelling := range []string{"/.state/", ".state/", "/.state", ".state"} {
+		t.Run("no duplicate rule for "+spelling, func(t *testing.T) {
+			home := t.TempDir()
+			path := filepath.Join(home, ".gitignore")
+			if err := os.WriteFile(path, []byte("a\n"+spelling+"\nb\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := ensureStateGitignore(home); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := strings.Count(string(got), ".state"); n != 1 {
+				t.Errorf("%q already ignores .state/, but the file now has %d such rules:\n%s",
+					spelling, n, got)
+			}
+		})
+	}
+
+	t.Run("creates the file when absent", func(t *testing.T) {
+		home := t.TempDir()
+		if err := ensureStateGitignore(home); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(filepath.Join(home, ".gitignore"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(got), "/.state/") {
+			t.Fatalf("created .gitignore does not ignore .state/:\n%s", got)
+		}
+	})
+
+	t.Run("appends cleanly to a file with no trailing newline", func(t *testing.T) {
+		home := t.TempDir()
+		path := filepath.Join(home, ".gitignore")
+		if err := os.WriteFile(path, []byte("no-trailing-newline"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureStateGitignore(home); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(got), "no-trailing-newline/.state/") {
+			t.Fatalf("the rule was glued onto the last line:\n%s", got)
+		}
+		if !strings.Contains(string(got), "no-trailing-newline") {
+			t.Fatalf("existing content lost:\n%s", got)
+		}
+	})
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+func tail(s string) string {
+	if len(s) > 400 {
+		return s[len(s)-400:]
+	}
+	return s
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
-	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -289,54 +288,69 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 // .state/ holds local-only state (targets.json) and .state/backups/<ts>/ —
 // verbatim copies of pre-existing native config files that routinely contain
 // API tokens. The README recommends syncing ~/.agentsync via chezmoi/git, so
-// without this a user would commit plaintext credential backups. Idempotent:
-// appends the rule if a .gitignore already exists (e.g. a cloned source repo)
-// and doesn't already ignore .state/.
+// without this a user would commit plaintext credential backups.
 //
-// The append is a read-modify-write, and it is no longer reached only from
-// `init` under the global lock — the first-run upgrade notice calls it on a
-// deliberately LOCK-FREE path. So the write must be atomic: a plain
-// os.WriteFile(O_TRUNC) lets a reader that landed inside another process's
-// truncate window write back its short read, and the file at stake is the
-// user's own hand-maintained .gitignore in a repo they commit (observed once
-// under concurrent first runs: 4000 lines truncated to 1). iox.AtomicWrite
-// (temp + rename) means a concurrent reader sees the old file or the new one,
-// never a truncated one. It cannot MERGE two concurrent appends — last writer
-// wins — but every writer here appends the same single rule, so the converged
-// state is correct either way.
+// The rule is APPENDED with O_APPEND rather than written with a
+// read-modify-write, because this is reachable from a deliberately LOCK-FREE
+// path (the first-run upgrade notice) and the file is a user's own
+// hand-maintained .gitignore in a repo they commit. Three properties follow,
+// each of which a read-modify-write got wrong:
 //
-// Treating the rule's equivalent spellings as already-present keeps a second,
-// redundant line off a home that ignores `.state/` without the leading slash.
+//   - It cannot TRUNCATE. A plain os.WriteFile(O_TRUNC) lets a reader that
+//     landed inside another writer's truncate window write back its short read
+//     (observed: 4000 lines reduced to one). iox.AtomicWrite does not fix this
+//     either — it uses a FIXED sibling temp name, so N concurrent writers share
+//     one temp inode and the same collapse reproduces.
+//   - It writes THROUGH a symlink, which chezmoi and Stow setups rely on;
+//     iox.AtomicWrite refuses a symlinked destination outright, which would
+//     silently leave .state/ untracked for exactly those users.
+//   - It preserves the file's existing mode instead of chmod-ing it.
+//
+// The cost is that two writers racing on a file that has no rule yet can each
+// append one, leaving a duplicate line. That is cosmetic and git-idempotent —
+// strictly better than losing the user's rules.
 func ensureStateGitignore(home string) error {
 	const rule = "/.state/"
+	// Accept the rule in any spelling git treats the same, so a home that
+	// already ignores .state/ another way does not accumulate a second line.
 	equivalent := map[string]bool{"/.state/": true, ".state/": true, "/.state": true, ".state": true}
 	p := filepath.Join(home, ".gitignore")
+
 	data, err := os.ReadFile(p)
-	switch {
-	case err == nil:
-		for _, line := range strings.Split(string(data), "\n") {
-			if equivalent[strings.TrimSpace(line)] {
-				return nil // already ignored
-			}
-		}
-		out := string(data)
-		if out != "" && !strings.HasSuffix(out, "\n") {
-			out += "\n"
-		}
-		out += rule + "\n"
-		if werr := iox.AtomicWrite(p, []byte(out), 0o644); werr != nil {
-			return fmt.Errorf("update .gitignore: %w", werr)
-		}
-		return nil
-	case os.IsNotExist(err):
-		body := "# agentsync: local state + plaintext config backups — never commit.\n" + rule + "\n"
-		if werr := iox.AtomicWrite(p, []byte(body), 0o644); werr != nil {
-			return fmt.Errorf("write .gitignore: %w", werr)
-		}
-		return nil
-	default:
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read .gitignore: %w", err)
 	}
+	existing := string(data)
+	for _, line := range strings.Split(existing, "\n") {
+		if equivalent[strings.TrimSpace(line)] {
+			return nil // already ignored
+		}
+	}
+
+	var b strings.Builder
+	if len(existing) == 0 {
+		b.WriteString("# agentsync: local state + plaintext config backups — never commit.\n")
+	} else if !strings.HasSuffix(existing, "\n") {
+		// The file does not end in a newline, so our rule would otherwise be
+		// glued onto the last line. This read-then-append is the one racy part,
+		// and its worst case is a stray blank line rather than data loss.
+		b.WriteString("\n")
+	}
+	b.WriteString(rule + "\n")
+
+	//nolint:forbidigo // appends to ~/.agentsync/.gitignore (canonical source), never a native destination; O_APPEND is the point — see the doc comment
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore: %w", err)
+	}
+	if _, werr := f.WriteString(b.String()); werr != nil {
+		_ = f.Close()
+		return fmt.Errorf("update .gitignore: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return fmt.Errorf("close .gitignore: %w", cerr)
+	}
+	return nil
 }
 
 // validateCloneURL rejects unsafe URL schemes for the source-repo

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -168,6 +168,10 @@ func scaffoldHome(cmd *cobra.Command, home string) error {
 	if err := ensureStateGitignore(home); err != nil {
 		return err
 	}
+	// Seed the upgrade-notice record so a brand-new home never gets a banner
+	// about changes that predate it — and so the notice path can read
+	// "home exists, no record" as an unambiguous upgrade.
+	seedUpgradeNoticeRecord(home)
 	w := cmd.OutOrStdout()
 	fmt.Fprintln(w, "agentsync home initialized at", home)
 	fmt.Fprintln(w, "")
@@ -272,6 +276,10 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 	if err := ensureStateGitignore(home); err != nil {
 		return err
 	}
+	// Seed the upgrade-notice record so a brand-new home never gets a banner
+	// about changes that predate it — and so the notice path can read
+	// "home exists, no record" as an unambiguous upgrade.
+	seedUpgradeNoticeRecord(home)
 	fmt.Fprintln(w, "cloned. Run `agentsync apply --dry-run` to preview against this machine.")
 	return nil
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/iox"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -291,14 +292,30 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 // without this a user would commit plaintext credential backups. Idempotent:
 // appends the rule if a .gitignore already exists (e.g. a cloned source repo)
 // and doesn't already ignore .state/.
+//
+// The append is a read-modify-write, and it is no longer reached only from
+// `init` under the global lock — the first-run upgrade notice calls it on a
+// deliberately LOCK-FREE path. So the write must be atomic: a plain
+// os.WriteFile(O_TRUNC) lets a reader that landed inside another process's
+// truncate window write back its short read, and the file at stake is the
+// user's own hand-maintained .gitignore in a repo they commit (observed once
+// under concurrent first runs: 4000 lines truncated to 1). iox.AtomicWrite
+// (temp + rename) means a concurrent reader sees the old file or the new one,
+// never a truncated one. It cannot MERGE two concurrent appends — last writer
+// wins — but every writer here appends the same single rule, so the converged
+// state is correct either way.
+//
+// Treating the rule's equivalent spellings as already-present keeps a second,
+// redundant line off a home that ignores `.state/` without the leading slash.
 func ensureStateGitignore(home string) error {
 	const rule = "/.state/"
+	equivalent := map[string]bool{"/.state/": true, ".state/": true, "/.state": true, ".state": true}
 	p := filepath.Join(home, ".gitignore")
 	data, err := os.ReadFile(p)
 	switch {
 	case err == nil:
 		for _, line := range strings.Split(string(data), "\n") {
-			if strings.TrimSpace(line) == rule {
+			if equivalent[strings.TrimSpace(line)] {
 				return nil // already ignored
 			}
 		}
@@ -307,13 +324,13 @@ func ensureStateGitignore(home string) error {
 			out += "\n"
 		}
 		out += rule + "\n"
-		if werr := os.WriteFile(p, []byte(out), 0o644); werr != nil { //nolint:forbidigo // updates ~/.agentsync/.gitignore (canonical source), not a native destination
+		if werr := iox.AtomicWrite(p, []byte(out), 0o644); werr != nil {
 			return fmt.Errorf("update .gitignore: %w", werr)
 		}
 		return nil
 	case os.IsNotExist(err):
 		body := "# agentsync: local state + plaintext config backups — never commit.\n" + rule + "\n"
-		if werr := os.WriteFile(p, []byte(body), 0o644); werr != nil { //nolint:forbidigo // creates ~/.agentsync/.gitignore (canonical source), not a native destination
+		if werr := iox.AtomicWrite(p, []byte(body), 0o644); werr != nil {
 			return fmt.Errorf("write .gitignore: %w", werr)
 		}
 		return nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,21 +43,28 @@ func NewRoot() *cobra.Command {
 	cmd.PersistentFlags().String("scope", "", "user | project (default: user; prompts when run inside a project tree)")
 	cmd.PersistentFlags().String("project", "", "explicit path to project root (implies --scope project)")
 
-	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
-		return enforceScopeStance(c)
-	}
-
-	// First-run-after-upgrade notice. This is the ONLY hook that reaches every
-	// installation channel — `go install` has no post-install step, a Homebrew
-	// cask's caveats print at install time only, and Scoop has nothing — so the
-	// binary tells the user itself, once per machine, on stderr.
+	// EXACTLY ONE PersistentPreRunE, composing every root-level pre-run concern.
 	//
-	// Cobra runs only the CLOSEST PersistentPreRunE in the chain, so a
-	// subcommand that grows its own would silently disable this. That is guarded
-	// by TestNoSubcommandOverridesPersistentPreRun.
+	// PersistentPreRunE is a plain field, so a second assignment in this
+	// function silently DISCARDS the first — nothing fails to compile and no
+	// test breaks, the dropped hook just quietly stops running. Wiring the
+	// upgrade notice as its own assignment did exactly that to F6's scope
+	// enforcement, and CI stayed green. Add new pre-run work INSIDE this
+	// closure; TestRootDeclaresExactlyOnePersistentPreRun fails the build on a
+	// second assignment, and cobra runs only the CLOSEST hook in the chain, so
+	// TestNoSubcommandOverridesPersistentPreRun guards the same hazard one level
+	// down.
 	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
+		// The first-run-after-upgrade notice is the ONLY hook that reaches every
+		// installation channel — `go install` has no post-install step, a
+		// Homebrew cask's caveats print at install time only, and Scoop has
+		// nothing — so the binary tells the user itself, once per machine, on
+		// stderr. It is best-effort and returns nothing: a UX marker must never
+		// fail a user's command.
 		maybePrintUpgradeNotice(c)
-		return nil
+		// Scope stance is the gate that can REFUSE the command, so it runs last
+		// and owns the returned error (#200 F6).
+		return enforceScopeStance(c)
 	}
 
 	cmd.AddCommand(

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,19 @@ func NewRoot() *cobra.Command {
 		return enforceScopeStance(c)
 	}
 
+	// First-run-after-upgrade notice. This is the ONLY hook that reaches every
+	// installation channel — `go install` has no post-install step, a Homebrew
+	// cask's caveats print at install time only, and Scoop has nothing — so the
+	// binary tells the user itself, once per machine, on stderr.
+	//
+	// Cobra runs only the CLOSEST PersistentPreRunE in the chain, so a
+	// subcommand that grows its own would silently disable this. That is guarded
+	// by TestNoSubcommandOverridesPersistentPreRun.
+	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
+		maybePrintUpgradeNotice(c)
+		return nil
+	}
+
 	cmd.AddCommand(
 		newInitCmd(),
 		newAgentCmd(),

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -111,21 +111,36 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// can have broken under a user who has no config. Return WITHOUT writing —
 	// creating .state/ here would materialize the home and make the user's first
 	// `agentsync init` refuse ("already contains files"). `init` seeds the record
-	// itself (seedUpgradeNoticeRecord), so "home exists + no record" means
-	// exactly one thing: a home created by a version that predates the record.
-	//
-	// This keys off the USER home even at project scope, and that is correct
-	// rather than an oversight: apply records state centrally under
-	// ~/.agentsync/.state/ keyed by project root, so any project-scope user who
-	// has ever applied HAS a user home and does see the notice. The only window
-	// where a project-scope user misses it is between `init --scope project` and
-	// their first apply — at which point agentsync has rendered nothing for them,
-	// so nothing has broken under them either. Pinned by
-	// TestUpgradeNotice_ProjectScopeUserSeesItAfterApply.
+	// itself (seedUpgradeNoticeRecord).
 	if !homeExists(home) {
 		return
 	}
 	recordPath := filepath.Join(home, ".state", state.LastRunFile)
+
+	// The home EXISTING is not enough to call this an upgrade. A project-scope
+	// user never runs `agentsync init` at user scope, but apply records state
+	// CENTRALLY under ~/.agentsync/.state/ keyed by project root — so the first
+	// project-scope command that touches state materializes a user home that
+	// `init` never seeded. Read literally, "home exists + no record" then
+	// misfires on a brand-new install: a 0.11.0-native user was told to run
+	// `agentsync migrate subagents` against a tree that never had an agents/
+	// directory.
+	//
+	// agentsync.toml is the marker that distinguishes the two: `init` writes it,
+	// central state never does. Its absence means this home was materialized for
+	// state-keeping, not by a user config that a release could have broken — so
+	// seed the record (the home already exists, so writing is safe here, unlike
+	// the fresh-install path above) and stay quiet.
+	//
+	// A project-scope-only user upgrading from an older release therefore does
+	// not get the banner. They are not left stranded: the retired layout is
+	// fail-closed at load, so their next command refuses with an error naming
+	// `agentsync migrate subagents` for that tree — a stronger mechanism than a
+	// one-time banner, and one that fires per tree rather than per machine.
+	if !hasUserConfig(home) {
+		seedUpgradeNoticeRecord(home)
+		return
+	}
 
 	rec, err := state.LoadLastRun(recordPath)
 	switch {
@@ -180,11 +195,23 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	_ = state.SaveLastRun(recordPath, rec)
 }
 
-// homeExists reports whether the agentsync home is present as a directory —
-// the signal that separates an upgrade from a first install.
+// homeExists reports whether the agentsync home is present as a directory.
 func homeExists(home string) bool {
 	fi, err := os.Stat(home)
 	return err == nil && fi.IsDir()
+}
+
+// hasUserConfig reports whether the home holds a USER-scope config, as opposed
+// to having been materialized purely to keep central state for a project tree.
+//
+// agentsync.toml is the discriminator: `agentsync init` writes it (and seeds the
+// run record alongside), while the central-state path under .state/ never does.
+// Without this check, the first project-scope command to record state creates
+// ~/.agentsync/ with no record, and "home exists + no record" reads as an
+// upgrade — firing a breaking-change banner at a brand-new user.
+func hasUserConfig(home string) bool {
+	_, err := os.Stat(filepath.Join(home, "agentsync.toml"))
+	return err == nil
 }
 
 // printUpgradeNotices renders the banner to stderr.

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -105,6 +105,17 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	if os.Getenv(NoUpgradeNoticeEnv) == "1" {
 		return
 	}
+	// A shell-completion request is not a user reading output. Cobra runs this
+	// hook for `__complete` too, and the generated bash/zsh scripts invoke it as
+	// `out=$(eval "${requestComp}" 2>/dev/null)` — stderr DISCARDED. So a single
+	// TAB after `agentsync ` would print the banner into /dev/null and then
+	// record it as seen, and the user's next real command would say nothing.
+	// That is the one failure direction this feature must not have: silently
+	// never telling them their config layout moved. Anyone with completions
+	// installed would have hit it before ever seeing the notice.
+	if isCompletionRequest(cmd) {
+		return
+	}
 
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	// A home that does not exist yet is a FRESH INSTALL, not an upgrade: nothing
@@ -198,6 +209,22 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// this notice fires for.
 	_ = ensureStateGitignore(home)
 	_ = state.SaveLastRun(recordPath, rec)
+}
+
+// isCompletionRequest reports whether cmd is (or is under) a shell-completion
+// command: cobra's hidden `__complete` / `__completeNoDesc` request commands, or
+// the user-facing `completion` generator.
+//
+// Their output is consumed by a shell, not read by a person — and the generated
+// scripts discard stderr — so anything "shown" during one is shown to nobody.
+func isCompletionRequest(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd, "completion":
+			return true
+		}
+	}
+	return false
 }
 
 // homeExists reports whether the agentsync home is present as a directory.

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -63,7 +63,7 @@ var upgradeNotices = []upgradeNotice{
 			"the canonical subagent directory moved: agents/ → subagents/ — run `agentsync migrate subagents` (per tree)",
 			"`agentsync verify` is now `agentsync check` (no alias) — doctor checks the MACHINE, check checks the CONFIG",
 			"`agentsync plugin install` is now `agentsync plugin add`, and `agentsync secrets` is now `agentsync secret` (no aliases)",
-			"`agentsync update` is deprecated — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`",
+			"`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`",
 			"`agentsync explain <plugin>` moved to `agentsync plugin explain <plugin>` (no alias; the old name now explains a FILE)",
 		},
 		Path: "/reference/upgrading/",

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -48,6 +48,11 @@ type upgradeNotice struct {
 // APPEND ONLY; never renumber or rename an ID — the ID is the key recorded in
 // .state/last-run.json, so a rename re-shows the notice to every user who
 // already dismissed it, and a duplicate makes the second entry unreachable.
+// Never DELETE an entry either: TestUpgradeNoticeNamesEveryRetiredCommand
+// requires every retirement to be named somewhere in this table, so removing
+// an old notice fails that guard — and the cheapest-looking fix, dropping the
+// retirement from the shared `retirements` table, silently un-guards the
+// resurrection check too. Old notices cost one struct literal; leave them.
 // TestUpgradeNoticeTableIsWellFormed enforces the shape.
 //
 // Every entry here needs a matching section in

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,8 +43,17 @@ type upgradeNotice struct {
 	Path string
 }
 
-// upgradeNotices is the ordered set of notices this binary can show. Append
-// only; never renumber an ID.
+// upgradeNotices is the ordered set of notices this binary can show.
+//
+// APPEND ONLY; never renumber or rename an ID — the ID is the key recorded in
+// .state/last-run.json, so a rename re-shows the notice to every user who
+// already dismissed it, and a duplicate makes the second entry unreachable.
+// TestUpgradeNoticeTableIsWellFormed enforces the shape.
+//
+// Every entry here needs a matching section in
+// website/src/content/docs/reference/upgrading.mdx — the page Path points at.
+// The two are maintained by hand in parallel; adding a notice without the
+// section ships a banner whose "read more" link lands on nothing.
 var upgradeNotices = []upgradeNotice{
 	{
 		ID:       "0.11.0-cli-surface",
@@ -71,6 +81,20 @@ var upgradeNotices = []upgradeNotice{
 // Output goes to STDERR, always. Several commands emit a machine-readable
 // payload on stdout (`status --json`, `diff --json`, `explain --json`), and a
 // banner there would corrupt what a caller is piping.
+//
+// Two accepted residuals, both deliberate:
+//
+//   - The silent returns are undiagnosable. Wiring internal/log through here
+//     would mean threading a writer + verbosity into a function whose entire
+//     contract is "never get in the way"; the failure modes are also
+//     self-announcing (the notice either shows again next run, or the user
+//     never sees it and reads the upgrade page instead). A corrupt record no
+//     longer hides the notice, which was the one silent failure that mattered.
+//   - "Once per machine" is lock-free, so N truly simultaneous invocations can
+//     each print. Taking the global lock for a banner would serialize every
+//     command in the tool behind a UX marker — a far worse trade than a
+//     duplicated banner in the rare concurrent case. iox.AtomicWrite keeps the
+//     record itself well-formed under that race.
 func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// A build with no version stamped is a local `go build` or a test binary.
 	// Showing (and recording) a notice there would fire in every test run and
@@ -89,18 +113,32 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// `agentsync init` refuse ("already contains files"). `init` seeds the record
 	// itself (seedUpgradeNoticeRecord), so "home exists + no record" means
 	// exactly one thing: a home created by a version that predates the record.
+	//
+	// This keys off the USER home even at project scope, and that is correct
+	// rather than an oversight: apply records state centrally under
+	// ~/.agentsync/.state/ keyed by project root, so any project-scope user who
+	// has ever applied HAS a user home and does see the notice. The only window
+	// where a project-scope user misses it is between `init --scope project` and
+	// their first apply — at which point agentsync has rendered nothing for them,
+	// so nothing has broken under them either. Pinned by
+	// TestUpgradeNotice_ProjectScopeUserSeesItAfterApply.
 	if !homeExists(home) {
 		return
 	}
 	recordPath := filepath.Join(home, ".state", state.LastRunFile)
 
 	rec, err := state.LoadLastRun(recordPath)
-	if err != nil {
-		return // corrupt record: say nothing rather than guess
-	}
-
-	if rec == nil {
-		rec = &state.LastRun{}
+	switch {
+	case errors.Is(err, state.ErrCorruptLastRun):
+		// A record that cannot be parsed carries no information, so the honest
+		// reading is "this machine has shown nothing" — show the notice and
+		// overwrite the file. Bailing here instead meant one truncated or empty
+		// last-run.json (a crash mid-write, a full disk) suppressed the notice
+		// PERMANENTLY, which is the one direction this feature must not fail in:
+		// the user silently never learns their config layout moved. LoadLastRun
+		// hands back a usable zero record for exactly this.
+	case err != nil:
+		return // real I/O trouble: say nothing rather than guess
 	}
 
 	var pending []upgradeNotice
@@ -132,6 +170,13 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	if mkErr := os.MkdirAll(filepath.Dir(recordPath), 0o755); mkErr != nil {
 		return
 	}
+	// This is a second path that can CREATE .state/ (init is the other), and
+	// ~/.agentsync is routinely a committed dotfiles repo — so the record must
+	// be ignored here too, or `git add -A` sweeps one machine's run marker into
+	// the repo and carries it to every other machine. A home created by a
+	// version that predates the .gitignore scaffolding is exactly the population
+	// this notice fires for.
+	_ = ensureStateGitignore(home)
 	_ = state.SaveLastRun(recordPath, rec)
 }
 
@@ -176,5 +221,6 @@ func seedUpgradeNoticeRecord(home string) {
 	for _, n := range upgradeNotices {
 		rec.MarkSeen(n.ID)
 	}
+	_ = ensureStateGitignore(home)
 	_ = state.SaveLastRun(filepath.Join(home, ".state", state.LastRunFile), rec)
 }

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// docsBaseURL is the published documentation site every notice links into.
+const docsBaseURL = "https://agentsync.cc"
+
+// NoUpgradeNoticeEnv opts a machine out of the first-run-after-upgrade notice
+// entirely: nothing is printed and nothing is recorded, so unsetting it shows
+// any still-unseen notice rather than swallowing it permanently.
+const NoUpgradeNoticeEnv = "AGENTSYNC_NO_UPGRADE_NOTICE"
+
+// upgradeNotice is one "this changed under you" message, shown at most once per
+// machine. agentsync is distributed through channels with no usable post-install
+// hook — `go install` has none at all, a Homebrew cask's caveats print only at
+// install time, Scoop has nothing, and only deb/rpm have real scripts — so the
+// binary itself is the ONLY place that reliably reaches an upgrading user.
+type upgradeNotice struct {
+	// ID is the stable key recorded in .state/last-run.json. It must never be
+	// reused or renamed: a rename re-shows the notice to everyone.
+	ID string
+	// Since is the version that introduced the change, for display only. The
+	// show/hide decision is made by ID, not by version comparison — a user who
+	// jumps several releases must still see every notice they missed, and a
+	// pre-release / non-semver build must not silently swallow one.
+	Since string
+	// Headline is one line: what changed.
+	Headline string
+	// Actions are the concrete "do this" lines. Keep them short and literal —
+	// this is the last thing a user reads before their cron job breaks.
+	Actions []string
+	// Path is the docs page, appended to docsBaseURL.
+	Path string
+}
+
+// upgradeNotices is the ordered set of notices this binary can show. Append
+// only; never renumber an ID.
+var upgradeNotices = []upgradeNotice{
+	{
+		ID:       "0.11.0-cli-surface",
+		Since:    "0.11.0",
+		Headline: "breaking changes to the canonical layout and the CLI surface",
+		Actions: []string{
+			"the canonical subagent directory moved: agents/ → subagents/ — run `agentsync migrate subagents` (per tree)",
+			"`agentsync verify` is now `agentsync check` (no alias) — doctor checks the MACHINE, check checks the CONFIG",
+			"`agentsync plugin install` is now `agentsync plugin add`, and `agentsync secrets` is now `agentsync secret` (no aliases)",
+			"`agentsync update` is deprecated — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`",
+			"`agentsync explain <plugin>` moved to `agentsync plugin explain <plugin>` (no alias; the old name now explains a FILE)",
+		},
+		Path: "/reference/upgrading/",
+	},
+}
+
+// maybePrintUpgradeNotice shows, at most once per machine, the notices a user
+// upgrading into this binary has not seen. It is wired as the root command's
+// PersistentPreRunE so every subcommand inherits it.
+//
+// It is BEST-EFFORT by construction: every read/write error degrades to
+// "say nothing". A UX marker must never fail a user's command, so this function
+// returns no error at all.
+//
+// Output goes to STDERR, always. Several commands emit a machine-readable
+// payload on stdout (`status --json`, `diff --json`, `explain --json`), and a
+// banner there would corrupt what a caller is piping.
+func maybePrintUpgradeNotice(cmd *cobra.Command) {
+	// A build with no version stamped is a local `go build` or a test binary.
+	// Showing (and recording) a notice there would fire in every test run and
+	// tell a developer nothing, so `dev` opts out of the whole mechanism.
+	if Version == "" || Version == "dev" {
+		return
+	}
+	if os.Getenv(NoUpgradeNoticeEnv) == "1" {
+		return
+	}
+
+	home := paths.AgentsyncHome(paths.OSEnv{})
+	// A home that does not exist yet is a FRESH INSTALL, not an upgrade: nothing
+	// can have broken under a user who has no config. Return WITHOUT writing —
+	// creating .state/ here would materialize the home and make the user's first
+	// `agentsync init` refuse ("already contains files"). `init` seeds the record
+	// itself (seedUpgradeNoticeRecord), so "home exists + no record" means
+	// exactly one thing: a home created by a version that predates the record.
+	if !homeExists(home) {
+		return
+	}
+	recordPath := filepath.Join(home, ".state", state.LastRunFile)
+
+	rec, err := state.LoadLastRun(recordPath)
+	if err != nil {
+		return // corrupt record: say nothing rather than guess
+	}
+
+	if rec == nil {
+		rec = &state.LastRun{}
+	}
+
+	var pending []upgradeNotice
+	for _, n := range upgradeNotices {
+		if rec.Seen(n.ID) {
+			continue
+		}
+		pending = append(pending, n)
+	}
+	if len(pending) == 0 && rec.Version == Version {
+		return // nothing to say and nothing to update
+	}
+
+	if len(pending) > 0 {
+		p, perr := newPrinter(cmd)
+		if perr != nil {
+			return
+		}
+		printUpgradeNotices(p, pending)
+	}
+
+	// Record AFTER printing, and only mark what we actually resolved: a write
+	// failure (read-only home, full disk) just means the notice shows again
+	// next time, which is the harmless direction to fail in.
+	for _, n := range pending {
+		rec.MarkSeen(n.ID)
+	}
+	rec.Version = Version
+	if mkErr := os.MkdirAll(filepath.Dir(recordPath), 0o755); mkErr != nil {
+		return
+	}
+	_ = state.SaveLastRun(recordPath, rec)
+}
+
+// homeExists reports whether the agentsync home is present as a directory —
+// the signal that separates an upgrade from a first install.
+func homeExists(home string) bool {
+	fi, err := os.Stat(home)
+	return err == nil && fi.IsDir()
+}
+
+// printUpgradeNotices renders the banner to stderr.
+func printUpgradeNotices(p *ui.Printer, notices []upgradeNotice) {
+	w := p.Err
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "%s %s\n",
+		p.Yellow(ui.GlyphWarn+" agentsync "+Version+":"),
+		p.Bold("you upgraded across a change that needs your attention"))
+	for _, n := range notices {
+		fmt.Fprintf(w, "  %s %s %s\n",
+			p.Yellow(ui.GlyphArrow), p.Bold("since "+n.Since+" —"), n.Headline)
+		for _, a := range n.Actions {
+			fmt.Fprintf(w, "      %s %s\n", p.Faint(ui.GlyphInfo), a)
+		}
+		fmt.Fprintf(w, "      %s %s\n", p.Faint("read more:"), p.Cyan(docsBaseURL+n.Path))
+	}
+	fmt.Fprintf(w, "  %s\n", p.Faint("(shown once; silence it with "+NoUpgradeNoticeEnv+"=1)"))
+	fmt.Fprintln(w, "")
+}
+
+// seedUpgradeNoticeRecord marks every notice this binary knows as already seen,
+// for a home being created RIGHT NOW. `init` calls it so a brand-new user never
+// gets an upgrade banner about changes that predate their install — and so the
+// notice path can treat "home exists, no record" as an unambiguous upgrade.
+//
+// Best-effort like the notice itself: a failure only means the new user may see
+// one stale banner, which is far better than a failed `init`.
+func seedUpgradeNoticeRecord(home string) {
+	if Version == "" || Version == "dev" {
+		return
+	}
+	rec := &state.LastRun{Version: Version}
+	for _, n := range upgradeNotices {
+		rec.MarkSeen(n.ID)
+	}
+	_ = state.SaveLastRun(filepath.Join(home, ".state", state.LastRunFile), rec)
+}

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -129,8 +129,14 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// agentsync.toml is the marker that distinguishes the two: `init` writes it,
 	// central state never does. Its absence means this home was materialized for
 	// state-keeping, not by a user config that a release could have broken — so
-	// seed the record (the home already exists, so writing is safe here, unlike
-	// the fresh-install path above) and stay quiet.
+	// stay quiet.
+	//
+	// Return WITHOUT seeding. Seeding here would mark every notice as seen for a
+	// user who has not seen them, and this check runs BEFORE the record is ever
+	// read — so it costs nothing to skip. It is not merely redundant but
+	// harmful: a home that later gains an agentsync.toml (a dotfiles restore
+	// landing after the first run, `agentsync init` run tomorrow) would be
+	// permanently silenced about changes it never heard.
 	//
 	// A project-scope-only user upgrading from an older release therefore does
 	// not get the banner. They are not left stranded: the retired layout is
@@ -138,7 +144,6 @@ func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// `agentsync migrate subagents` for that tree — a stronger mechanism than a
 	// one-time banner, and one that fires per tree rather than per machine.
 	if !hasUserConfig(home) {
-		seedUpgradeNoticeRecord(home)
 		return
 	}
 
@@ -210,8 +215,8 @@ func homeExists(home string) bool {
 // ~/.agentsync/ with no record, and "home exists + no record" reads as an
 // upgrade — firing a breaking-change banner at a brand-new user.
 func hasUserConfig(home string) bool {
-	_, err := os.Stat(filepath.Join(home, "agentsync.toml"))
-	return err == nil
+	fi, err := os.Stat(filepath.Join(home, "agentsync.toml"))
+	return err == nil && fi.Mode().IsRegular()
 }
 
 // printUpgradeNotices renders the banner to stderr.

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUpgradeNoticeTableIsWellFormed guards the append-only rule the table
+// states but nothing enforced. An ID is the durable key recorded in
+// .state/last-run.json: renaming one re-shows its notice to every user who
+// already dismissed it, and duplicating one makes the second unreachable.
+//
+// This is an INTERNAL test on purpose. The first version reached the unexported
+// table through a hand-maintained `UpgradeNoticeView` copy in export_test.go —
+// which is the model-vs-artifact hazard CLAUDE.md names outright: a sixth field
+// added to upgradeNotice would be silently invisible to its own guard. Reading
+// the real struct removes the parallel model and the seam with it.
+func TestUpgradeNoticeTableIsWellFormed(t *testing.T) {
+	if len(upgradeNotices) == 0 {
+		t.Fatal("no notices defined; this guard would vacuously pass")
+	}
+	ids := map[string]bool{}
+	for _, n := range upgradeNotices {
+		switch {
+		case n.ID == "":
+			t.Errorf("notice with empty ID (%q): the ID is the recorded key", n.Headline)
+		case ids[n.ID]:
+			t.Errorf("duplicate notice ID %q — the second is silently unreachable", n.ID)
+		}
+		ids[n.ID] = true
+		if n.Since == "" {
+			t.Errorf("notice %q has no Since; the banner prints it", n.ID)
+		}
+		if n.Headline == "" {
+			t.Errorf("notice %q has no Headline", n.ID)
+		}
+		if len(n.Actions) == 0 {
+			t.Errorf("notice %q lists no actions, so it says what broke but not what to do", n.ID)
+		}
+		if !strings.HasPrefix(n.Path, "/") {
+			t.Errorf("notice %q Path %q must start with '/' (it is appended to the docs base URL)", n.ID, n.Path)
+		}
+	}
+}
+
+// TestEveryNoticeHasAnUpgradingDocsSection pins the cross-reference the notice
+// table asserts in prose: each entry links to the upgrading page, so a notice
+// without a matching section ships a banner whose "read more" lands on nothing.
+//
+// The banner is the ONLY channel that reaches every install path (no packaging
+// channel agentsync ships through has a usable post-install hook), so a dead
+// link in it is the whole feature failing at the last step.
+func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
+	root := repoRootFromCaller(t)
+	page := readFileForGuard(t, root, "website/src/content/docs/reference/upgrading.mdx")
+	for _, n := range upgradeNotices {
+		heading := "## " + n.Since
+		if !strings.Contains(page, heading+"\n") {
+			t.Errorf("notice %q (since %s) has no %q section in upgrading.mdx — its "+
+				"\"read more\" link lands on a page that does not document it", n.ID, n.Since, heading)
+		}
+	}
+}

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -127,11 +127,12 @@ func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 				"A retiring line must: name the old spelling FIRST, then every replacement; join them "+
 				"with one of the sanctioned break phrases %q (replacements joined by %q); assert %q; and "+
 				"claim no grace period (%q).\n\n"+
-				"If you reworded a bullet and this failed, ADDING your phrasing to sanctionedBreakPhrases "+
-				"is a legitimate fix — the allowlist exists to make that a decision, not to freeze the "+
-				"wording.\n\n    lines naming it:\n      %s",
+				"Two legitimate fixes if you reworded a bullet: ADD your connector to "+
+				"sanctionedBreakPhrases, or REMOVE an over-broad entry from continuityClaims — that "+
+				"blocklist is a net over phrasings that have actually been attempted, not a contract, "+
+				"and it has rejected true sentences before.\n\n    lines naming it:\n      %s",
 				r.Old, r.replacementPhrase(), sanctionedBreakPhrases, sanctionedJoiners,
-				"no alias", continuityClaims, strings.Join(naming, "\n      "))
+				requiredAliasClause, continuityClaims, strings.Join(naming, "\n      "))
 		}
 	}
 
@@ -173,6 +174,16 @@ var sanctionedBreakPhrases = []string{
 // otherwise reads as naming both.
 var sanctionedJoiners = []string{"/", ",", "and", ", and"}
 
+// requiredAliasClause is the alias-free assertion every retiring line must
+// carry, in the parenthesized form all four shipped lines use.
+//
+// It is a named constant because the check and the failure MESSAGE drifted
+// apart the moment they were two literals: the check was tightened to require
+// the parenthetical while the message kept telling authors to write the bare
+// words, so a line that followed the advice exactly still failed. One literal,
+// used by both.
+const requiredAliasClause = "(no alias"
+
 // continuityClaims are phrasings that promise the old spelling still works.
 //
 // This is the one blocklist here, and it does NOT compose with the required
@@ -188,12 +199,21 @@ var sanctionedJoiners = []string{"/", ",", "and", ", and"}
 // replacements with a negation, or connects them with unsanctioned wording all
 // fail regardless of vocabulary. This list is a cheap net over the phrasings
 // that have actually been attempted, not a proof.
+//
+// Entries are removed when they reject TRUE sentences, and four were: "legacy
+// spelling" rejected "the legacy spelling was deleted", "both spellings"
+// rejected "the upgrading page lists both spellings", "keep working" rejected
+// "rename it in CI to keep working", and "remains available" rejected
+// "explaining a FILE remains available under the old name" — the likeliest
+// reword of the one row whose old name genuinely does still resolve. A
+// false FAILURE on an honest line costs more than a false pass here, because
+// the structural rules already carry the load and a guard that rejects the
+// truth is one people delete.
 var continuityClaims = []string{
 	"deprecat", "still work", "an alias for", "alias is kept", "kept as an alias",
 	"no action needed", "grace period", "will be removed", "for one minor",
 	"one more minor", "until 0.", "supported through", "keeps working",
-	"keep working", "not yet removed", "remains available", "legacy spelling",
-	"both spellings",
+	"not yet removed",
 }
 
 // anyLineRetires reports whether some line states the retirement.
@@ -225,7 +245,7 @@ func lineRetires(line string, r retirement) bool {
 	// alias policy yet, so the old name is accepted" and "no aliases were
 	// harmed; both spellings run" both contain "no alias" and both promise the
 	// opposite of what this clause is supposed to mean.
-	if !strings.Contains(lower, "(no alias") {
+	if !strings.Contains(lower, requiredAliasClause) {
 		return false
 	}
 
@@ -366,6 +386,15 @@ func TestLineRetires(t *testing.T) {
 		// A legitimate reword: it must PASS. Sorting positions while indexing
 		// lengths in declaration order rejected it, and blamed the break phrase.
 		{"replacements reordered", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin upgrade --all` / `agentsync plugin outdated`", upd, true},
+
+		// The OLD spelling's lookup must be boundary-aware too. Both directions
+		// break under a raw strings.Index, and neither was covered: the first
+		// goes true→false (a legitimate line rejected because the first textual
+		// hit is inside a longer word), the second false→true (the connector
+		// glued to the spelling, so no sanctioned phrase actually separates
+		// them).
+		{"prose plural before the real one", "`agentsync updates` never existed; `agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`", upd, true},
+		{"connector glued to the spelling", "`agentsync updateis now `agentsync plugin outdated` / `agentsync plugin upgrade --all` (no alias)", upd, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -405,6 +434,24 @@ func TestRetiringSpellings(t *testing.T) {
 
 		{"no invocation at all", "the canonical subagent directory moved: agents/ → subagents/", nil},
 		{"unsanctioned phrasing", "`agentsync verify` has been superseded by `agentsync check`", nil},
+
+		// A command is not retired by gaining a flag. Requiring merely that SOME
+		// invocation follows left these parsing as retirements of live commands.
+		{"self-replacement with a flag", "`agentsync status` is now `agentsync status --scope project` by default", nil},
+		{"self-replacement exact", "`agentsync status` is now `agentsync status` — same thing", nil},
+
+		// Punctuation and markup between the spelling and the phrase must not
+		// make a real retiring clause extract nothing — silence is the failure
+		// mode this parser's own guard cannot distinguish from correctness.
+		{"colon after backtick", "`agentsync verify`: is now `agentsync check` (no alias)", []string{"verify"}},
+		{"bold markup", "**`agentsync verify`** is now `agentsync check` (no alias)", []string{"verify"}},
+
+		// The word bound must cover more than today's longest spelling: too
+		// short and a future retirement extracts nothing, silently.
+		{"four-word spelling", "`agentsync plugin explain all things` is now `agentsync plugin explain` (no alias)", []string{"plugin explain all things"}},
+
+		// A bare "agentsync " with nothing after it names no command.
+		{"empty spelling", "`agentsync ` is now `agentsync check`", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -496,35 +543,63 @@ func retiringSpellings(line string) []string {
 
 // retiringSpellingAt reads one candidate spelling out of the text following an
 // "agentsync " prefix, returning it only if a sanctioned break phrase and then
-// another invocation follow.
+// a DIFFERENT invocation follow.
+//
+// "Different" is load-bearing. Requiring merely that some invocation follows
+// left `agentsync status` is now `agentsync status --scope project“ parsing as
+// a retirement of `status` — a live command, whose failure then steers the
+// author into a bogus table row that breaks the pinned set and the resurrection
+// guard. A command is not retired by gaining a flag.
 func retiringSpellingAt(rest string) (string, bool) {
-	// maxSpellingWords bounds the search: the longest retired spelling is two
-	// words plus a placeholder ("explain <plugin>", "plugin install").
-	const maxSpellingWords = 3
 	words := strings.Fields(rest)
 	if len(words) > maxSpellingWords {
 		words = words[:maxSpellingWords]
 	}
 	for n := 1; n <= len(words); n++ {
-		spelling := strings.TrimRight(strings.Join(words[:n], " "), "`,.;:")
+		spelling := trimSpellingPunct(strings.Join(words[:n], " "))
+		if spelling == "" {
+			continue // a token of pure punctuation names nothing
+		}
 		idx := strings.Index(rest, spelling)
 		if idx < 0 {
 			continue
 		}
-		after := strings.TrimLeft(rest[idx+len(spelling):], "` ")
+		// Skip punctuation AND markup on both sides: the spelling may be
+		// followed by "`:", "`,", "**" or a bare space before the phrase.
+		after := strings.TrimLeft(rest[idx+len(spelling):], "`*_,.;: ")
 		norm := normalizeConnector(after)
 		for _, phrase := range sanctionedBreakPhrases {
 			if norm != phrase && !strings.HasPrefix(norm, phrase+" ") {
 				continue
 			}
-			// A retirement names what replaces it. Without this, any "is now"
-			// sentence about a live command reads as a retirement.
-			if strings.HasPrefix(strings.TrimPrefix(norm, phrase), " agentsync ") {
-				return spelling, true
+			repl := strings.TrimPrefix(strings.TrimPrefix(norm, phrase), " ")
+			if !strings.HasPrefix(repl, "agentsync ") {
+				continue // names no replacement: not a retirement
 			}
+			repl = strings.TrimPrefix(repl, "agentsync ")
+			if repl == spelling || strings.HasPrefix(repl, spelling+" ") {
+				continue // replaced by itself: a flag, not a retirement
+			}
+			return spelling, true
 		}
 	}
 	return "", false
+}
+
+// maxSpellingWords bounds how many words the parser will consider as one old
+// spelling. Deliberately generous: the longest retired spelling today is two
+// words plus a placeholder, and a bound that is too SHORT fails silently —
+// a longer spelling simply extracts nothing, which is indistinguishable from
+// "this line retires nothing". TestRetiringSpellings pins the bound in both
+// directions so it cannot quietly stop covering a future retirement.
+const maxSpellingWords = 4
+
+// trimSpellingPunct strips markup and trailing punctuation from a candidate
+// spelling. Both edges: an earlier version trimmed only the right, so a
+// bold-quoted `**`+"`agentsync verify`"+`**` produced a garbled spelling and an
+// unmatchable failure message.
+func trimSpellingPunct(s string) string {
+	return strings.Trim(s, "`*_,.;:")
 }
 
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -77,43 +77,96 @@ func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
 // whose scripts just broke, and whose worst possible failure is telling them
 // their command still works for a while.
 //
-// Two directions, both load-bearing:
+// The assertion is on the OUTCOME, not on wording. A first attempt paired
+// "the line mentions the old name" with "no line says `deprecat`", and three
+// reviewers independently broke it in one try — "`agentsync update` still
+// works; an alias is kept for one more minor" satisfies both, and so does
+// naming a replacement that does not exist. A blocklist of bad phrasings is
+// unbounded ("legacy", "sunset", "will be removed in 0.12", "no action needed
+// yet"); requiring the line to say what to run INSTEAD is not, and it rules
+// out the whole class, since a line promising continuity has no reason to
+// name a replacement.
 //
-//   - Every retired top-level spelling must be NAMED somewhere in the notice.
-//     A retirement the banner omits is one a user discovers as an unexplained
-//     "unknown command" — exactly what the banner exists to prevent. The list
-//     is retiredCommands (command_surface_internal_test.go), shared so a
-//     future retirement cannot be added to one and forgotten in the other.
-//   - No action line may describe anything as deprecated. This release has no
-//     deprecations and no aliases: everything listed is a hard break. "Is
-//     deprecated" tells a reader their cron line has a grace period it does
-//     not have, which is worse than saying nothing.
+// Three directions, all load-bearing:
+//
+//   - Every retirement must be NAMED by some action line. One the banner omits
+//     is one the user meets as an unexplained "unknown command" — exactly what
+//     the banner exists to prevent.
+//   - The line that names it must also name EVERY replacement. "What broke"
+//     without "what to run instead" is half a notice, and it is the half that
+//     leaves the user stuck.
+//   - No action line may call anything deprecated. Kept as cheap
+//     defense-in-depth on the single phrasing that actually shipped; the
+//     replacement requirement above is what carries the weight.
+//
+// Matching goes through containsInvocation for the same reason the prose scan
+// does: `agentsync secret` is a strict prefix of `agentsync secrets`, and
+// "agentsync updates the cache" would otherwise satisfy the naming check
+// vacuously.
 func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
-	if len(upgradeNotices) == 0 || len(retiredCommands) == 0 {
-		t.Fatal("no notices or no retired commands; this guard would vacuously pass")
+	if len(upgradeNotices) == 0 || len(retirements) == 0 {
+		t.Fatal("no notices or no retirements; this guard would vacuously pass")
 	}
 	var lines []string
 	for _, n := range upgradeNotices {
 		lines = append(lines, n.Actions...)
 	}
-	all := strings.Join(lines, "\n")
 
-	for old, replacement := range retiredCommands {
-		if !strings.Contains(all, "agentsync "+old) {
+	for _, r := range retirements {
+		var naming []string
+		for _, line := range lines {
+			if containsInvocation(line, "agentsync "+r.Old) {
+				naming = append(naming, line)
+			}
+		}
+		if len(naming) == 0 {
 			t.Errorf("the upgrade notice never mentions `agentsync %s`, which was retired in favor of "+
-				"`%s`. A user whose script calls it gets an unexplained \"unknown command\" — the notice "+
-				"is the only channel that reaches every install path, so an omission here is silent.",
-				old, replacement)
+				"`%s`. A user whose script calls it gets no explanation — the notice is the only channel "+
+				"that reaches every install path, so an omission here is silent.", r.Old, r.replacements())
+			continue
+		}
+		if !anyLineNamesAll(naming, r.New) {
+			t.Errorf("the upgrade notice mentions `agentsync %s` but no single line tells the user to run "+
+				"%s instead. A notice that says what broke without saying what replaces it leaves the "+
+				"reader exactly as stuck as no notice at all.\n    lines naming it: %s",
+				r.Old, r.replacements(), strings.Join(naming, "\n                     "))
 		}
 	}
-	for _, line := range lines {
+
+	// Headlines are scanned too, not just actions: the headline is the most
+	// prominent line in the banner, so "these commands are deprecated" there
+	// would be read first and checked last.
+	scanned := lines
+	for _, n := range upgradeNotices {
+		scanned = append(scanned, n.Headline)
+	}
+	for _, line := range scanned {
 		if strings.Contains(strings.ToLower(line), "deprecat") {
-			t.Errorf("an upgrade-notice action line calls something deprecated:\n    %s\n"+
+			t.Errorf("an upgrade-notice line calls something deprecated:\n    %s\n"+
 				"Nothing in this release is deprecated — the renames are hard and alias-free. Saying "+
 				"otherwise promises a grace period that does not exist, to the exact audience whose "+
 				"automation already broke.", line)
 		}
 	}
+}
+
+// anyLineNamesAll reports whether at least one line names every replacement.
+// It requires them on ONE line rather than across the set: a reader follows the
+// bullet about their broken command, not a union of all of them.
+func anyLineNamesAll(lines, replacements []string) bool {
+	for _, line := range lines {
+		all := true
+		for _, rep := range replacements {
+			if !containsInvocation(line, "agentsync "+rep) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
 }
 
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -76,7 +76,9 @@ func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
 // since it is only added at Execute time and never appears in NewRoot's tree.
 func TestNoCommandIsNamedCompletion(t *testing.T) {
 	var offenders []string
+	seen := 0
 	walkCommands(NewRoot(), func(path string, c *cobra.Command) {
+		seen++
 		names := append([]string{c.Name()}, c.Aliases...)
 		for _, n := range names {
 			if n == "completion" {
@@ -84,6 +86,9 @@ func TestNoCommandIsNamedCompletion(t *testing.T) {
 			}
 		}
 	})
+	if seen == 0 {
+		t.Fatal("the command walk yielded nothing; this guard would vacuously pass")
+	}
 	if len(offenders) > 0 {
 		t.Fatalf("these commands are named (or aliased) `completion`: %s\n"+
 			"isCompletionRequest exempts that name from the first-run upgrade notice, so this command "+

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -175,16 +175,25 @@ var sanctionedJoiners = []string{"/", ",", "and", ", and"}
 
 // continuityClaims are phrasings that promise the old spelling still works.
 //
-// This is the one blocklist here, and it is deliberately narrow. The rules in
-// lineRetires constrain the text BETWEEN the names; three reviewers showed that
-// the same false promise simply relocates to the head or tail of the line
-// ("No action needed yet: …", "… — the old spelling still works until 0.12.0",
-// "… but an alias is kept for one more minor"). A blocklist cannot be complete,
-// which is why it is paired with requireAliasFree below rather than relied on.
+// This is the one blocklist here, and it does NOT compose with the required
+// "(no alias" clause into completeness — an earlier version of this comment
+// claimed it did, and a reviewer produced five survivors in one pass
+// ("supported through 0.12", "keeps working for now", "is not yet removed",
+// "remains available", "the legacy spelling is accepted"). Those are named
+// below, and the next reviewer will find more: the set of ways to promise
+// continuity in English is open, so no substring list closes it.
+//
+// What the rules around it DO close is the structural half — a line that omits
+// the alias-free parenthetical, names its replacement backwards, joins two
+// replacements with a negation, or connects them with unsanctioned wording all
+// fail regardless of vocabulary. This list is a cheap net over the phrasings
+// that have actually been attempted, not a proof.
 var continuityClaims = []string{
 	"deprecat", "still work", "an alias for", "alias is kept", "kept as an alias",
 	"no action needed", "grace period", "will be removed", "for one minor",
-	"one more minor", "until 0.",
+	"one more minor", "until 0.", "supported through", "keeps working",
+	"keep working", "not yet removed", "remains available", "legacy spelling",
+	"both spellings",
 }
 
 // anyLineRetires reports whether some line states the retirement.
@@ -209,10 +218,14 @@ func lineRetires(line string, r retirement) bool {
 			return false
 		}
 	}
-	// Every retiring line asserts the absence of an alias. It is the single
-	// clause that directly contradicts "still works" / "an alias is kept", and
-	// all four shipped action lines already carry it.
-	if !strings.Contains(lower, "no alias") {
+	// Every retiring line asserts the absence of an alias, in the parenthesized
+	// form all four shipped lines use: "(no alias)", "(no aliases)",
+	// "(no alias; …)". Requiring the parenthetical rather than the bare words
+	// is what stops the assertion being satisfied incidentally — "there is no
+	// alias policy yet, so the old name is accepted" and "no aliases were
+	// harmed; both spellings run" both contain "no alias" and both promise the
+	// opposite of what this clause is supposed to mean.
+	if !strings.Contains(lower, "(no alias") {
 		return false
 	}
 
@@ -223,32 +236,40 @@ func lineRetires(line string, r retirement) bool {
 	oldEnd := oldAt + len("agentsync "+r.Old)
 
 	// Locate every replacement AFTER the old spelling, on a word boundary.
-	at := make([]int, 0, len(r.Replacements))
+	//
+	// Each span carries its OWN end. Sorting bare positions while indexing the
+	// lengths in declaration order desynchronizes the two the moment a line
+	// names the replacements in a different order than the table lists them —
+	// which rejected a perfectly good reword and blamed the break phrase for it.
+	spans := make([]span, 0, len(r.Replacements))
 	for _, rep := range r.Replacements {
 		i := indexInvocation(line, "agentsync "+rep, oldEnd)
 		if i < 0 {
 			return false
 		}
-		at = append(at, i)
+		spans = append(spans, span{at: i, end: i + len("agentsync "+rep)})
 	}
-	sort.Ints(at)
+	sort.Slice(spans, func(a, b int) bool { return spans[a].at < spans[b].at })
 
-	if !isSanctioned(normalizeConnector(line[oldEnd:at[0]]), sanctionedBreakPhrases) {
+	if !isSanctioned(normalizeConnector(line[oldEnd:spans[0].at]), sanctionedBreakPhrases) {
 		return false
 	}
 	// Consecutive replacements must be joined plainly, not by a clause that
 	// negates or qualifies the one that follows.
-	for k := 1; k < len(at); k++ {
-		prevEnd := at[k-1] + len("agentsync "+r.Replacements[k-1])
-		if prevEnd > at[k] {
-			return false
+	for k := 1; k < len(spans); k++ {
+		if spans[k-1].end > spans[k].at {
+			return false // overlapping matches; nothing sane to measure
 		}
-		if !isSanctioned(normalizeConnector(line[prevEnd:at[k]]), sanctionedJoiners) {
+		if !isSanctioned(normalizeConnector(line[spans[k-1].end:spans[k].at]), sanctionedJoiners) {
 			return false
 		}
 	}
 	return true
 }
+
+// span is one replacement's location on a line: where it starts and where it
+// ends. Both travel together through the sort.
+type span struct{ at, end int }
 
 func isSanctioned(s string, allowed []string) bool {
 	for _, a := range allowed {
@@ -341,11 +362,55 @@ func TestLineRetires(t *testing.T) {
 		{"unsanctioned connector", "`agentsync verify` has been superseded by `agentsync check` (no alias)", ver, false},
 		// Only one replacement named.
 		{"partial replacements", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated`", upd, false},
+		// Replacements named in a different order than the table declares them.
+		// A legitimate reword: it must PASS. Sorting positions while indexing
+		// lengths in declaration order rejected it, and blamed the break phrase.
+		{"replacements reordered", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin upgrade --all` / `agentsync plugin outdated`", upd, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := lineRetires(tc.line, tc.r); got != tc.want {
 				t.Errorf("lineRetires() = %v, want %v for:\n    %s", got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// TestRetiringSpellings gives the banner-prose parser the table every other
+// helper here earned, and for the same reason: it is the only input to
+// TestEveryRetiringNoticeLineHasATableRow, whose passing state is "found
+// nothing unclaimed" — so a parser that extracted nothing at all would look
+// identical to a correct one, below even the claimed == 0 floor.
+func TestRetiringSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		// The shipped forms, including the line that retires TWO spellings.
+		{"is-now form", "`agentsync verify` is now `agentsync check` (no alias) — doctor checks the MACHINE", []string{"verify"}},
+		{"two on one line", "`agentsync plugin install` is now `agentsync plugin add`, and `agentsync secrets` is now `agentsync secret` (no aliases)", []string{"plugin install", "secrets"}},
+		{"removed-use form", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`", []string{"update"}},
+		{"moved-to form", "`agentsync explain <plugin>` moved to `agentsync plugin explain <plugin>` (no alias; the old name now explains a FILE)", []string{"explain <plugin>"}},
+
+		// The trap: an ordinary sentence about a LIVE command. Reading this as
+		// a retirement demanded a bogus table row for `status`, which would then
+		// break the pinned set and the resurrection guard.
+		{"live command, no replacement", "`agentsync status` is now scope-aware (no alias needed) — it reads the project tree", nil},
+		{"live command, apply", "`agentsync apply` is now atomic per agent", nil},
+
+		// A retiring clause with the old spelling unquoted must still parse:
+		// requiring a backtick made a real retirement extract nothing, silently.
+		{"unquoted old spelling", "agentsync foo is now `agentsync bar` (no alias)", []string{"foo"}},
+
+		{"no invocation at all", "the canonical subagent directory moved: agents/ → subagents/", nil},
+		{"unsanctioned phrasing", "`agentsync verify` has been superseded by `agentsync check`", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := retiringSpellings(tc.line)
+			if strings.Join(got, "|") != strings.Join(tc.want, "|") {
+				t.Errorf("retiringSpellings() = %q, want %q\n    %s", got, tc.want, tc.line)
 			}
 		})
 	}
@@ -394,11 +459,27 @@ func TestEveryRetiringNoticeLineHasATableRow(t *testing.T) {
 	}
 }
 
-// retiringSpellings extracts the old spellings a notice line retires: every
-// `agentsync <words>` that is immediately followed by a sanctioned break phrase.
+// retiringSpellings extracts the old spellings a notice line retires: an
+// `agentsync <words>` followed by a sanctioned break phrase AND then by another
+// `agentsync` invocation.
+//
+// That last requirement is the whole difference between a guard and a trap. An
+// earlier version accepted spelling + phrase alone, so an ordinary future line
+// like "`agentsync status` is now scope-aware (no alias needed)" was read as
+// retiring `status` — and the failure told the author that spelling was
+// "un-guarded everywhere", steering them to add a bogus row that would then
+// break the pinned set AND the resurrection guard, since `status` still
+// resolves. A retirement says what replaces it; a sentence that names no
+// replacement is not one.
+//
+// The spelling is found by trying successively longer word prefixes rather than
+// by hunting a closing backtick, so a bare (unquoted) old spelling parses the
+// same way lineRetires reads it. Requiring a backtick made a real retiring
+// clause extract nothing at all, which is silent — the failure mode this guard
+// exists to prevent.
 func retiringSpellings(line string) []string {
-	var out []string
 	const prefix = "agentsync "
+	var out []string
 	for i := 0; ; {
 		j := strings.Index(line[i:], prefix)
 		if j < 0 {
@@ -406,23 +487,44 @@ func retiringSpellings(line string) []string {
 		}
 		at := i + j
 		rest := line[at+len(prefix):]
-		// The spelling runs to the closing backtick that quotes it.
-		end := strings.Index(rest, "`")
-		if end <= 0 {
-			i = at + len(prefix)
-			continue
-		}
-		spelling := rest[:end]
-		after := rest[end+1:]
-		for _, phrase := range sanctionedBreakPhrases {
-			if normalizeConnector(after) == phrase ||
-				strings.HasPrefix(normalizeConnector(after), phrase+" ") {
-				out = append(out, spelling)
-				break
-			}
+		if sp, ok := retiringSpellingAt(rest); ok {
+			out = append(out, sp)
 		}
 		i = at + len(prefix)
 	}
+}
+
+// retiringSpellingAt reads one candidate spelling out of the text following an
+// "agentsync " prefix, returning it only if a sanctioned break phrase and then
+// another invocation follow.
+func retiringSpellingAt(rest string) (string, bool) {
+	// maxSpellingWords bounds the search: the longest retired spelling is two
+	// words plus a placeholder ("explain <plugin>", "plugin install").
+	const maxSpellingWords = 3
+	words := strings.Fields(rest)
+	if len(words) > maxSpellingWords {
+		words = words[:maxSpellingWords]
+	}
+	for n := 1; n <= len(words); n++ {
+		spelling := strings.TrimRight(strings.Join(words[:n], " "), "`,.;:")
+		idx := strings.Index(rest, spelling)
+		if idx < 0 {
+			continue
+		}
+		after := strings.TrimLeft(rest[idx+len(spelling):], "` ")
+		norm := normalizeConnector(after)
+		for _, phrase := range sanctionedBreakPhrases {
+			if norm != phrase && !strings.HasPrefix(norm, phrase+" ") {
+				continue
+			}
+			// A retirement names what replaces it. Without this, any "is now"
+			// sentence about a live command reads as a retirement.
+			if strings.HasPrefix(strings.TrimPrefix(norm, phrase), " agentsync ") {
+				return spelling, true
+			}
+		}
+	}
+	return "", false
 }
 
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -205,10 +206,16 @@ const requiredAliasClause = "(no alias"
 // rejected "the upgrading page lists both spellings", "keep working" rejected
 // "rename it in CI to keep working", and "remains available" rejected
 // "explaining a FILE remains available under the old name" — the likeliest
-// reword of the one row whose old name genuinely does still resolve. A
-// false FAILURE on an honest line costs more than a false pass here, because
-// the structural rules already carry the load and a guard that rejects the
-// truth is one people delete.
+// reword of the one row whose old name genuinely does still resolve.
+//
+// Be honest about what that trade costs, because an earlier version of this
+// comment was not. The structural rules do NOT cover the tail: lineRetires
+// stops reading at the last replacement, so anything appended after it is seen
+// by this list and nothing else. Removing an entry therefore widens a real gap
+// rather than merely trimming a redundant one. It is still the right trade — a
+// false FAILURE lands on an author who wrote the truth, and a guard that
+// rejects the truth is one people delete — but do not remove entries believing
+// something else will catch them.
 var continuityClaims = []string{
 	"deprecat", "still work", "an alias for", "alias is kept", "kept as an alias",
 	"no action needed", "grace period", "will be removed", "for one minor",
@@ -444,7 +451,12 @@ func TestRetiringSpellings(t *testing.T) {
 		// make a real retiring clause extract nothing — silence is the failure
 		// mode this parser's own guard cannot distinguish from correctness.
 		{"colon after backtick", "`agentsync verify`: is now `agentsync check` (no alias)", []string{"verify"}},
-		{"bold markup", "**`agentsync verify`** is now `agentsync check` (no alias)", []string{"verify"}},
+		{"bold markup outside the quotes", "**`agentsync verify`** is now `agentsync check` (no alias)", []string{"verify"}},
+		// Markup INSIDE the quoted invocation is the case that actually reaches
+		// trimSpellingPunct: with right-edge-only trimming this yields
+		// "**verify" and the whole table still passed, so the helper's own
+		// comment described a fix nothing pinned.
+		{"bold markup inside the quotes", "`agentsync **verify**` is now `agentsync check` (no alias)", []string{"verify"}},
 
 		// The word bound must cover more than today's longest spelling: too
 		// short and a future retirement extracts nothing, silently.
@@ -456,8 +468,11 @@ func TestRetiringSpellings(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := retiringSpellings(tc.line)
-			if strings.Join(got, "|") != strings.Join(tc.want, "|") {
-				t.Errorf("retiringSpellings() = %q, want %q\n    %s", got, tc.want, tc.line)
+			// DeepEqual, not a joined string: `nil` and `[""]` join to the
+			// same thing, so the empty-spelling guard could be deleted with
+			// this test still green.
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("retiringSpellings() = %#v, want %#v\n    %s", got, tc.want, tc.line)
 			}
 		})
 	}
@@ -577,8 +592,11 @@ func retiringSpellingAt(rest string) (string, bool) {
 				continue // names no replacement: not a retirement
 			}
 			repl = strings.TrimPrefix(repl, "agentsync ")
-			if repl == spelling || strings.HasPrefix(repl, spelling+" ") {
-				continue // replaced by itself: a flag, not a retirement
+			// `norm` is lowercased and `spelling` is not, so compare in one
+			// case: otherwise a capitalized spelling slips past this check.
+			lowSpelling := strings.ToLower(spelling)
+			if repl == lowSpelling || strings.HasPrefix(repl, lowSpelling+" ") {
+				continue // the "replacement" extends the old name: not a retirement
 			}
 			return spelling, true
 		}

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -208,8 +208,8 @@ const requiredAliasClause = "(no alias"
 // "explaining a FILE remains available under the old name" — the likeliest
 // reword of the one row whose old name genuinely does still resolve.
 //
-// Be honest about what that trade costs, because an earlier version of this
-// comment was not. The structural rules do NOT cover the tail: lineRetires
+// Be honest about what that trade costs. The structural rules do NOT cover the
+// tail: lineRetires
 // stops reading at the last replacement, so anything appended after it is seen
 // by this list and nothing else. Removing an entry therefore widens a real gap
 // rather than merely trimming a redundant one. It is still the right trade — a
@@ -261,6 +261,15 @@ func lineRetires(line string, r retirement) bool {
 		return false
 	}
 	oldEnd := oldAt + len("agentsync "+r.Old)
+
+	// A row with no replacements has nothing to locate, and the span logic
+	// below indexes spans[0] unconditionally — so this returned a panic that
+	// killed the whole package rather than a verdict. The well-formedness guard
+	// rejects such a row first, but a crash is not a failure report, and an
+	// empty Replacements is the mutation this file is designed around.
+	if len(r.Replacements) == 0 {
+		return false
+	}
 
 	// Locate every replacement AFTER the old spelling, on a word boundary.
 	//
@@ -464,6 +473,11 @@ func TestRetiringSpellings(t *testing.T) {
 
 		// A bare "agentsync " with nothing after it names no command.
 		{"empty spelling", "`agentsync ` is now `agentsync check`", nil},
+		// A capitalized spelling must still be recognised as replacing itself.
+		// Without folding, this yields ["Status"] — a bogus retirement of a
+		// live command, which is exactly what the self-replacement rule exists
+		// to prevent, and it was the one line added in round 14 with no row.
+		{"capitalized self-replacement", "`agentsync Status` is now `agentsync status --scope project`", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -564,7 +578,17 @@ func retiringSpellings(line string) []string {
 // left `agentsync status` is now `agentsync status --scope project“ parsing as
 // a retirement of `status` — a live command, whose failure then steers the
 // author into a bogus table row that breaks the pinned set and the resurrection
-// guard. A command is not retired by gaining a flag.
+// guard.
+//
+// The rule is BROADER than "gaining a flag": it rejects any replacement that
+// extends the old spelling, so a genuine `agentsync mcp` → `agentsync mcp list`
+// retirement would extract nothing. That gap is accepted, and the obvious
+// narrowing was measured and does not work — matching `spelling+" -"` to catch
+// only the flag form lets `agentsync status` is now `agentsync status` — same
+// thing through, because the trailing prose means the two are not string-equal.
+// If a release ever does retire a bare command for its own subcommand, this is
+// the line to revisit; the symptom is a banner clause going unclaimed, which
+// TestEveryRetiringNoticeLineHasATableRow reports rather than swallows.
 func retiringSpellingAt(rest string) (string, bool) {
 	words := strings.Fields(rest)
 	if len(words) > maxSpellingWords {
@@ -592,8 +616,8 @@ func retiringSpellingAt(rest string) (string, bool) {
 				continue // names no replacement: not a retirement
 			}
 			repl = strings.TrimPrefix(repl, "agentsync ")
-			// `norm` is lowercased and `spelling` is not, so compare in one
-			// case: otherwise a capitalized spelling slips past this check.
+			// `norm` is lowercased and `spelling` is not, so fold before
+			// comparing: a capitalized spelling otherwise slips past.
 			lowSpelling := strings.ToLower(spelling)
 			if repl == lowSpelling || strings.HasPrefix(repl, lowSpelling+" ") {
 				continue // the "replacement" extends the old name: not a retirement

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // TestUpgradeNoticeTableIsWellFormed guards the append-only rule the table
@@ -59,5 +61,33 @@ func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
 			t.Errorf("notice %q (since %s) has no %q section in upgrading.mdx — its "+
 				"\"read more\" link lands on a page that does not document it", n.ID, n.Since, heading)
 		}
+	}
+}
+
+// TestNoCommandIsNamedCompletion guards the one soft spot in the notice's
+// completion exemption.
+//
+// isCompletionRequest matches the literal name "completion" anywhere up the
+// parent chain, because that is what cobra calls its generated
+// completion-script command. If agentsync ever adds a real command by that name
+// — or a subcommand under one — it would be silently exempted from the upgrade
+// notice, and the failure would be invisible: the notice simply never fires for
+// that path. Cobra's own generated command is excluded here by construction,
+// since it is only added at Execute time and never appears in NewRoot's tree.
+func TestNoCommandIsNamedCompletion(t *testing.T) {
+	var offenders []string
+	walkCommands(NewRoot(), func(path string, c *cobra.Command) {
+		names := append([]string{c.Name()}, c.Aliases...)
+		for _, n := range names {
+			if n == "completion" {
+				offenders = append(offenders, path)
+			}
+		}
+	})
+	if len(offenders) > 0 {
+		t.Fatalf("these commands are named (or aliased) `completion`: %s\n"+
+			"isCompletionRequest exempts that name from the first-run upgrade notice, so this command "+
+			"would silently never show it. Rename the command, or narrow isCompletionRequest to cobra's "+
+			"generated command only.", strings.Join(offenders, ", "))
 	}
 }

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -122,13 +123,15 @@ func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 			continue
 		}
 		if !anyLineRetires(naming, r) {
-			t.Errorf("no upgrade-notice line retires `agentsync %s` in favor of %s.\n"+
-				"The line must name the old spelling FIRST, then every replacement, joined by one of the "+
-				"sanctioned break phrases %v. A line that merely mentions both — or mentions them "+
-				"backwards, or calls the old one an alias that still works — reads to a user as a grace "+
-				"period they do not have.\n    lines naming it:\n      %s",
-				r.Old, r.replacementPhrase(), sanctionedBreakPhrases,
-				strings.Join(naming, "\n      "))
+			t.Errorf("no upgrade-notice line retires `agentsync %s` in favor of %s.\n\n"+
+				"A retiring line must: name the old spelling FIRST, then every replacement; join them "+
+				"with one of the sanctioned break phrases %q (replacements joined by %q); assert %q; and "+
+				"claim no grace period (%q).\n\n"+
+				"If you reworded a bullet and this failed, ADDING your phrasing to sanctionedBreakPhrases "+
+				"is a legitimate fix — the allowlist exists to make that a decision, not to freeze the "+
+				"wording.\n\n    lines naming it:\n      %s",
+				r.Old, r.replacementPhrase(), sanctionedBreakPhrases, sanctionedJoiners,
+				"no alias", continuityClaims, strings.Join(naming, "\n      "))
 		}
 	}
 
@@ -156,15 +159,35 @@ func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 //
 // Keep it short. Every entry is a promise about tone as well as meaning, and
 // the test exists precisely so that inventing a new one is a decision rather
-// than a slip.
+// than a slip. If a reworded bullet fails, ADDING the new phrasing here is a
+// legitimate fix — the failure message says so.
 var sanctionedBreakPhrases = []string{
 	"is now",
 	"moved to",
 	"was removed (no alias) — use",
 }
 
-// anyLineRetires reports whether some line states the retirement: the old
-// spelling, then a sanctioned break phrase, then every replacement.
+// sanctionedJoiners are the ways two replacements may be joined when a
+// retirement has more than one. Constrained for the same reason as the
+// connector: "`plugin outdated`, and definitely NOT `plugin upgrade --all`"
+// otherwise reads as naming both.
+var sanctionedJoiners = []string{"/", ",", "and", ", and"}
+
+// continuityClaims are phrasings that promise the old spelling still works.
+//
+// This is the one blocklist here, and it is deliberately narrow. The rules in
+// lineRetires constrain the text BETWEEN the names; three reviewers showed that
+// the same false promise simply relocates to the head or tail of the line
+// ("No action needed yet: …", "… — the old spelling still works until 0.12.0",
+// "… but an alias is kept for one more minor"). A blocklist cannot be complete,
+// which is why it is paired with requireAliasFree below rather than relied on.
+var continuityClaims = []string{
+	"deprecat", "still work", "an alias for", "alias is kept", "kept as an alias",
+	"no action needed", "grace period", "will be removed", "for one minor",
+	"one more minor", "until 0.",
+}
+
+// anyLineRetires reports whether some line states the retirement.
 func anyLineRetires(lines []string, r retirement) bool {
 	for _, line := range lines {
 		if lineRetires(line, r) {
@@ -174,56 +197,232 @@ func anyLineRetires(lines []string, r retirement) bool {
 	return false
 }
 
-// lineRetires checks one line. It finds where the old spelling ends and where
-// the earliest replacement begins, requires that order, and requires the text
-// between them to be a sanctioned break phrase.
+// lineRetires checks one line against every rule.
+//
+// The positional rules constrain the middle of the sentence; the whole-line
+// rules constrain its edges. Both are needed: each design that had only one of
+// them was broken by moving the false claim to the part it did not read.
 func lineRetires(line string, r retirement) bool {
-	oldAt := strings.Index(line, "agentsync "+r.Old)
+	lower := strings.ToLower(line)
+	for _, bad := range continuityClaims {
+		if strings.Contains(lower, bad) {
+			return false
+		}
+	}
+	// Every retiring line asserts the absence of an alias. It is the single
+	// clause that directly contradicts "still works" / "an alias is kept", and
+	// all four shipped action lines already carry it.
+	if !strings.Contains(lower, "no alias") {
+		return false
+	}
+
+	oldAt := indexInvocation(line, "agentsync "+r.Old, 0)
 	if oldAt < 0 {
 		return false
 	}
 	oldEnd := oldAt + len("agentsync "+r.Old)
 
-	first := -1
+	// Locate every replacement AFTER the old spelling, on a word boundary.
+	at := make([]int, 0, len(r.Replacements))
 	for _, rep := range r.Replacements {
-		// Every replacement must be named, and named AFTER the old spelling.
-		at := indexAfter(line, "agentsync "+rep, oldEnd)
-		if at < 0 || !containsInvocation(line[oldEnd:], "agentsync "+rep) {
+		i := indexInvocation(line, "agentsync "+rep, oldEnd)
+		if i < 0 {
 			return false
 		}
-		if first < 0 || at < first {
-			first = at
-		}
+		at = append(at, i)
 	}
-	if first < 0 {
+	sort.Ints(at)
+
+	if !isSanctioned(normalizeConnector(line[oldEnd:at[0]]), sanctionedBreakPhrases) {
 		return false
 	}
-	connector := normalizeConnector(line[oldEnd:first])
-	for _, ok := range sanctionedBreakPhrases {
-		if connector == ok {
+	// Consecutive replacements must be joined plainly, not by a clause that
+	// negates or qualifies the one that follows.
+	for k := 1; k < len(at); k++ {
+		prevEnd := at[k-1] + len("agentsync "+r.Replacements[k-1])
+		if prevEnd > at[k] {
+			return false
+		}
+		if !isSanctioned(normalizeConnector(line[prevEnd:at[k]]), sanctionedJoiners) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSanctioned(s string, allowed []string) bool {
+	for _, a := range allowed {
+		if s == a {
 			return true
 		}
 	}
 	return false
 }
 
-// indexAfter finds needle at or after off, returning an absolute index.
-func indexAfter(s, needle string, off int) int {
-	if off > len(s) {
+// indexInvocation finds needle at or after off, on a trailing word boundary,
+// returning an absolute index.
+//
+// Boundary-aware on purpose. A raw strings.Index made the guard CERTIFY a false
+// claim: in "`agentsync verify` is now `agentsync checkpointless` — actually run
+// `agentsync check`" it located the replacement inside `checkpointless`, read the
+// connector as "is now", and passed. Prefix extension is live vocabulary in this
+// table (`secret` inside `secrets`).
+func indexInvocation(s, needle string, off int) int {
+	if needle == "" || off > len(s) {
 		return -1
 	}
-	i := strings.Index(s[off:], needle)
-	if i < 0 {
-		return -1
+	for i := off; ; {
+		j := strings.Index(s[i:], needle)
+		if j < 0 {
+			return -1
+		}
+		at := i + j
+		end := at + len(needle)
+		if end == len(s) || !isWordByte(s[end]) {
+			return at
+		}
+		i = at + 1
 	}
-	return off + i
 }
 
-// normalizeConnector reduces the text between an old spelling and its
-// replacement to comparable form: markdown backticks dropped, whitespace
-// collapsed, case folded.
+// normalizeConnector reduces the text between two invocations to comparable
+// form: markdown backticks dropped, whitespace collapsed, case folded.
+// Punctuation is preserved — the em dash is part of what makes a phrase a
+// phrase, not noise.
 func normalizeConnector(s string) string {
 	return strings.ToLower(strings.Join(strings.Fields(strings.ReplaceAll(s, "`", "")), " "))
+}
+
+// TestLineRetires exercises lineRetires directly.
+//
+// It needs its own table for the reason containsInvocation needed one: every
+// real notice line passes, so an always-true lineRetires is indistinguishable
+// from a working one by the guard that calls it. Three successive designs of
+// this check were each broken by a reviewer within one attempt, and each
+// evasion below is one of those attempts — kept as cases so the next rewrite
+// cannot quietly reopen a hole an earlier one closed.
+func TestLineRetires(t *testing.T) {
+	upd := retirement{Old: "update", Replacements: []string{"plugin outdated", "plugin upgrade --all"}}
+	ver := retirement{Old: "verify", Replacements: []string{"check"}}
+
+	cases := []struct {
+		name string
+		line string
+		r    retirement
+		want bool
+	}{
+		// The shipped wording, in both sanctioned forms.
+		{"removed-use form", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`", upd, true},
+		{"is-now form", "`agentsync verify` is now `agentsync check` (no alias) — doctor checks the MACHINE", ver, true},
+
+		// Round 8: the bug that actually shipped.
+		{"deprecated", "`agentsync update` is deprecated (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`", upd, false},
+
+		// Round 9: named both, avoided the one banned word.
+		{"alias-shaped", "`agentsync update` still works: it is now an alias for `agentsync plugin outdated` / `agentsync plugin upgrade --all`", upd, false},
+		{"wrong replacement", "`agentsync update` is now `agentsync apply --force` (no alias)", upd, false},
+		{"prose only", "note: agentsync updates the native config in place (no alias)", upd, false},
+
+		// Round 10: unordered co-occurrence read a backwards sentence as correct.
+		{"reversed", "`agentsync check` is now spelled `agentsync verify` (no alias)", ver, false},
+
+		// Round 11: the same false promise, relocated outside the connector.
+		{"tail continuity", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all` — the old spelling still works until 0.12.0", upd, false},
+		{"lead continuity", "No action needed yet: `agentsync update` is now `agentsync plugin outdated` / `agentsync plugin upgrade --all` (no alias)", upd, false},
+		{"alias kept in tail", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`, but an alias is kept for one more minor", upd, false},
+		{"second replacement negated", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated`, and definitely NOT `agentsync plugin upgrade --all`", upd, false},
+
+		// Round 11: a raw index let a prefix extension certify a false claim.
+		{"prefix extension", "`agentsync verify` is now `agentsync checkpointless` (no alias) — actually run `agentsync check`", ver, false},
+
+		// The alias-free assertion is required, not incidental.
+		{"missing no-alias clause", "`agentsync verify` is now `agentsync check`", ver, false},
+		// An unsanctioned connector fails even when everything else is right.
+		{"unsanctioned connector", "`agentsync verify` has been superseded by `agentsync check` (no alias)", ver, false},
+		// Only one replacement named.
+		{"partial replacements", "`agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated`", upd, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lineRetires(tc.line, tc.r); got != tc.want {
+				t.Errorf("lineRetires() = %v, want %v for:\n    %s", got, tc.want, tc.line)
+			}
+		})
+	}
+}
+
+// TestEveryRetiringNoticeLineHasATableRow is the reverse direction, and it is
+// the half that was missing.
+//
+// Every other guard runs table→world: for each row, check the world agrees.
+// Nothing ran world→table, so DELETING a row was completely silent — three
+// reviewers each removed `secrets` from `retirements` and watched the whole
+// package stay green, with that spelling then un-guarded in the resurrection
+// check, the prose scan, and the banner at once. Deletion is the likelier
+// mutation, too: a merge conflict resolved the wrong way, or someone
+// "de-duplicating" `secret` and `secrets`.
+//
+// The banner is the external oracle. Each of its action lines that RETIRES
+// something — an `agentsync <old>` followed by a sanctioned break phrase — must
+// be claimed by a row. Orphan a clause and this fails.
+func TestEveryRetiringNoticeLineHasATableRow(t *testing.T) {
+	claimed := 0
+	for _, n := range upgradeNotices {
+		for _, line := range n.Actions {
+			for _, spelling := range retiringSpellings(line) {
+				found := false
+				for _, r := range retirements {
+					if r.Old == spelling {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("the upgrade notice retires `agentsync %s`, but no row in `retirements` "+
+						"claims it:\n    %s\n"+
+						"That spelling is therefore un-guarded everywhere — the resurrection check, the "+
+						"stale-prose scan, and this file's own content guard all read that table.",
+						spelling, line)
+					continue
+				}
+				claimed++
+			}
+		}
+	}
+	if claimed == 0 {
+		t.Fatal("no notice line was recognised as retiring anything; this guard would vacuously pass")
+	}
+}
+
+// retiringSpellings extracts the old spellings a notice line retires: every
+// `agentsync <words>` that is immediately followed by a sanctioned break phrase.
+func retiringSpellings(line string) []string {
+	var out []string
+	const prefix = "agentsync "
+	for i := 0; ; {
+		j := strings.Index(line[i:], prefix)
+		if j < 0 {
+			return out
+		}
+		at := i + j
+		rest := line[at+len(prefix):]
+		// The spelling runs to the closing backtick that quotes it.
+		end := strings.Index(rest, "`")
+		if end <= 0 {
+			i = at + len(prefix)
+			continue
+		}
+		spelling := rest[:end]
+		after := rest[end+1:]
+		for _, phrase := range sanctionedBreakPhrases {
+			if normalizeConnector(after) == phrase ||
+				strings.HasPrefix(normalizeConnector(after), phrase+" ") {
+				out = append(out, spelling)
+				break
+			}
+		}
+		i = at + len(prefix)
+	}
 }
 
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -12,11 +12,8 @@ import (
 // .state/last-run.json: renaming one re-shows its notice to every user who
 // already dismissed it, and duplicating one makes the second unreachable.
 //
-// This is an INTERNAL test on purpose. The first version reached the unexported
-// table through a hand-maintained `UpgradeNoticeView` copy in export_test.go —
-// which is the model-vs-artifact hazard CLAUDE.md names outright: a sixth field
-// added to upgradeNotice would be silently invisible to its own guard. Reading
-// the real struct removes the parallel model and the seam with it.
+// It is an INTERNAL test so it reads the real struct: a parallel view type in
+// export_test.go would hide a newly-added field from its own guard.
 func TestUpgradeNoticeTableIsWellFormed(t *testing.T) {
 	if len(upgradeNotices) == 0 {
 		t.Fatal("no notices defined; this guard would vacuously pass")
@@ -64,45 +61,44 @@ func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
 	}
 }
 
-// TestUpgradeNoticeNamesEveryRetiredCommand pins the notice's actual CONTENT —
-// the one thing this feature exists to get right, and the one thing nothing
-// checked.
+// TestUpgradeNoticeNamesEveryRetiredCommand pins what the banner SAYS.
 //
-// The bug that motivated it shipped: after the top-level `update` command was
-// removed outright, the action line still read "`agentsync update` is
-// deprecated". Every guard stayed green. `upgrade_notice.go` is exempt from
-// TestNoStaleRenamedCommandReferences — it names old spellings for a living —
-// and that exemption is whole-file, so it can catch a MISSING mention but never
-// a WRONG one. A human caught it, on a banner whose entire audience is people
-// whose scripts just broke, and whose worst possible failure is telling them
-// their command still works for a while.
+// The motivating bug shipped: after the top-level `update` was removed, the
+// action line still read "`agentsync update` is deprecated". Every guard stayed
+// green, because `upgrade_notice.go` is exempt from the stale-command scan (it
+// names old spellings for a living) and that exemption is whole-file — it can
+// catch a MISSING mention, never a WRONG one.
 //
-// The assertion is on the OUTCOME, not on wording. A first attempt paired
-// "the line mentions the old name" with "no line says `deprecat`", and three
-// reviewers independently broke it in one try — "`agentsync update` still
-// works; an alias is kept for one more minor" satisfies both, and so does
-// naming a replacement that does not exist. A blocklist of bad phrasings is
-// unbounded ("legacy", "sunset", "will be removed in 0.12", "no action needed
-// yet"); requiring the line to say what to run INSTEAD is not, and it rules
-// out the whole class, since a line promising continuity has no reason to
-// name a replacement.
+// Two later attempts to pin it were each defeated on the first try, so the
+// shape below is chosen for what survived rather than for elegance:
 //
-// Three directions, all load-bearing:
+//   - "no line says `deprecat`" fell to "still works; an alias is kept for one
+//     more minor", and to a line naming a replacement that does not exist.
+//   - "the line must also name the replacement" fell to "`agentsync update`
+//     still works: it is now an alias for `agentsync plugin outdated` …", which
+//     names both by construction, and to a REVERSED line — "`agentsync check`
+//     … now spelled `agentsync verify`" — because an unordered co-occurrence
+//     test reads a backwards sentence as a correct one.
 //
-//   - Every retirement must be NAMED by some action line. One the banner omits
-//     is one the user meets as an unexplained "unknown command" — exactly what
-//     the banner exists to prevent.
-//   - The line that names it must also name EVERY replacement. "What broke"
-//     without "what to run instead" is half a notice, and it is the half that
-//     leaves the user stuck.
-//   - No action line may call anything deprecated. Kept as cheap
-//     defense-in-depth on the single phrasing that actually shipped; the
-//     replacement requirement above is what carries the weight.
+// So the assertion is on the RELATIONSHIP between the two names, not on their
+// presence and not on which words the line avoids:
 //
-// Matching goes through containsInvocation for the same reason the prose scan
-// does: `agentsync secret` is a strict prefix of `agentsync secrets`, and
-// "agentsync updates the cache" would otherwise satisfy the naming check
-// vacuously.
+//  1. Some action line names the retirement.
+//  2. On that line the old spelling comes BEFORE its replacements — the
+//     direction of the sentence is the claim it makes.
+//  3. The connector between them — the text that carries the actual meaning —
+//     must be one of a small ALLOWLIST of break phrases.
+//
+// Rule 3 is the load-bearing one, and it is an allowlist for the reason a
+// blocklist kept failing: "legacy", "sunset", "no action needed yet", "is now
+// an alias for" is an open set, while the ways agentsync is willing to say
+// "this is gone" is a closed one we control. A new phrasing fails this test,
+// and adding it here is a deliberate act a reviewer sees.
+//
+// It is still a structural approximation of a semantic contract. It cannot
+// judge a sentence that is well-formed and false. What it does guarantee is
+// that every retirement is named, points forward at a real replacement, and
+// says so in wording someone signed off on.
 func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 	if len(upgradeNotices) == 0 || len(retirements) == 0 {
 		t.Fatal("no notices or no retirements; this guard would vacuously pass")
@@ -122,20 +118,24 @@ func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 		if len(naming) == 0 {
 			t.Errorf("the upgrade notice never mentions `agentsync %s`, which was retired in favor of "+
 				"`%s`. A user whose script calls it gets no explanation — the notice is the only channel "+
-				"that reaches every install path, so an omission here is silent.", r.Old, r.replacements())
+				"that reaches every install path, so an omission here is silent.", r.Old, r.replacementPhrase())
 			continue
 		}
-		if !anyLineNamesAll(naming, r.New) {
-			t.Errorf("the upgrade notice mentions `agentsync %s` but no single line tells the user to run "+
-				"%s instead. A notice that says what broke without saying what replaces it leaves the "+
-				"reader exactly as stuck as no notice at all.\n    lines naming it: %s",
-				r.Old, r.replacements(), strings.Join(naming, "\n                     "))
+		if !anyLineRetires(naming, r) {
+			t.Errorf("no upgrade-notice line retires `agentsync %s` in favor of %s.\n"+
+				"The line must name the old spelling FIRST, then every replacement, joined by one of the "+
+				"sanctioned break phrases %v. A line that merely mentions both — or mentions them "+
+				"backwards, or calls the old one an alias that still works — reads to a user as a grace "+
+				"period they do not have.\n    lines naming it:\n      %s",
+				r.Old, r.replacementPhrase(), sanctionedBreakPhrases,
+				strings.Join(naming, "\n      "))
 		}
 	}
 
-	// Headlines are scanned too, not just actions: the headline is the most
-	// prominent line in the banner, so "these commands are deprecated" there
-	// would be read first and checked last.
+	// Headlines are scanned too: the headline is the most prominent line in the
+	// banner, so "these commands are deprecated" there would be read first and
+	// checked last. Cheap defense-in-depth on the one phrasing that shipped;
+	// the rules above are what carry the weight.
 	scanned := lines
 	for _, n := range upgradeNotices {
 		scanned = append(scanned, n.Headline)
@@ -150,23 +150,80 @@ func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
 	}
 }
 
-// anyLineNamesAll reports whether at least one line names every replacement.
-// It requires them on ONE line rather than across the set: a reader follows the
-// bullet about their broken command, not a union of all of them.
-func anyLineNamesAll(lines, replacements []string) bool {
+// sanctionedBreakPhrases is the closed set of ways the banner may say "this
+// spelling is gone". The connector between the old name and its replacement
+// must be exactly one of these, after normalization.
+//
+// Keep it short. Every entry is a promise about tone as well as meaning, and
+// the test exists precisely so that inventing a new one is a decision rather
+// than a slip.
+var sanctionedBreakPhrases = []string{
+	"is now",
+	"moved to",
+	"was removed (no alias) — use",
+}
+
+// anyLineRetires reports whether some line states the retirement: the old
+// spelling, then a sanctioned break phrase, then every replacement.
+func anyLineRetires(lines []string, r retirement) bool {
 	for _, line := range lines {
-		all := true
-		for _, rep := range replacements {
-			if !containsInvocation(line, "agentsync "+rep) {
-				all = false
-				break
-			}
-		}
-		if all {
+		if lineRetires(line, r) {
 			return true
 		}
 	}
 	return false
+}
+
+// lineRetires checks one line. It finds where the old spelling ends and where
+// the earliest replacement begins, requires that order, and requires the text
+// between them to be a sanctioned break phrase.
+func lineRetires(line string, r retirement) bool {
+	oldAt := strings.Index(line, "agentsync "+r.Old)
+	if oldAt < 0 {
+		return false
+	}
+	oldEnd := oldAt + len("agentsync "+r.Old)
+
+	first := -1
+	for _, rep := range r.Replacements {
+		// Every replacement must be named, and named AFTER the old spelling.
+		at := indexAfter(line, "agentsync "+rep, oldEnd)
+		if at < 0 || !containsInvocation(line[oldEnd:], "agentsync "+rep) {
+			return false
+		}
+		if first < 0 || at < first {
+			first = at
+		}
+	}
+	if first < 0 {
+		return false
+	}
+	connector := normalizeConnector(line[oldEnd:first])
+	for _, ok := range sanctionedBreakPhrases {
+		if connector == ok {
+			return true
+		}
+	}
+	return false
+}
+
+// indexAfter finds needle at or after off, returning an absolute index.
+func indexAfter(s, needle string, off int) int {
+	if off > len(s) {
+		return -1
+	}
+	i := strings.Index(s[off:], needle)
+	if i < 0 {
+		return -1
+	}
+	return off + i
+}
+
+// normalizeConnector reduces the text between an old spelling and its
+// replacement to comparable form: markdown backticks dropped, whitespace
+// collapsed, case folded.
+func normalizeConnector(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.ReplaceAll(s, "`", "")), " "))
 }
 
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -64,6 +64,58 @@ func TestEveryNoticeHasAnUpgradingDocsSection(t *testing.T) {
 	}
 }
 
+// TestUpgradeNoticeNamesEveryRetiredCommand pins the notice's actual CONTENT —
+// the one thing this feature exists to get right, and the one thing nothing
+// checked.
+//
+// The bug that motivated it shipped: after the top-level `update` command was
+// removed outright, the action line still read "`agentsync update` is
+// deprecated". Every guard stayed green. `upgrade_notice.go` is exempt from
+// TestNoStaleRenamedCommandReferences — it names old spellings for a living —
+// and that exemption is whole-file, so it can catch a MISSING mention but never
+// a WRONG one. A human caught it, on a banner whose entire audience is people
+// whose scripts just broke, and whose worst possible failure is telling them
+// their command still works for a while.
+//
+// Two directions, both load-bearing:
+//
+//   - Every retired top-level spelling must be NAMED somewhere in the notice.
+//     A retirement the banner omits is one a user discovers as an unexplained
+//     "unknown command" — exactly what the banner exists to prevent. The list
+//     is retiredCommands (command_surface_internal_test.go), shared so a
+//     future retirement cannot be added to one and forgotten in the other.
+//   - No action line may describe anything as deprecated. This release has no
+//     deprecations and no aliases: everything listed is a hard break. "Is
+//     deprecated" tells a reader their cron line has a grace period it does
+//     not have, which is worse than saying nothing.
+func TestUpgradeNoticeNamesEveryRetiredCommand(t *testing.T) {
+	if len(upgradeNotices) == 0 || len(retiredCommands) == 0 {
+		t.Fatal("no notices or no retired commands; this guard would vacuously pass")
+	}
+	var lines []string
+	for _, n := range upgradeNotices {
+		lines = append(lines, n.Actions...)
+	}
+	all := strings.Join(lines, "\n")
+
+	for old, replacement := range retiredCommands {
+		if !strings.Contains(all, "agentsync "+old) {
+			t.Errorf("the upgrade notice never mentions `agentsync %s`, which was retired in favor of "+
+				"`%s`. A user whose script calls it gets an unexplained \"unknown command\" — the notice "+
+				"is the only channel that reaches every install path, so an omission here is silent.",
+				old, replacement)
+		}
+	}
+	for _, line := range lines {
+		if strings.Contains(strings.ToLower(line), "deprecat") {
+			t.Errorf("an upgrade-notice action line calls something deprecated:\n    %s\n"+
+				"Nothing in this release is deprecated — the renames are hard and alias-free. Saying "+
+				"otherwise promises a grace period that does not exist, to the exact audience whose "+
+				"automation already broke.", line)
+		}
+	}
+}
+
 // TestNoCommandIsNamedCompletion guards the one soft spot in the notice's
 // completion exemption.
 //

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -577,11 +577,28 @@ func TestUpgradeNotice_ShellCompletionDoesNotConsumeIt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Every completion entry point, including a bare TAB, a partial word, and
-	// NESTED completion (`agentsync mcp <TAB>`). The nested form is the reason
-	// isCompletionRequest walks the PARENT CHAIN rather than checking cmd.Name()
-	// — cobra dispatches it to the subcommand, so a name-only check would miss
-	// it and every `agentsync <group> <TAB>` would eat the notice.
+	// Every completion entry point.
+	//
+	// WHICH case makes the parent-chain walk load-bearing, precisely — an
+	// earlier version of this comment got it backwards. Measured dispatch
+	// chains (the command whose PersistentPreRunE actually runs, and its
+	// ancestors):
+	//
+	//	__complete ""          -> [__complete agentsync]
+	//	__complete mcp ""      -> [__complete agentsync]   (NOT the mcp command)
+	//	completion bash        -> [bash completion agentsync]
+	//
+	// Cobra resolves the completion TARGET inside `__complete`'s own RunE and
+	// never runs the target's hooks — so every `__complete` form is caught by
+	// the name alone, nested or not. It is `completion <shell>` that needs the
+	// walk, because cobra dispatches to the shell subcommand UNDER `completion`
+	// and only its parent carries the name.
+	//
+	// So `completion bash` / `completion zsh` are the discriminating cases here;
+	// mutating isCompletionRequest to a name-only check fails on those first.
+	// The `__complete` rows still earn their place as entry-point coverage —
+	// they are what a real TAB press invokes — but do not delete the
+	// `completion <shell>` rows believing the others subsume them.
 	for _, args := range [][]string{
 		{"__complete", ""},
 		{"__complete", "ap"},

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -403,3 +403,154 @@ func TestUpgradeNotice_RecordIsGitignored(t *testing.T) {
 		t.Fatalf("`.state/` is not gitignored, so the run record would be committed:\n%s", data)
 	}
 }
+
+// TestUpgradeNotice_CorruptRecordStillShowsAndRepairs is the case that made the
+// difference between "the notice shows again later" and "the user never learns
+// their config layout moved".
+//
+// A truncated / empty / wrong-shaped last-run.json is the classic crash- or
+// full-disk artifact. Treating that like an I/O failure suppressed the notice
+// PERMANENTLY — the file was never rewritten, so every subsequent run hit the
+// same parse error. A record that cannot be parsed carries no information, so
+// the honest reading is "nothing has been shown here": print, then overwrite.
+func TestUpgradeNotice_CorruptRecordStillShowsAndRepairs(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"empty file (crash mid-write)", ""},
+		{"truncated json", `{"version":"0.10.1","notices_`},
+		{"wrong shape: array", `[]`},
+		{"wrong shape: string", `"nope"`},
+		{"wrong field types", `{"version":42,"notices_seen":"x"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+			mustRun(t, env, "init")
+			withVersion(t, "0.11.0")
+
+			rec := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
+			if err := os.WriteFile(rec, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, stderr, err := runCLISplit(t, env, "version")
+			if err != nil {
+				t.Fatalf("version: %v\n%s", err, stderr)
+			}
+			if !strings.Contains(stderr, "migrate subagents") {
+				t.Fatalf("a corrupt record must not suppress the notice:\n%s", stderr)
+			}
+			// And it must be REPAIRED, or the notice repeats forever instead.
+			got := readLastRun(t, tmp)
+			if got == nil || len(got.NoticesSeen) == 0 {
+				t.Fatalf("corrupt record was not repaired: %+v", got)
+			}
+			_, stderr2, err := runCLISplit(t, env, "version")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(stderr2, "migrate subagents") {
+				t.Errorf("notice repeated after the record was repaired:\n%s", stderr2)
+			}
+		})
+	}
+}
+
+// TestUpgradeNotice_KeyedByIDNotVersion pins the central design decision, which
+// nothing exercised: the show/hide choice is made by notice ID, never by
+// comparing versions.
+//
+// It matters in both directions. A user who jumps 0.9 → 0.12 must still see a
+// notice introduced in 0.11 (version comparison would be tempting and wrong),
+// and a machine that has already seen an ID must stay silent even when the
+// recorded version looks old.
+func TestUpgradeNotice_KeyedByIDNotVersion(t *testing.T) {
+	t.Run("unseen id shows even though the recorded version is current", func(t *testing.T) {
+		tmp := t.TempDir()
+		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		withVersion(t, "0.11.0")
+		writeLastRun(t, tmp, `{"version":"0.11.0","notices_seen":["some-other-id"]}`)
+
+		_, stderr, err := runCLISplit(t, env, "version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stderr, "migrate subagents") {
+			t.Fatalf("an UNSEEN notice id must show regardless of the recorded version:\n%s", stderr)
+		}
+	})
+
+	t.Run("seen id stays silent even though the recorded version is ancient", func(t *testing.T) {
+		tmp := t.TempDir()
+		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		withVersion(t, "0.11.0")
+		writeLastRun(t, tmp, `{"version":"0.9.0","notices_seen":["0.11.0-cli-surface"]}`)
+
+		_, stderr, err := runCLISplit(t, env, "version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(stderr, "migrate subagents") {
+			t.Fatalf("a SEEN notice id must stay silent regardless of the recorded version:\n%s", stderr)
+		}
+	})
+}
+
+// writeLastRun plants a run record verbatim.
+func writeLastRun(t *testing.T, tmp, body string) {
+	t.Helper()
+	p := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUpgradeNotice_StateOnlyHomeIsNotSilencedForever pins that skipping the
+// notice for a state-only home does NOT record it as seen.
+//
+// The first version of that check seeded the record before returning. Since the
+// check runs before the record is ever read, seeding bought nothing — and it
+// permanently silenced anyone whose home gained an agentsync.toml afterwards
+// (a dotfiles restore landing after the first run, or simply running `init`
+// tomorrow). They would never hear about the breaking changes at all.
+func TestUpgradeNotice_StateOnlyHomeIsNotSilencedForever(t *testing.T) {
+	tmp := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	withVersion(t, "0.11.0")
+
+	// Project-scope use materializes ~/.agentsync for central state, with no
+	// user-scope agentsync.toml. The notice must stay quiet…
+	mustRun(t, env, "init", "--project", proj)
+	mustRun(t, env, "agent", "add", "claude", "--project", proj)
+	_, stderr, err := runCLISplit(t, env, "apply", "--project", proj)
+	if err != nil {
+		t.Fatalf("apply --project: %v\n%s", err, stderr)
+	}
+	if strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("state-only home must not see the banner:\n%s", stderr)
+	}
+	// …and must not have recorded the notices as seen.
+	if rec := readLastRun(t, tmp); rec != nil && len(rec.NoticesSeen) > 0 {
+		t.Fatalf("a state-only home recorded notices as SEEN, so a user who later gains a "+
+			"user config is silenced forever: %+v", rec)
+	}
+
+	// Now the user config arrives — a dotfiles restore, or `init` tomorrow. They
+	// have a pre-0.11 config now, so they must hear about the changes.
+	if err := os.WriteFile(filepath.Join(tmp, ".agentsync", "agentsync.toml"),
+		[]byte("[agents]\nclaude = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err = runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("a home that gained a user config was permanently silenced:\n%s", stderr)
+	}
+}

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -230,202 +230,101 @@ func TestUpgradeNotice_JSONPayloadStaysClean(t *testing.T) {
 	}
 }
 
-// TestUpgradeNotice_ProjectScopeUserSeesItAfterApply pins why keying off the
-// USER home is right even for someone who only ever works at project scope.
+// TestUpgradeNotice_BrandNewProjectScopeUserIsNotToldToMigrate is the
+// regression for a misfire that told a 0.11.0-native user to run `agentsync
+// migrate subagents` against a tree that never had an agents/ directory.
 //
-// apply records state centrally under ~/.agentsync/.state/ keyed by project
-// root, so a project-scope user has a user home from their first apply onward.
-// The only window where they miss the notice is before that first apply — when
-// agentsync has rendered nothing for them, so nothing has broken under them.
-func TestUpgradeNotice_ProjectScopeUserSeesItAfterApply(t *testing.T) {
+// A project-scope user never runs `agentsync init` at user scope — but apply
+// records state CENTRALLY under ~/.agentsync/.state/ keyed by project root, so
+// the first project-scope command that touches state materializes a user home
+// that `init` never seeded. "Home exists + no record" then reads as an upgrade.
+//
+// Note the shape of this test: it runs the real sequence and asserts SILENCE
+// throughout. The previous version deleted the record and asserted the notice
+// SHOWED — which is the same observable as the bug, so it could never have
+// caught it.
+func TestUpgradeNotice_BrandNewProjectScopeUserIsNotToldToMigrate(t *testing.T) {
 	tmp := t.TempDir()
 	proj := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	withVersion(t, "0.11.0")
 
-	mustRun(t, env, "init", "--project", proj)
-	mustRun(t, env, "agent", "add", "claude", "--project", proj)
-	mustRun(t, env, "apply", "--project", proj)
-
-	// The first apply materialized the central state home; clear the record so
-	// this stands in for an upgrading project-scope user.
-	if err := os.Remove(filepath.Join(tmp, ".agentsync", ".state", "last-run.json")); err != nil && !os.IsNotExist(err) {
-		t.Fatal(err)
-	}
-
-	_, stderr, err := runCLISplit(t, env, "status", "--project", proj)
-	if err != nil {
-		t.Fatalf("status: %v\n%s", err, stderr)
-	}
-	if !strings.Contains(stderr, "migrate subagents") {
-		t.Fatalf("a project-scope user who has applied must see the notice:\n%s", stderr)
+	// Never any user-scope `init` — this user only ever works in a project.
+	for _, args := range [][]string{
+		{"init", "--project", proj},
+		{"agent", "add", "claude", "--project", proj}, // materializes ~/.agentsync for central state
+		{"apply", "--project", proj},
+		{"status", "--project", proj},
+	} {
+		_, stderr, err := runCLISplit(t, env, args...)
+		if err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, stderr)
+		}
+		if strings.Contains(stderr, "migrate subagents") {
+			t.Fatalf("`%s` showed the upgrade banner to a brand-new project-scope user — "+
+				"their tree never had an agents/ directory:\n%s", strings.Join(args, " "), stderr)
+		}
 	}
 }
 
-// TestUpgradeNotice_UnreadableStateDoesNotFailCommand pins the best-effort
-// contract: a UX marker must never take a user's command down with it.
-//
-// Named for what it actually exercises. With .state replaced by a regular file,
-// ReadFile fails with ENOTDIR — which is NOT os.ErrNotExist — so LoadLastRun
-// returns an I/O error and maybePrintUpgradeNotice bails long before
-// MkdirAll/SaveLastRun. It is the unreadable path, not the unwritable one; the
-// old name meant the write-failure branch looked covered when it was not.
-func TestUpgradeNotice_UnreadableStateDoesNotFailCommand(t *testing.T) {
+// TestUpgradeNotice_UserConfigStillGetsTheNotice is the negative control for the
+// fix above: narrowing the trigger to "the home holds an agentsync.toml" must
+// not silence the genuine upgrader it exists for.
+func TestUpgradeNotice_UserConfigStillGetsTheNotice(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	mustRun(t, env, "init")
 	withVersion(t, "0.11.0")
 
-	// Replace .state with a regular FILE so MkdirAll/AtomicWrite cannot succeed
-	// — a uid-independent way to make the record unwritable (the container runs
-	// as root, where a chmod would not bite).
+	// A home created by a version that predates the run record.
+	if err := os.Remove(filepath.Join(tmp, ".agentsync", ".state", "last-run.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("a real upgrader with a user config must still see the notice:\n%s", stderr)
+	}
+}
+
+// TestUpgradeNotice_WriteFailureStillPrints covers the last uncovered branch:
+// the notice printed, then recording it failed. It must not fail the command,
+// and the notice must show again next run rather than being lost.
+//
+// A .state symlinked to a nonexistent target is the uid-independent way in (the
+// container runs as root, where chmod would not bite): ReadFile returns ENOENT
+// so the load succeeds, then MkdirAll fails on the dangling link.
+func TestUpgradeNotice_WriteFailureStillPrints(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "0.11.0")
+
 	stateDir := filepath.Join(tmp, ".agentsync", ".state")
 	if err := os.RemoveAll(stateDir); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(stateDir, []byte("not a directory\n"), 0o644); err != nil {
+	if err := os.Symlink(filepath.Join(tmp, "nonexistent-target"), stateDir); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, stderr, err := runCLISplit(t, env, "version"); err != nil {
-		t.Fatalf("an unreadable run record must not fail the command: %v\n%s", err, stderr)
+	_, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatalf("a failed record write must not fail the command: %v\n%s", err, stderr)
 	}
-}
-
-// TestUpgradeNotice_CorruptRecordStillShowsAndRepairs is the case that made the
-// difference between "the notice shows again later" and "the user never learns
-// their config layout moved".
-//
-// A truncated / empty / wrong-shaped last-run.json is the classic crash- or
-// full-disk artifact. Treating that like an I/O failure suppressed the notice
-// PERMANENTLY — the file was never rewritten, so every subsequent run hit the
-// same parse error. A record that cannot be parsed carries no information, so
-// the honest reading is "nothing has been shown here": print, then overwrite.
-func TestUpgradeNotice_CorruptRecordStillShowsAndRepairs(t *testing.T) {
-	for _, tc := range []struct{ name, body string }{
-		{"empty file (crash mid-write)", ""},
-		{"truncated json", `{"version":"0.10.1","notices_`},
-		{"wrong shape: array", `[]`},
-		{"wrong shape: string", `"nope"`},
-		{"wrong field types", `{"version":42,"notices_seen":"x"}`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			tmp := t.TempDir()
-			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-			mustRun(t, env, "init")
-			withVersion(t, "0.11.0")
-
-			rec := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
-			if err := os.WriteFile(rec, []byte(tc.body), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			_, stderr, err := runCLISplit(t, env, "version")
-			if err != nil {
-				t.Fatalf("version: %v\n%s", err, stderr)
-			}
-			if !strings.Contains(stderr, "migrate subagents") {
-				t.Fatalf("a corrupt record must not suppress the notice:\n%s", stderr)
-			}
-			// And it must be REPAIRED, or the notice repeats forever instead.
-			got := readLastRun(t, tmp)
-			if got == nil || len(got.NoticesSeen) == 0 {
-				t.Fatalf("corrupt record was not repaired: %+v", got)
-			}
-			_, stderr2, err := runCLISplit(t, env, "version")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if strings.Contains(stderr2, "migrate subagents") {
-				t.Errorf("notice repeated after the record was repaired:\n%s", stderr2)
-			}
-		})
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("the notice must still print when only the RECORD write fails:\n%s", stderr)
 	}
-}
-
-// TestUpgradeNotice_KeyedByIDNotVersion pins the central design decision, which
-// nothing exercised: the show/hide choice is made by notice ID, never by
-// comparing versions.
-//
-// It matters in both directions. A user who jumps 0.9 → 0.12 must still see a
-// notice introduced in 0.11 (version comparison would be tempting and wrong),
-// and a machine that has already seen an ID must stay silent even when the
-// recorded version looks old.
-func TestUpgradeNotice_KeyedByIDNotVersion(t *testing.T) {
-	t.Run("unseen id shows even though the recorded version is current", func(t *testing.T) {
-		tmp := t.TempDir()
-		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-		mustRun(t, env, "init")
-		withVersion(t, "0.11.0")
-		writeLastRun(t, tmp, `{"version":"0.11.0","notices_seen":["some-other-id"]}`)
-
-		_, stderr, err := runCLISplit(t, env, "version")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(stderr, "migrate subagents") {
-			t.Fatalf("an UNSEEN notice id must show regardless of the recorded version:\n%s", stderr)
-		}
-	})
-
-	t.Run("seen id stays silent even though the recorded version is ancient", func(t *testing.T) {
-		tmp := t.TempDir()
-		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-		mustRun(t, env, "init")
-		withVersion(t, "0.11.0")
-		writeLastRun(t, tmp, `{"version":"0.9.0","notices_seen":["0.11.0-cli-surface"]}`)
-
-		_, stderr, err := runCLISplit(t, env, "version")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if strings.Contains(stderr, "migrate subagents") {
-			t.Fatalf("a SEEN notice id must stay silent regardless of the recorded version:\n%s", stderr)
-		}
-	})
-}
-
-// writeLastRun plants a run record verbatim.
-func writeLastRun(t *testing.T, tmp, body string) {
-	t.Helper()
-	p := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+	// Unrecorded means it shows again — the harmless direction to fail in.
+	_, stderr2, err := runCLISplit(t, env, "version")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// TestUpgradeNoticeTableIsWellFormed guards the append-only rule that the table
-// states but nothing enforced. An ID is the durable key: renaming one re-shows
-// its notice to every user who already dismissed it, and duplicating one hides
-// the second silently.
-func TestUpgradeNoticeTableIsWellFormed(t *testing.T) {
-	ids := map[string]bool{}
-	for _, n := range cli.UpgradeNoticesForTest() {
-		switch {
-		case n.ID == "":
-			t.Errorf("notice with empty ID (%q): the ID is the recorded key", n.Headline)
-		case ids[n.ID]:
-			t.Errorf("duplicate notice ID %q — the second is silently unreachable", n.ID)
-		}
-		ids[n.ID] = true
-		if n.Since == "" {
-			t.Errorf("notice %q has no Since; the banner prints it", n.ID)
-		}
-		if n.Headline == "" {
-			t.Errorf("notice %q has no Headline", n.ID)
-		}
-		if len(n.Actions) == 0 {
-			t.Errorf("notice %q lists no actions, so it tells the user what broke but not what to do", n.ID)
-		}
-		if !strings.HasPrefix(n.Path, "/") {
-			t.Errorf("notice %q Path %q must start with '/' (it is appended to the docs base URL)", n.ID, n.Path)
-		}
-	}
-	if len(ids) == 0 {
-		t.Fatal("no notices defined; this guard would vacuously pass")
+	if !strings.Contains(stderr2, "migrate subagents") {
+		t.Errorf("an unrecordable notice must repeat, not vanish:\n%s", stderr2)
 	}
 }
 

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -577,12 +577,20 @@ func TestUpgradeNotice_ShellCompletionDoesNotConsumeIt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Every completion entry point, including a bare TAB and a partial word.
+	// Every completion entry point, including a bare TAB, a partial word, and
+	// NESTED completion (`agentsync mcp <TAB>`). The nested form is the reason
+	// isCompletionRequest walks the PARENT CHAIN rather than checking cmd.Name()
+	// — cobra dispatches it to the subcommand, so a name-only check would miss
+	// it and every `agentsync <group> <TAB>` would eat the notice.
 	for _, args := range [][]string{
 		{"__complete", ""},
 		{"__complete", "ap"},
+		{"__complete", "mcp", ""},
+		{"__complete", "plugin", "up"},
+		{"__complete", "--scope", ""},
 		{"__completeNoDesc", ""},
 		{"completion", "bash"},
+		{"completion", "zsh"},
 	} {
 		if _, _, err := runCLISplit(t, env, args...); err != nil {
 			t.Fatalf("%v: %v", args, err)

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -1,0 +1,257 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/cli"
+)
+
+// The acceptance suite for the first-run-after-upgrade notice. agentsync ships
+// through channels with no usable post-install hook (`go install` has none at
+// all), so the binary is the only thing that reliably reaches an upgrading
+// user — which makes the "exactly once, never in the way" contract below the
+// whole feature.
+
+// withVersion stamps a release version for the duration of one test. The
+// package default is "dev", which opts the whole mechanism out.
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := cli.Version
+	cli.Version = v
+	t.Cleanup(func() { cli.Version = prev })
+}
+
+// readLastRun returns the parsed .state/last-run.json, or nil when absent.
+func readLastRun(t *testing.T, tmp string) *struct {
+	Version     string   `json:"version"`
+	NoticesSeen []string `json:"notices_seen"`
+} {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(tmp, ".agentsync", ".state", "last-run.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read last-run.json: %v", err)
+	}
+	var rec struct {
+		Version     string   `json:"version"`
+		NoticesSeen []string `json:"notices_seen"`
+	}
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("parse last-run.json: %v\n%s", err, data)
+	}
+	return &rec
+}
+
+// TestUpgradeNotice_ShownOnceOnUpgrade is the core case: an EXISTING home with
+// no run record is a user upgrading from a version that predates the record, so
+// they see the notice — once.
+func TestUpgradeNotice_ShownOnceOnUpgrade(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init") // the home now exists — this is an upgrade, not a first install
+
+	withVersion(t, "0.11.0")
+
+	stdout, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatalf("version: %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("upgrade notice not shown on stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "agentsync.cc/reference/upgrading/") {
+		t.Errorf("notice does not link to the docs page:\n%s", stderr)
+	}
+	// The notice must never land on stdout — several commands emit a
+	// machine-readable payload there.
+	if strings.Contains(stdout, "migrate subagents") {
+		t.Fatalf("upgrade notice leaked onto stdout:\n%s", stdout)
+	}
+
+	rec := readLastRun(t, tmp)
+	if rec == nil {
+		t.Fatal("last-run.json was not recorded")
+	}
+	if rec.Version != "0.11.0" || len(rec.NoticesSeen) == 0 {
+		t.Fatalf("unexpected record: %+v", rec)
+	}
+
+	// Second run: silent.
+	_, stderr2, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr2, "migrate subagents") {
+		t.Fatalf("upgrade notice repeated on a second run:\n%s", stderr2)
+	}
+}
+
+// TestUpgradeNotice_SilentOnFreshInstall pins the distinction that matters: a
+// user with no config at all has had nothing broken under them, so greeting
+// them with a changelog would be noise.
+func TestUpgradeNotice_SilentOnFreshInstall(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	withVersion(t, "0.11.0")
+
+	// No `init` — the home does not exist.
+	_, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatalf("version: %v\n%s", err, stderr)
+	}
+	if strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("a fresh install must not see the upgrade notice:\n%s", stderr)
+	}
+
+	// It must still record the notices as seen, so that the user's first real
+	// `init` — which creates the home — doesn't retroactively trigger them.
+	if rec := readLastRun(t, tmp); rec != nil && len(rec.NoticesSeen) == 0 {
+		t.Errorf("fresh install recorded no seen notices, so they will fire later: %+v", rec)
+	}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err = runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("notice fired after a fresh install created the home:\n%s", stderr)
+	}
+}
+
+// TestUpgradeNotice_DevBuildIsSilent pins the opt-out that keeps every test,
+// BDD scenario, and local `go build` free of the banner.
+func TestUpgradeNotice_DevBuildIsSilent(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "dev")
+
+	_, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("a dev build must not show the upgrade notice:\n%s", stderr)
+	}
+	if rec := readLastRun(t, tmp); rec != nil {
+		t.Errorf("a dev build must not write a run record: %+v", rec)
+	}
+}
+
+// TestUpgradeNotice_EnvOptOut silences the notice AND declines to record it, so
+// unsetting the variable later still surfaces an unseen notice rather than
+// swallowing it permanently.
+func TestUpgradeNotice_EnvOptOut(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "0.11.0")
+
+	optOut := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "AGENTSYNC_NO_UPGRADE_NOTICE": "1"}
+	_, stderr, err := runCLISplit(t, optOut, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("AGENTSYNC_NO_UPGRADE_NOTICE=1 did not silence the notice:\n%s", stderr)
+	}
+	if rec := readLastRun(t, tmp); rec != nil {
+		t.Errorf("opting out must not record the notices as seen: %+v", rec)
+	}
+
+	// Unsetting it surfaces the still-unseen notice. (t.Setenv persists for the
+	// rest of the test, so the opt-out must be cleared explicitly — omitting the
+	// key would leave the previous run's value in place.)
+	cleared := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "AGENTSYNC_NO_UPGRADE_NOTICE": ""}
+	_, stderr, err = runCLISplit(t, cleared, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("notice was swallowed permanently by a one-off opt-out:\n%s", stderr)
+	}
+}
+
+// TestUpgradeNotice_JSONPayloadStaysClean is the reason the banner goes to
+// stderr: `status --json` is piped into other tools.
+func TestUpgradeNotice_JSONPayloadStaysClean(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	withVersion(t, "0.11.0")
+
+	stdout, stderr, err := runCLISplit(t, env, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("notice should have fired on this run:\n%s", stderr)
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("the upgrade notice corrupted the --json payload: %v\n%s", err, stdout)
+	}
+}
+
+// TestUpgradeNotice_UnwritableStateDoesNotFailCommand pins the best-effort
+// contract: a UX marker must never take a user's command down with it.
+func TestUpgradeNotice_UnwritableStateDoesNotFailCommand(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "0.11.0")
+
+	// Replace .state with a regular FILE so MkdirAll/AtomicWrite cannot succeed
+	// — a uid-independent way to make the record unwritable (the container runs
+	// as root, where a chmod would not bite).
+	stateDir := filepath.Join(tmp, ".agentsync", ".state")
+	if err := os.RemoveAll(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stateDir, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := runCLISplit(t, env, "version"); err != nil {
+		t.Fatalf("an unwritable run record must not fail the command: %v\n%s", err, stderr)
+	}
+}
+
+// TestNoSubcommandOverridesPersistentPreRun is the structural guard the notice
+// depends on: cobra runs only the CLOSEST PersistentPreRunE in the chain, so a
+// subcommand growing its own would silently disable the banner for that command
+// — with nothing failing. Fail loudly here instead.
+func TestNoSubcommandOverridesPersistentPreRun(t *testing.T) {
+	root := cli.NewRoot()
+	if root.PersistentPreRunE == nil {
+		t.Fatal("root has no PersistentPreRunE; the upgrade notice is not wired")
+	}
+	var offenders []string
+	var walk func(c *cobra.Command, path string)
+	walk = func(c *cobra.Command, path string) {
+		for _, sub := range c.Commands() {
+			name := strings.TrimSpace(path + " " + sub.Name())
+			if sub.PersistentPreRunE != nil || sub.PersistentPreRun != nil {
+				offenders = append(offenders, name)
+			}
+			walk(sub, name)
+		}
+	}
+	walk(root, "")
+	if len(offenders) > 0 {
+		t.Fatalf("these subcommands define their own PersistentPreRun(E), which SHADOWS the root's "+
+			"and silently disables the upgrade notice for them: %s\n"+
+			"Call maybePrintUpgradeNotice from the subcommand hook, or move the logic into RunE.",
+			strings.Join(offenders, ", "))
+	}
+}

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -554,3 +554,51 @@ func TestUpgradeNotice_StateOnlyHomeIsNotSilencedForever(t *testing.T) {
 		t.Fatalf("a home that gained a user config was permanently silenced:\n%s", stderr)
 	}
 }
+
+// TestUpgradeNotice_ShellCompletionDoesNotConsumeIt is the regression for the
+// way this feature could have failed for almost everyone who has completions
+// installed.
+//
+// Cobra runs the root PersistentPreRunE for its hidden `__complete` request
+// too, and the generated bash/zsh scripts invoke it as
+// `out=$(eval "${requestComp}" 2>/dev/null)` — stderr DISCARDED. So one TAB
+// after `agentsync ` printed the banner into /dev/null and recorded it as seen,
+// and the user's next real command said nothing. Silently never telling a user
+// their config layout moved is the single outcome this feature exists to
+// prevent.
+func TestUpgradeNotice_ShellCompletionDoesNotConsumeIt(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "0.11.0")
+
+	// A home created by a version that predates the record — a real upgrader.
+	if err := os.Remove(filepath.Join(tmp, ".agentsync", ".state", "last-run.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	// Every completion entry point, including a bare TAB and a partial word.
+	for _, args := range [][]string{
+		{"__complete", ""},
+		{"__complete", "ap"},
+		{"__completeNoDesc", ""},
+		{"completion", "bash"},
+	} {
+		if _, _, err := runCLISplit(t, env, args...); err != nil {
+			t.Fatalf("%v: %v", args, err)
+		}
+		if rec := readLastRun(t, tmp); rec != nil && len(rec.NoticesSeen) > 0 {
+			t.Fatalf("`%v` recorded the notice as seen. Completion output is consumed by a shell "+
+				"with stderr discarded, so the user never saw it — and now never will: %+v", args, rec)
+		}
+	}
+
+	// The user's next real command still gets it.
+	_, stderr, err := runCLISplit(t, env, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("completion consumed the notice; the real command shows nothing:\n%s", stderr)
+	}
+}

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -79,8 +79,14 @@ func TestUpgradeNotice_ShownOnceOnUpgrade(t *testing.T) {
 	if rec == nil {
 		t.Fatal("last-run.json was not recorded")
 	}
-	if rec.Version != "0.11.0" || len(rec.NoticesSeen) == 0 {
-		t.Fatalf("unexpected record: %+v", rec)
+	// Pin the literal ID, not just "some id". The ID is the real key — a rename
+	// re-shows the notice to everyone who already dismissed it — so a test that
+	// only counts entries would not notice the one edit that matters.
+	if rec.Version != "0.11.0" {
+		t.Errorf("recorded version = %q, want 0.11.0", rec.Version)
+	}
+	if len(rec.NoticesSeen) != 1 || rec.NoticesSeen[0] != "0.11.0-cli-surface" {
+		t.Fatalf("recorded notice ids = %v, want exactly [0.11.0-cli-surface]", rec.NoticesSeen)
 	}
 
 	// Second run: silent.
@@ -110,10 +116,18 @@ func TestUpgradeNotice_SilentOnFreshInstall(t *testing.T) {
 		t.Fatalf("a fresh install must not see the upgrade notice:\n%s", stderr)
 	}
 
-	// It must still record the notices as seen, so that the user's first real
-	// `init` — which creates the home — doesn't retroactively trigger them.
-	if rec := readLastRun(t, tmp); rec != nil && len(rec.NoticesSeen) == 0 {
-		t.Errorf("fresh install recorded no seen notices, so they will fire later: %+v", rec)
+	// It must write NOTHING. Creating .state/ here would materialize the home
+	// and make the user's first `agentsync init` refuse ("already contains
+	// files") — so the contract is "return without writing", and `init` seeds
+	// the record itself.
+	//
+	// The previous assertion here (`rec != nil && len(rec.NoticesSeen) == 0`)
+	// stated the opposite in its comment AND passed vacuously: on the correct
+	// behavior rec is nil, so the guard short-circuits and asserts nothing, and
+	// on the regression (a full record written) it also passes. Pin rec == nil.
+	if rec := readLastRun(t, tmp); rec != nil {
+		t.Errorf("a fresh install must write no run record at all (it would materialize the home "+
+			"and break `init`); got: %+v", rec)
 	}
 	if _, err := runCLI(t, env, "init"); err != nil {
 		t.Fatal(err)
@@ -190,22 +204,73 @@ func TestUpgradeNotice_JSONPayloadStaysClean(t *testing.T) {
 	mustRun(t, env, "agent", "add", "claude")
 	withVersion(t, "0.11.0")
 
-	stdout, stderr, err := runCLISplit(t, env, "status", "--json")
-	if err != nil {
-		t.Fatalf("status --json: %v\n%s", err, stderr)
-	}
-	if !strings.Contains(stderr, "migrate subagents") {
-		t.Fatalf("notice should have fired on this run:\n%s", stderr)
-	}
-	var payload any
-	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
-		t.Fatalf("the upgrade notice corrupted the --json payload: %v\n%s", err, stdout)
+	// Every --json surface, not just one: the banner fires on the FIRST run, so
+	// whichever machine-readable command a user happens to run first is the one
+	// that would get a corrupted payload.
+	for _, args := range [][]string{
+		{"status", "--json"},
+		{"diff", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			// Reset the record so the notice fires on THIS run.
+			_ = os.Remove(filepath.Join(tmp, ".agentsync", ".state", "last-run.json"))
+
+			stdout, stderr, err := runCLISplit(t, env, args...)
+			if err != nil {
+				t.Fatalf("%v: %v\n%s", args, err, stderr)
+			}
+			if !strings.Contains(stderr, "migrate subagents") {
+				t.Fatalf("notice should have fired on this run:\n%s", stderr)
+			}
+			var payload any
+			if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+				t.Fatalf("the upgrade notice corrupted the --json payload: %v\n%s", err, stdout)
+			}
+		})
 	}
 }
 
-// TestUpgradeNotice_UnwritableStateDoesNotFailCommand pins the best-effort
+// TestUpgradeNotice_ProjectScopeUserSeesItAfterApply pins why keying off the
+// USER home is right even for someone who only ever works at project scope.
+//
+// apply records state centrally under ~/.agentsync/.state/ keyed by project
+// root, so a project-scope user has a user home from their first apply onward.
+// The only window where they miss the notice is before that first apply — when
+// agentsync has rendered nothing for them, so nothing has broken under them.
+func TestUpgradeNotice_ProjectScopeUserSeesItAfterApply(t *testing.T) {
+	tmp := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	withVersion(t, "0.11.0")
+
+	mustRun(t, env, "init", "--project", proj)
+	mustRun(t, env, "agent", "add", "claude", "--project", proj)
+	mustRun(t, env, "apply", "--project", proj)
+
+	// The first apply materialized the central state home; clear the record so
+	// this stands in for an upgrading project-scope user.
+	if err := os.Remove(filepath.Join(tmp, ".agentsync", ".state", "last-run.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := runCLISplit(t, env, "status", "--project", proj)
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "migrate subagents") {
+		t.Fatalf("a project-scope user who has applied must see the notice:\n%s", stderr)
+	}
+}
+
+// TestUpgradeNotice_UnreadableStateDoesNotFailCommand pins the best-effort
 // contract: a UX marker must never take a user's command down with it.
-func TestUpgradeNotice_UnwritableStateDoesNotFailCommand(t *testing.T) {
+//
+// Named for what it actually exercises. With .state replaced by a regular file,
+// ReadFile fails with ENOTDIR — which is NOT os.ErrNotExist — so LoadLastRun
+// returns an I/O error and maybePrintUpgradeNotice bails long before
+// MkdirAll/SaveLastRun. It is the unreadable path, not the unwritable one; the
+// old name meant the write-failure branch looked covered when it was not.
+func TestUpgradeNotice_UnreadableStateDoesNotFailCommand(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	mustRun(t, env, "init")
@@ -223,7 +288,144 @@ func TestUpgradeNotice_UnwritableStateDoesNotFailCommand(t *testing.T) {
 	}
 
 	if _, stderr, err := runCLISplit(t, env, "version"); err != nil {
-		t.Fatalf("an unwritable run record must not fail the command: %v\n%s", err, stderr)
+		t.Fatalf("an unreadable run record must not fail the command: %v\n%s", err, stderr)
+	}
+}
+
+// TestUpgradeNotice_CorruptRecordStillShowsAndRepairs is the case that made the
+// difference between "the notice shows again later" and "the user never learns
+// their config layout moved".
+//
+// A truncated / empty / wrong-shaped last-run.json is the classic crash- or
+// full-disk artifact. Treating that like an I/O failure suppressed the notice
+// PERMANENTLY — the file was never rewritten, so every subsequent run hit the
+// same parse error. A record that cannot be parsed carries no information, so
+// the honest reading is "nothing has been shown here": print, then overwrite.
+func TestUpgradeNotice_CorruptRecordStillShowsAndRepairs(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"empty file (crash mid-write)", ""},
+		{"truncated json", `{"version":"0.10.1","notices_`},
+		{"wrong shape: array", `[]`},
+		{"wrong shape: string", `"nope"`},
+		{"wrong field types", `{"version":42,"notices_seen":"x"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+			mustRun(t, env, "init")
+			withVersion(t, "0.11.0")
+
+			rec := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
+			if err := os.WriteFile(rec, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, stderr, err := runCLISplit(t, env, "version")
+			if err != nil {
+				t.Fatalf("version: %v\n%s", err, stderr)
+			}
+			if !strings.Contains(stderr, "migrate subagents") {
+				t.Fatalf("a corrupt record must not suppress the notice:\n%s", stderr)
+			}
+			// And it must be REPAIRED, or the notice repeats forever instead.
+			got := readLastRun(t, tmp)
+			if got == nil || len(got.NoticesSeen) == 0 {
+				t.Fatalf("corrupt record was not repaired: %+v", got)
+			}
+			_, stderr2, err := runCLISplit(t, env, "version")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(stderr2, "migrate subagents") {
+				t.Errorf("notice repeated after the record was repaired:\n%s", stderr2)
+			}
+		})
+	}
+}
+
+// TestUpgradeNotice_KeyedByIDNotVersion pins the central design decision, which
+// nothing exercised: the show/hide choice is made by notice ID, never by
+// comparing versions.
+//
+// It matters in both directions. A user who jumps 0.9 → 0.12 must still see a
+// notice introduced in 0.11 (version comparison would be tempting and wrong),
+// and a machine that has already seen an ID must stay silent even when the
+// recorded version looks old.
+func TestUpgradeNotice_KeyedByIDNotVersion(t *testing.T) {
+	t.Run("unseen id shows even though the recorded version is current", func(t *testing.T) {
+		tmp := t.TempDir()
+		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		withVersion(t, "0.11.0")
+		writeLastRun(t, tmp, `{"version":"0.11.0","notices_seen":["some-other-id"]}`)
+
+		_, stderr, err := runCLISplit(t, env, "version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stderr, "migrate subagents") {
+			t.Fatalf("an UNSEEN notice id must show regardless of the recorded version:\n%s", stderr)
+		}
+	})
+
+	t.Run("seen id stays silent even though the recorded version is ancient", func(t *testing.T) {
+		tmp := t.TempDir()
+		env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		withVersion(t, "0.11.0")
+		writeLastRun(t, tmp, `{"version":"0.9.0","notices_seen":["0.11.0-cli-surface"]}`)
+
+		_, stderr, err := runCLISplit(t, env, "version")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(stderr, "migrate subagents") {
+			t.Fatalf("a SEEN notice id must stay silent regardless of the recorded version:\n%s", stderr)
+		}
+	})
+}
+
+// writeLastRun plants a run record verbatim.
+func writeLastRun(t *testing.T, tmp, body string) {
+	t.Helper()
+	p := filepath.Join(tmp, ".agentsync", ".state", "last-run.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUpgradeNoticeTableIsWellFormed guards the append-only rule that the table
+// states but nothing enforced. An ID is the durable key: renaming one re-shows
+// its notice to every user who already dismissed it, and duplicating one hides
+// the second silently.
+func TestUpgradeNoticeTableIsWellFormed(t *testing.T) {
+	ids := map[string]bool{}
+	for _, n := range cli.UpgradeNoticesForTest() {
+		switch {
+		case n.ID == "":
+			t.Errorf("notice with empty ID (%q): the ID is the recorded key", n.Headline)
+		case ids[n.ID]:
+			t.Errorf("duplicate notice ID %q — the second is silently unreachable", n.ID)
+		}
+		ids[n.ID] = true
+		if n.Since == "" {
+			t.Errorf("notice %q has no Since; the banner prints it", n.ID)
+		}
+		if n.Headline == "" {
+			t.Errorf("notice %q has no Headline", n.ID)
+		}
+		if len(n.Actions) == 0 {
+			t.Errorf("notice %q lists no actions, so it tells the user what broke but not what to do", n.ID)
+		}
+		if !strings.HasPrefix(n.Path, "/") {
+			t.Errorf("notice %q Path %q must start with '/' (it is appended to the docs base URL)", n.ID, n.Path)
+		}
+	}
+	if len(ids) == 0 {
+		t.Fatal("no notices defined; this guard would vacuously pass")
 	}
 }
 
@@ -253,5 +455,52 @@ func TestNoSubcommandOverridesPersistentPreRun(t *testing.T) {
 			"and silently disables the upgrade notice for them: %s\n"+
 			"Call maybePrintUpgradeNotice from the subcommand hook, or move the logic into RunE.",
 			strings.Join(offenders, ", "))
+	}
+}
+
+// TestUpgradeNotice_RecordIsGitignored pins the docs' flat claim that the run
+// record "never travels with a dotfiles repo".
+//
+// The notice path is a SECOND place that can create `.state/` — `init` is the
+// other — and it fires precisely for homes that already existed, which is to
+// say homes created by a version that may predate the .gitignore scaffolding.
+// Without the rule, one `git add -A` in a dotfiles repo commits one machine's
+// run marker and carries it to every other machine, where it silently
+// suppresses the notice.
+func TestUpgradeNotice_RecordIsGitignored(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	withVersion(t, "0.11.0")
+
+	home := filepath.Join(tmp, ".agentsync")
+	// Simulate the target population: a pre-existing dotfiles home whose
+	// .gitignore predates the .state rule (or never had one).
+	if err := os.Remove(filepath.Join(home, ".gitignore")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, ".state")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := runCLISplit(t, env, "version"); err != nil {
+		t.Fatalf("version: %v\n%s", err, stderr)
+	}
+	if readLastRun(t, tmp) == nil {
+		t.Fatal("no record was written, so this test proves nothing about ignoring it")
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".gitignore"))
+	if err != nil {
+		t.Fatalf("the notice created .state/ without restoring the .gitignore rule: %v", err)
+	}
+	var ignored bool
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "/.state/" {
+			ignored = true
+		}
+	}
+	if !ignored {
+		t.Fatalf("`.state/` is not gitignored, so the run record would be committed:\n%s", data)
 	}
 }

--- a/internal/render/writer_lint_test.go
+++ b/internal/render/writer_lint_test.go
@@ -33,6 +33,7 @@ func TestNoDirectAtomicWriteOutsideAllowedFiles(t *testing.T) {
 		"internal/state/store.go":          true,
 		"internal/state/lastrun.go":        true, // writes .state/last-run.json (agentsync's own run record)
 		"internal/secrets/age.go":          true, // writes secrets.age under ~/.agentsync/
+		"internal/cli/init.go":             true, // writes ~/.agentsync/.gitignore (canonical source); atomic because the lock-free upgrade-notice path also calls it
 		"internal/cli/plugin.go":           true,
 		"internal/cli/marketplace.go":      true,
 		"internal/cli/agent.go":            true,

--- a/internal/render/writer_lint_test.go
+++ b/internal/render/writer_lint_test.go
@@ -31,6 +31,7 @@ func TestNoDirectAtomicWriteOutsideAllowedFiles(t *testing.T) {
 		"internal/render/writer.go":        true,
 		"internal/source/writer.go":        true,
 		"internal/state/store.go":          true,
+		"internal/state/lastrun.go":        true, // writes .state/last-run.json (agentsync's own run record)
 		"internal/secrets/age.go":          true, // writes secrets.age under ~/.agentsync/
 		"internal/cli/plugin.go":           true,
 		"internal/cli/marketplace.go":      true,

--- a/internal/render/writer_lint_test.go
+++ b/internal/render/writer_lint_test.go
@@ -33,7 +33,6 @@ func TestNoDirectAtomicWriteOutsideAllowedFiles(t *testing.T) {
 		"internal/state/store.go":          true,
 		"internal/state/lastrun.go":        true, // writes .state/last-run.json (agentsync's own run record)
 		"internal/secrets/age.go":          true, // writes secrets.age under ~/.agentsync/
-		"internal/cli/init.go":             true, // writes ~/.agentsync/.gitignore (canonical source); atomic because the lock-free upgrade-notice path also calls it
 		"internal/cli/plugin.go":           true,
 		"internal/cli/marketplace.go":      true,
 		"internal/cli/agent.go":            true,

--- a/internal/state/lastrun.go
+++ b/internal/state/lastrun.go
@@ -61,22 +61,45 @@ func (l *LastRun) MarkSeen(id string) {
 	sort.Strings(l.NoticesSeen)
 }
 
-// LoadLastRun reads the run record at path. A MISSING file returns (nil, nil):
-// absence is meaningful — it distinguishes "this machine has run a version that
-// predates the record" from "this machine has a record". A corrupt file is
-// reported as an error; callers degrade to skipping the notice rather than
-// failing the command.
+// ErrCorruptLastRun reports a run record that exists but cannot be parsed.
+//
+// It is distinguished from an I/O error on purpose. A record is a UX marker with
+// no authority: an unparseable one carries no information, so the honest reading
+// is "this machine has shown nothing", NOT "say nothing forever". Treating a
+// parse failure like an I/O failure meant a single truncated file — the classic
+// crash-mid-write artifact, or an empty file after a full disk — suppressed the
+// notice permanently, silently contradicting the documented contract that a
+// corrupt record only means the notice shows again later.
+//
+// LoadLastRun therefore returns a USABLE zero record alongside this error, so a
+// caller that wants the forgiving behavior can take it and overwrite the file,
+// while one that wants to bail can still check the error.
+var ErrCorruptLastRun = errors.New("corrupt last-run record")
+
+// LoadLastRun reads the run record at path.
+//
+// It always returns a non-nil record, so callers never nil-check before calling
+// Seen/MarkSeen. A MISSING file yields the zero record with a nil error —
+// absence is not an error condition, and "has this machine seen notice X?" is
+// correctly "no" for a machine with no record at all. (Distinguishing a fresh
+// install from an upgrade is NOT this function's job: that is the existence of
+// the agentsync home, checked by the caller.)
+//
+// A record that exists but does not parse yields the zero record wrapped with
+// ErrCorruptLastRun. Any other failure (a real I/O error — .state is a regular
+// file, permissions, a bad mount) returns the zero record and that error;
+// callers skip the notice rather than fail the command.
 func LoadLastRun(path string) (*LastRun, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+			return &LastRun{}, nil
 		}
-		return nil, fmt.Errorf("read %s: %w", path, err)
+		return &LastRun{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	var l LastRun
 	if err := json.Unmarshal(data, &l); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return &LastRun{}, fmt.Errorf("%w at %s: %w", ErrCorruptLastRun, path, err)
 	}
 	return &l, nil
 }

--- a/internal/state/lastrun.go
+++ b/internal/state/lastrun.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/spxrogers/agentsync/internal/iox"
+)
+
+// LastRunFile is the basename of the per-machine run record inside .state/.
+const LastRunFile = "last-run.json"
+
+// LastRun records what the last agentsync invocation on this machine was, so a
+// release can tell a user once — and only once — what changed under them.
+//
+// It is deliberately a SEPARATE file from targets.json rather than a field on
+// Targets, for three reasons:
+//
+//   - targets.json is drift state guarded by SchemaVersion; a UX marker has no
+//     business gating on (or bumping) that version.
+//   - targets.json is written only by the MUTATING commands. A read-only
+//     `status` must be able to record that it showed the notice, or the notice
+//     repeats forever for a user whose daily loop never applies.
+//   - a corrupt or unwritable run record must never be able to take the drift
+//     state down with it. Callers treat every error here as "skip the notice".
+//
+// It lives under .state/, which `init` gitignores, so a committed dotfiles repo
+// never carries one machine's run record to another.
+type LastRun struct {
+	// Version is the agentsync version that last ran on this machine. Empty on
+	// a record written by a build with no version stamped.
+	Version string `json:"version"`
+	// NoticesSeen holds the ids of the upgrade notices already shown, so a
+	// version jump that skips releases still shows each notice exactly once and
+	// a re-install never re-shows one.
+	NoticesSeen []string `json:"notices_seen,omitempty"`
+}
+
+// Seen reports whether the notice id has already been shown on this machine.
+func (l *LastRun) Seen(id string) bool {
+	if l == nil {
+		return false
+	}
+	for _, s := range l.NoticesSeen {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkSeen adds id to the seen set (idempotent, kept sorted for a stable file).
+func (l *LastRun) MarkSeen(id string) {
+	if l == nil || id == "" || l.Seen(id) {
+		return
+	}
+	l.NoticesSeen = append(l.NoticesSeen, id)
+	sort.Strings(l.NoticesSeen)
+}
+
+// LoadLastRun reads the run record at path. A MISSING file returns (nil, nil):
+// absence is meaningful — it distinguishes "this machine has run a version that
+// predates the record" from "this machine has a record". A corrupt file is
+// reported as an error; callers degrade to skipping the notice rather than
+// failing the command.
+func LoadLastRun(path string) (*LastRun, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var l LastRun
+	if err := json.Unmarshal(data, &l); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &l, nil
+}
+
+// SaveLastRun writes the run record atomically. Callers MUST treat a failure as
+// non-fatal — a read-only home or a full disk must not fail the user's command
+// over a UX marker.
+func SaveLastRun(path string, l *LastRun) error {
+	if l == nil {
+		return fmt.Errorf("save nil last-run record")
+	}
+	data, err := json.MarshalIndent(l, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal last-run: %w", err)
+	}
+	return iox.AtomicWrite(path, append(data, '\n'), 0o644)
+}

--- a/internal/state/lastrun_test.go
+++ b/internal/state/lastrun_test.go
@@ -1,0 +1,186 @@
+package state_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// The run record is a UX marker with no authority over anything else, so its
+// whole contract is "degrade usefully". These pin the degradations.
+
+func TestLoadLastRun(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	cases := []struct {
+		name        string
+		write       *string // nil = do not create the file
+		wantCorrupt bool
+		wantErr     bool
+		check       func(t *testing.T, l *state.LastRun)
+	}{
+		{
+			name:  "missing file is not an error",
+			write: nil,
+			check: func(t *testing.T, l *state.LastRun) {
+				if l.Version != "" || len(l.NoticesSeen) != 0 {
+					t.Errorf("missing file should yield the zero record, got %+v", l)
+				}
+				// The point of returning a usable value: no nil-check needed.
+				if l.Seen("anything") {
+					t.Error("a machine with no record has seen nothing")
+				}
+			},
+		},
+		{
+			name:  "well-formed record round-trips",
+			write: ptr(`{"version":"0.11.0","notices_seen":["a","b"]}`),
+			check: func(t *testing.T, l *state.LastRun) {
+				if l.Version != "0.11.0" || !l.Seen("a") || !l.Seen("b") {
+					t.Errorf("unexpected record: %+v", l)
+				}
+				if l.Seen("c") {
+					t.Error("Seen reported an id that is not in the record")
+				}
+			},
+		},
+		{
+			name:  "JSON null yields a usable zero value",
+			write: ptr(`null`),
+			check: func(t *testing.T, l *state.LastRun) {
+				if l.Seen("x") {
+					t.Error("null record should have seen nothing")
+				}
+			},
+		},
+		{
+			name:        "empty file is corrupt, not fatal",
+			write:       ptr(``),
+			wantCorrupt: true,
+		},
+		{
+			name:        "truncated json is corrupt",
+			write:       ptr(`{"version":"0.11.0","notices_`),
+			wantCorrupt: true,
+		},
+		{
+			name:        "wrong shape (array) is corrupt",
+			write:       ptr(`["nope"]`),
+			wantCorrupt: true,
+		},
+		{
+			name:        "wrong field types are corrupt",
+			write:       ptr(`{"version":42}`),
+			wantCorrupt: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "last-run.json")
+			if tc.write != nil {
+				if err := os.WriteFile(p, []byte(*tc.write), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := state.LoadLastRun(p)
+			// The contract that makes callers simple: NEVER nil, whatever happens.
+			if got == nil {
+				t.Fatal("LoadLastRun returned a nil record; callers rely on it never being nil")
+			}
+			if tc.wantCorrupt {
+				if !errors.Is(err, state.ErrCorruptLastRun) {
+					t.Fatalf("want ErrCorruptLastRun, got %v", err)
+				}
+				// A corrupt record must still hand back something usable, so the
+				// caller can show the notice and overwrite the file.
+				if got.Seen("anything") {
+					t.Error("a corrupt record must not claim to have seen a notice")
+				}
+				return
+			}
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.check != nil {
+				tc.check(t, got)
+			}
+		})
+	}
+}
+
+// TestLoadLastRun_UnreadableIsAPlainError distinguishes "cannot read" from
+// "read it, cannot parse" — the caller shows the notice for one and stays quiet
+// for the other, so conflating them is the bug this separation prevents.
+func TestLoadLastRun_UnreadableIsAPlainError(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	// A path whose PARENT is a regular file: ReadFile fails ENOTDIR, which is
+	// not os.ErrNotExist and not a parse failure.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := state.LoadLastRun(filepath.Join(blocker, "last-run.json"))
+	if err == nil {
+		t.Fatal("an unreadable path must report an error")
+	}
+	if errors.Is(err, state.ErrCorruptLastRun) {
+		t.Error("an I/O failure must NOT be reported as a corrupt record: the caller treats them differently")
+	}
+	if got == nil {
+		t.Error("LoadLastRun must never return a nil record")
+	}
+}
+
+func TestMarkSeenAndSave(t *testing.T) {
+	testenv.RequireContainer(t)
+
+	t.Run("MarkSeen is idempotent and sorted", func(t *testing.T) {
+		var l state.LastRun
+		l.MarkSeen("b")
+		l.MarkSeen("a")
+		l.MarkSeen("b") // duplicate
+		l.MarkSeen("")  // ignored
+		if len(l.NoticesSeen) != 2 || l.NoticesSeen[0] != "a" || l.NoticesSeen[1] != "b" {
+			t.Fatalf("want sorted unique [a b], got %v", l.NoticesSeen)
+		}
+	})
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		var l *state.LastRun
+		if l.Seen("x") {
+			t.Error("nil record cannot have seen anything")
+		}
+		l.MarkSeen("x") // must not panic
+	})
+
+	t.Run("save then load round-trips", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "last-run.json")
+		rec := &state.LastRun{Version: "0.11.0"}
+		rec.MarkSeen("0.11.0-cli-surface")
+		if err := state.SaveLastRun(p, rec); err != nil {
+			t.Fatal(err)
+		}
+		got, err := state.LoadLastRun(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Version != "0.11.0" || !got.Seen("0.11.0-cli-surface") {
+			t.Fatalf("round trip lost data: %+v", got)
+		}
+	})
+
+	t.Run("saving nil is refused, not a panic", func(t *testing.T) {
+		if err := state.SaveLastRun(filepath.Join(t.TempDir(), "x.json"), nil); err == nil {
+			t.Error("SaveLastRun(nil) must return an error")
+		}
+	})
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -1,5 +1,6 @@
-// Package state persists agentsync's last-applied hashes and marketplace/plugin
-// pinning to ~/.agentsync/.state/targets.json.
+// Package state persists agentsync's own bookkeeping under ~/.agentsync/.state/:
+// the last-applied hashes and marketplace/plugin pinning in targets.json, and
+// the per-machine run record in last-run.json (see lastrun.go).
 package state
 
 import "time"

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -158,6 +158,7 @@ export default defineConfig({
 						{ label: 'CLI commands', slug: 'reference/cli' },
 						{ label: 'Configuration & layout', slug: 'reference/configuration' },
 						{ label: 'Environment variables', slug: 'reference/environment' },
+						{ label: 'Upgrading', slug: 'reference/upgrading' },
 					],
 				},
 				{

--- a/website/src/content/docs/reference/environment.mdx
+++ b/website/src/content/docs/reference/environment.mdx
@@ -18,6 +18,7 @@ the rest are escape hatches you'll rarely need.
 | `AGENTSYNC_ALLOW_SYMLINK_DEST=1` | Write through symlinked destinations (e.g. chezmoi-managed files). |
 | `AGENTSYNC_ALLOW_INSECURE_URLS=1` | Accept `http://` / `git://` plugin & marketplace sources. |
 | `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` | Let `check` validate reference *shape* only, skipping resolution (CI without an age key). |
+| `AGENTSYNC_NO_UPGRADE_NOTICE=1` | Never show the one-time [upgrade notice](/reference/upgrading/). |
 
 ## All overrides
 
@@ -32,6 +33,7 @@ the rest are escape hatches you'll rarely need.
 | `AGENTSYNC_ALLOW_OFFLINE_VERIFY=1` | Skip `${secret:…}` resolution in `check`; reference *shape* (well-formed `${secret:…}`/`${env:…}`) is still validated (CI without an age key). |
 | `AGENTSYNC_AGE_SKIP_PERM_CHECK=1` | Skip the 0600 mode check on the age identity file (ACL'd NFS). |
 | `AGENTSYNC_MAX_TARBALL_MB=<N>` | Override the per-tarball decompressed-bytes cap (default 512; 0 disables). |
+| `AGENTSYNC_NO_UPGRADE_NOTICE=1` | Suppress the one-time first-run-after-upgrade notice (see [Upgrading](/reference/upgrading/)). Nothing is printed and nothing is recorded, so unsetting it later still surfaces an unseen notice. |
 | `AGENTSYNC_TEST_IN_CONTAINER=1` | Bypass the host test guard (use only with `go test -run` for a single case). |
 
 <Aside type="caution" title="The ALLOW_* flags loosen a safety default">

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -135,9 +135,11 @@ the daily loop vanished at the one step that writes. `apply`, `status`, `diff`,
   likely to sit in a cron line. It was cut before shipping: it would have been
   the *only* alias in a release whose point is that the renames are hard, and
   "no aliases except this one" is a worse rule to remember than "no aliases".
-  A cron line calling `agentsync update` now fails as an unknown command — which
-  is louder, and more useful, than a warning printed to a stderr the scheduler
-  throws away.
+  A cron line calling `agentsync update` now fails as an unknown command, and
+  "louder" here means something specific: what a scheduler acts on is the **exit
+  status**, not the text. A deprecation warning would have gone to the same
+  discarded stderr as everything else, leaving the job green while doing nothing;
+  a non-zero exit is the one signal cron, systemd, and CI all actually surface.
 - **`explain` has no alias either**, and it is the one change that can break a
   script *silently*: the top-level name still exists but now answers a
   *different* question (see below), so `agentsync explain <plugin-id>` fails

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -21,6 +21,15 @@ newest first. It is what the CLI's one-time upgrade notice links to.
 	dotfiles repo). A brand-new install never sees it — nothing can have broken
 	under a user who has no config yet. Silence it permanently with
 	`AGENTSYNC_NO_UPGRADE_NOTICE=1`.
+
+	Each notice is keyed by a stable **id**, never by comparing versions, so
+	jumping several releases still shows every notice you missed. A record that
+	is missing or unreadable just means the notice shows again later — it is
+	never a reason to fail your command.
+
+	*Maintainers: every section on this page pairs with an entry in
+	`upgradeNotices` (`internal/cli/upgrade_notice.go`). Add both, and never
+	rename a shipped id.*
 </Aside>
 
 ## 0.11.0

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -44,7 +44,7 @@ rather than working quietly for a while. Scripts and CI pipelines need updating.
 | `agentsync plugin install` | `agentsync plugin add` |
 | `agentsync secrets …` | `agentsync secret …` |
 | `agentsync explain <plugin>` | `agentsync plugin explain <plugin>` |
-| `agentsync update` | `agentsync plugin outdated` *(deprecated alias kept for one minor)* |
+| `agentsync update` | `agentsync plugin outdated` |
 | `~/.agentsync/agents/` | `~/.agentsync/subagents/` *(run `agentsync migrate subagents`)* |
 
 ### The canonical subagent directory moved: `agents/` → `subagents/`
@@ -130,13 +130,18 @@ the daily loop vanished at the one step that writes. `apply`, `status`, `diff`,
 | `agentsync explain <plugin>` | `agentsync plugin explain <plugin>` |
 | `agentsync explain --list` | `agentsync plugin list` |
 
-- **`update` still works for one more minor**, forwarding with a warning that
-  names the replacement — including `--apply`, `--auto-safe`, `--scope`, and
-  `--project`, so an existing cron line keeps working. Move it over anyway.
-- **`explain` has no alias.** The top-level name now answers a *different*
-  question — see below — so `agentsync explain <plugin-id>` fails from this
-  release. This is the one change that can break a script silently, which is
-  most of why the upgrade notice exists.
+- **`update` was removed, with no alias.** A draft of this release kept a
+  deprecated forwarding alias for one minor, since `update` is the spelling most
+  likely to sit in a cron line. It was cut before shipping: it would have been
+  the *only* alias in a release whose point is that the renames are hard, and
+  "no aliases except this one" is a worse rule to remember than "no aliases".
+  A cron line calling `agentsync update` now fails as an unknown command — which
+  is louder, and more useful, than a warning printed to a stderr the scheduler
+  throws away.
+- **`explain` has no alias either**, and it is the one change that can break a
+  script *silently*: the top-level name still exists but now answers a
+  *different* question (see below), so `agentsync explain <plugin-id>` fails
+  from this release. That is most of why the upgrade notice exists.
 - **`plugin upgrade <id>` now re-applies.** It used to re-fetch and leave your
   agents stale until the next `apply`; both it and `--all` now finish by
   re-applying, so one verb has one ending state.

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -1,0 +1,149 @@
+---
+title: Upgrading
+description: What changed between agentsync releases, and the exact command to run. This is the page the CLI's first-run-after-upgrade notice links to.
+sidebar:
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page lists every change that needs you to *do* something after an upgrade,
+newest first. It is what the CLI's one-time upgrade notice links to.
+
+<Aside type="note" title="How the notice works">
+	agentsync ships through channels with no usable post-install hook — `go
+	install` has none at all, a Homebrew cask's caveats print only at install
+	time, Scoop has nothing — so the **binary tells you itself**, on stderr, the
+	first time you run a version carrying a notice you haven't seen.
+
+	It is shown **once per machine** and recorded in
+	`~/.agentsync/.state/last-run.json` (gitignored, so it never travels with a
+	dotfiles repo). A brand-new install never sees it — nothing can have broken
+	under a user who has no config yet. Silence it permanently with
+	`AGENTSYNC_NO_UPGRADE_NOTICE=1`.
+</Aside>
+
+## 0.11.0
+
+The v1.x CLI surface was locked in this release, so several names moved. All of
+them are **hard renames with no aliases** — the old spellings fail, loudly,
+rather than working quietly for a while. Scripts and CI pipelines need updating.
+
+| Old | New |
+|---|---|
+| `agentsync verify` | `agentsync check` |
+| `agentsync plugin install` | `agentsync plugin add` |
+| `agentsync secrets …` | `agentsync secret …` |
+| `agentsync explain <plugin>` | `agentsync plugin explain <plugin>` |
+| `agentsync update` | `agentsync plugin outdated` *(deprecated alias kept for one minor)* |
+| `~/.agentsync/agents/` | `~/.agentsync/subagents/` *(run `agentsync migrate subagents`)* |
+
+### The canonical subagent directory moved: `agents/` → `subagents/`
+
+The canonical tree carried the `[agents]` **harness registry** (in
+`agentsync.toml`) and the **subagent** files one directory apart — the same word
+naming two different types. Only the subagent side moved.
+
+```bash
+agentsync migrate subagents                        # your ~/.agentsync tree
+agentsync migrate subagents --project ~/code/repo  # a project's committed tree
+```
+
+Run it once per tree. It moves the files **and** rewrites that tree's recorded
+`source_id` values in one step. If a file exists under both `agents/` and
+`subagents/` it refuses and lists the collisions — nothing is ever overwritten.
+After a user-scope move, commit the rename: `~/.agentsync` is usually a dotfiles
+repo.
+
+Until you migrate, **every command that loads the source refuses**, naming this
+command, and `doctor` reports it as a failing check. That is deliberate: an
+unmigrated tree loads with *zero* subagents, and one `apply` would then delete
+every subagent it had already rendered.
+
+**Nothing else named `agents` changed.** The `[agents]` table, `--agents` on
+`status`/`diff`/`mcp add`, the `agents` field on MCP/LSP servers, the `agents`
+array in `status --json`, and the `agentsync agent` command group are all
+exactly as they were. Rendered *destination* paths are untouched too — every
+harness spells its own directory `agents/`, so the mapping is now deliberately
+asymmetric (`subagents/reviewer.md` → `~/.claude/agents/reviewer.md`).
+
+### `verify` is now `check`
+
+`verify` and `doctor` overlapped with no stated boundary. They now split along
+the axis they actually differ on: **`doctor` validates your machine** (PATH,
+home/state writability, adapter detection, secrets backend, destination git
+state); **`check` validates your config** (schema lint plus every
+`${secret:…}`/`${env:…}` reference, scope-aware). Reach for `doctor` when
+something is *set up* wrong and `check` when something is *written* wrong.
+
+`AGENTSYNC_ALLOW_OFFLINE_VERIFY` keeps its name — it names the behavior, not the
+command.
+
+### The noun groups share one verb set
+
+`plugin install` became `plugin add` (every other group creates with `add`, and
+"install" wrongly suggested installing into the agent), and the `secrets` group
+became singular `secret`. Both are hard renames.
+
+Two gaps closed at the same time: **`mcp enable` / `mcp disable`** (the
+`enabled` field already existed and the loader already read it — only a
+hand-edit could flip it), and **`secret list` / `secret remove`** (previously
+`secret edit`, which decrypts the whole vault into `$EDITOR`, was the only way
+to see or delete a key). `secret list` prints **keys only**.
+
+### Every component you can author, you can now list
+
+`skill`, `subagent`, `command`, `hook`, and `lsp` each gained `list` (and `ls`).
+There is no `add` for them on purpose — unlike an MCP server, none is
+flag-authorable.
+
+### `--scope` / `--project` are root flags
+
+Declared once, inherited everywhere. `mcp add … --scope project` now actually
+writes the project tree (it used to silently write the user tree), and a command
+that *cannot* honor scope — `doctor`, `revert`, `version`, and the `plugin` /
+`marketplace` / `secret` groups — refuses the flag with the reason instead of
+ignoring it.
+
+### `--agents` works on `apply` now
+
+`apply` had no `--agents` while `status` / `diff` did, so the filter you use in
+the daily loop vanished at the one step that writes. `apply`, `status`, `diff`,
+`reconcile`, and `revert` all take it now, with identical parsing.
+
+### Plugin lifecycle verbs moved under `plugin`
+
+| Before | After |
+|---|---|
+| `agentsync update` | `agentsync plugin outdated` |
+| `agentsync update --apply` | `agentsync plugin upgrade --all` |
+| `agentsync update --apply --auto-safe` | `agentsync plugin upgrade --all --lossless` |
+| `agentsync explain <plugin>` | `agentsync plugin explain <plugin>` |
+| `agentsync explain --list` | `agentsync plugin list` |
+
+- **`update` still works for one more minor**, forwarding with a warning that
+  names the replacement — including `--apply`, `--auto-safe`, `--scope`, and
+  `--project`, so an existing cron line keeps working. Move it over anyway.
+- **`explain` has no alias.** The top-level name now answers a *different*
+  question — see below — so `agentsync explain <plugin-id>` fails from this
+  release. This is the one change that can break a script silently, which is
+  most of why the upgrade notice exists.
+- **`plugin upgrade <id>` now re-applies.** It used to re-fetch and leave your
+  agents stale until the next `apply`; both it and `--all` now finish by
+  re-applying, so one verb has one ending state.
+- **`--auto-safe` became `--lossless`** on the plugin side only, because the
+  name meant two unrelated things. `reconcile --auto-safe` is unchanged.
+
+### New: `agentsync explain <path>`
+
+The freed name answers "where did this file come from?" — which canonical file,
+which plugin, what the adapter changed on the way, and whether it has drifted.
+
+```bash
+agentsync explain ~/.claude/agents/reviewer.md
+agentsync explain ~/.claude.json#/mcpServers/github
+```
+
+It prints metadata only — never file content — so unlike `diff` it still answers
+with a locked secrets vault. Full details in
+[the CLI reference](/reference/cli/#explain-pathpointer).


### PR DESCRIPTION
## Summary

Follow-up to #202, now merged — this branch is rebased onto it, so the diff below is this change alone.

agentsync ships through channels with **no usable post-install hook**: `go install` (what the README recommends until the first tag) has none at all, a Homebrew *cask*'s `caveats` print only at install time, Scoop has nothing, and only deb/rpm have real scripts. So a hook-based "here's what broke" message would reach a minority and silently miss everyone else. The binary is the only thing that reliably reaches an upgrading user.

That matters because #202 hard-renames five commands and removes a sixth, **with no aliases anywhere** (`verify`→`check`, `plugin install`→`add`, `secrets`→`secret`, `explain <plugin>`→`plugin explain`, `update` removed outright, plus the `agents/`→`subagents/` directory). The directory move is already loud — the load gate hard-errors with the exact fix. The renames are the *silent* half: a CI pipeline running `agentsync verify` just starts failing with "unknown command", nothing connecting it to a rename.

The first run of a release carrying an unseen notice prints what changed, the exact command to run, and a link to `agentsync.cc/reference/upgrading/`:

```
⚠ agentsync 0.11.0: you upgraded across a change that needs your attention
  → since 0.11.0 — breaking changes to the canonical layout and the CLI surface
      • the canonical subagent directory moved: agents/ → subagents/ — run `agentsync migrate subagents` (per tree)
      • `agentsync verify` is now `agentsync check` (no alias) — doctor checks the MACHINE, check checks the CONFIG
      • `agentsync plugin install` is now `agentsync plugin add`, and `agentsync secrets` is now `agentsync secret` (no aliases)
      • `agentsync update` was REMOVED (no alias) — use `agentsync plugin outdated` / `agentsync plugin upgrade --all`
      • `agentsync explain <plugin>` moved to `agentsync plugin explain <plugin>` (no alias; the old name now explains a FILE)
      read more: https://agentsync.cc/reference/upgrading/
  (shown once; silence it with AGENTSYNC_NO_UPGRADE_NOTICE=1)
```

**18 commits: 1 implementing the notice, 17 hardening it** across a fifteen-round adversarial review. Six of those failure modes were *silent* — the one outcome this feature exists to prevent — and every one shipped CI-green.

## The contract

Every line is test-pinned, because a banner that misfires is worse than no banner:

- **Once per machine**, recorded in `~/.agentsync/.state/last-run.json`. Deliberately a **separate file** from `targets.json`: a read-only `status` must be able to record that it showed the notice (targets.json is written only by the *mutating* commands, so a user whose daily loop never applies would see it forever), and a UX marker has no business gating on — or bumping — the drift state's `SchemaVersion`. `.state/` is gitignored, so the record never travels with a dotfiles repo.
- **stderr, always** — `status --json` / `diff --json` / `explain --json` pipe their payload on stdout.
- **Never on a fresh install.** Nothing can have broken under a user with no config. Two traps here, both found by tests: writing the record when the home is absent *materializes* it, so the user's first `agentsync init` refuses with "already contains files"; and the home existing is **not** sufficient evidence of an upgrade, because a project-scope user's home is created by central state, not by `init`. The trigger is `agentsync.toml`.
- **Silent for an unversioned (`dev`) build** — keeps it out of local `go build`s and the entire test/BDD/e2e suite.
- **Silent for shell completion.** Cobra runs the root pre-run hook for its hidden `__complete` request too, and completion scripts discard stderr.
- **Best-effort throughout.** A corrupt, missing, or unwritable record only means the notice shows again later — including a truncated or empty file, which is repaired rather than treated as fatal. It can never fail a command, and it takes no lock.
- **`AGENTSYNC_NO_UPGRADE_NOTICE=1` opts out without recording**, so unsetting it later still surfaces an unseen notice rather than swallowing it permanently.

Notices are keyed by a stable **ID**, not a version comparison, so a user who jumps several releases still sees each one they missed, and a pre-release/non-semver build can't silently drop one.

## What the review changed

**The notice disabled #202's scope enforcement.** Wiring it added a *second* `cmd.PersistentPreRunE =` in `NewRoot`. Cobra's hook is a plain field, so the assignment discarded the one calling `enforceScopeStance` — every scope-unaware command went back to accepting `--scope`/`--project` and ignoring it, which is exactly the bug #200 F6 shipped to kill. Nothing failed, because all three of #202's scope tests read annotations and none executed the hook.

**Shell completion consumed the notice.** One TAB after `agentsync ` printed the banner into `/dev/null` and recorded it as seen — so anyone with completions installed would have hit that before ever seeing the notice once.

**A corrupt record suppressed it permanently.** One truncated `last-run.json` — the classic crash-mid-write artifact — meant the user *never* learned their canonical layout had moved. An unparseable record carries no information, so it now reads as "nothing shown here": print, then repair.

**A brand-new project-scope install got the "you upgraded" banner** — told to run `agentsync migrate subagents` against a tree born as `subagents/`.

**`ensureStateGitignore` could truncate a user's `.gitignore`** — measured, 4000 rules to 1 — because the lock-free notice path made it the only read-modify-write in the tool that can run concurrently with itself. That fix took three attempts and is the most useful thing here: `iox.AtomicWrite` does *not* fix it (a fixed sibling temp name means concurrent writers share one inode) and silently broke two other things — it refuses symlinked destinations, so chezmoi/Stow users would never have gotten `.state/` ignored at all, and it chmods 0600→0644. `O_APPEND` fixes all three. The concurrency test written alongside it **passed 10/10 against the known-broken implementation** under `-race`, which is what CI runs, so the guard is now structural and detects 5/5 deterministically.

**The banner said "deprecated" where #202 says "removed".** For the one audience this feature exists to reach, that is the worst thing to get wrong: a user told their cron line "still works for one more minor" has no reason to touch it, and it is already broken.

## Version

Keyed to **v0.11.0**. If it ships under a different number, three things must move together: the `Since` string in `upgradeNotices`, the notice **ID** `0.11.0-cli-surface`, and the `## 0.11.0` heading on the upgrading page. Nothing ties them to the tag, and **the ID must never change once shipped** — renaming it re-shows the banner to everyone who already dismissed it. Release-checklist material.

> Unrelated observation: `CHANGELOG.md`'s newest *released* section is `[0.7.3]`, so 0.8.x–0.10.1 have no entries on `main`. Not touched here — flagging in case it's an oversight.

## Type of change

- [x] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

`internal/cli/upgrade_notice_test.go` covers the contract clause by clause: shown once on upgrade; silent on a fresh install **and** after that user's first `init`; silent for a `dev` build; `AGENTSYNC_NO_UPGRADE_NOTICE=1` silences without recording, and clearing it re-surfaces the notice; `--json` payloads still parse; an unreadable record doesn't fail the command; a *failed write* still prints and repeats rather than vanishing; the record is gitignored; a state-only home stays quiet **and** unrecorded; keyed by ID in **both** directions; a corrupt record repaired across five malformed shapes; and every shell-completion entry point silent and unrecorded.

Structural guards, each traceable to a demonstrated silent mutation: the notice table is well-formed and every entry has a matching upgrading-page section; no command is named `completion`; `root.go` assigns `PersistentPreRunE` exactly once; `ensureStateGitignore` uses `O_APPEND` and no whole-file writer; and the banner's *content* is pinned — every retirement must be named, before its replacements, joined by a sanctioned break phrase, with an alias-free assertion and no continuity claim. That last guard went through four designs, each defeated by a reviewer; the surviving one keeps every historical evasion as a permanent case.

Verified on the final commit, rebased onto merged `main`: `go test ./...`, `-race -shuffle=on`, `-tags=e2e`, `-tags=bdd` all green; `golangci-lint run ./...` 0 issues with the repo's pinned gofumpt; `bun run check:links` 0 broken. Smoke-tested with a real `-ldflags "-X main.version=0.11.0"` binary: fires once, silent on the second run.

- [x] `just test-release` is green (the release bar)
- [x] `just lint` is clean

## Known residuals

Filed rather than fixed, none blocking:

- The `%v`-of-error path in `plugin_poll.go` can re-embed a raw untrusted plugin id via `*fs.PathError` (pre-existing; `internal/untrusted`'s package doc names both the hazard and the remedy).
- The `warning: lossless:` evaluation-error branch has no coverage.
- `flagExists` would certify `--scope`/`--project` on scope-unaware commands (unreachable — no replacement carries them, and the table is pinned).
- `source.IsLegacySubagentDir` has no callers and no tests.
- `continuityClaims` cannot close the tail gap — no substring list can decide English semantics, and that limit is documented at the code rather than claimed away.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. — none of those are touched, and no secret material reaches the run record (a version string and notice IDs).
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — new `website/.../reference/upgrading.mdx` + sidebar entry, `AGENTSYNC_NO_UPGRADE_NOTICE` in all three environment tables, `docs/components.md` for `internal/state`, and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya6B2SFz1Lcj1uqyM6EyVs