### PR TITLE
fix(cli): correct the AtomicWrite concurrency claim, pin notice ID→Since, explain a partial migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,27 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Documentation
 
+- **The upgrade notice's `iox.AtomicWrite` claim was the opposite of the
+  truth.** `upgrade_notice.go` stated that "iox.AtomicWrite keeps the record
+  itself well-formed under that race", and `docs/architecture.md` §10 repeated
+  it — while `TestEnsureStateGitignoreDoesNotUseATruncatingWrite`, in the same
+  package, *bans* `iox.AtomicWrite` from the sibling write two lines away and
+  names the reason: its temp file has a fixed name, so concurrent writers share
+  one inode. Both writes sit on the same deliberately lock-free path.
+  `state.SaveLastRun` genuinely can tear there; that is tolerable only because
+  a torn record is read as `ErrCorruptLastRun` ("this machine has shown
+  nothing") and repaired on the next run, whereas a torn `.gitignore` destroys
+  rules the user cannot recover. Both sites now state the asymmetry as a
+  deliberate trade with its precondition — nothing may depend on the record —
+  instead of asserting a safety property that does not hold.
+- **The `Since` / notice-ID / upgrading-page agreement is now pinned in code.**
+  All three must match, the ID is frozen once published while the other two are
+  not, and the check was a hand-run pre-tag ritual recorded only in a commit
+  message. `TestUpgradeNoticeTableIsWellFormed` now requires every notice ID to
+  be spelled `<Since>-<slug>`, so a release that renumbers fails the build
+  rather than shipping a banner whose ID names a version it never mentions.
+  (`TestEveryNoticeHasAnUpgradingDocsSection` already pinned Since → heading;
+  what stays manual is only "does `Since` match the tag being cut".)
 - **`revert --strict` was documented but never existed.** `revert` registers
   only `--to`, `--all`, and `--dry-run`; strictness follows the invocation
   (naming an agent is strict, `--all` skips-with-a-warning). The user guide's
@@ -233,6 +254,19 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **A failed `migrate subagents` now says what state it left the tree in.** The
+  rename loop is deliberately not atomic — unwinding successful renames would
+  mean a second pass over the filesystem that just failed — so a mid-loop
+  failure leaves files split across `agents/` and `subagents/`. Re-running was
+  already the correct and safe recovery (the collision check only ever sees what
+  remains under `agents/`, so a resumed run picks up exactly the remainder), but
+  the error said none of that, while the *collision* branch beside it explicitly
+  states "Nothing was moved" — so a user reading a bare move failure had to
+  assume the worst and reconcile two directories by hand. It now reports how
+  many files were moved, that nothing was lost or overwritten, and that
+  re-running resumes. `TestMigrateSubagents_ResumesAfterAPartialMove` pins the
+  resume property itself, which was previously unasserted and is one `os.Stat`
+  away from becoming a refusal.
 - **The upgrade notice no longer describes a removed command as deprecated.**
   After the top-level `update` was cut outright, the banner's action line still
   read "`agentsync update` is deprecated". Every guard stayed green: the notice

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -849,12 +849,23 @@ free to change at any time — only the ID is frozen once published.
 
 **One consequence worth knowing.** Being lock-free makes the notice path the
 only read-modify-write in the tool that can run concurrently with itself, and it
-calls `ensureStateGitignore`. That write is `O_APPEND` for exactly this reason —
-`iox.AtomicWrite` does NOT make it safe (a fixed sibling temp name means
-concurrent writers share one inode) and additionally refuses symlinked
-destinations, which would silently leave chezmoi/Stow users with `.state/`
-unignored. A structural guard pins the append and forbids whole-file writers
-there.
+performs two writes with *different* answers to that.
+
+`ensureStateGitignore` is `O_APPEND` — `iox.AtomicWrite` does NOT make it safe
+(a fixed sibling temp name means concurrent writers share one inode) and it
+additionally refuses symlinked destinations, which would silently leave
+chezmoi/Stow users with `.state/` unignored. A structural guard pins the append
+and forbids whole-file writers there.
+
+`state.SaveLastRun` *does* go through `iox.AtomicWrite`, and therefore *can*
+tear under the same race. That is a deliberate asymmetry, not an exemption: a
+torn `.gitignore` destroys rules the user wrote and cannot recover, while a torn
+`last-run.json` is a UX marker that `LoadLastRun` reports as
+`ErrCorruptLastRun` — read as "this machine has shown nothing", printed, and
+overwritten. It self-repairs at a cost of one duplicate banner, which is exactly
+why invariant 5 above treats a corrupt record as forgiving rather than fatal.
+The record is safe to tear *because* nothing depends on it; a field that made it
+authoritative would need a unique temp name or the global lock.
 
 **The banner's content is pinned too**, not just its plumbing: every retired
 command must be named, before its replacements, joined by a sanctioned break

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -209,7 +209,8 @@ func migrateSubagentTree(userAgentsyncHome, srcHome string, sc adapter.Scope, pr
 				"move %s → %s: %w. %d of %d file(s) were already moved and are correctly placed in %s; "+
 					"the rest remain in %s. Nothing was lost or overwritten — fix the cause and re-run "+
 					"`agentsync migrate subagents`, which resumes with the files still left behind",
-				from, to, err, i, len(names), newDir, legacyDir)
+				from, to, err, i, len(names), newDir, legacyDir,
+			)
 		}
 	}
 	// Drop the legacy directory once the move emptied it. A failure here is

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -189,11 +189,27 @@ func migrateSubagentTree(userAgentsyncHome, srcHome string, sc adapter.Scope, pr
 	if err := os.MkdirAll(newDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", newDir, err)
 	}
-	for _, name := range names {
+	// The loop is NOT atomic, and deliberately so: an all-or-nothing move would
+	// mean unwinding renames that already succeeded, which is a second failure
+	// path over the same filesystem that just failed. A partial move is instead
+	// made SAFE to leave — every moved file is already in its final location,
+	// the collision check above only ever sees what still remains in agents/,
+	// and re-running therefore picks up exactly the remainder. The state rewrite
+	// is skipped on this path, which self-heals on the next apply
+	// (RecordOpsState overwrites SourceID unconditionally).
+	//
+	// Say all of that in the error. The collision branch above states "Nothing
+	// was moved" precisely because a user who reads a bare move failure has to
+	// assume the worst and reconcile two directories by hand.
+	for i, name := range names {
 		from := filepath.Join(legacyDir, name)
 		to := filepath.Join(newDir, name)
 		if err := os.Rename(from, to); err != nil { //nolint:forbidigo // moves a canonical subagent file inside an agentsync home, not a native destination
-			return nil, fmt.Errorf("move %s → %s: %w", from, to, err)
+			return nil, fmt.Errorf(
+				"move %s → %s: %w. %d of %d file(s) were already moved and are correctly placed in %s; "+
+					"the rest remain in %s. Nothing was lost or overwritten — fix the cause and re-run "+
+					"`agentsync migrate subagents`, which resumes with the files still left behind",
+				from, to, err, i, len(names), newDir, legacyDir)
 		}
 	}
 	// Drop the legacy directory once the move emptied it. A failure here is

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -262,6 +262,72 @@ func TestMigrateSubagents_BothDirsCollisionRefused(t *testing.T) {
 	}
 }
 
+// TestMigrateSubagents_ResumesAfterAPartialMove pins the claim the move-failure
+// error now makes to the user: "re-run … resumes with the files still left
+// behind".
+//
+// The rename loop is deliberately not atomic — unwinding successful renames
+// would be a second failure path over the filesystem that just failed — so a
+// mid-loop failure leaves files split across BOTH directories. That is only an
+// acceptable design if re-running is genuinely safe, and the subtle way it
+// could fail is the collision check: it refuses when a name exists under both
+// directories, and a naive reading of "some files are now in subagents/" is
+// exactly that shape. It is not, because a moved file no longer exists under
+// agents/ — but nothing asserted the distinction, and the two branches (refuse
+// vs resume) are one `os.Stat` apart.
+//
+// So: reproduce the on-disk state a partial move leaves and assert the re-run
+// completes rather than refusing, with both halves intact byte-for-byte.
+func TestMigrateSubagents_ResumesAfterAPartialMove(t *testing.T) {
+	tmpHome := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+	agentsyncHome := filepath.Join(tmpHome, ".agentsync")
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The exact residue of a loop that moved `planner` and then failed on
+	// `reviewer`: one file already in its final home, one still behind, and no
+	// name present in both.
+	const plannerBody = "planner body\n"
+	seedLegacySubagent(t, agentsyncHome, "reviewer", migTestSubagent)
+	newDir := filepath.Join(agentsyncHome, "subagents")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "planner.md"), []byte(plannerBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "migrate", "subagents")
+	if err != nil {
+		t.Fatalf("re-run after a partial move must resume, not refuse: %v\n%s", err, out)
+	}
+	// It must report only the REMAINDER as moved. Claiming the already-migrated
+	// file too would be a lie the user cannot check.
+	if !strings.Contains(out, "reviewer.md") {
+		t.Errorf("resumed migration did not report moving the leftover file:\n%s", out)
+	}
+	if strings.Contains(out, "planner.md") {
+		t.Errorf("resumed migration claimed to move a file that was already migrated:\n%s", out)
+	}
+
+	// Both halves are intact and the legacy directory is gone.
+	for name, want := range map[string]string{
+		"reviewer.md": migTestSubagent,
+		"planner.md":  plannerBody,
+	} {
+		got, rerr := os.ReadFile(filepath.Join(newDir, name))
+		if rerr != nil || string(got) != want {
+			t.Errorf("%s after resume: %v / %q, want %q", name, rerr, got, want)
+		}
+	}
+	if _, serr := os.Stat(filepath.Join(agentsyncHome, "agents")); !os.IsNotExist(serr) {
+		t.Errorf("legacy agents/ survived the resumed migration: %v", serr)
+	}
+}
+
 // TestMigrateSubagents_ProjectScopeIsIndependent is case (4): a project tree
 // migrates on its own, and the state rewrite touches only that tree's keys —
 // another project's (and the user tree's) recorded SourceIDs are left alone.

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -95,11 +95,26 @@ var upgradeNotices = []upgradeNotice{
 //     self-announcing (the notice either shows again next run, or the user
 //     never sees it and reads the upgrade page instead). A corrupt record no
 //     longer hides the notice, which was the one silent failure that mattered.
+//
 //   - "Once per machine" is lock-free, so N truly simultaneous invocations can
 //     each print. Taking the global lock for a banner would serialize every
 //     command in the tool behind a UX marker — a far worse trade than a
-//     duplicated banner in the rare concurrent case. iox.AtomicWrite keeps the
-//     record itself well-formed under that race.
+//     duplicated banner in the rare concurrent case.
+//
+//     The record write inherits that: state.SaveLastRun goes through
+//     iox.AtomicWrite, whose temp file has a FIXED sibling name, so concurrent
+//     writers share one inode and can tear the file — the same property that
+//     disqualifies AtomicWrite for the ensureStateGitignore call this function
+//     makes one line earlier (see TestEnsureStateGitignoreDoesNotUseATruncatingWrite,
+//     which bans it there by name). Do NOT read this as "AtomicWrite is safe here". It is
+//     TOLERATED here and not there because the two failures are not
+//     comparable: a torn .gitignore destroys rules the user wrote and cannot
+//     get back, while a torn last-run.json is a UX marker that LoadLastRun
+//     reads as ErrCorruptLastRun, i.e. "this machine has shown nothing" — so
+//     it self-repairs on the next run at the cost of one duplicate banner.
+//     That is the whole reason the corrupt-record path is forgiving. If a
+//     future field ever makes this record authoritative for anything, it needs
+//     a unique temp name (os.CreateTemp in the parent) or the lock.
 func maybePrintUpgradeNotice(cmd *cobra.Command) {
 	// A build with no version stamped is a local `go build` or a test binary.
 	// Showing (and recording) a notice there would fire in every test run and

--- a/internal/cli/upgrade_notice_table_internal_test.go
+++ b/internal/cli/upgrade_notice_table_internal_test.go
@@ -32,6 +32,23 @@ func TestUpgradeNoticeTableIsWellFormed(t *testing.T) {
 		if n.Since == "" {
 			t.Errorf("notice %q has no Since; the banner prints it", n.ID)
 		}
+		// The ID, the Since string, and the `## <Since>` heading on the
+		// upgrading page must all agree, and the ID is FROZEN once published
+		// while the other two are not — so a release that renumbers (0.11.0
+		// slips to 0.12.0) can leave the ID naming a version the banner never
+		// mentions. That agreement was a hand-checked pre-tag ritual recorded
+		// only in a commit message, which is the artifact nobody re-reads at
+		// release time. Two thirds of it are mechanical: pin ID → Since here,
+		// and TestEveryNoticeHasAnUpgradingDocsSection pins Since → heading.
+		// What stays manual is only "does Since match the tag you are about to
+		// cut", which is one glance rather than a three-way diff.
+		if n.Since != "" && !strings.HasPrefix(n.ID, n.Since+"-") {
+			t.Errorf("notice ID %q does not start with %q.\n"+
+				"The ID is frozen once shipped but Since is not, so this is the pair that silently "+
+				"drifts when a release renumbers. Spell the ID `<Since>-<slug>`; if the VERSION is what "+
+				"changed, fix Since (and the `## %s` heading in upgrading.mdx) — never the published ID.",
+				n.ID, n.Since+"-", n.Since)
+		}
 		if n.Headline == "" {
 			t.Errorf("notice %q has no Headline", n.ID)
 		}

--- a/internal/iox/atomic.go
+++ b/internal/iox/atomic.go
@@ -28,6 +28,18 @@ var ErrSymlinkDest = errors.New("destination is a symlink")
 // content (rename did not run) or the new content (rename ran). Never
 // partial.
 //
+// ATOMIC AGAINST A CRASH, NOT AGAINST A CONCURRENT WRITER. The temp file's
+// name is FIXED (dest + ".agentsync.tmp"), so two processes writing the same
+// dest share one temp inode: B's O_TRUNC can land inside A's write window, and
+// A then renames a short or empty file into place. Callers get atomicity from
+// the global lock (internal/cli/lock.go), which is why almost every writer in
+// the tool holds it. The exception is state.SaveLastRun on the deliberately
+// lock-free upgrade-notice path, where a torn record is a self-repairing UX
+// marker rather than data loss — see internal/cli/upgrade_notice.go. Anything
+// else that needs to write dest without the lock must NOT reach for this:
+// append (cf. ensureStateGitignore, whose read-modify-write lost user data
+// under exactly this race) or take the lock.
+//
 // If dest is an existing symlink, AtomicWrite refuses unless
 // AGENTSYNC_ALLOW_SYMLINK_DEST=1. Replacing the symlink with a regular file
 // via rename would silently break a chezmoi/Stow setup where the user's


### PR DESCRIPTION
## Summary

Three review follow-ups to #202 / #203 / #209. **No behavior changes.** Two replace a stated invariant that was false; one improves an error a user only sees when something has already gone wrong.

**1. The upgrade notice asserted the opposite of the truth about `iox.AtomicWrite`.**

`upgrade_notice.go` claimed *"iox.AtomicWrite keeps the record itself well-formed under that race"*, and `docs/architecture.md` §10 repeated it — while `TestEnsureStateGitignoreDoesNotUseATruncatingWrite`, in the same package, **bans** `iox.AtomicWrite` from the sibling write one line away and names the reason: a fixed temp name (`dest + ".agentsync.tmp"`) means concurrent writers share one inode. Both writes sit on the same deliberately lock-free path, so the two statements cannot both hold.

`state.SaveLastRun` genuinely can tear there. That is tolerable, but only because a torn record is read as `ErrCorruptLastRun` ("this machine has shown nothing") and repaired on the next run — which is the actual reason the corrupt-record path is forgiving — whereas a torn `.gitignore` destroys rules the user cannot recover. Both sites now state the asymmetry as a deliberate trade with its precondition (*nothing may depend on this record*) instead of a safety property that does not hold.

The property belongs to `AtomicWrite`, not to its callers, so its own doc comment now carries it: **atomic against a crash, not against a concurrent writer.** Its existing text ("Never partial") was true for crashes and quietly false for concurrency, which is plausibly how the wrong claim got written downstream in the first place. Every current caller is safe because it holds the global lock; the comment names the one lock-free exception and tells a future caller to append or take the lock.

**2. The `Since` / notice-ID / upgrading-page agreement is now pinned in code.**

All three must match, the ID is frozen once published while the other two are not, and the check lived only in a commit-message body — the artifact nobody re-reads at release time. `TestUpgradeNoticeTableIsWellFormed` now requires every ID to be spelled `<Since>-<slug>`, so a release that renumbers fails the build instead of shipping a banner whose ID names a version it never mentions. `TestEveryNoticeHasAnUpgradingDocsSection` already pinned Since → heading; what stays manual is only "does `Since` match the tag being cut".

**3. A failed `migrate subagents` now says what state it left the tree in.**

The rename loop is deliberately non-atomic — unwinding successful renames would mean a second pass over the filesystem that just failed — so a mid-loop failure splits files across `agents/` and `subagents/`. Re-running was already the correct and safe recovery, but the error said none of that, while the *collision* branch beside it explicitly states "Nothing was moved" — so a user reading a bare move failure had to assume the worst and reconcile two directories by hand.

The resume property was also unasserted, and it is one `os.Stat` from becoming a refusal: the collision check tolerates a partial move only because a moved file no longer exists under `agents/`. That distinction is now pinned.

## Type of change

- [x] Bug fix <!-- error message + two false invariants; no behavior change -->
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

Two new guards, **both mutation-checked** — each was run against a deliberately reintroduced defect and confirmed to fail with the intended message, then restored:

- `TestMigrateSubagents_ResumesAfterAPartialMove` — reproduces the on-disk residue of a partial move (one file already in `subagents/`, one still in `agents/`, no name in both) and asserts the re-run *resumes* rather than firing the collision refusal, reports only the remainder as moved, leaves both halves byte-identical, and removes `agents/`. Mutation: made the collision check refuse whenever `subagents/` is non-empty → fails with the collision error.
- `TestUpgradeNoticeTableIsWellFormed` (extended) — every notice ID must start with `<Since>-`. Mutation: `0.11.0-cli-surface` → `0.11-cli-surface` → fails.

Verification run:

- `go test ./internal/... -count=1` (with `AGENTSYNC_TEST_IN_CONTAINER=1`) — all green.
- `GOTOOLCHAIN=go1.26.2 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...` — **0 issues**. (Toolchain pinned per the container quirk documented in `CLAUDE.md`.)
- `GOTOOLCHAIN=go1.26.2 go mod tidy` — no diff.
- gofumpt rewrote `upgrade_notice.go` and `atomic.go`; both re-staged before commit.

- [ ] `just test-release` is green (the release bar) — **not run: no Docker daemon in this environment**, so the hermetic container gate could not execute. The equivalent unit/integration coverage was run on the host with the `AGENTSYNC_TEST_IN_CONTAINER` guard set, as above. Worth a CI confirmation before merge.
- [x] `just lint` is clean (run as the pinned `golangci-lint` invocation above, since `just` is not installed here)

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants — **not applicable**: no secret-bearing field, no dest→source path, and no `source.Write*` call is touched. `internal/iox/atomic.go` is comment-only.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. `docs/architecture.md` §10 corrected (the generated website contract page picks this up at build; nothing to hand-sync) and `CHANGELOG.md` updated under `[Unreleased]`.

---

### Reviewer note — one finding deliberately left open

`apply --dry-run`'s comment *"it touches neither destinations nor state"* (`internal/cli/apply.go:37`) is now literally false: a dry run can create `~/.agentsync/.state/`, write `last-run.json`, and append to `.gitignore` via the upgrade-notice path. The drift-state-vs-UX-marker distinction makes it defensible as written, and it was consciously deferred — but that sentence is quoted verbatim in `migrate.go` as justification for lock-free reasoning, so it is the one remaining spot where a future reader could take it at face value and reason wrongly about what the lock protects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAbPkizCv3pVmQZva8nkLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAbPkizCv3pVmQZva8nkLc)_