### PR TITLE
docs(architecture): document the upgrade notice and last-run record

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -778,7 +778,94 @@ manifest SHAs, bound component paths to the plugin cache, and reject
 
 ---
 
-## 10. Package layering
+## 10. The first-run upgrade notice
+
+A breaking rename is only half-shipped if the user never learns about it, and
+agentsync has **no usable post-install hook on any channel it ships through**:
+`go install` has none at all, a Homebrew *cask*'s `caveats` print only at
+install time, Scoop has nothing, and only deb/rpm have real scripts. So a
+hook-based message would reach a minority and silently miss everyone else. The
+binary is the only thing that reliably reaches an upgrading user, which makes
+this the single channel for anything a user must act on — and a banner that
+misfires is worse than none.
+
+**Where it runs.** `maybePrintUpgradeNotice` is wired into the root command's
+`PersistentPreRunE` (`internal/cli/upgrade_notice.go`), so every subcommand
+inherits it. Cobra's hook is a plain field, so it shares ONE closure with
+`enforceScopeStance` (which runs last and owns the returned error, since it is
+the half that can *refuse* the command) rather than taking a second assignment:
+a second `cmd.PersistentPreRunE =` silently DISCARDS the first — it did exactly
+that to the scope enforcement once, with CI green throughout.
+`TestRootDeclaresExactlyOnePersistentPreRun` fails the build on a second
+assignment, and because cobra runs only the *closest* hook in the chain,
+`TestNoSubcommandOverridesPersistentPreRun` guards the same hazard one level
+down.
+
+**The record.** `.state/last-run.json` (`internal/state/lastrun.go`), a
+**separate file from `targets.json`** on purpose:
+
+- a read-only `status` must be able to record that it showed the notice, and
+  `targets.json` is written only by the *mutating* commands — a user whose daily
+  loop never applies would otherwise see the banner forever;
+- a UX marker has no business gating on, or bumping, the drift state's
+  `SchemaVersion`.
+
+`.state/` is gitignored, so the record never travels with a dotfiles repo.
+
+**Keyed by ID, never by version comparison.** Each notice carries a stable `ID`
+recorded in `NoticesSeen []string`; the show/skip decision is a pure string
+membership test (`rec.Seen(n.ID)`). That is what lets a user who jumps several
+releases see each notice they missed, and stops a pre-release or non-semver
+build silently dropping one. The table is therefore **append-only: never rename,
+renumber, or delete an entry.** A rename re-shows the notice to everyone who
+already dismissed it; a duplicate makes the second unreachable; a deletion
+orphans a retirement that other guards read. `Since` and the notice body are
+free to change at any time — only the ID is frozen once published.
+
+**Invariants, each test-pinned:**
+
+1. **stderr, always** — `status --json` / `diff --json` / `explain --json` pipe
+   their payload on stdout, and a banner there corrupts what a caller parses.
+2. **Never on a fresh install.** Nothing can have broken for a user with no
+   config. The trigger is a regular `agentsync.toml`, not the home directory:
+   a project-scope user's home is created by central state, not by `init`.
+   Writing the record when the home is absent also *materializes* it, so the
+   user's first `agentsync init` would refuse with "already contains files" —
+   hence `init` seeds the record itself (`seedUpgradeNoticeRecord`), and a
+   machine set up today is never later told about a rename that predates it.
+3. **Silent for an unversioned (`dev`) build**, which keeps it out of local
+   `go build`s and the entire test/BDD/e2e suite.
+4. **Silent for shell completion.** Cobra runs the root pre-run hook for its
+   hidden `__complete` request too, and completion scripts discard stderr — so
+   one TAB would otherwise print the banner into `/dev/null` and record it seen.
+5. **Best-effort throughout, and it takes no lock.** Every read/write failure
+   degrades to "say nothing" or "show again later"; it can never fail a user's
+   command. A corrupt or truncated record reads as "nothing shown here" —
+   printed, then repaired — because an unparseable record carries no
+   information, and treating it as fatal permanently suppressed the one message
+   the user needed.
+6. **Opting out does not record.** `AGENTSYNC_NO_UPGRADE_NOTICE=1` suppresses
+   without marking seen, so unsetting it later still surfaces an unseen notice.
+
+**One consequence worth knowing.** Being lock-free makes the notice path the
+only read-modify-write in the tool that can run concurrently with itself, and it
+calls `ensureStateGitignore`. That write is `O_APPEND` for exactly this reason —
+`iox.AtomicWrite` does NOT make it safe (a fixed sibling temp name means
+concurrent writers share one inode) and additionally refuses symlinked
+destinations, which would silently leave chezmoi/Stow users with `.state/`
+unignored. A structural guard pins the append and forbids whole-file writers
+there.
+
+**The banner's content is pinned too**, not just its plumbing: every retired
+command must be named, before its replacements, joined by a sanctioned break
+phrase, carrying an alias-free assertion and no continuity claim. The shared
+`retirements` table is the oracle for that check, for the resurrection guard,
+and for the stale-prose scan — so a retirement cannot be added to one and
+forgotten in the others.
+
+---
+
+## 11. Package layering
 
 ```mermaid
 flowchart TD

--- a/docs/components.md
+++ b/docs/components.md
@@ -494,4 +494,4 @@ rollback history, reached only from `cli`) is likewise a leaf. `drift`, `git`,
 `iox`, `jsonkeys`, `paths`, `log`, and `untrusted` depend on nothing internal —
 they're the foundation; `ui` (presentation) builds only on `untrusted`. See the
 rendered dependency graph in
-[architecture §10](architecture.md#10-package-layering).
+[architecture §11](architecture.md#11-package-layering).


### PR DESCRIPTION
## Summary

The one-time first-run-after-upgrade banner shipped in #203, but its rationale
ended up spread across code comments, the website's Upgrading page, and a single
package-level line in `docs/components.md`. `docs/architecture.md` said nothing
about it at all — so the invariants that make the mechanism safe were only
discoverable by reading `internal/cli/upgrade_notice.go` top to bottom.

This adds **§10 The first-run upgrade notice**, covering:

- **Why the binary is the only channel.** No channel agentsync ships through has
  a usable post-install hook (`go install` has none, a Homebrew cask's `caveats`
  print at install time only, Scoop has nothing), so a hook-based message would
  reach a minority and silently miss everyone else.
- **Where it runs.** One `PersistentPreRunE` closure shared with
  `enforceScopeStance` — which runs last and owns the returned error, since it is
  the half that can *refuse* the command. Cobra's hook is a plain field, so a
  second assignment silently discards the first;
  `TestRootDeclaresExactlyOnePersistentPreRun` and
  `TestNoSubcommandOverridesPersistentPreRun` guard that at both levels.
- **The record.** Why `.state/last-run.json` is a separate file from
  `targets.json`: a read-only `status` must be able to record that it showed the
  notice, and a UX marker has no business gating on the drift state's
  `SchemaVersion`.
- **Keyed by ID, never by version comparison** — and therefore append-only:
  never rename, renumber, or delete an entry. `Since` and the body stay free to
  change; only the ID is frozen once published.
- **Six test-pinned invariants** — stderr always (a banner on stdout corrupts
  `--json`), never on a fresh install, silent for `dev` builds, silent for shell
  completion, best-effort throughout, and opting out does not record.
- **The `O_APPEND` consequence** of the path being deliberately lock-free.

Package layering renumbers §10 → §11; the one cross-reference to its anchor in
`docs/components.md` moves with it.

Two errors were caught and fixed before commit: the draft named a test
(`TestRootAssignsPersistentPreRunOnce`) that does not exist, and cross-referenced
a "`--scope` contract" section that is not in the file.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [ ] Tests / CI / tooling

## Test plan

Docs-only — no Go source, test, or CLI surface changed.

- [ ] `just test-release` is green (the release bar) — **not run here**: no
      Docker daemon is available in this environment, so the hermetic container
      gate is left to CI. `go test ./...` passes in full.
- [x] `just lint` is clean — `golangci-lint` reports **0 issues** on the pinned
      `go1.26.2` toolchain, and lint rewrote nothing (`git diff --stat` after the
      run shows only the two doc files).
- [x] `bun run check:links` — **32 pages, 112 in-site links, 0 broken.** This is
      the load-bearing check for this change: the website generates its
      architecture page from `docs/architecture.md`, so renumbering package
      layering moved a live anchor.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed. — n/a, no behavior changed.
      Every claim in the new section is anchored to an existing test by name, and
      each of those names was verified to exist.
- [x] If this touches `internal/secrets`, `internal/capture`, or any
      `source.Write*` path, I've re-read the secret-handling invariants in
      `CLAUDE.md` / `SECURITY.md` and not weakened them. — untouched.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. —
      this PR *is* the doc update; no `CHANGELOG.md` entry, as nothing
      user-visible changed (the feature itself was changelogged in #203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya6B2SFz1Lcj1uqyM6EyVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya6B2SFz1Lcj1uqyM6EyVs)_