### PR TITLE
docs(cli): name apply in plugin upgrade's one-line help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Documentation
 
+- **`plugin upgrade`'s one-line help now names `apply` instead of saying
+  "re-apply".** Both `upgrade` forms genuinely run the full apply pipeline
+  (`render.Plan` + `render.Apply`, honoring `--scope`/`--project`) — but in the
+  `agentsync plugin` command list, "and re-apply" read as loose jargon rather
+  than as "runs `agentsync apply`", so the one behavior a reader most needs to
+  know about the command — that it writes to your agents' native config, not
+  just to the plugin cache — was the one the summary buried. Reworded to "and
+  run apply" (and matched in the website CLI reference table). Behavior is
+  unchanged.
+
 - **The upgrade notice's `iox.AtomicWrite` claim was the opposite of the
   truth.** `upgrade_notice.go` stated that "iox.AtomicWrite keeps the record
   itself well-formed under that race", and `docs/architecture.md` §10 repeated

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -305,7 +305,7 @@ func newPluginUpgradeCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "upgrade [<id>]",
-		Short: "(network) re-fetch a plugin (or every pending bump) and re-apply",
+		Short: "(network) re-fetch a plugin (or every pending bump) and run apply",
 		Long: `upgrade re-fetches a plugin, updates its recorded version + manifest sha,
 and re-applies the result to your agents so the upgrade lands in the same
 command.

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -28,7 +28,7 @@ import { Aside } from '@astrojs/starlight/components';
 | `marketplace add\|remove\|list <url-or-name>` | Manage marketplaces. | |
 | `plugin add\|upgrade\|enable\|disable\|remove <id[@marketplace]>` / `list` / `outdated` / `explain` | Manage plugins (the lifecycle subcommands all accept the same `id[@marketplace]` ref `add` accepts; the bare id also works, and a qualifier naming a different marketplace than the one the plugin was installed from is refused). | `add <id[@marketplace]>` |
 | `secret set\|get\|list\|remove <key>` / `secret edit` | Manage age-encrypted secrets (`list` prints KEYS only; `edit` opens the whole vault, no `<key>`; `set` refuses an empty value unless `--allow-empty`). | `set --stdin` |
-| `plugin outdated` / `plugin upgrade [<id>]` | **(network)** Poll marketplaces and report pending bumps / re-fetch a plugin (or `--all` pending bumps) and re-apply. | `upgrade --all --lossless --scope --project` |
+| `plugin outdated` / `plugin upgrade [<id>]` | **(network)** Poll marketplaces and report pending bumps / re-fetch a plugin (or `--all` pending bumps) and run `apply`. | `upgrade --all --lossless --scope --project` |
 | `apply` | Render source → write agent configs (offline). Git-versions each destination dir (opt-out). | `--agents --dry-run --scope --project --no-git-backup` |
 | `revert <agent>` | Roll a destination dir back to a prior apply checkpoint (local-only git history). | `--agents --to --all --dry-run` |
 | `status` | Summarize drift / pending across agents (skill dirs collapse by default). `--exit-code` → exit `2` on any drift, `0` when clean (CI gate). | `--agents --verbose --json --exit-code --scope --project` |


### PR DESCRIPTION
Both `plugin upgrade` forms genuinely run the full apply pipeline
(render.Plan + render.Apply, honoring --scope/--project), but the
command-list summary said only "and re-apply" — which reads as loose
jargon rather than "runs agentsync apply", burying the one behavior a
reader most needs to know: it writes to the agents' native config, not
just the plugin cache.

Reword the Short to "and run apply" and match the website CLI reference
table. Behavior unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RZp4mQX7uUE2mQK7ZsA4Gv