### PR TITLE
fix(marketplace): namespace plugin-provided components by their plugin (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   hyphens". **Invoke plugin agents and commands by their new names.** Components
   you hand-author in `~/.agentsync/` are **not** renamed. (That is not the same
   as "a plugin can never take your name": derived names are not injective, so a
-  plugin's derived name can land on one of yours. agentsync reports that clash
-  naming both sides rather than letting either win silently.) MCP and LSP servers are unchanged: a same-id divergence across
-  sources is still refused rather than renamed apart, because it can be a silent
-  endpoint hijack. A one-time upgrade notice points at the docs.
+  plugin's derived name can land on one of yours. agentsync reports that clash,
+  naming both sides, rather than letting either win silently.) MCP and LSP
+  servers are unchanged: a same-id divergence across sources is still refused
+  rather than renamed apart, because it can be a silent endpoint hijack. A
+  one-time upgrade notice points at the docs.
   ([#211](https://github.com/spxrogers/agentsync/issues/211))
 - **`apply` now reclaims orphaned subagents and commands, not just skills.** A
   subagent or slash command removed from — or renamed in — the canonical source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   agentsync import claude:subagent` reproduced this with any installed plugin.
   `import` now skips such components with a warning naming the plugin (and errors
   if you name one explicitly); reconcile's `[w]rite-back` refuses the item and
-  points at `[o]verride`. This covers MCP and LSP servers too — they are not
-  namespaced, but capturing one still mints a canonical copy that diverges from
-  the plugin's the moment it updates. Components you hand-wrote into an agent's
-  native config are still captured normally.
+  points at `[o]verride`. This covers MCP servers, LSP servers, and hooks too —
+  they are not namespaced, but capturing one still mints a canonical copy that
+  diverges from the plugin's the moment it updates. Hooks are filtered per
+  *handler*, so a plugin contributing to an event you also hook never costs you
+  your own handler. Components you hand-wrote into an agent's native config are
+  still captured normally.
 - **A residual name collision is now reported instead of silently dropping a
   component.** Namespacing makes the common case work, but the derived name is
   not injective: plugin `a` shipping `b-c` and plugin `a-b` shipping `c` both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   - A single adapter rendering two divergent ops for one path was reported as
     "different content than an earlier agent", sending the user looking for a
     second agent that did not exist. That case now names its real cause.
+- **`import` and `reconcile` no longer capture plugin-provided components back
+  into the canonical source.** A plugin's component has no canonical file of its
+  own — it is re-derived from the plugin cache on every load — so capturing one
+  minted a canonical copy that then collided with the plugin's own projection,
+  breaking the next `apply`. An adapter's `Ingest` cannot tell a file agentsync
+  rendered from a plugin apart from a hand-written one, so `agentsync apply &&
+  agentsync import claude:subagent` reproduced this with any installed plugin.
+  `import` now skips such components with a warning naming the plugin (and errors
+  if you name one explicitly); reconcile's `[w]rite-back` refuses the item and
+  points at `[o]verride`. Components you hand-wrote into an agent's native config
+  are still captured normally.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,50 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two plugins shipping a same-named component no longer break `status` and
+  `apply`.** `feature-dev` and `pr-review-toolkit` — both stock official Claude
+  plugins — each ship `agents/code-reviewer.md`, which made both commands exit 1
+  with `codex subagents "code-reviewer" and "code-reviewer" resolve to the same
+  agent name`. Every remedy the error named was one the user structurally could
+  not perform: both files live under the marketplace-managed plugin cache, which
+  is overwritten on the next update. The Claude adapter failed the same way for
+  the same reason, tripping the apply pipeline's shared-path divergence guard.
+  ([#211](https://github.com/spxrogers/agentsync/issues/211))
+  - The collision error itself printed two file *stems*, and colliding
+    components almost always share a stem — so it rendered as the same string
+    twice, with no plugin origin. It now names each side's providing plugin (or
+    the canonical file, for a hand-authored component).
+  - A single adapter rendering two divergent ops for one path was reported as
+    "different content than an earlier agent", sending the user looking for a
+    second agent that did not exist. That case now names its real cause.
+
 ### Changed
 
+- **BREAKING (plugins): plugin-provided subagents, skills, and slash commands are
+  namespaced by their plugin.** A component projected from a plugin now renders as
+  `<plugin>-<name>` — `feature-dev`'s `code-reviewer` becomes
+  `feature-dev-code-reviewer` at `~/.claude/agents/feature-dev-code-reviewer.md`,
+  its `code-review` skill becomes `feature-dev-code-review`, and its `/review`
+  command becomes `/feature-dev-review`. The frontmatter `name` key follows the
+  rename when present (an absent one stays absent). This is what lets two plugins
+  ship one component name; it is also what Claude Code does natively, addressing
+  a plugin's agent as `plugin:agent` — agentsync uses a hyphen because Claude Code
+  documents a subagent `name` as a "Unique identifier using lowercase letters and
+  hyphens". **Invoke plugin agents and commands by their new names.** Components
+  you hand-author in `~/.agentsync/` are **not** renamed — a plugin can never take
+  a name you chose. MCP and LSP servers are unchanged: a same-id divergence across
+  sources is still refused rather than renamed apart, because it can be a silent
+  endpoint hijack. A one-time upgrade notice points at the docs.
+  ([#211](https://github.com/spxrogers/agentsync/issues/211))
+- **`apply` now reclaims orphaned subagents and commands, not just skills.** A
+  subagent or slash command removed from — or renamed in — the canonical source
+  previously left its destination file behind until an interactive `reconcile`;
+  `apply` now deletes it, backing up a destination you hand-edited since the last
+  apply before removal, exactly as it already did for skills. This is what keeps
+  the namespacing rename from leaving a stale un-namespaced file beside the new
+  one, which Claude Code would still load.
 - **BREAKING (canonical layout): the subagent directory is now `subagents/`,
   not `agents/`.** The canonical tree carried both the `[agents]` harness
   registry (`agentsync.toml`) and the subagent files one directory apart — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   agentsync import claude:subagent` reproduced this with any installed plugin.
   `import` now skips such components with a warning naming the plugin (and errors
   if you name one explicitly); reconcile's `[w]rite-back` refuses the item and
-  points at `[o]verride`. Components you hand-wrote into an agent's native config
-  are still captured normally.
+  points at `[o]verride`. This covers MCP and LSP servers too — they are not
+  namespaced, but capturing one still mints a canonical copy that diverges from
+  the plugin's the moment it updates. Components you hand-wrote into an agent's
+  native config are still captured normally.
+- **A residual name collision is now reported instead of silently dropping a
+  component.** Namespacing makes the common case work, but the derived name is
+  not injective: plugin `a` shipping `b-c` and plugin `a-b` shipping `c` both
+  derive `a-b-c`, and a hand-authored `feature-dev-code-reviewer` collides with
+  what plugin `feature-dev` derives. Those reached the render pipeline, where
+  divergent content aborted with a message naming neither origin and **identical
+  content was silently deduped**. `checkProjectedConflicts` now guards name-keyed
+  components exactly as it guards MCP/LSP server ids, naming each side's
+  providing plugin (or your own canonical file).
+- **`apply` refuses to reclaim an orphaned destination it cannot read first.** A
+  pre-delete read failing with anything other than "already gone" (`EACCES`,
+  `EIO`, `EISDIR`) previously fell through to the delete, destroying a
+  hand-edited file with no backup. Convergence is never worth data loss.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   content was silently deduped**. `checkProjectedConflicts` now guards name-keyed
   components exactly as it guards MCP/LSP server ids, naming each side's
   providing plugin (or your own canonical file).
+- **`status`, `apply`, and `reconcile` no longer hang on a non-regular
+  destination.** A FIFO left at a path agentsync manages made `os.ReadFile`
+  BLOCK forever rather than fail — wedging `status` (an advertised read-only
+  command), `apply --dry-run`, and reconcile's orphan listing. Every
+  destination read now shares one shape guard, so none of them can disagree
+  about what is safe to read.
+- **`reconcile --auto-writeback` no longer exits non-zero forever** on a
+  plugin-provided item. That refusal is structural, not a transient failure, so
+  counting it as one broke `reconcile && deploy` until the plugin was disabled;
+  it is now skipped with a reason, like a foreign collision.
 - **`apply` refuses to reclaim an orphaned destination it cannot read first.** A
   pre-delete read failing with anything other than "already gone" (`EACCES`,
   `EIO`, `EISDIR`) previously fell through to the delete, destroying a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   a plugin's agent as `plugin:agent` — agentsync uses a hyphen because Claude Code
   documents a subagent `name` as a "Unique identifier using lowercase letters and
   hyphens". **Invoke plugin agents and commands by their new names.** Components
-  you hand-author in `~/.agentsync/` are **not** renamed — a plugin can never take
-  a name you chose. MCP and LSP servers are unchanged: a same-id divergence across
+  you hand-author in `~/.agentsync/` are **not** renamed. (That is not the same
+  as "a plugin can never take your name": derived names are not injective, so a
+  plugin's derived name can land on one of yours. agentsync reports that clash
+  naming both sides rather than letting either win silently.) MCP and LSP servers are unchanged: a same-id divergence across
   sources is still refused rather than renamed apart, because it can be a silent
   endpoint hijack. A one-time upgrade notice points at the docs.
   ([#211](https://github.com/spxrogers/agentsync/issues/211))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -752,12 +752,18 @@ auto-resolves only the cases that can't lose work (`converged`, `pending`).
 a removed component doesn't linger in the destination: emptied key-merge sections
 (an MCP/hook/LSP section whose source went empty — cleaned via a synthesized
 empty-merge op) and **whole-file components** whose `source_id` is under
-`skills/`, `subagents/`, or `commands/` — a whole skill, one bundled
-`scripts/`/`references/`/`assets/` file within one, a subagent, or a slash
-command that the source no longer renders. In every case the writer deletes the
+`skills/`, `subagents/`, `commands/`, or the RETIRED `agents/` spelling — a whole
+skill, one bundled `scripts/`/`references/`/`assets/` file within one, a
+subagent, or a slash command that the source no longer renders. The retired
+prefix is listed because the canonical `agents/` → `subagents/` rename ships in
+the same release as namespacing: an upgrading user's state still holds the old
+spelling, and the only rewriter runs from `migrate subagents`, which no-ops for a
+user whose subagents come only from plugins. Without it their pre-rename
+destination would never be reclaimed — the exact leftover this exists to remove. In every case the writer deletes the
 orphaned file and **backs up an `orphan-drifted` dest first** (a hand-edit is
 never destroyed un-preserved). If that pre-delete read fails for any reason other
-than "already gone" — `EACCES`, `EIO`, `EISDIR` — that one delete is **skipped**
+than "already gone" — `EACCES`, `EIO`, `EISDIR`, or a non-regular shape like a
+FIFO whose read would BLOCK rather than fail — that one delete is **skipped**
 with a warning rather than performed blind: agentsync cannot tell whether the
 destination held an unsynced edit, and convergence is never worth data loss. The
 run itself continues, because a lingering orphan is not data loss while a failed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -613,6 +613,28 @@ on `hooks/<event>.toml`. A pure deletion carries no content to re-reference, so
 the funnel's secret guarantees are not in play; anything that writes *content*
 back still must go through `capture.Capture`.)
 
+**Plugin-provided components are never captured.** A component projected from an
+installed plugin has no canonical file of its own — it is re-derived from the
+plugin cache on every load — so writing a destination back for one would *mint* a
+canonical file under its (namespaced) name. The next load would then hold two
+components of that name, the captured copy and the plugin's own projection,
+rendering to one destination path, which apply refuses. Both dest→source entry
+points refuse:
+
+- **`import`** skips a plugin-provided component with a warning naming the
+  plugin, and errors outright if the user named one explicitly. An adapter's
+  `Ingest` reads the agent's native config, where a file agentsync rendered from
+  a plugin is indistinguishable from a hand-written one — so import projects the
+  plugins separately (`pluginProvided`) and matches by component name, which is
+  exact now that plugin components are namespaced.
+- **`reconcile`'s `[w]rite-back`** refuses the item and points at `[o]verride`.
+  It works from the PROJECTED canonical, so provenance is already on the
+  components (`pluginProvidedSourceIDs`) and no re-projection is needed.
+
+The edit belongs upstream in the plugin, or the plugin can be disabled. This is
+the capture-side complement to
+[plugin component namespacing](#plugin-component-namespacing).
+
 Re-reference matches by value, so it cannot distinguish a *moved or rotated*
 secret from a deliberate non-secret edit. As a **fail-closed backstop**,
 `capture.Capture` re-scans the about-to-be-written model

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -342,8 +342,11 @@ name) onto the component. Three consequences worth knowing:
   Claude's Agent Skills require the frontmatter `name` to match the skill
   directory. An absent `name` stays absent, so this never invents an identity the
   upstream artifact did not declare.
-- **Hand-authored components are never renamed**, so a plugin can never take a
-  name the user chose. `Plugin`/`BaseName` are empty for them.
+- **Hand-authored components are never renamed.** `Plugin`/`BaseName` are empty
+  for them. Note this is not the same as "a plugin can never take your name": the
+  derived name is not injective, so a plugin CAN land on a name you chose. That
+  residual is caught and reported by `checkProjectedConflicts` (below), never
+  silently resolved in the plugin's favour.
 
 The separator is a hyphen because Claude Code documents a subagent `name` as a
 "Unique identifier using lowercase letters and hyphens" — its familiar
@@ -672,15 +675,20 @@ serialized, each classified non-secret in `walkerCovered`).
 event because a plugin contributed one would silently drop the user's own. The
 join key is a content signature (event + matcher + type + command), which is what
 lets import match a plugin's projected handler against the agent's native ingest —
-the ingest carries no provenance at all. Reconcile needs no hook case: key-level
-write-back is implemented for MCP servers only and already errors for every other
-pointer shape.
+the ingest carries no provenance at all. Reconcile resolves hooks to no owner by
+construction: key-level write-back is implemented for MCP servers only and
+already errors for every other pointer shape, so no hook keys are registered for
+it to find. The lookup still returns "" explicitly rather than falling through,
+so implementing hook write-back later cannot silently permit the capture.
 
-The pointer lookup does **not** switch on the native root key. Those keys are
-per-agent data (`generic.MCPTarget.RootKey` grows with every agent added:
-`/context_servers`, `/servers`, `/amp.mcpServers`), so a hand-maintained allowlist
-would silently drop the refusal for each one someone forgets. It matches on the
-component id instead. Continue is the one adapter that renders MCP as a
+The key-item lookup takes the component KIND from the op's SourceID, never from
+the pointer's root key. Root keys are per-agent data (`generic.MCPTarget.RootKey`
+grows with every agent added: `/context_servers`, `/servers`, `/amp.mcpServers`),
+so a hand-maintained allowlist silently drops the refusal for each one someone
+forgets. Probing the id against both kinds instead would be worse than imprecise:
+a plugin shipping an LSP server named `github` would make an `/mcpServers/github`
+pointer resolve to it, refusing write-back of the user's own MCP server and
+blaming a plugin that does not own it. Continue is the one adapter that renders MCP as a
 **whole-file** op (one file per server), so servers are registered under both the
 bare `mcp/<id>` key and the `mcp/<id>.toml` SourceID form.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -757,9 +757,14 @@ empty-merge op) and **whole-file components** whose `source_id` is under
 command that the source no longer renders. In every case the writer deletes the
 orphaned file and **backs up an `orphan-drifted` dest first** (a hand-edit is
 never destroyed un-preserved). If that pre-delete read fails for any reason other
-than "already gone" — `EACCES`, `EIO`, `EISDIR` — the reclaim is **refused**
-rather than performed blind: agentsync cannot tell whether the destination held
-an unsynced edit, and convergence is never worth data loss. Empty-directory pruning applies to **skills
+than "already gone" — `EACCES`, `EIO`, `EISDIR` — that one delete is **skipped**
+with a warning rather than performed blind: agentsync cannot tell whether the
+destination held an unsynced edit, and convergence is never worth data loss. The
+run itself continues, because a lingering orphan is not data loss while a failed
+apply would wedge every other agent's writes. A skipped delete is **retried**:
+`PruneStaleState` keeps the state entry for a reclaimable destination that is
+still on disk, so the next apply tries again and warns again rather than
+forgetting the file forever. Empty-directory pruning applies to **skills
 only** — a skill is a directory under the Agent Skills spec, so removal must
 reclaim the whole tree, pruned up to but never including the agent's skills root;
 subagents and commands are flat files in a directory the agent always owns.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,6 +315,58 @@ read-only-on-import, components-only-on-apply rule above:
 
 See the capability matrix for source links.
 
+### Plugin component namespacing
+
+`LoadProjected` flattens every enabled plugin's components into one canonical
+model, and adapters derive each destination path from the component's `Name`. So
+two plugins shipping a same-named component render two files at one path — a
+real, stock case: `feature-dev` and `pr-review-toolkit` (both official Claude
+plugins) each ship `agents/code-reviewer.md`. Apply refused, correctly, since
+silently keeping one is data loss. But both files live under the
+marketplace-managed plugin cache, so the remedy the error named — "rename one" —
+was one the user structurally could not perform (issue #211).
+
+**A plugin-provided subagent, skill, or command is therefore renamed to
+`<plugin>-<name>` at projection**, in `marketplace.namespaceProjected`, which
+also stamps `Plugin` (the providing plugin's id) and `BaseName` (the upstream
+name) onto the component. Three consequences worth knowing:
+
+- **It is not an adapter concern, structurally.** Provenance is dropped when
+  `loadProjected` appends each plugin's components into flat slices, so by the
+  time an adapter can *detect* a collision, the information needed to *resolve*
+  it is gone. Rewriting `Name` (rather than teaching each adapter an "effective
+  name") is also what keeps every render site correct with no adapter change.
+- **The frontmatter `name` key is rewritten in step, when present.** Renaming
+  only the file would leave the components colliding anyway: Codex's `name` *is*
+  the agent's identity and the Codex adapter prefers it over the file stem, and
+  Claude's Agent Skills require the frontmatter `name` to match the skill
+  directory. An absent `name` stays absent, so this never invents an identity the
+  upstream artifact did not declare.
+- **Hand-authored components are never renamed**, so a plugin can never take a
+  name the user chose. `Plugin`/`BaseName` are empty for them.
+
+The separator is a hyphen because Claude Code documents a subagent `name` as a
+"Unique identifier using lowercase letters and hyphens" — its familiar
+`plugin:agent` form is a *scoped identifier* Claude Code derives from the plugin
+directory, never a `name` value, and `:` is rejected by
+`source.ValidateComponentID` (it becomes a filename, and a colon is illegal on
+Windows). A plugin id comes from a marketplace, outside agentsync's trust
+boundary, so every derived name is re-validated through that same write-boundary
+sanitizer before it can reach a path or a diagnostic.
+
+MCP and LSP servers are deliberately **not** namespaced. They are id-keyed and
+already covered by `checkProjectedConflicts`, whose hard failure on a same-id
+divergence is a security property: two sources claiming one server id can be a
+silent endpoint hijack, which is a case to refuse rather than to rename apart.
+Hooks have no name key at all.
+
+The rename happens once, on the first apply after upgrading, so `apply` reclaims
+the pre-rename destination files it previously wrote — see
+[§7 Safety primitives](#7-safety-primitives). Without that, a stale
+`~/.claude/agents/code-reviewer.md` would sit beside the two namespaced files and
+Claude Code would load it, leaving the user with *more* duplicate agents than
+before.
+
 ### WarnEmitter (optional)
 
 A second optional extension lets callers redirect the warnings an adapter's
@@ -612,14 +664,24 @@ auto-resolves only the cases that can't lose work (`converged`, `pending`).
 **Orphan reclamation on `apply`.** `apply` itself reclaims two kinds of orphan so
 a removed component doesn't linger in the destination: emptied key-merge sections
 (an MCP/hook/LSP section whose source went empty — cleaned via a synthesized
-empty-merge op) and **skill files** (a whole skill, or one bundled
-`scripts/`/`references/`/`assets/` file, removed from `~/.agentsync/skills/`). A
-skill is a directory under the Agent Skills spec, so removal must reclaim the
-whole tree; the writer deletes each orphaned file, **backs up an `orphan-drifted`
-dest first** (a hand-edit is never destroyed un-preserved), and prunes the
-now-empty directories up to — never including — the agent's skills root. Other
-replace-strategy orphans (subagents, commands) are still surfaced for the
-interactive `reconcile` loop rather than auto-deleted.
+empty-merge op) and **whole-file components** whose `source_id` is under
+`skills/`, `subagents/`, or `commands/` — a whole skill, one bundled
+`scripts/`/`references/`/`assets/` file within one, a subagent, or a slash
+command that the source no longer renders. In every case the writer deletes the
+orphaned file and **backs up an `orphan-drifted` dest first** (a hand-edit is
+never destroyed un-preserved). Empty-directory pruning applies to **skills
+only** — a skill is a directory under the Agent Skills spec, so removal must
+reclaim the whole tree, pruned up to but never including the agent's skills root;
+subagents and commands are flat files in a directory the agent always owns.
+
+Subagents and commands joined skills here because [plugin component
+namespacing](#plugin-component-namespacing) renames every plugin-provided
+component exactly once, on the first apply after upgrading. Without reclamation
+the pre-rename file would linger, and Claude Code reads *every* file in its
+agents directory — its docs are explicit that two same-`name` definitions in one
+directory mean it loads only one, "chosen by filesystem read order rather than a
+documented precedence". The same convergence argument covers an ordinary removal
+from the canonical source, which previously lingered until a `reconcile`.
 
 **Granularity.** Structured files (JSON/JSONC/TOML) are tracked per **JSON
 pointer**, so agentsync can own `$.mcpServers.github` inside `~/.claude.json`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,11 +354,33 @@ Windows). A plugin id comes from a marketplace, outside agentsync's trust
 boundary, so every derived name is re-validated through that same write-boundary
 sanitizer before it can reach a path or a diagnostic.
 
-MCP and LSP servers are deliberately **not** namespaced. They are id-keyed and
+MCP and LSP servers are deliberately **not** renamed. They are id-keyed and
 already covered by `checkProjectedConflicts`, whose hard failure on a same-id
 divergence is a security property: two sources claiming one server id can be a
 silent endpoint hijack, which is a case to refuse rather than to rename apart.
+They ARE stamped with provenance, so the capture paths can still refuse them.
 Hooks have no name key at all.
+
+**The derived name is not injective, so the collision guard stays.** Plugin `a`
+shipping `b-c` and plugin `a-b` shipping `c` both derive `a-b-c`, and a user who
+hand-authors `feature-dev-code-reviewer` collides with what plugin `feature-dev`
+derives. `checkProjectedConflicts` therefore guards name-keyed components exactly
+as it guards MCP/LSP ids — fatal for the mutating loads, a warning for the lenient
+read-only ones — and its message names each side's origin (the providing plugin,
+or the user's own canonical file). Without it those cases reach the render
+pipeline, where divergent content aborts with a message that can name neither
+origin (a `FileOp` carries no provenance) and **identical content is silently
+deduped**, dropping a component with no report at all. The silent drop is the
+reason the guard exists; the loud one it merely makes actionable.
+
+Namespacing itself never fails. An earlier revision validated the derived name at
+projection and returned an error — a regression, because the projection's own
+`validateProjectedName` permits `:` and control runes, and because `loadProjected`
+propagates a projection error regardless of `lenient`, taking down the read-only
+commands whose whole design is to degrade and show state. The name safety lives
+downstream at the single dispatch waist, where `render.Plan` runs
+`ValidateComponentID` over every component id before any of them is joined into a
+destination path.
 
 The rename happens once, on the first apply after upgrading, so `apply` reclaims
 the pre-rename destination files it previously wrote — see
@@ -626,10 +648,27 @@ points refuse:
   `Ingest` reads the agent's native config, where a file agentsync rendered from
   a plugin is indistinguishable from a hand-written one — so import projects the
   plugins separately (`pluginProvided`) and matches by component name, which is
-  exact now that plugin components are namespaced.
+  exact now that plugin components are namespaced. If that projection FAILS the
+  filter fails **closed** (the import refuses) rather than proceeding with an
+  empty skip set: the filter exists to stop import poisoning the canonical
+  source, and it is fed by plugin data, so a fail-open would be a way to switch
+  the defence off.
 - **`reconcile`'s `[w]rite-back`** refuses the item and points at `[o]verride`.
   It works from the PROJECTED canonical, so provenance is already on the
-  components (`pluginProvidedSourceIDs`) and no re-projection is needed.
+  components (`pluginProvidedSourceIDs`) and no re-projection is needed. The
+  check sits at `writeBackItem`, the dispatch waist, so it covers both shapes:
+  whole-file components matched by SourceID, and key-level MCP/LSP servers
+  matched from the item's JSON pointer.
+
+This covers **MCP and LSP servers too**, which are not namespaced but are still
+plugin-owned: capturing one mints a canonical copy that renders identically today
+and diverges the moment the plugin updates, at which point `checkProjectedConflicts`
+refuses every load. `MCPServer.Plugin` / `LSPServer.Plugin` carry that provenance
+(derived state, never serialized, classified non-secret in `walkerCovered`).
+
+Both lookups are scoped to the canonical the render actually uses: at project
+scope that is the project-only overlay, so a user-scope plugin never shadows a
+project component that merely shares its name.
 
 The edit belongs upstream in the plugin, or the plugin can be disabled. This is
 the capture-side complement to
@@ -691,7 +730,10 @@ empty-merge op) and **whole-file components** whose `source_id` is under
 `scripts/`/`references/`/`assets/` file within one, a subagent, or a slash
 command that the source no longer renders. In every case the writer deletes the
 orphaned file and **backs up an `orphan-drifted` dest first** (a hand-edit is
-never destroyed un-preserved). Empty-directory pruning applies to **skills
+never destroyed un-preserved). If that pre-delete read fails for any reason other
+than "already gone" — `EACCES`, `EIO`, `EISDIR` — the reclaim is **refused**
+rather than performed blind: agentsync cannot tell whether the destination held
+an unsynced edit, and convergence is never worth data loss. Empty-directory pruning applies to **skills
 only** — a skill is a directory under the Agent Skills spec, so removal must
 reclaim the whole tree, pruned up to but never including the agent's skills root;
 subagents and commands are flat files in a directory the agent always owns.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -696,6 +696,17 @@ Both lookups are scoped to the canonical the render actually uses: at project
 scope that is the project-only overlay, so a user-scope plugin never shadows a
 project component that merely shares its name.
 
+**One exception, and it is asymmetric on purpose.** A component the user ALSO
+declares is not treated as plugin-provided — but only for **hooks**, because
+`source.WriteHooks` replaces the whole `hooks/<event>.toml`, so a handler import
+declines to capture is *erased* from the canonical source. Everywhere else
+(`WriteMCP`, `WriteSkill`, …) writes one file per component, so a refusal deletes
+nothing — and letting the user's claim win there would be worse: import would
+capture the drifted native content, the user's copy and the plugin's projection
+would diverge, and every later mutating load would hard-fail in
+`checkProjectedConflicts`. The override exists to prevent a DELETION, not to
+decide ownership.
+
 The edit belongs upstream in the plugin, or the plugin can be disabled. This is
 the capture-side complement to
 [plugin component namespacing](#plugin-component-namespacing).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -660,11 +660,29 @@ points refuse:
   whole-file components matched by SourceID, and key-level MCP/LSP servers
   matched from the item's JSON pointer.
 
-This covers **MCP and LSP servers too**, which are not namespaced but are still
-plugin-owned: capturing one mints a canonical copy that renders identically today
-and diverges the moment the plugin updates, at which point `checkProjectedConflicts`
-refuses every load. `MCPServer.Plugin` / `LSPServer.Plugin` carry that provenance
-(derived state, never serialized, classified non-secret in `walkerCovered`).
+This covers **MCP servers, LSP servers, and hooks too** — plugin-owned but not
+namespaced. Capturing an MCP/LSP server mints a canonical copy that renders
+identically today and diverges the moment the plugin updates, at which point
+`checkProjectedConflicts` refuses every load. `MCPServer.Plugin` /
+`LSPServer.Plugin` / `Hook.Plugin` carry that provenance (derived state, never
+serialized, each classified non-secret in `walkerCovered`).
+
+**Hooks are filtered per HANDLER, not per event.** A canonical
+`hooks/<event>.toml` holds many handlers from many sources, so refusing a whole
+event because a plugin contributed one would silently drop the user's own. The
+join key is a content signature (event + matcher + type + command), which is what
+lets import match a plugin's projected handler against the agent's native ingest —
+the ingest carries no provenance at all. Reconcile needs no hook case: key-level
+write-back is implemented for MCP servers only and already errors for every other
+pointer shape.
+
+The pointer lookup does **not** switch on the native root key. Those keys are
+per-agent data (`generic.MCPTarget.RootKey` grows with every agent added:
+`/context_servers`, `/servers`, `/amp.mcpServers`), so a hand-maintained allowlist
+would silently drop the refusal for each one someone forgets. It matches on the
+component id instead. Continue is the one adapter that renders MCP as a
+**whole-file** op (one file per server), so servers are registered under both the
+bare `mcp/<id>` key and the `mcp/<id>.toml` SourceID form.
 
 Both lookups are scoped to the canonical the render actually uses: at project
 scope that is the project-only overlay, so a user-scope plugin never shadows a

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -66,6 +66,15 @@ agentsync and the agent's plugin manager, and double-install with the agent's
 own per-plugin install dir. See
 [architecture.md § PluginIngester (read-only)](architecture.md#pluginingester-read-only).
 
+Those native paths are flat, so a plugin's **subagents, skills, and commands are
+namespaced by their plugin**: `feature-dev`'s `code-reviewer` lands as
+`~/.claude/agents/feature-dev-code-reviewer.md`. Without it, two plugins shipping
+one component name would render two files at one path. Components you
+hand-author in `~/.agentsync/` are never renamed. MCP and LSP servers keep their
+ids — a same-id divergence across sources is refused rather than renamed apart,
+because it can be a silent endpoint hijack. See
+[architecture.md § Plugin component namespacing](architecture.md#plugin-component-namespacing).
+
 ---
 
 ## Component × agent

--- a/docs/components.md
+++ b/docs/components.md
@@ -351,8 +351,13 @@ noop-registered agent unless `AGENTSYNC_ALLOW_UNIMPLEMENTED=1`.
 
 ### `internal/render`
 Orchestrates apply: canonical + registry → per-agent `FileOp`s/`Skip`s, runs
-collision detection and backups, records state, synthesizes cleanup ops for
-orphaned owned keys, and builds the translation report. `Plan` also validates
+collision detection and backups, records state, and builds the translation
+report. It reclaims two kinds of orphan: emptied key-merge sections (synthesized
+cleanup ops for orphaned owned keys) and **whole-file components** whose
+`source_id` is under `skills/`, `subagents/`, `commands/`, or the retired
+`agents/` spelling — a destination whose source no longer renders it is deleted,
+backing up a hand-edit first, and SKIPPED (with the state entry kept, so the next
+apply retries) when it cannot be read. `Plan` also validates
 every component id that becomes a destination filename — subagent/command/skill
 `Name` plus MCP/LSP server ids (a per-server-file adapter like continuedev joins
 the id into a path) — against `source.ValidateComponentID` before any adapter
@@ -361,8 +366,14 @@ symmetric with the dest→source write boundary (see architecture §7).
 - **Key:** `Plan`; `Apply`; `PreviewApply` (dry-run: collision preview +
   synced/would-change verdict); `Writer`
   (`NewWriter`/`NewPreviewWriter`); `TranslationReport` (`PrintText`/`PrintJSON`);
-  `BuildReport`; `RecordOpsState`; `OrphanFiles`; `PruneStaleState`;
-  `BackupFile`/`PruneBackups`; `CollisionReport`.
+  `BuildReport`; `RecordOpsState`; `PruneStaleState`;
+  `BackupFile`/`PruneBackups`; `CollisionReport`; and the orphan-reclamation
+  trio — `OrphanFiles` (what state owns but the plan no longer renders),
+  `OrphanDeletes` (the deletes apply will perform), `OrphanIsReclaimable` (is
+  this component KIND reclaimed at all — drives reconcile's prompt wording) and
+  `OrphanDeleteWillProceed` (will THIS destination actually be removed on this
+  run — keeps the apply summary from counting a skipped delete). `IsRegularOrAbsent`
+  is shared with `internal/cli`'s destination reads so a FIFO cannot block them.
 - **Depends on:** adapter, secrets, source, state, paths, iox, drift.
 - **Files:** `pipeline.go`, `writer.go`, `state_apply.go`, `report.go`.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -401,7 +401,10 @@ manifests into canonical components.
   (one installed plugin in isolation — lets `explain <id>` attribute coverage to
   the named plugin rather than the flattened union); `Fetcher` (interface) with
   `GitFetcher`/`NPMFetcher`/`RelativeFetcher`; `LoadProjected`/
-  `LoadProjectedLenient`/`LoadProjectedExcluding`.
+  `LoadProjectedLenient`/`LoadProjectedExcluding`; `namespaceProjected` (renames
+  each plugin-provided subagent/skill/command to `<plugin>-<name>` and stamps its
+  provenance, so two plugins shipping one name cannot collide at a destination
+  path — see architecture.md § Plugin component namespacing).
 - **Depends on:** source, log.
 - **Files:** `manifest.go`, `treehash.go` (the `tree:v1:` content hash),
   `projection.go`, `loadprojected.go`, `fetcher.go`, `fetch_git.go`,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -192,8 +192,9 @@ every enabled plugin's components into one destination directory, two plugins
 shipping a same-named component would render two files at one path — so a
 plugin-provided subagent, skill, or command renders as `<plugin>-<name>`:
 `feature-dev`'s `code-reviewer` lands as `feature-dev-code-reviewer`. Components
-you hand-author in `~/.agentsync/` are never renamed, so a plugin can never take
-a name you chose. See
+you hand-author in `~/.agentsync/` are never renamed. A plugin's derived name can
+still land on one of yours (the mapping is not injective); agentsync reports that
+clash naming both sides rather than letting either win silently. See
 [architecture.md § Plugin component namespacing](architecture.md#plugin-component-namespacing).
 
 ### Translation report & coverage

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -187,6 +187,15 @@ for discovery, `apply` never re-emits it. See
 [architecture.md § PluginIngester (read-only)](architecture.md#pluginingester-read-only)
 for the full rationale.
 
+**Plugin components are namespaced by their plugin.** Because apply flattens
+every enabled plugin's components into one destination directory, two plugins
+shipping a same-named component would render two files at one path — so a
+plugin-provided subagent, skill, or command renders as `<plugin>-<name>`:
+`feature-dev`'s `code-reviewer` lands as `feature-dev-code-reviewer`. Components
+you hand-author in `~/.agentsync/` are never renamed, so a plugin can never take
+a name you chose. See
+[architecture.md § Plugin component namespacing](architecture.md#plugin-component-namespacing).
+
 ### Translation report & coverage
 Every `apply` and `plugin explain` ends with a report showing, per plugin per agent,
 what landed (`check` only schema-lints the source and validates secrets — it

--- a/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
+++ b/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
@@ -1,7 +1,9 @@
 # Namespace plugin-provided components by plugin — Design Spec
 
 **Date:** 2026-07-28
-**Status:** Approved in brainstorming.
+**Status:** Approved in brainstorming; amended after a four-lens adversarial
+review — see [Amendments](#amendments-after-review) for the two design points
+this document originally got wrong.
 **Issue:** [#211 — Cross-plugin subagent name collisions are unresolvable — the codex error names a remedy the user cannot perform](https://github.com/spxrogers/agentsync/issues/211)
 
 ---
@@ -147,7 +149,7 @@ message meant to identify the conflict is informative precisely when it fires.
 
 ### 6. Orphan reclamation extended to subagents and commands
 
-`skillOrphanDeletes` (`internal/render/state_apply.go:183`) reclaims only
+`skillOrphanDeletes` (now `orphanDeletes`, `internal/render/state_apply.go`) reclaims only
 `skills/` SourceIDs. `PruneStaleState` drops the state entry for a destination
 that stopped being rendered but does not delete the file.
 
@@ -210,3 +212,37 @@ own change. Filed separately.
 `docs/concepts.md`, `docs/architecture.md`, `docs/capability-matrix.md`,
 `docs/components.md`, `CHANGELOG.md`, and
 `website/src/content/docs/reference/upgrading.mdx`.
+
+---
+
+## Amendments after review
+
+Two things in the design above were changed during review. They are recorded here
+rather than edited away, because both were wrong for reasons worth keeping.
+
+**§2 said the derived name is validated with `source.ValidateComponentID` at
+projection. That validation was removed.** It was a *second*, stricter rune set
+than the projection's own `validateProjectedName` (which permits `:` and control
+runes), so a plugin that projected fine before started hard-failing — and
+`loadProjected` propagates a projection error regardless of `lenient`, taking
+down `status`/`diff`/`explain`, whose entire design is to degrade and show state.
+It was also redundant: `render.Plan` already runs `ValidateComponentID` over every
+component id at the single dispatch waist, before any id is joined into a
+destination path. The lesson is the codebase's own: one guard at one waist beats
+two that can drift.
+
+**§5 said the residual collision keeps its detector in the codex adapter. It
+moved to `checkProjectedConflicts`.** The codex check only fires for codex; every
+other agent fell through to the render pipeline, whose message can name neither
+origin (a `FileOp` carries no provenance) — and where two colliding components
+with *identical* bytes were silently deduped, dropping one with no report at all.
+That silent drop is the real bug; the loud one was merely unactionable.
+`checkProjectedConflicts` is where the codebase already guards cross-source id
+collisions for MCP/LSP, it runs with provenance in hand, and it has the
+strict-vs-lenient split this needs. Codex keeps its narrower frontmatter-vs-stem
+check as a backstop.
+
+**Also broadened during review:** the capture refusal covers MCP servers, LSP
+servers, and hooks (hooks per *handler*, since one canonical `hooks/<event>.toml`
+holds handlers from many sources), not just the three name-keyed kinds; and the
+"Known adjacent gap" below was closed rather than deferred.

--- a/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
+++ b/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
@@ -263,7 +263,11 @@ the upgrade notice promises.
 **Also broadened during review:** the capture refusal covers MCP servers, LSP
 servers, and hooks (hooks per *handler*, since one canonical `hooks/<event>.toml`
 holds handlers from many sources), not just the three name-keyed kinds; and the
-"Known adjacent gap" below was closed rather than deferred. A component the USER
+"Known adjacent gap" below was closed rather than deferred. A HOOK HANDLER the USER
 also declares is never treated as plugin-provided, even when a plugin ships an
 identical one — without that check, `import` dropped the user's own hook handler
-and `WriteHooks`' whole-file replace erased it from the canonical source.
+and `WriteHooks`' whole-file replace erased it from the canonical source. The
+override is **hooks-only**, deliberately: every other writer is
+one-file-per-component, so a refusal deletes nothing, whereas capturing a component
+the plugin also provides would make the two diverge and wedge every later mutating
+load in `checkProjectedConflicts`. See architecture.md § 5.

--- a/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
+++ b/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
@@ -1,0 +1,212 @@
+# Namespace plugin-provided components by plugin — Design Spec
+
+**Date:** 2026-07-28
+**Status:** Approved in brainstorming.
+**Issue:** [#211 — Cross-plugin subagent name collisions are unresolvable — the codex error names a remedy the user cannot perform](https://github.com/spxrogers/agentsync/issues/211)
+
+---
+
+## Summary
+
+Two installed plugins that each ship a component with the same name make
+`agentsync status` and `agentsync apply` exit 1, and every remedy the error
+suggests is one the user structurally cannot perform. The reproduction is two
+*stock official* plugins — `feature-dev@claude-plugins-official` and
+`pr-review-toolkit@claude-plugins-official` — each shipping
+`agents/code-reviewer.md`.
+
+The fix: **plugin-provided subagents, skills, and commands are always namespaced
+by their plugin**, at projection time. `feature-dev` + `code-reviewer` renders as
+`feature-dev-code-reviewer`; `pr-review-toolkit` + `code-reviewer` renders as
+`pr-review-toolkit-code-reviewer`. A component the user hand-authored in
+`~/.agentsync/` is never renamed.
+
+---
+
+## Goals / Non-goals
+
+**Goals**
+
+- A stock two-plugin install applies cleanly, with both components reachable.
+- Plugin components get stable, predictable names that do not depend on what
+  else is installed.
+- The collision detector stays, for the cases namespacing cannot reach, and its
+  message becomes actionable.
+- Existing users' stale pre-rename destination files are removed, not orphaned.
+
+**Non-goals**
+
+- A canonical-side override/precedence knob (let the user pin which plugin wins
+  a contested name, or rename a plugin-provided component). Deferred: automatic
+  namespacing makes the reported case work without one.
+- Fixing `import`'s re-capture of plugin-projected components (see
+  [Known adjacent gap](#known-adjacent-gap)).
+
+---
+
+## Why the fix cannot live in an adapter
+
+Both plugins project to `source.Subagent{Name: "code-reviewer"}` — the *file
+stem* collides, not merely the frontmatter `name`. Plugin provenance is dropped
+at `internal/marketplace/loadprojected.go:91`, a plain
+`c.Subagents = append(c.Subagents, proj.Subagents...)`, and `source.Subagent` has
+nowhere to keep it. By the time any adapter can detect the collision, the one
+piece of information needed to resolve it is already gone.
+
+It is also not codex-specific. The codex adapter errors first
+(`internal/adapter/codex/subagent.go:65`), but the Claude adapter emits two write
+ops at the same `~/.claude/agents/code-reviewer.md`. The `seen` map in
+`internal/render/pipeline.go` is not reset per agent, so its cross-agent
+divergence guard fires *within* a single adapter too, aborting with a message
+that misattributes the conflict to a second agent:
+
+```
+agent "claude" renders different content than an earlier agent for the same path …
+```
+
+Skills (`skills/<name>/SKILL.md`) and commands (`commands/<name>.md`) are the
+same class: name-keyed components rendered to a name-derived destination path.
+
+---
+
+## Design
+
+### 1. Rename at projection, not in adapters
+
+`projectOnePlugin` (`internal/marketplace/loadprojected.go`) already holds the
+plugin's filesystem id. After `projectWithFuncs` returns, each projected
+subagent, skill, and command is stamped with its provenance and its `Name` is
+rewritten to the namespaced form.
+
+Because `Name` is what every adapter derives its destination path and identity
+from, all render sites become correct with **no adapter changes**. The stamping
+runs *after* `resolveConflicts`, so the intra-plugin `dedupOrConflict`
+`reflect.DeepEqual` comparison is unaffected.
+
+`ProjectInstalled` shares `projectOnePlugin`, so `agentsync plugin explain`
+reports the same namespaced names the render produces.
+
+### 2. Separator: `-`
+
+Forced, not chosen. Claude Code documents a subagent `name` as a "Unique
+identifier using lowercase letters and hyphens", so `:` is not available — the
+familiar `plugin:agent` form is a *scoped identifier* Claude Code derives from
+the plugin directory, never a value written into a `name` field. Codex states no
+charset rule and treats `name` as the agent's identity, so a hyphenated name is
+equally valid there.
+
+The derived name is validated with `source.ValidateComponentID`, which already
+rejects path separators, `..`, `:`, and control/bidi runes — so a pathological
+plugin id cannot produce an unwritable or deceptive component name.
+
+### 3. Schema
+
+`source.Subagent`, `source.Skill`, and `source.Command` each gain:
+
+| Field | Meaning |
+| --- | --- |
+| `Plugin string` | Providing plugin's id; empty for a hand-authored component |
+| `BaseName string` | The pre-namespace name, for reporting and `explain` |
+
+Both are `toml:"-"`. These are file-backed components whose canonical form is a
+file on disk, and a projected component is never written back into
+`~/.agentsync/`, so neither field is ever serialized.
+
+Safe against `TestNewSecretFieldGuard`: that guard covers `MCPServerSpec`,
+`LSPServerSpec`, `Hook`, and their wrappers. Subagents, skills, and commands are
+text components the secret walker deliberately never visits, so no new field
+joins `walkSecretFields`.
+
+### 4. Frontmatter `name` follows the rename
+
+Renaming only `Name` would leave both components still colliding:
+
+- The codex adapter prefers `Frontmatter["name"]` over `s.Name` when deriving
+  the Codex agent identity (`internal/adapter/codex/subagent.go:58`).
+- Claude's Agent Skills require the frontmatter `name` to match the skill
+  directory name.
+
+So projection also rewrites `Frontmatter["name"]` **when the key is present**,
+leaving it absent when it was absent. That preserves the #144 contract that a
+deliberately-divergent frontmatter name survives Render → Ingest, while keeping
+the identity consistent with the path.
+
+### 5. The hard error stays; the message is fixed
+
+Namespacing cannot reach every collision:
+
+- two hand-authored canonical components with the same effective name;
+- the pathological case of plugin `a` shipping `b-c` against plugin `a-b`
+  shipping `c`.
+
+The detector in `codex/subagent.go` remains. Its message currently prints
+`%q and %q` from two file stems, which for the reported case renders as
+`"code-reviewer" and "code-reviewer"` — the same string twice, with no origin.
+It gains provenance (`from plugin X` / `hand-authored`) so the half of the
+message meant to identify the conflict is informative precisely when it fires.
+
+### 6. Orphan reclamation extended to subagents and commands
+
+`skillOrphanDeletes` (`internal/render/state_apply.go:183`) reclaims only
+`skills/` SourceIDs. `PruneStaleState` drops the state entry for a destination
+that stopped being rendered but does not delete the file.
+
+Without extending reclamation, always-namespacing would leave every existing
+user with a stale `~/.claude/agents/code-reviewer.md` beside the two new
+namespaced files — and Claude Code would load it. The fix would *add* a
+duplicate agent rather than remove one. Reclamation therefore extends to the
+`subagents/` and `commands/` SourceID prefixes, matching how skills already
+behave.
+
+### 7. Upgrade notice
+
+Always-namespacing renames every plugin-provided handle for every user, so it
+gets an `upgradeNotices` entry (the #203 mechanism) and the matching section in
+`website/src/content/docs/reference/upgrading.mdx`, per that table's documented
+contract that the two are maintained in parallel.
+
+---
+
+## Testing
+
+Anchored to the on-disk artifact, per the CLAUDE.md fidelity rule — the oracle is
+the rendered file tree, not the parsed model.
+
+- **Cross-plugin collision, end to end.** Fixtures of two plugin trees each
+  shipping `agents/code-reviewer.md` with differing content. Assert the render
+  produces two distinct destination files with distinct frontmatter names, and
+  that apply succeeds where it previously exited 1.
+- **Same for skills and commands**, since they share the failure class.
+- **Hand-authored components are untouched** — a canonical `subagents/foo.md`
+  keeps the bare name `foo` alongside a plugin that also ships `foo`.
+- **Frontmatter `name` absence is preserved** — a component with no `name` key
+  does not gain one.
+- **Claude-side path collision regression**, pinning that the pre-fix failure
+  came from the single-adapter path through `internal/render/pipeline.go`.
+- **Orphan reclamation** — a destination file written under a pre-rename name is
+  deleted on the next apply.
+- **The hard error still fires** for two hand-authored same-name components, and
+  its message names provenance.
+
+---
+
+## Known adjacent gap
+
+`importSubagent` walks the *native* ingested canonical and has no way to tell a
+plugin-projected file from a hand-authored one, so `agentsync import
+claude:subagent` after an apply copies plugin components into
+`~/.agentsync/subagents/`. Those then collide with the plugin's own projection on
+the next apply.
+
+**This is pre-existing and independent of this change** — it reproduces today
+with any single non-colliding plugin component. The provenance fields added here
+would make a filter cheap, but it changes `import` semantics and belongs in its
+own change. Filed separately.
+
+---
+
+## Docs touched in the same commit
+
+`docs/concepts.md`, `docs/architecture.md`, `docs/capability-matrix.md`,
+`docs/components.md`, `CHANGELOG.md`, and
+`website/src/content/docs/reference/upgrading.mdx`.

--- a/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
+++ b/docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md
@@ -242,7 +242,28 @@ collisions for MCP/LSP, it runs with provenance in hand, and it has the
 strict-vs-lenient split this needs. Codex keeps its narrower frontmatter-vs-stem
 check as a backstop.
 
+**§3 (Schema) is now incomplete.** It says only `Subagent`, `Skill`, and
+`Command` gain provenance, and that no field joins the structs
+`TestNewSecretFieldGuard` covers. Both changed: `MCPServer`, `LSPServer`, and
+`Hook` each carry a `Plugin` field too — they are never RENAMED (an id collision
+can be an endpoint hijack, refused rather than renamed apart; a hook has no name
+key at all), but the dest→source paths still need to know a plugin owns them. The
+guard did fire, and all three are classified `false` in `walkerCovered`
+(`internal/secrets/walk_test.go`), which is the mechanism working as designed
+rather than an exemption.
+
+**§6 (Orphan reclamation) is now incomplete.** Reclamation covers the RETIRED
+`agents/` SourceID spelling as well as `subagents/` and `commands/`. The
+canonical directory rename ships in this same release, so an upgrading user's
+state still holds the old spelling, and the only rewriter no-ops for a user whose
+subagents come only from plugins — which is the reported scenario. Without it
+their pre-rename destination is never reclaimed, which is the opposite of what
+the upgrade notice promises.
+
 **Also broadened during review:** the capture refusal covers MCP servers, LSP
 servers, and hooks (hooks per *handler*, since one canonical `hooks/<event>.toml`
 holds handlers from many sources), not just the three name-keyed kinds; and the
-"Known adjacent gap" below was closed rather than deferred.
+"Known adjacent gap" below was closed rather than deferred. A component the USER
+also declares is never treated as plugin-provided, even when a plugin ships an
+identical one — without that check, `import` dropped the user's own hook handler
+and `WriteHooks`' whole-file replace erased it from the canonical source.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -556,8 +556,10 @@ subagent `name` (or in a filename on Windows).
 
 **Components you write yourself are never renamed.** Anything in your own
 `~/.agentsync/subagents/`, `skills/`, or `commands/` keeps the name you gave it,
-even when an installed plugin ships one by the same name — a plugin can never
-take your name. MCP and LSP servers keep their ids too: two sources claiming one
+even when an installed plugin ships one by the same name. In the rare case where
+a plugin's *derived* name lands on one of yours (`feature-dev` shipping
+`code-reviewer` versus your own `feature-dev-code-reviewer`), agentsync says so
+and names both sides rather than picking a winner. MCP and LSP servers keep their ids too: two sources claiming one
 server id is refused rather than renamed apart, because repointing a trusted
 server's endpoint is a hijack, not a naming clash.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -178,7 +178,8 @@ component reports it and exits cleanly rather than erroring. Add `--dry-run` to
 list the source files an import would write without touching `~/.agentsync/`.
 
 **Import never re-captures a plugin's own components** — subagents, skills,
-commands, MCP servers, and LSP servers alike. Once you have applied, a plugin's
+commands, MCP servers, LSP servers, and hooks alike (hooks per *handler*, so a
+plugin hooking an event you also hook never costs you your own handler). Once you have applied, a plugin's
 components are sitting in the agent's native config indistinguishable from ones
 you wrote yourself — the agent's config gives no hint which ones agentsync put
 there. Importing them would create canonical copies that collide

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -477,10 +477,10 @@ skipped — and the report tells you exactly which:
   → claude    ✓ full        1 mcp · 5 commands · 3 subagents · 1 lsp
   → codex     ◐ partial     1 mcp · 5 commands · 3 subagents · 1 lsp  (3 reduced · 1 dropped)
       → codex couldn't fully translate — reduced = rendered without some fields; dropped = not emitted:
-        • subagent ai-architect   reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
-        • subagent deploy-expert  reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
-        • subagent perf-optimizer reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
-        • lsp atlassian-lsp       dropped  Codex has no LSP configuration concept
+        • subagent atlassian-ai-architect   reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • subagent atlassian-deploy-expert  reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • subagent atlassian-perf-optimizer reduced  Codex agents are TOML with no per-agent tools allowlist; dropped tools, color
+        • lsp atlassian-lsp                 dropped  Codex has no LSP configuration concept
 ```
 
 Each row's count tail lists every component kind the plugin hosts for that agent
@@ -518,6 +518,33 @@ agentsync plugin explain atlassian@anthropic --json            # machine-readabl
 
 (`agentsync plugin list` prints the installed ids. The top-level `explain` name
 answers a different question — see [Where did this file come from?](#where-did-this-file-come-from).)
+
+#### Plugin components are namespaced by their plugin
+
+A plugin's **subagents, skills, and slash commands** render under
+`<plugin>-<name>`, which is why the report above reads `atlassian-ai-architect`
+rather than `ai-architect`:
+
+| Plugin | Ships | Lands at | You invoke |
+|---|---|---|---|
+| `atlassian` | `agents/ai-architect.md` | `~/.claude/agents/atlassian-ai-architect.md` | `@agent-atlassian-ai-architect` |
+| `atlassian` | `commands/jira.md` | `~/.claude/commands/atlassian-jira.md` | `/atlassian-jira` |
+
+Every agent reads its components from one flat directory, so without this two
+plugins shipping a same-named component would write two files at one path. That
+is not hypothetical: `feature-dev` and `pr-review-toolkit` — both stock official
+plugins — each ship `agents/code-reviewer.md`, and before namespacing that made
+`agentsync apply` fail with no way out, since neither file is yours to rename.
+Claude Code reaches the same end natively, addressing a plugin's agent as
+`plugin:agent`; agentsync uses a hyphen because a colon is not legal in a
+subagent `name` (or in a filename on Windows).
+
+**Components you write yourself are never renamed.** Anything in your own
+`~/.agentsync/subagents/`, `skills/`, or `commands/` keeps the name you gave it,
+even when an installed plugin ships one by the same name — a plugin can never
+take your name. MCP and LSP servers keep their ids too: two sources claiming one
+server id is refused rather than renamed apart, because repointing a trusted
+server's endpoint is a hijack, not a naming clash.
 
 Control fan-out per plugin with `agents = [...]` in the plugin's TOML file. (A
 per-component `[plugin.overrides.<agent>]` table was specced but is **not wired

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -177,10 +177,11 @@ LSP, memory, **and plugins**) in one pass. A bulk import that finds nothing for 
 component reports it and exits cleanly rather than erroring. Add `--dry-run` to
 list the source files an import would write without touching `~/.agentsync/`.
 
-**Import never re-captures a plugin's own components.** Once you have applied,
-a plugin's subagents, skills, and commands are sitting in the agent's native
-config as ordinary files — and the agent's config gives no hint which ones
-agentsync put there. Importing them would create canonical copies that collide
+**Import never re-captures a plugin's own components** — subagents, skills,
+commands, MCP servers, and LSP servers alike. Once you have applied, a plugin's
+components are sitting in the agent's native config indistinguishable from ones
+you wrote yourself — the agent's config gives no hint which ones agentsync put
+there. Importing them would create canonical copies that collide
 with the plugin's own on the next apply, so `import` skips them and says which
 plugin provides each. Naming one explicitly
 (`agentsync import claude:subagent:feature-dev-code-reviewer`) is an error rather

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -177,6 +177,19 @@ LSP, memory, **and plugins**) in one pass. A bulk import that finds nothing for 
 component reports it and exits cleanly rather than erroring. Add `--dry-run` to
 list the source files an import would write without touching `~/.agentsync/`.
 
+**Import never re-captures a plugin's own components.** Once you have applied,
+a plugin's subagents, skills, and commands are sitting in the agent's native
+config as ordinary files — and the agent's config gives no hint which ones
+agentsync put there. Importing them would create canonical copies that collide
+with the plugin's own on the next apply, so `import` skips them and says which
+plugin provides each. Naming one explicitly
+(`agentsync import claude:subagent:feature-dev-code-reviewer`) is an error rather
+than a silent no-op. Components you wrote into the native config yourself are
+still captured normally. To change a plugin's component, change it upstream, or
+run `agentsync plugin disable <id>` to stop projecting it. `reconcile` refuses
+`[w]rite-back` on one for the same reason — use `[o]verride` to restore the
+plugin's version.
+
 **Plugins are a special case.** The `plugin` component (Claude and Codex) reads
 the agent's installed plugins and their marketplaces and re-fetches each one into
 the agentsync cache, pinning a manifest SHA — the same artifacts `marketplace

--- a/internal/adapter/codex/collision_test.go
+++ b/internal/adapter/codex/collision_test.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestRenderSubagents_CollisionErrorNamesOrigins pins the message half of issue
+// #211. The collision detector itself is correct and stays — Codex's `name` IS
+// the agent's identity, so two TOMLs cannot claim one, and silently overwriting
+// would be the bug. What was broken was what the error TOLD the user.
+//
+// It printed two file stems, and colliding subagents almost always SHARE a stem,
+// so it rendered as `"code-reviewer" and "code-reviewer"` — the same string
+// twice, with no origin. The half of the message meant to identify the conflict
+// was structurally uninformative precisely when it fired.
+func TestRenderSubagents_CollisionErrorNamesOrigins(t *testing.T) {
+	a := &Adapter{}
+	p := Paths{AgentsDir: "/codex/agents"}
+
+	t.Run("names each side's plugin", func(t *testing.T) {
+		// The pathological residue namespacing cannot resolve: plugin "a" ships
+		// "b-c" while plugin "a-b" ships "c", so both derive the same name.
+		c := source.Canonical{Subagents: []source.Subagent{
+			{Name: "a-b-c", BaseName: "b-c", Plugin: "a", Frontmatter: map[string]any{}},
+			{Name: "a-b-c", BaseName: "c", Plugin: "a-b", Frontmatter: map[string]any{}},
+		}}
+		_, _, err := a.renderSubagents(c, p)
+		if err == nil {
+			t.Fatal("two subagents resolving to one Codex name must be an error")
+		}
+		for _, want := range []string{`plugin "a"`, `plugin "a-b"`, `as "b-c"`, `as "c"`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should carry %s so the user can tell the sides apart; got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("names the canonical file for a hand-authored subagent", func(t *testing.T) {
+		// Two hand-authored components whose frontmatter names collide: the
+		// genuinely user-resolvable case, where "rename one" IS actionable — so
+		// the message must point at the files the user can actually edit.
+		c := source.Canonical{Subagents: []source.Subagent{
+			{Name: "reviewer", Frontmatter: map[string]any{"name": "shared"}},
+			{Name: "auditor", Frontmatter: map[string]any{"name": "shared"}},
+		}}
+		_, _, err := a.renderSubagents(c, p)
+		if err == nil {
+			t.Fatal("two frontmatter names resolving to one Codex name must be an error")
+		}
+		for _, want := range []string{"subagents/reviewer.md", "subagents/auditor.md", `"shared"`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should carry %s; got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("distinct names render both", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			{Name: "a-reviewer", BaseName: "reviewer", Plugin: "a", Frontmatter: map[string]any{"name": "a-reviewer"}},
+			{Name: "b-reviewer", BaseName: "reviewer", Plugin: "b", Frontmatter: map[string]any{"name": "b-reviewer"}},
+		}}
+		ops, _, err := a.renderSubagents(c, p)
+		if err != nil {
+			t.Fatalf("namespaced subagents must not collide: %v", err)
+		}
+		if len(ops) != 2 || ops[0].Path == ops[1].Path {
+			t.Fatalf("want two ops at distinct paths; got %d: %+v", len(ops), ops)
+		}
+	})
+}

--- a/internal/adapter/codex/subagent.go
+++ b/internal/adapter/codex/subagent.go
@@ -43,13 +43,28 @@ var codexAgentKnownKeys = map[string]bool{"name": true, "description": true, "mo
 // agent's identity, two subagents with distinct file stems that resolve to the
 // same effective `name` would write two TOMLs claiming one identity; that
 // collision is reported as an error rather than emitted silently.
+//
+// The common cause of that collision used to be two plugins each shipping a
+// same-named agent — for which the error's "rename one" was advice the user
+// structurally could NOT take, since both files live under the
+// marketplace-managed plugin cache (issue #211). Plugin-provided components are
+// now namespaced by their plugin at projection time
+// (marketplace.namespaceProjected), so that case no longer reaches here. What
+// remains is genuinely user-resolvable — two hand-authored canonical subagents,
+// or the pathological overlap of plugin "a" shipping "b-c" against plugin "a-b"
+// shipping "c" — so the error stays, and names each side's origin so the user
+// can tell which files to edit.
 func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp, []adapter.Skip, error) {
 	var ops []adapter.FileOp
 	var skips []adapter.Skip
 	// seenNames maps each effective Codex agent name already rendered to the
-	// canonical name (file stem) that first produced it, so a later subagent
-	// resolving to the same effective name is caught as a collision.
-	seenNames := map[string]string{}
+	// subagent that first produced it, so a later subagent resolving to the same
+	// effective name is caught as a collision. The whole subagent is kept (not
+	// just its stem) because the error must name each side's ORIGIN: colliding
+	// subagents almost always SHARE a file stem, so printing the two stems
+	// rendered as the same string twice — structurally uninformative precisely
+	// when it fired.
+	seenNames := map[string]source.Subagent{}
 	for _, s := range c.Subagents {
 		// Codex treats the `name` field as the source of truth; prefer the
 		// frontmatter name when present, falling back to the filename-derived
@@ -64,11 +79,11 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		// "capture it or acknowledge it, never drop it silently" invariant.
 		if first, ok := seenNames[name]; ok {
 			return nil, nil, fmt.Errorf(
-				"codex subagents %q and %q resolve to the same agent name %q; rename one or set distinct frontmatter names",
-				first, s.Name, name,
+				"codex subagents %s and %s both resolve to the agent name %q; rename one or set distinct frontmatter names",
+				subagentOrigin(first), subagentOrigin(s), name,
 			)
 		}
-		seenNames[name] = s.Name
+		seenNames[name] = s
 		af := codexAgentFile{
 			Name:                  name,
 			Description:           fmString(s.Frontmatter, "description"),
@@ -98,6 +113,18 @@ func (a *Adapter) renderSubagents(c source.Canonical, p Paths) ([]adapter.FileOp
 		})
 	}
 	return ops, skips, nil
+}
+
+// subagentOrigin identifies one side of a name collision by where it came from,
+// which is the only thing that distinguishes the two sides when — as is almost
+// always the case — they share a file stem. A plugin-provided subagent names its
+// plugin and its upstream name; a hand-authored one names the canonical file the
+// user can actually edit.
+func subagentOrigin(s source.Subagent) string {
+	if s.Plugin != "" {
+		return fmt.Sprintf("%q (from plugin %q, as %q)", s.Name, s.Plugin, s.BaseName)
+	}
+	return fmt.Sprintf("%q (%s)", s.Name, source.SubagentSourceID(s.Name))
 }
 
 // fmString returns the string value at key in a frontmatter map, or "".

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -168,7 +168,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 		// reports in its headline, so a delete-only run no longer previews as
 		// "Plan: 0 ops … 0 to write" and then surprises with "removed: …" on the
 		// real run. Dry-run never prunes state, so the state entries
-		// SkillOrphanDeletes reads are still intact here.
+		// OrphanDeletes reads are still intact here.
 		if removedKeys, removedFiles, _ := removalCounts(plan, s, userHome, sc, projectRoot); removedKeys+removedFiles > 0 {
 			fmt.Fprintf(w, "%s %s (the real apply will remove these)\n",
 				p.Bold("Removals:"), removedLabel(removedKeys, removedFiles))
@@ -217,7 +217,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 	}
 
 	// Count convergence-time removals NOW, before PruneStaleState drops the
-	// state entries SkillOrphanDeletes reads — so the summary can report
+	// state entries OrphanDeletes reads — so the summary can report
 	// "removed: N key(s)/file(s)" instead of mislabeling a delete-only run as
 	// "up to date" / "applied: 0 ops".
 	removedKeys, removedFiles, appliedOps := removalCounts(plan, s, userHome, sc, projectRoot)
@@ -394,9 +394,10 @@ func planSyncCounts(plan render.RenderPlan, wouldChange map[string]bool) (toWrit
 // report them instead of mislabeling a delete-only run "up to date" / "applied: 0
 // ops":
 //
-//   - removedFiles: whole skill-file deletes (a skill, or a bundled file, removed
-//     from source), surfaced by render.SkillOrphanDeletes and deduped across
-//     agents that share a skills dir; and
+//   - removedFiles: whole-file component deletes (a skill, a bundled file within
+//     one, a subagent, or a command removed from — or renamed in — source),
+//     surfaced by render.OrphanDeletes and deduped across agents that share a
+//     destination dir; and
 //   - removedKeys: orphan-cleanup key removals — an emptied merge section renders
 //     as a "{}" key-merge op carrying the owned pointers to drop
 //     (render.orphanCleanupOps), so each such op removes len(OwnedKeys) keys
@@ -407,14 +408,14 @@ func planSyncCounts(plan render.RenderPlan, wouldChange map[string]bool) (toWrit
 // appliedOps is plan.Total() with the pure "{}" removal ops subtracted, so a
 // mixed run reports the removal under "removed:" and does not also count it as an
 // applied write. MUST be called BEFORE PruneStaleState, which drops the state
-// entries SkillOrphanDeletes reads. (Dry-run never prunes, so it can call this
+// entries OrphanDeletes reads. (Dry-run never prunes, so it can call this
 // at any point.)
 func removalCounts(plan render.RenderPlan, s *state.Targets, userHome string, sc adapter.Scope, projectRoot string) (removedKeys, removedFiles, appliedOps int) {
 	appliedOps = plan.Total()
-	skillDeletes := map[string]bool{}
+	fileDeletes := map[string]bool{}
 	for name, res := range plan.PerAgent {
-		for _, del := range render.SkillOrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
-			skillDeletes[del.Path] = true
+		for _, del := range render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
+			fileDeletes[del.Path] = true
 		}
 		for _, op := range res.Ops {
 			// An orphan-cleanup op is a key-merge op whose rendered content is the
@@ -428,7 +429,7 @@ func removalCounts(plan render.RenderPlan, s *state.Targets, userHome string, sc
 			}
 		}
 	}
-	removedFiles = len(skillDeletes)
+	removedFiles = len(fileDeletes)
 	if appliedOps < 0 {
 		appliedOps = 0
 	}
@@ -459,7 +460,7 @@ func removedLabel(keys, files int) string {
 // git-backed apply's deletions unrecoverable. It is a superset of the eventual
 // `written` set (a planned op may turn out already-in-sync), which is exactly
 // right for deciding which roots to baseline. MUST be called before
-// render.PruneStaleState, which drops the state entries SkillOrphanDeletes
+// render.PruneStaleState, which drops the state entries OrphanDeletes
 // reads.
 func baselinePaths(plan render.RenderPlan, s *state.Targets, userHome string, sc adapter.Scope, projectRoot string) map[string]bool {
 	out := map[string]bool{}
@@ -467,7 +468,7 @@ func baselinePaths(plan render.RenderPlan, s *state.Targets, userHome string, sc
 		for _, op := range res.Ops {
 			out[op.Path] = true
 		}
-		for _, del := range render.SkillOrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
+		for _, del := range render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
 			out[del.Path] = true
 		}
 	}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -420,7 +420,7 @@ func removalCounts(plan render.RenderPlan, s *state.Targets, userHome string, sc
 			// entry is kept so the next run retries — so counting it here would
 			// print "removed: N" on every run alongside the warning saying it was
 			// not removed.
-			if render.OrphanDeleteWillProceed(del.Path) {
+			if render.OrphanDeleteWillProceed(del) {
 				fileDeletes[del.Path] = true
 			}
 		}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -415,7 +415,14 @@ func removalCounts(plan render.RenderPlan, s *state.Targets, userHome string, sc
 	fileDeletes := map[string]bool{}
 	for name, res := range plan.PerAgent {
 		for _, del := range render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
-			fileDeletes[del.Path] = true
+			// Count only what apply will actually remove. An orphan whose
+			// destination cannot be read is SKIPPED with a warning, and its state
+			// entry is kept so the next run retries — so counting it here would
+			// print "removed: N" on every run alongside the warning saying it was
+			// not removed.
+			if render.OrphanDeleteWillProceed(del.Path) {
+				fileDeletes[del.Path] = true
+			}
 		}
 		for _, op := range res.Ops {
 			// An orphan-cleanup op is a key-merge op whose rendered content is the

--- a/internal/cli/apply_orphan_rename_test.go
+++ b/internal/cli/apply_orphan_rename_test.go
@@ -1,0 +1,128 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestApply_SubagentAndCommandOrphanCleanup pins the reclamation that issue #211
+// required apply to grow. Before it, only "skills/" SourceIDs were reclaimed:
+// PruneStaleState dropped the state entry for a subagent or command that stopped
+// being rendered, but the destination file itself lingered forever.
+//
+// That mattered because namespacing plugin-provided components RENAMES every one
+// of them exactly once, on the first apply after upgrading — and Claude Code
+// reads every file in its agents directory, so a stale pre-rename file left
+// beside the new namespaced one would leave the user with MORE duplicate agents
+// than before, not fewer. Claude's own docs are explicit that two same-name
+// definitions in one directory mean it loads only one, "chosen by filesystem read
+// order rather than a documented precedence".
+//
+// The same convergence argument covers the ordinary case exercised here: a
+// component removed from (or renamed in) the canonical source.
+func TestApply_SubagentAndCommandOrphanCleanup(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	srcSubagent := filepath.Join(tmp, ".agentsync", "subagents", "reviewer.md")
+	srcCommand := filepath.Join(tmp, ".agentsync", "commands", "review.md")
+	destSubagent := filepath.Join(tmp, ".claude", "agents", "reviewer.md")
+	destCommand := filepath.Join(tmp, ".claude", "commands", "review.md")
+	exists := func(p string) bool { _, err := os.Stat(p); return err == nil }
+
+	if err := os.WriteFile(srcSubagent, []byte("---\nname: reviewer\n---\nreview it\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcCommand, []byte("---\ndescription: d\n---\nreview it\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 1: %v\n%s", err, out)
+	}
+	if !exists(destSubagent) || !exists(destCommand) {
+		t.Fatal("apply 1 did not write the subagent and command")
+	}
+
+	// Remove both from source. apply must reclaim the destination files rather
+	// than leave them behind as components the agent still loads.
+	if err := os.Remove(srcSubagent); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(srcCommand); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 2: %v\n%s", err, out)
+	}
+	if exists(destSubagent) {
+		t.Fatalf("orphaned subagent %s was not reclaimed", destSubagent)
+	}
+	if exists(destCommand) {
+		t.Fatalf("orphaned command %s was not reclaimed", destCommand)
+	}
+	// The directories themselves must survive — unlike a skill (which IS a
+	// directory), these are flat files in a directory the agent always owns.
+	if !exists(filepath.Join(tmp, ".claude", "agents")) || !exists(filepath.Join(tmp, ".claude", "commands")) {
+		t.Fatal("the agents/commands roots must not be pruned")
+	}
+}
+
+// TestApply_OrphanedSubagentDriftIsBackedUp holds the line that reclamation must
+// not cross: an orphan delete can remove agentsync's own output freely, but a
+// destination the user hand-edited since the last apply is unsynced content, and
+// the write path's never-destroy-unsynced-content invariant applies to deletes
+// too. Extending reclamation from skills to subagents and commands extends this
+// guarantee with it rather than opening a hole.
+func TestApply_OrphanedSubagentDriftIsBackedUp(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	srcSubagent := filepath.Join(tmp, ".agentsync", "subagents", "reviewer.md")
+	destSubagent := filepath.Join(tmp, ".claude", "agents", "reviewer.md")
+	if err := os.WriteFile(srcSubagent, []byte("---\nname: reviewer\n---\nreview it\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 1: %v\n%s", err, out)
+	}
+
+	// Hand-edit the destination, then remove the component from source.
+	if err := os.WriteFile(destSubagent, []byte("---\nname: reviewer\n---\nMY UNSYNCED EDIT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(srcSubagent); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 2: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(destSubagent); err == nil {
+		t.Fatal("the orphaned subagent should still be reclaimed")
+	}
+
+	// The hand-edit must survive somewhere under the backup root.
+	backups := filepath.Join(tmp, ".agentsync", ".state", "backups")
+	var found bool
+	err := filepath.Walk(backups, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil //nolint:nilerr // a missing backup root is reported by !found below
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr == nil && strings.Contains(string(data), "MY UNSYNCED EDIT") {
+			found = true
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk backups: %v", err)
+	}
+	if !found {
+		t.Fatal("an orphan delete must back up a drifted destination before removing it")
+	}
+}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1352,10 +1352,11 @@ func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameO
 			display = displayOf(it)
 		}
 		if name != "" {
-			return nil, fmt.Errorf("%s %q is provided by the plugin %q, not hand-authored — importing it "+
-				"would create a canonical copy that collides with the plugin's own on the next apply; "+
-				"change it upstream, or run `agentsync plugin disable %q` to stop projecting it",
-				kind, display, plugin, plugin)
+			return nil, fmt.Errorf("%s %q is provided by the plugin %q — importing it would create a "+
+				"canonical copy that DIVERGES from the plugin's the moment it updates, and every load "+
+				"after that would refuse. Change it upstream, edit your own copy under ~/.agentsync/ "+
+				"directly if you already have one, or run `agentsync plugin disable %q` to stop "+
+				"projecting it", kind, display, plugin, plugin)
 		}
 		io.warnf("skipping %s %q: it is projected from the plugin %q, so agentsync already manages it "+
 			"(capturing it would collide with the plugin's own on the next apply)", kind, display, plugin)

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1194,36 +1194,53 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 		}
 		disabled = d
 	}
+	// A component the USER also declares must never be registered as
+	// plugin-provided, even when a plugin ships a byte-identical one.
+	//
+	// This is a data-loss guard, not a nicety. Hooks are the sharp case: the
+	// projected canonical holds the user's handler AND the plugin's, keyed by
+	// content, with no cross-source dedup. Without this check the key resolves to
+	// the plugin, importHook drops the handler, and source.WriteHooks REPLACES
+	// the whole hooks/<event>.toml — erasing the user's own hand-authored handler
+	// from a tree that is usually a committed dotfiles repo, while reporting
+	// "agentsync already manages it" about a line they wrote themselves.
+	//
+	// For MCP/LSP the same collision is a false DENIAL rather than a deletion
+	// (`import claude:mcp:foo` would refuse the user's own mcp/foo.toml), and for
+	// the namespaced kinds it needs a hand-authored component named exactly
+	// `<plugin>-<name>`. All three are the same mistake, so all three are guarded
+	// by construction here rather than per-kind at the use sites.
 	out := map[string]string{}
+	mine := map[string]bool{}
+	claim := func(key, plugin string) {
+		if plugin == "" {
+			mine[key] = true
+			delete(out, key)
+			return
+		}
+		if !mine[key] {
+			out[key] = plugin
+		}
+	}
 	collect := func(c source.Canonical) {
 		for _, sk := range c.Skills {
-			if sk.Plugin != "" {
-				out["skill/"+sk.Name] = sk.Plugin
-			}
+			claim("skill/"+sk.Name, sk.Plugin)
 		}
 		for _, sa := range c.Subagents {
-			if sa.Plugin != "" {
-				out["subagent/"+sa.Name] = sa.Plugin
-			}
+			claim("subagent/"+sa.Name, sa.Plugin)
 		}
 		for _, cmd := range c.Commands {
-			if cmd.Plugin != "" {
-				out["command/"+cmd.Name] = cmd.Plugin
-			}
+			claim("command/"+cmd.Name, cmd.Plugin)
 		}
 		// MCP/LSP servers are not namespaced (a same-id divergence is refused, not
 		// renamed apart — see namespaceProjected), but they ARE plugin-owned, and
 		// capturing one still mints a canonical copy that diverges from the
 		// plugin's own on its next update.
 		for _, m := range c.MCPServers {
-			if m.Plugin != "" {
-				out["mcp/"+m.ID] = m.Plugin
-			}
+			claim("mcp/"+m.ID, m.Plugin)
 		}
 		for _, l := range c.LSPServers {
-			if l.Plugin != "" {
-				out["lsp/"+l.ID] = l.Plugin
-			}
+			claim("lsp/"+l.ID, l.Plugin)
 		}
 		// Hooks are keyed by CONTENT, not by event. A canonical hooks/<event>.toml
 		// holds many handlers from many sources, so refusing a whole event would
@@ -1231,9 +1248,7 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 		// carries no provenance, so the signature is what identifies a handler as
 		// the plugin's.
 		for _, h := range c.Hooks {
-			if h.Plugin != "" {
-				out["hook/"+hookSignature(h)] = h.Plugin
-			}
+			claim("hook/"+hookSignature(h), h.Plugin)
 		}
 	}
 	// Scope parity with render is what makes "the skipped set is exactly the

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1194,53 +1194,62 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 		}
 		disabled = d
 	}
-	// A component the USER also declares must never be registered as
-	// plugin-provided, even when a plugin ships a byte-identical one.
+	// When BOTH the user and a plugin declare a component, which one owns the key
+	// depends on what SKIPPING would do — and that differs by kind, so the caller
+	// says which rule applies.
 	//
-	// This is a data-loss guard, not a nicety. Hooks are the sharp case: the
-	// projected canonical holds the user's handler AND the plugin's, keyed by
-	// content, with no cross-source dedup. Without this check the key resolves to
-	// the plugin, importHook drops the handler, and source.WriteHooks REPLACES
-	// the whole hooks/<event>.toml — erasing the user's own hand-authored handler
-	// from a tree that is usually a committed dotfiles repo, while reporting
-	// "agentsync already manages it" about a line they wrote themselves.
+	//   skipWouldDelete=true (HOOKS ONLY). source.WriteHooks REPLACES the whole
+	//   hooks/<event>.toml, so a handler import declines to capture is ERASED
+	//   from the canonical source — a tree that is usually a committed dotfiles
+	//   repo. A plugin shipping a byte-identical handler would therefore delete
+	//   the user's own line while reporting "agentsync already manages it" about
+	//   it. Here the user's claim must win.
 	//
-	// For MCP/LSP the same collision is a false DENIAL rather than a deletion
-	// (`import claude:mcp:foo` would refuse the user's own mcp/foo.toml), and for
-	// the namespaced kinds it needs a hand-authored component named exactly
-	// `<plugin>-<name>`. All three are the same mistake, so all three are guarded
-	// by construction here rather than per-kind at the use sites.
+	//   skipWouldDelete=false (everything else). WriteMCP/WriteSkill/… write ONE
+	//   file per component, so skipping deletes nothing — it only declines to
+	//   update. Letting the user's claim win there is actively WORSE: import
+	//   would capture the drifted native content into mcp/<id>.toml, the user's
+	//   copy and the plugin's projection would then DIVERGE, and every later
+	//   mutating load (apply, reconcile, import, plugin upgrade) would hard-fail
+	//   in checkProjectedConflicts — a permanent wedge in place of a refusal that
+	//   costs nothing. So the plugin keeps the key and the capture is refused.
+	//
+	// The asymmetry is the point: the override exists to prevent a DELETION, not
+	// to decide ownership.
 	out := map[string]string{}
 	mine := map[string]bool{}
-	claim := func(key, plugin string) {
+	claim := func(key, plugin string, skipWouldDelete bool) {
 		if plugin == "" {
 			mine[key] = true
-			delete(out, key)
+			if skipWouldDelete {
+				delete(out, key)
+			}
 			return
 		}
-		if !mine[key] {
-			out[key] = plugin
+		if skipWouldDelete && mine[key] {
+			return
 		}
+		out[key] = plugin
 	}
 	collect := func(c source.Canonical) {
 		for _, sk := range c.Skills {
-			claim("skill/"+sk.Name, sk.Plugin)
+			claim("skill/"+sk.Name, sk.Plugin, false)
 		}
 		for _, sa := range c.Subagents {
-			claim("subagent/"+sa.Name, sa.Plugin)
+			claim("subagent/"+sa.Name, sa.Plugin, false)
 		}
 		for _, cmd := range c.Commands {
-			claim("command/"+cmd.Name, cmd.Plugin)
+			claim("command/"+cmd.Name, cmd.Plugin, false)
 		}
 		// MCP/LSP servers are not namespaced (a same-id divergence is refused, not
 		// renamed apart — see namespaceProjected), but they ARE plugin-owned, and
 		// capturing one still mints a canonical copy that diverges from the
 		// plugin's own on its next update.
 		for _, m := range c.MCPServers {
-			claim("mcp/"+m.ID, m.Plugin)
+			claim("mcp/"+m.ID, m.Plugin, false)
 		}
 		for _, l := range c.LSPServers {
-			claim("lsp/"+l.ID, l.Plugin)
+			claim("lsp/"+l.ID, l.Plugin, false)
 		}
 		// Hooks are keyed by CONTENT, not by event. A canonical hooks/<event>.toml
 		// holds many handlers from many sources, so refusing a whole event would
@@ -1248,7 +1257,7 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 		// carries no provenance, so the signature is what identifies a handler as
 		// the plugin's.
 		for _, h := range c.Hooks {
-			claim("hook/"+hookSignature(h), h.Plugin)
+			claim("hook/"+hookSignature(h), h.Plugin, true)
 		}
 	}
 	// Scope parity with render is what makes "the skipped set is exactly the

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1114,7 +1114,7 @@ func importMCP(io *importIO, home string, c source.Canonical, name string) ([]st
 			matched = append(matched, m)
 		}
 	}
-	matched, err := skipPluginProvided(io, "mcp", name, matched, func(m source.MCPServer) string { return m.ID })
+	matched, err := skipPluginProvided(io, "mcp", name, matched, func(m source.MCPServer) string { return m.ID }, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1258,11 +1258,28 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 // destination: its event, matcher, type, and command. It is the join key between
 // a plugin's projected hooks (which carry provenance) and the agent's native
 // ingest (which does not), so import can drop exactly the handlers a plugin
-// contributed and keep the ones the user wrote. The separator is a NUL, which
-// cannot appear in any of the parts, so distinct handlers can never collide into
-// one signature.
+// contributed and keep the ones the user wrote.
+//
+// Parts are LENGTH-PREFIXED rather than joined by a separator. A separator-based
+// signature has to assume the separator cannot occur inside a part, and that
+// assumption does not hold here: a plugin's hooks come from JSON, where "\u0000"
+// is a legal string escape, and Command is carried through verbatim. Under a bare
+// separator, a plugin could therefore craft a handler whose signature equals a
+// user's — and the user's own handler would be silently dropped from import.
+// Length prefixes make the encoding injective for ANY byte content, so that
+// collision is impossible rather than merely unlikely.
 func hookSignature(h source.Hook) string {
-	return strings.Join([]string{h.Event.Unverified(), h.Matcher, h.Type, h.Command}, "\x00")
+	var b strings.Builder
+	for _, part := range []string{h.Event.Unverified(), h.Matcher, h.Type, h.Command} {
+		fmt.Fprintf(&b, "%d:%s", len(part), part)
+	}
+	return b.String()
+}
+
+// hookDisplay renders a handler for a user-facing message: the opaque
+// length-prefixed hookSignature is a join key, not something anyone can act on.
+func hookDisplay(h source.Hook) string {
+	return fmt.Sprintf("%s %s %s", h.Event.Unverified(), h.Matcher, h.Command)
 }
 
 // skipPluginProvided partitions native components into the ones to capture and
@@ -1273,7 +1290,7 @@ func hookSignature(h source.Hook) string {
 // A NAMED import of a plugin-provided component is an error, not a silent
 // no-op: the user asked for that exact component by name and deserves to be told
 // why it cannot be captured, and what to do instead.
-func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string) ([]T, error) {
+func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string, displayOf func(T) string) ([]T, error) {
 	// Nothing matched → nothing to wrongly capture, so an unusable filter is
 	// harmless here. Checking this FIRST keeps a broken plugin cache from
 	// refusing an import that would not have touched a plugin component anyway.
@@ -1298,14 +1315,17 @@ func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameO
 			out = append(out, it)
 			continue
 		}
-		// A hook's key is a NUL-joined content signature (hookSignature); render
-		// it with spaces so the message reads as the handler it names rather than
-		// as escape sequences. Every other kind's key is already its display name.
-		display := strings.ReplaceAll(key, "\x00", " ")
+		// For most kinds the key IS the display name. A hook's key is an opaque
+		// length-prefixed signature (hookSignature), so displayOf supplies
+		// something a user can act on instead.
+		display := key
+		if displayOf != nil {
+			display = displayOf(it)
+		}
 		if name != "" {
 			return nil, fmt.Errorf("%s %q is provided by the plugin %q, not hand-authored — importing it "+
 				"would create a canonical copy that collides with the plugin's own on the next apply; "+
-				"change it upstream, or run `agentsync plugin disable %s` to stop projecting it",
+				"change it upstream, or run `agentsync plugin disable %q` to stop projecting it",
 				kind, display, plugin, plugin)
 		}
 		io.warnf("skipping %s %q: it is projected from the plugin %q, so agentsync already manages it "+
@@ -1321,7 +1341,7 @@ func importSkill(io *importIO, home string, c source.Canonical, name string) ([]
 			matched = append(matched, sk)
 		}
 	}
-	matched, err := skipPluginProvided(io, "skill", name, matched, func(sk source.Skill) string { return sk.Name })
+	matched, err := skipPluginProvided(io, "skill", name, matched, func(sk source.Skill) string { return sk.Name }, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1366,7 +1386,7 @@ func importSubagent(io *importIO, home string, c source.Canonical, name string) 
 			matched = append(matched, sa)
 		}
 	}
-	matched, err := skipPluginProvided(io, "subagent", name, matched, func(sa source.Subagent) string { return sa.Name })
+	matched, err := skipPluginProvided(io, "subagent", name, matched, func(sa source.Subagent) string { return sa.Name }, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1404,7 +1424,7 @@ func importCommand(io *importIO, home string, c source.Canonical, name string) (
 			matched = append(matched, cm)
 		}
 	}
-	matched, err := skipPluginProvided(io, "command", name, matched, func(cm source.Command) string { return cm.Name })
+	matched, err := skipPluginProvided(io, "command", name, matched, func(cm source.Command) string { return cm.Name }, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1462,7 +1482,7 @@ func importHook(io *importIO, home string, c source.Canonical, name string) ([]s
 	// plugin contributed one handler would silently drop the user's own. A named
 	// import errors only when EVERY handler for that event is plugin-provided —
 	// otherwise the user's handlers are captured and the plugin's are skipped.
-	kept, err := skipPluginProvided(io, "hook", "", matched, hookSignature)
+	kept, err := skipPluginProvided(io, "hook", "", matched, hookSignature, hookDisplay)
 	if err != nil {
 		return nil, err
 	}
@@ -1514,7 +1534,7 @@ func importLSP(io *importIO, home string, c source.Canonical, name string) ([]st
 			matched = append(matched, ls)
 		}
 	}
-	matched, err := skipPluginProvided(io, "lsp", name, matched, func(ls source.LSPServer) string { return ls.ID })
+	matched, err := skipPluginProvided(io, "lsp", name, matched, func(ls source.LSPServer) string { return ls.ID }, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -283,6 +283,19 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		return fmt.Errorf("ingest %s: %w", agentName, err)
 	}
 
+	// Ingest cannot tell a file agentsync rendered from an installed plugin apart
+	// from one the user hand-wrote, so compute the set apply projects and skip it
+	// below. A failure here is not fatal: import then behaves as it did before
+	// (capturing plugin components as if hand-authored), so warn and continue
+	// rather than refuse an import the user may need.
+	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, sc); ppErr != nil {
+		io.warnf("could not determine which components your plugins provide (%v); "+
+			"a plugin-provided component captured now would collide with the plugin's own "+
+			"on the next apply — remove it from %s if that happens", ppErr, srcHome)
+	} else {
+		io.pluginProvided = pp
+	}
+
 	// Three selector depths, narrowing from broad to specific:
 	//   <agent>                     -> every importable component
 	//   <agent>:<component>         -> every entry of that component
@@ -847,6 +860,12 @@ type importIO struct {
 	// or single-component import, where the indented item lines stand alone.
 	section      string
 	sectionShown bool
+	// pluginProvided is per-RUN context rather than IO, carried here because
+	// this struct is already threaded to every importer: "<kind>/<name>" → the
+	// plugin id providing it, for every component apply projects from an
+	// installed plugin. See pluginProvided() for why import must skip those.
+	// Empty (a projection failure, or no plugins) disables the filter.
+	pluginProvided map[string]string
 }
 
 // item prints one "imported X" / "would import X" line, prefixed with a glyph
@@ -1128,12 +1147,116 @@ func idsFromWritten(written []string) []string {
 	return out
 }
 
+// pluginProvided maps "<kind>/<name>" to the plugin id that provides that
+// component, for every component apply projects from an installed plugin at this
+// scope. It is what keeps `import` from capturing agentsync's OWN output back
+// into the canonical source.
+//
+// The problem it solves: an adapter's Ingest reads the agent's native config and
+// cannot tell a file agentsync rendered from a plugin apart from one the user
+// hand-wrote — they are the same kind of file in the same directory. So
+// `agentsync apply && agentsync import claude:subagent` used to copy every
+// plugin-provided subagent into ~/.agentsync/subagents/ as if the user had
+// authored it. The next load then had TWO components with that name (the
+// captured copy and the plugin's own projection) rendering to one destination
+// path, which apply refuses.
+//
+// Matching is by effective name, which is exact rather than heuristic now that
+// plugin components are namespaced: a hand-authored component can only shadow a
+// plugin-provided one by being named `<plugin>-<name>` on purpose.
+//
+// It mirrors apply's projection so the skipped set is exactly the rendered set:
+// lenient (an unrelated strict plugin conflict must not abort an import), honours
+// the project tree's `disabled = true` plugin markers, and at project scope
+// unions BOTH homes' projections. A projection failure yields nil — import then
+// behaves as it did before, which is the pre-existing bug rather than a new one,
+// so the caller warns instead of failing the run.
+func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.Scope) (map[string]string, error) {
+	pluginCacheRoot := filepath.Join(agentsyncHome, ".state", "cache", "plugins")
+	var disabled []string
+	projHome := ""
+	if sc == adapter.ScopeProject && projectRoot != "" {
+		projHome = project.Home(projectRoot)
+		d, err := projectDisabledPlugins(fs, projHome)
+		if err != nil {
+			return nil, fmt.Errorf("read project plugin disables: %w", err)
+		}
+		disabled = d
+	}
+	out := map[string]string{}
+	collect := func(c source.Canonical) {
+		for _, sk := range c.Skills {
+			if sk.Plugin != "" {
+				out["skill/"+sk.Name] = sk.Plugin
+			}
+		}
+		for _, sa := range c.Subagents {
+			if sa.Plugin != "" {
+				out["subagent/"+sa.Name] = sa.Plugin
+			}
+		}
+		for _, cmd := range c.Commands {
+			if cmd.Plugin != "" {
+				out["command/"+cmd.Name] = cmd.Plugin
+			}
+		}
+	}
+	c, err := marketplace.LoadProjectedLenient(fs, agentsyncHome, pluginCacheRoot, disabled)
+	if err != nil {
+		return nil, fmt.Errorf("project user plugins: %w", err)
+	}
+	collect(c)
+	if projHome != "" {
+		pc, perr := marketplace.LoadProjectedLenient(fs, projHome, pluginCacheRoot, disabled)
+		if perr != nil {
+			return nil, fmt.Errorf("project %s plugins: %w", projHome, perr)
+		}
+		collect(pc)
+	}
+	return out, nil
+}
+
+// skipPluginProvided partitions native components into the ones to capture and
+// the ones a plugin already provides. It returns the survivors; skipped items are
+// reported through io so the omission is never silent (a native file that
+// vanishes from an import with no explanation reads as a bug).
+//
+// A NAMED import of a plugin-provided component is an error, not a silent
+// no-op: the user asked for that exact component by name and deserves to be told
+// why it cannot be captured, and what to do instead.
+func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string) ([]T, error) {
+	if len(io.pluginProvided) == 0 {
+		return items, nil
+	}
+	out := make([]T, 0, len(items))
+	for _, it := range items {
+		plugin, provided := io.pluginProvided[kind+"/"+nameOf(it)]
+		if !provided {
+			out = append(out, it)
+			continue
+		}
+		if name != "" {
+			return nil, fmt.Errorf("%s %q is provided by the plugin %q, not hand-authored — importing it "+
+				"would create a canonical copy that collides with the plugin's own on the next apply; "+
+				"change it upstream, or run `agentsync plugin disable %s` to stop projecting it",
+				kind, nameOf(it), plugin, plugin)
+		}
+		io.warnf("skipping %s %q: it is projected from the plugin %q, so agentsync already manages it "+
+			"(capturing it would collide with the plugin's own on the next apply)", kind, nameOf(it), plugin)
+	}
+	return out, nil
+}
+
 func importSkill(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
 	var matched []source.Skill
 	for _, sk := range c.Skills {
 		if name == "" || sk.Name == name {
 			matched = append(matched, sk)
 		}
+	}
+	matched, err := skipPluginProvided(io, "skill", name, matched, func(sk source.Skill) string { return sk.Name })
+	if err != nil {
+		return nil, err
 	}
 	if len(matched) == 0 {
 		if name != "" {
@@ -1176,6 +1299,10 @@ func importSubagent(io *importIO, home string, c source.Canonical, name string) 
 			matched = append(matched, sa)
 		}
 	}
+	matched, err := skipPluginProvided(io, "subagent", name, matched, func(sa source.Subagent) string { return sa.Name })
+	if err != nil {
+		return nil, err
+	}
 	if len(matched) == 0 {
 		if name != "" {
 			return nil, fmt.Errorf("subagent %q not found in native config", name)
@@ -1209,6 +1336,10 @@ func importCommand(io *importIO, home string, c source.Canonical, name string) (
 		if name == "" || cm.Name == name {
 			matched = append(matched, cm)
 		}
+	}
+	matched, err := skipPluginProvided(io, "command", name, matched, func(cm source.Command) string { return cm.Name })
+	if err != nil {
+		return nil, err
 	}
 	if len(matched) == 0 {
 		if name != "" {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -285,9 +285,11 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 
 	// Ingest cannot tell a file agentsync rendered from an installed plugin apart
 	// from one the user hand-wrote, so compute the set apply projects and skip it
-	// below. A failure here is not fatal: import then behaves as it did before
-	// (capturing plugin components as if hand-authored), so warn and continue
-	// rather than refuse an import the user may need.
+	// below. A failure here is recorded, not swallowed: skipPluginProvided then
+	// refuses any component capture (fail CLOSED). Proceeding with an empty skip
+	// set would silently disable the defence — and since the projection is fed by
+	// plugin data, an upstream roll or a tampered cache could trigger it on
+	// demand.
 	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, sc); ppErr != nil {
 		io.pluginProvidedErr = ppErr
 	} else {
@@ -1176,10 +1178,10 @@ func idsFromWritten(written []string) []string {
 //
 // It mirrors apply's projection so the skipped set is exactly the rendered set:
 // lenient (an unrelated strict plugin conflict must not abort an import), honours
-// the project tree's `disabled = true` plugin markers, and at project scope
-// unions BOTH homes' projections. A projection failure yields nil — import then
-// behaves as it did before, which is the pre-existing bug rather than a new one,
-// so the caller warns instead of failing the run.
+// the project tree's `disabled = true` plugin markers, and reads the home whose
+// components the render at this scope actually uses. A projection failure is
+// returned, and the caller records it so every component capture then refuses —
+// see skipPluginProvided.
 func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.Scope) (map[string]string, error) {
 	pluginCacheRoot := filepath.Join(agentsyncHome, ".state", "cache", "plugins")
 	var disabled []string
@@ -1223,6 +1225,16 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 				out["lsp/"+l.ID] = l.Plugin
 			}
 		}
+		// Hooks are keyed by CONTENT, not by event. A canonical hooks/<event>.toml
+		// holds many handlers from many sources, so refusing a whole event would
+		// drop the user's own handlers alongside the plugin's. The native ingest
+		// carries no provenance, so the signature is what identifies a handler as
+		// the plugin's.
+		for _, h := range c.Hooks {
+			if h.Plugin != "" {
+				out["hook/"+hookSignature(h)] = h.Plugin
+			}
+		}
 	}
 	// Scope parity with render is what makes "the skipped set is exactly the
 	// rendered set" true. At PROJECT scope every adapter renders from the
@@ -1240,6 +1252,17 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 	}
 	collect(c)
 	return out, nil
+}
+
+// hookSignature identifies one hook HANDLER by everything that reaches a
+// destination: its event, matcher, type, and command. It is the join key between
+// a plugin's projected hooks (which carry provenance) and the agent's native
+// ingest (which does not), so import can drop exactly the handlers a plugin
+// contributed and keep the ones the user wrote. The separator is a NUL, which
+// cannot appear in any of the parts, so distinct handlers can never collide into
+// one signature.
+func hookSignature(h source.Hook) string {
+	return strings.Join([]string{h.Event.Unverified(), h.Matcher, h.Type, h.Command}, "\x00")
 }
 
 // skipPluginProvided partitions native components into the ones to capture and
@@ -1269,19 +1292,24 @@ func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameO
 	}
 	out := make([]T, 0, len(items))
 	for _, it := range items {
-		plugin, provided := io.pluginProvided[kind+"/"+nameOf(it)]
+		key := nameOf(it)
+		plugin, provided := io.pluginProvided[kind+"/"+key]
 		if !provided {
 			out = append(out, it)
 			continue
 		}
+		// A hook's key is a NUL-joined content signature (hookSignature); render
+		// it with spaces so the message reads as the handler it names rather than
+		// as escape sequences. Every other kind's key is already its display name.
+		display := strings.ReplaceAll(key, "\x00", " ")
 		if name != "" {
 			return nil, fmt.Errorf("%s %q is provided by the plugin %q, not hand-authored — importing it "+
 				"would create a canonical copy that collides with the plugin's own on the next apply; "+
 				"change it upstream, or run `agentsync plugin disable %s` to stop projecting it",
-				kind, nameOf(it), plugin, plugin)
+				kind, display, plugin, plugin)
 		}
 		io.warnf("skipping %s %q: it is projected from the plugin %q, so agentsync already manages it "+
-			"(capturing it would collide with the plugin's own on the next apply)", kind, nameOf(it), plugin)
+			"(capturing it would collide with the plugin's own on the next apply)", kind, display, plugin)
 	}
 	return out, nil
 }
@@ -1429,6 +1457,21 @@ func importHook(io *importIO, home string, c source.Canonical, name string) ([]s
 			matched = append(matched, h)
 		}
 	}
+	// Filter at HANDLER granularity, not per event: one event's canonical file
+	// holds handlers from many sources, so refusing the whole event because a
+	// plugin contributed one handler would silently drop the user's own. A named
+	// import errors only when EVERY handler for that event is plugin-provided —
+	// otherwise the user's handlers are captured and the plugin's are skipped.
+	kept, err := skipPluginProvided(io, "hook", "", matched, hookSignature)
+	if err != nil {
+		return nil, err
+	}
+	if name != "" && len(matched) > 0 && len(kept) == 0 {
+		return nil, fmt.Errorf("every handler for hook event %q is provided by an installed plugin, "+
+			"so there is nothing of your own to capture; change it upstream, or run "+
+			"`agentsync plugin disable <id>` to stop projecting it", name)
+	}
+	matched = kept
 	if len(matched) == 0 {
 		if name != "" {
 			return nil, fmt.Errorf("hook event %q not found in native config", name)

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -289,9 +289,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// (capturing plugin components as if hand-authored), so warn and continue
 	// rather than refuse an import the user may need.
 	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, sc); ppErr != nil {
-		io.warnf("could not determine which components your plugins provide (%v); "+
-			"a plugin-provided component captured now would collide with the plugin's own "+
-			"on the next apply — remove it from %s if that happens", ppErr, srcHome)
+		io.pluginProvidedErr = ppErr
 	} else {
 		io.pluginProvided = pp
 	}
@@ -864,8 +862,15 @@ type importIO struct {
 	// this struct is already threaded to every importer: "<kind>/<name>" → the
 	// plugin id providing it, for every component apply projects from an
 	// installed plugin. See pluginProvided() for why import must skip those.
-	// Empty (a projection failure, or no plugins) disables the filter.
-	pluginProvided map[string]string
+	//
+	// pluginProvidedErr is set when that projection FAILED. The filter then fails
+	// CLOSED: every component capture refuses, rather than silently proceeding
+	// with an empty skip set. Failing open would be the worse bug — the filter
+	// exists to stop import poisoning the canonical source, and the projection is
+	// fed by plugin data, so an attacker-influenced projection failure would be a
+	// way to switch the defence off.
+	pluginProvided    map[string]string
+	pluginProvidedErr error
 }
 
 // item prints one "imported X" / "would import X" line, prefixed with a glyph
@@ -1107,6 +1112,10 @@ func importMCP(io *importIO, home string, c source.Canonical, name string) ([]st
 			matched = append(matched, m)
 		}
 	}
+	matched, err := skipPluginProvided(io, "mcp", name, matched, func(m source.MCPServer) string { return m.ID })
+	if err != nil {
+		return nil, err
+	}
 	if len(matched) == 0 {
 		if name != "" {
 			return nil, fmt.Errorf("mcp server %q not found in native config", name)
@@ -1200,19 +1209,36 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 				out["command/"+cmd.Name] = cmd.Plugin
 			}
 		}
+		// MCP/LSP servers are not namespaced (a same-id divergence is refused, not
+		// renamed apart — see namespaceProjected), but they ARE plugin-owned, and
+		// capturing one still mints a canonical copy that diverges from the
+		// plugin's own on its next update.
+		for _, m := range c.MCPServers {
+			if m.Plugin != "" {
+				out["mcp/"+m.ID] = m.Plugin
+			}
+		}
+		for _, l := range c.LSPServers {
+			if l.Plugin != "" {
+				out["lsp/"+l.ID] = l.Plugin
+			}
+		}
 	}
-	c, err := marketplace.LoadProjectedLenient(fs, agentsyncHome, pluginCacheRoot, disabled)
+	// Scope parity with render is what makes "the skipped set is exactly the
+	// rendered set" true. At PROJECT scope every adapter renders from the
+	// project-only overlay (`renderC = *c.Project`), never the user canonical, so
+	// a user-scope plugin contributes nothing to the project destination and must
+	// not shadow a project component that happens to share its derived name.
+	// Collecting only the relevant home keeps over-refusal off the table.
+	home := agentsyncHome
+	if projHome != "" {
+		home = projHome
+	}
+	c, err := marketplace.LoadProjectedLenient(fs, home, pluginCacheRoot, disabled)
 	if err != nil {
-		return nil, fmt.Errorf("project user plugins: %w", err)
+		return nil, fmt.Errorf("project plugins from %s: %w", home, err)
 	}
 	collect(c)
-	if projHome != "" {
-		pc, perr := marketplace.LoadProjectedLenient(fs, projHome, pluginCacheRoot, disabled)
-		if perr != nil {
-			return nil, fmt.Errorf("project %s plugins: %w", projHome, perr)
-		}
-		collect(pc)
-	}
 	return out, nil
 }
 
@@ -1225,6 +1251,19 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 // no-op: the user asked for that exact component by name and deserves to be told
 // why it cannot be captured, and what to do instead.
 func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string) ([]T, error) {
+	// Nothing matched → nothing to wrongly capture, so an unusable filter is
+	// harmless here. Checking this FIRST keeps a broken plugin cache from
+	// refusing an import that would not have touched a plugin component anyway.
+	if len(items) == 0 {
+		return items, nil
+	}
+	if io.pluginProvidedErr != nil {
+		return nil, fmt.Errorf("cannot safely import %ss: agentsync could not determine which "+
+			"components your installed plugins provide (%w). Capturing a plugin-provided component "+
+			"would create a canonical copy that collides with the plugin's own on the next apply, so "+
+			"this import is refused rather than risk it. Fix the plugin cache (`agentsync doctor`, "+
+			"`agentsync plugin upgrade --all`) and retry", kind, io.pluginProvidedErr)
+	}
 	if len(io.pluginProvided) == 0 {
 		return items, nil
 	}
@@ -1431,6 +1470,10 @@ func importLSP(io *importIO, home string, c source.Canonical, name string) ([]st
 		if name == "" || ls.ID == name {
 			matched = append(matched, ls)
 		}
+	}
+	matched, err := skipPluginProvided(io, "lsp", name, matched, func(ls source.LSPServer) string { return ls.ID })
+	if err != nil {
+		return nil, err
 	}
 	if len(matched) == 0 {
 		if name != "" {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1290,6 +1290,11 @@ func hookDisplay(h source.Hook) string {
 // A NAMED import of a plugin-provided component is an error, not a silent
 // no-op: the user asked for that exact component by name and deserves to be told
 // why it cannot be captured, and what to do instead.
+//
+// nameOf yields the map key. displayOf, when non-nil, yields what the user sees;
+// it exists because a hook's key is an opaque length-prefixed signature rather
+// than a name anyone could act on. Pass nil wherever the key IS the display name,
+// which is every kind except hooks.
 func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string, displayOf func(T) string) ([]T, error) {
 	// Nothing matched → nothing to wrongly capture, so an unusable filter is
 	// harmless here. Checking this FIRST keeps a broken plugin cache from

--- a/internal/cli/import_hook_signature_internal_test.go
+++ b/internal/cli/import_hook_signature_internal_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// TestHookSignature_Injective pins that the hook join key is injective for ANY
+// byte content, including a part that itself contains the byte a separator-based
+// encoding would use.
+//
+// Scope, stated honestly: the previous NUL-joined encoding was already injective
+// for NUL-free inputs, so this is not closing a live hole. A forged collision
+// needed BOTH handlers to carry an embedded NUL — the victim's own field
+// included — which no real hand-written hook does. What was wrong was the code
+// asserting an invariant ("NUL cannot appear in any of the parts") that the
+// inputs do not guarantee: a plugin's hooks come from JSON, where NUL is a legal
+// string escape, and Command is carried through verbatim. Length prefixes make
+// the claim true by construction rather than by assumption, which is the point —
+// the key decides whether a user's own handler is dropped from import.
+func TestHookSignature_Injective(t *testing.T) {
+	mk := func(event, matcher, typ, command string) source.Hook {
+		return source.Hook{
+			Event: untrusted.Wrap(event), Matcher: matcher, Type: typ, Command: command,
+		}
+	}
+	nul := string(rune(0))
+
+	// The case that actually distinguishes the two encodings. Under NUL-joining
+	// both of these flatten to "E<NUL>M<NUL>X<NUL>T<NUL>C" — the same string from
+	// two different handlers. Length prefixes keep them apart.
+	a := mk("E", "M"+nul+"X", "T", "C")
+	b := mk("E", "M", "X"+nul+"T", "C")
+	if hookSignature(a) == hookSignature(b) {
+		t.Errorf("handlers differing only in where an embedded NUL falls must not "+
+			"share a signature; both = %q", hookSignature(a))
+	}
+
+	// It still has to actually JOIN: identical handlers must agree, or the filter
+	// would never match a plugin's projected handler to the native ingest.
+	victim := mk("PreToolUse", "Bash", "command", "mine")
+	if hookSignature(victim) != hookSignature(mk("PreToolUse", "Bash", "command", "mine")) {
+		t.Error("identical handlers must produce identical signatures")
+	}
+
+	// And genuinely different handlers stay different — the ordinary case.
+	if hookSignature(victim) == hookSignature(mk("PreToolUse", "Bash", "command", "theirs")) {
+		t.Error("handlers with different commands must not share a signature")
+	}
+	if hookSignature(victim) == hookSignature(mk("PostToolUse", "Bash", "command", "mine")) {
+		t.Error("handlers on different events must not share a signature")
+	}
+}

--- a/internal/cli/import_plugin_fanout_test.go
+++ b/internal/cli/import_plugin_fanout_test.go
@@ -61,8 +61,9 @@ func TestImport_PluginComponentsFanOutToOpenCode(t *testing.T) {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
 
-	// The skill landed at the shared .claude/skills path OpenCode reads natively.
-	skill := filepath.Join(tmp, ".claude", "skills", "greeter", "SKILL.md")
+	// The skill landed at the shared .claude/skills path OpenCode reads natively,
+	// under its plugin-namespaced name (issue #211).
+	skill := filepath.Join(tmp, ".claude", "skills", "toolkit-greeter", "SKILL.md")
 	data, err := os.ReadFile(skill)
 	if err != nil {
 		t.Fatalf("plugin skill did not project to the shared skills path: %v", err)

--- a/internal/cli/plugin_explain_test.go
+++ b/internal/cli/plugin_explain_test.go
@@ -487,8 +487,9 @@ func TestExplain_ScopesToNamedPlugin(t *testing.T) {
 	}
 	// The reviewer subagent renders but loses its tools/color frontmatter, so it
 	// surfaces as a "reduced" subagent skip (the label is humanized — no internal
-	// "-frontmatter" suffix leaks to the user).
-	if !strings.Contains(outNoisy, "subagent reviewer") || !strings.Contains(outNoisy, "reduced") {
+	// "-frontmatter" suffix leaks to the user). It reports under its
+	// plugin-namespaced name, since that is the name it renders as (issue #211).
+	if !strings.Contains(outNoisy, "subagent noisy-reviewer") || !strings.Contains(outNoisy, "reduced") {
 		t.Errorf("explain noisy@cross-mp should surface its own reduced subagent skip; got:\n%s", outNoisy)
 	}
 	if strings.Contains(outNoisy, "subagent-frontmatter") {

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -178,3 +178,154 @@ func TestApply_HandAuthoredComponentKeepsBareName(t *testing.T) {
 		t.Fatalf("the plugin's subagent should still render, namespaced: %v", err)
 	}
 }
+
+// TestImport_SkipsPluginProvidedComponents closes the loop between `apply` and
+// `import`. An adapter's Ingest reads the agent's native config and cannot tell a
+// file agentsync rendered from a plugin apart from one the user hand-wrote — they
+// are the same kind of file in the same directory. So `apply` then `import`
+// copied every plugin-provided component into ~/.agentsync/ as if the user had
+// authored it, and the next load held TWO components of that name (the captured
+// copy and the plugin's own projection) rendering to one destination path, which
+// apply refuses.
+//
+// The end-to-end oracle is that apply still works afterwards: capturing a
+// plugin's output must not brick the next run.
+func TestImport_SkipsPluginProvidedComponents(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Re-import every text component. The plugin's own output is now sitting in
+	// the native config, and must not be captured back.
+	for _, component := range []string{"subagent", "skill", "command"} {
+		if out, err := runCLI(t, env, "import", "claude:"+component); err != nil {
+			t.Fatalf("import claude:%s: %v\n%s", component, err, out)
+		}
+	}
+
+	for _, rel := range []string{
+		filepath.Join("subagents", "feature-dev-code-reviewer.md"),
+		filepath.Join("skills", "feature-dev-code-review", "SKILL.md"),
+		filepath.Join("commands", "feature-dev-review.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(tmp, ".agentsync", rel)); err == nil {
+			t.Errorf("import captured the plugin-provided component %s into the canonical source; "+
+				"it would collide with the plugin's own projection on the next apply", rel)
+		}
+	}
+
+	// The real proof: the next apply still works. Before the fix it failed with
+	// two components resolving to one destination path.
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply after import must still succeed: %v\n%s", err, out)
+	}
+}
+
+// TestImport_NamedPluginComponentIsAnError pins that a NAMED import of a
+// plugin-provided component says why rather than silently importing nothing. The
+// user asked for that exact component; "no output" would read as a bug.
+func TestImport_NamedPluginComponentIsAnError(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:subagent:feature-dev-code-reviewer")
+	if err == nil {
+		t.Fatalf("importing a plugin-provided component by name must error; got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "feature-dev") {
+		t.Errorf("the error should name the providing plugin; got: %v", err)
+	}
+}
+
+// TestImport_StillCapturesHandAuthoredAlongsidePlugins is the other half: the
+// filter must be surgical. A component the user hand-wrote into the native
+// config is still captured even while a plugin's components are being skipped —
+// otherwise the fix would silently break ordinary import for anyone with a
+// plugin installed.
+func TestImport_StillCapturesHandAuthoredAlongsidePlugins(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	// A subagent the user wrote straight into the agent's native config.
+	mine := filepath.Join(tmp, ".claude", "agents", "my-own.md")
+	if err := os.WriteFile(mine, []byte("---\nname: my-own\n---\nMine.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "import", "claude:subagent"); err != nil {
+		t.Fatalf("import claude:subagent: %v\n%s", err, out)
+	}
+	captured := filepath.Join(tmp, ".agentsync", "subagents", "my-own.md")
+	data, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("a hand-authored native subagent must still be captured: %v", err)
+	}
+	if !strings.Contains(string(data), "Mine.") {
+		t.Fatalf("captured the wrong content:\n%s", data)
+	}
+}
+
+// TestReconcile_WriteBackRefusesPluginProvidedComponent is the sibling of the
+// import filter, on the other dest→source path. A plugin-provided component has
+// no canonical file of its own — it is projected from the plugin cache on every
+// load — so capturing a hand-edit of one would MINT a canonical file with the
+// component's namespaced name, and the next load would hold two components of
+// that name rendering to one destination path.
+//
+// The oracle is again the next apply: reconcile must not leave the tree in a
+// state that apply refuses.
+func TestReconcile_WriteBackRefusesPluginProvidedComponent(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Hand-edit the plugin's rendered subagent, so reconcile sees drift.
+	dest := filepath.Join(tmp, ".claude", "agents", "feature-dev-code-reviewer.md")
+	if err := os.WriteFile(dest,
+		[]byte("---\nname: feature-dev-code-reviewer\n---\nHAND EDITED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --auto-writeback must refuse this item rather than mint a canonical copy.
+	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
+	if !strings.Contains(out, "feature-dev") {
+		t.Errorf("reconcile should explain that the component comes from a plugin; got:\n%s", out)
+	}
+	captured := filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")
+	if _, err := os.Stat(captured); err == nil {
+		t.Fatal("write-back minted a canonical copy of a plugin-provided component; " +
+			"it collides with the plugin's own projection on the next apply")
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply after reconcile must still succeed: %v\n%s", err, out)
+	}
+}

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -767,6 +767,12 @@ func TestImport_FailsClosedWhenPluginProjectionFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot safely import") {
 		t.Errorf("the refusal should explain itself; got: %v", err)
 	}
+	// Assert the WRAPPED cause too, so an incidental failure (a missing file, a
+	// parse error elsewhere) cannot satisfy this test in place of the tamper the
+	// fixture actually induces.
+	if !strings.Contains(err.Error(), "manifest SHA mismatch") {
+		t.Errorf("the refusal must be caused by the induced tamper; got: %v", err)
+	}
 	// Nothing may have been captured.
 	if _, serr := os.Stat(filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")); serr == nil {
 		t.Fatal("a failed projection must not let a plugin component be captured")

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -814,9 +814,11 @@ func TestReconcile_HookWriteBackIsRefused(t *testing.T) {
 	}
 
 	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
-	if !strings.Contains(out, "not implemented") {
-		t.Errorf("hook write-back must be refused as unimplemented — the hook-provenance "+
-			"lookup relies on it; got:\n%s", out)
+	// Match the POINTER too: a bare "not implemented" could drift onto some
+	// other item's refusal and this test would stop proving anything about hooks.
+	if !strings.Contains(out, "not implemented") || !strings.Contains(out, "/hooks/") {
+		t.Errorf("hook write-back must be refused as unimplemented, naming the hook pointer — "+
+			"the hook-provenance lookup relies on it; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -540,6 +540,62 @@ func TestProjectScope_PluginNamespacingAndImportFilter(t *testing.T) {
 	}
 }
 
+// TestProjectScope_UserPluginDoesNotShadowProjectComponent is the test that can
+// actually FAIL on the scope fix, which the sibling above cannot: it copies the
+// plugin pin into the project tree, so the old user-union logic and the new
+// project-only logic produce an identical skip set.
+//
+// Here the plugin exists at USER scope ONLY. It therefore contributes nothing to
+// the project destination, and a project component that happens to share its
+// derived name must still be captured. Under the old union the user plugin's
+// entry would appear in the project skip set and silently swallow it.
+func TestProjectScope_UserPluginDoesNotShadowProjectComponent(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	for _, args := range [][]string{
+		{"init"},
+		{"agent", "add", "claude"},
+		{"init", "--scope", "project", "--project", proj},
+		{"agent", "add", "claude", "--scope", "project", "--project", proj},
+	} {
+		if out, err := runCLI(t, env, args...); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Plugin installed at USER scope only — the project tree gets no pin.
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmpHome, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("user plugin import: %v\n%s", err, out)
+	}
+
+	// A PROJECT-scope native subagent named exactly what the user-scope plugin
+	// derives. It is the user's own file at this scope and must be captured.
+	agentsDir := filepath.Join(proj, ".claude", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "feature-dev-code-reviewer.md"),
+		[]byte("---\nname: feature-dev-code-reviewer\n---\nProject's own.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "import", "claude:subagent", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project subagent import: %v\n%s", err, out)
+	}
+	captured := filepath.Join(proj, ".agentsync", "subagents", "feature-dev-code-reviewer.md")
+	data, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("a user-scope plugin must not shadow a project component sharing its derived name: %v", err)
+	}
+	if !strings.Contains(string(data), "Project's own.") {
+		t.Fatalf("captured the wrong content:\n%s", data)
+	}
+}
+
 // TestImport_DryRunSkipsPluginProvidedComponents pins that the preview tells the
 // same story as the real run. A dry-run that listed plugin components as
 // "would import" would be worse than useless — it would advertise a capture the
@@ -565,5 +621,154 @@ func TestImport_DryRunSkipsPluginProvidedComponents(t *testing.T) {
 	}
 	if !strings.Contains(out, "it is projected from the plugin") {
 		t.Errorf("dry-run must report the skip like the real run; got:\n%s", out)
+	}
+}
+
+// makeServerMarketplace builds a marketplace whose plugin ships an MCP server
+// and a hook — the two component kinds that are plugin-owned but NOT namespaced,
+// so the capture refusal has to recognise them by id/content rather than by name.
+func makeServerMarketplace(t *testing.T, dir string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "server-marketplace")
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(mpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".claude-plugin/marketplace.json", `{
+		"name": "srv-mp",
+		"owner": {"name": "tester"},
+		"plugins": [{"name": "srv", "source": "./plugins/srv"}]
+	}`)
+	write("plugins/srv/.claude-plugin/plugin.json", `{
+		"name": "srv",
+		"version": "1.0.0",
+		"mcpServers": {"pluginapi": {"command": "plugin-server", "args": ["--serve"]}},
+		"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "plugin-guard"}]}]}
+	}`)
+	return mpDir
+}
+
+// TestImport_SkipsPluginProvidedMCPServer covers the component kind that is
+// plugin-owned but NOT namespaced. An MCP server keeps its id (a same-id
+// divergence across sources is a possible endpoint hijack, refused rather than
+// renamed apart), so the refusal must recognise it by id — and capturing one
+// still mints a canonical mcp/<id>.toml that renders identically today and
+// diverges the moment the plugin updates, at which point every load hard-fails.
+func TestImport_SkipsPluginProvidedMCPServer(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:mcp")
+	if err != nil {
+		t.Fatalf("import claude:mcp: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "it is projected from the plugin") {
+		t.Errorf("import must announce the skipped plugin MCP server; got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "mcp", "pluginapi.toml")); err == nil {
+		t.Fatal("import captured a plugin-provided MCP server into the canonical source")
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply after import must still succeed: %v\n%s", err, out)
+	}
+}
+
+// TestImport_SkipsPluginHooksButKeepsYourOwn pins that hooks are filtered at
+// HANDLER granularity. A canonical hooks/<event>.toml holds handlers from many
+// sources, so refusing the whole event because a plugin contributed one would
+// silently drop the user's own — an over-refusal that loses real config.
+func TestImport_SkipsPluginHooksButKeepsYourOwn(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// A hand-written handler on the SAME event the plugin contributes to.
+	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
+	if err := os.MkdirAll(hooksSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksSrc, "PreToolUse.toml"),
+		[]byte("[[hook]]\nmatcher = \"Edit\"\ntype = \"command\"\ncommand = \"my-own-guard\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Remove the canonical copy so import has to re-capture from native config.
+	if err := os.Remove(filepath.Join(hooksSrc, "PreToolUse.toml")); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:hook"); err != nil {
+		t.Fatalf("import claude:hook: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(hooksSrc, "PreToolUse.toml"))
+	if err != nil {
+		t.Fatalf("the user's own handler must still be captured: %v", err)
+	}
+	if !strings.Contains(string(data), "my-own-guard") {
+		t.Fatalf("the user's own handler was dropped:\n%s", data)
+	}
+	if strings.Contains(string(data), "plugin-guard") {
+		t.Fatalf("the plugin's handler must not be captured:\n%s", data)
+	}
+}
+
+// TestImport_FailsClosedWhenPluginProjectionFails pins the fail-CLOSED contract.
+//
+// The skip filter is what stops import capturing agentsync's own output back
+// into the canonical source. It is computed from plugin data, so a plugin the
+// user does not control can make that computation fail — an upstream roll
+// changes the tree hash and the manifest-SHA pin no longer verifies. If a
+// failure left the filter empty, that would be a way to switch the defence off
+// on demand, so the import refuses instead.
+func TestImport_FailsClosedWhenPluginProjectionFails(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Tamper the cached plugin tree so the pinned manifest SHA no longer
+	// verifies — the projection now fails for a reason outside the user's
+	// control, which is exactly the trigger the guard must survive.
+	cached := filepath.Join(tmp, ".agentsync", ".state", "cache", "plugins",
+		"feature-dev", "agents", "code-reviewer.md")
+	if err := os.WriteFile(cached, []byte("---\nname: code-reviewer\n---\nTAMPERED.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:subagent")
+	if err == nil {
+		t.Fatalf("import must refuse when it cannot determine what the plugins provide; got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "cannot safely import") {
+		t.Errorf("the refusal should explain itself; got: %v", err)
+	}
+	// Nothing may have been captured.
+	if _, serr := os.Stat(filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")); serr == nil {
+		t.Fatal("a failed projection must not let a plugin component be captured")
 	}
 }

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -332,9 +332,16 @@ func TestReconcile_WriteBackRefusesPluginProvidedComponent(t *testing.T) {
 	// item label (.claude/agents/feature-dev-code-reviewer.md) on every outcome,
 	// including a successful write-back, so matching "feature-dev" alone would
 	// pass even if the refusal never fired.
-	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
-	if !strings.Contains(out, "projected from the plugin") {
-		t.Errorf("reconcile must refuse write-back with its own reason; got:\n%s", out)
+	// --auto-writeback must SKIP it, not fail: the refusal is structural and
+	// permanent, so counting it as a write-back failure would make every future
+	// run exit non-zero and break `reconcile && deploy` until the plugin is
+	// disabled. (The foreign-collision case ten lines up sets this precedent.)
+	out, err := runCLI(t, env, "reconcile", "--auto-writeback")
+	if err != nil {
+		t.Fatalf("a structural refusal must not fail the run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "provided by plugin") {
+		t.Errorf("reconcile must say why it skipped the item; got:\n%s", out)
 	}
 	captured := filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")
 	if _, err := os.Stat(captured); err == nil {
@@ -425,7 +432,7 @@ func TestReconcile_WriteBackRefusesPluginSkillBundledFile(t *testing.T) {
 	}
 
 	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
-	if !strings.Contains(out, "projected from the plugin") {
+	if !strings.Contains(out, "provided by plugin") {
 		t.Errorf("write-back of a plugin skill's bundled file must be refused; got:\n%s", out)
 	}
 	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "skills", "bundler-deploy")); err == nil {
@@ -1031,5 +1038,55 @@ func TestApply_ReclaimsRetiredSubagentSourceID(t *testing.T) {
 	if _, err := os.Stat(dest); err == nil {
 		t.Fatal("a destination recorded under the RETIRED agents/ SourceID must still be " +
 			"reclaimed — that is the pre-rename leftover the upgrade notice promises to remove")
+	}
+}
+
+// TestImport_CoDeclaredMCPServerStaysRefused pins the OTHER half of the
+// co-declaration rule, and it is the opposite of the hook case on purpose.
+//
+// Skipping an MCP server deletes nothing — WriteMCP writes one file per server,
+// so a refused capture just declines to update. Letting the user's claim win
+// there would be actively worse: import would capture the DRIFTED native content
+// into mcp/<id>.toml, the user's copy and the plugin's projection would then
+// diverge, and every later mutating load would hard-fail in
+// checkProjectedConflicts — a permanent wedge in place of a refusal that costs
+// nothing.
+//
+// So: hooks override (skipping deletes), everything else refuses (skipping is
+// free). The asymmetry is the contract.
+func TestImport_CoDeclaredMCPServerStaysRefused(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// The user declares the SAME server id, byte-identical to the plugin's, so
+	// checkProjectedConflicts is happy and both coexist in the projection.
+	mcpDir := filepath.Join(tmp, ".agentsync", "mcp")
+	if err := os.MkdirAll(mcpDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mcpDir, "pluginapi.toml"),
+		[]byte("[server]\ncommand = \"plugin-server\"\nargs = [\"--serve\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Naming it explicitly must still be refused: capturing is what creates the
+	// divergence that wedges every later load.
+	out, err := runCLI(t, env, "import", "claude:mcp:pluginapi")
+	if err == nil {
+		t.Fatalf("a co-declared MCP server must still be refused; got:\n%s", out)
+	}
+
+	// And the tree must still be usable — the whole point of refusing.
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply must still succeed after the refusal: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "status"); err != nil {
+		t.Fatalf("status must still succeed after the refusal: %v\n%s", err, out)
 	}
 }

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -142,8 +142,10 @@ func TestApply_CrossPluginCollisionsNamespaceApart(t *testing.T) {
 // TestApply_HandAuthoredComponentKeepsBareName pins the other half of the
 // contract: namespacing applies to PLUGIN-provided components only. A component
 // the user wrote in ~/.agentsync/ keeps the bare name they chose, even when an
-// installed plugin ships one by the same name — a plugin can never take a name
-// out from under the user, and an upgrade never renames their own files.
+// installed plugin ships one by the same name, and an upgrade never renames
+// their own files. (A plugin's DERIVED name can still land on one of theirs —
+// the mapping is not injective — which checkProjectedConflicts reports rather
+// than resolving silently; see TestCheckProjectedConflicts_NameKeyedComponents.)
 func TestApply_HandAuthoredComponentKeepsBareName(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
@@ -776,5 +778,111 @@ func TestImport_FailsClosedWhenPluginProjectionFails(t *testing.T) {
 	// Nothing may have been captured.
 	if _, serr := os.Stat(filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")); serr == nil {
 		t.Fatal("a failed projection must not let a plugin component be captured")
+	}
+}
+
+// TestReconcile_HookWriteBackIsRefused pins the OTHER half of the argument that
+// reconcile needs no hook-provenance case: hook key-level write-back is not
+// implemented at all, so a plugin hook cannot be captured through it.
+//
+// That reasoning is load-bearing — pluginProvidedSourceIDs deliberately registers
+// no hook keys because of it — and it was previously unenforced. If someone
+// implements hook write-back without also registering those keys, this fails
+// loudly instead of silently permitting the capture.
+func TestReconcile_HookWriteBackIsRefused(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
+	if err := os.MkdirAll(hooksSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksSrc, "PreToolUse.toml"),
+		[]byte("[[hook]]\nmatcher = \"Bash\"\ntype = \"command\"\ncommand = \"guard\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Drift the rendered hook so reconcile has something to act on.
+	settings := filepath.Join(tmp, ".claude", "settings.json")
+	data, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte(strings.Replace(string(data), "guard", "EDITED", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
+	if !strings.Contains(out, "not implemented") {
+		t.Errorf("hook write-back must be refused as unimplemented — the hook-provenance "+
+			"lookup relies on it; got:\n%s", out)
+	}
+}
+
+// TestImport_HookFilterKeysOnFullContent pins that the handler filter joins on
+// the WHOLE handler, not just event+matcher. A plugin and the user contributing
+// to the same event with the same matcher is the case that separates a correct
+// content signature from a coarser key — under event+matcher alone the user's
+// handler would be attributed to the plugin and silently dropped.
+func TestImport_HookFilterKeysOnFullContent(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// SAME event AND SAME matcher as the plugin's handler (PreToolUse / Bash),
+	// differing only in the command.
+	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
+	if err := os.MkdirAll(hooksSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksSrc, "PreToolUse.toml"),
+		[]byte("[[hook]]\nmatcher = \"Bash\"\ntype = \"command\"\ncommand = \"my-own-guard\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	if err := os.Remove(filepath.Join(hooksSrc, "PreToolUse.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "import", "claude:hook"); err != nil {
+		t.Fatalf("import claude:hook: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(hooksSrc, "PreToolUse.toml"))
+	if err != nil {
+		t.Fatalf("the user's handler must survive even when it shares the plugin's matcher: %v", err)
+	}
+	if !strings.Contains(string(data), "my-own-guard") {
+		t.Fatalf("a same-event same-matcher handler was dropped:\n%s", data)
+	}
+	if strings.Contains(string(data), "plugin-guard") {
+		t.Fatalf("the plugin's handler must still be skipped:\n%s", data)
+	}
+}
+
+// TestImport_NamedHookEventAllPluginProvided covers the distinct branch where a
+// NAMED hook import matches only plugin-provided handlers: it errors, rather than
+// reporting a successful import of nothing.
+func TestImport_NamedHookEventAllPluginProvided(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:hook:PreToolUse")
+	if err == nil {
+		t.Fatalf("a named import whose every handler is plugin-provided must error; got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "provided by an installed plugin") {
+		t.Errorf("the error should say why nothing was captured; got: %v", err)
 	}
 }

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -1,0 +1,180 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeCollidingMarketplace builds a local marketplace with TWO plugins that each
+// ship a same-named subagent, skill, and command, mirroring the real reproduction
+// in issue #211: feature-dev@claude-plugins-official and
+// pr-review-toolkit@claude-plugins-official both ship agents/code-reviewer.md.
+//
+// The bodies differ per plugin deliberately. Identical content would be deduped
+// by the apply pipeline's shared-path dedup and prove nothing — the failure this
+// guards against is precisely two DIVERGENT components claiming one destination.
+func makeCollidingMarketplace(t *testing.T, dir string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "colliding-marketplace")
+
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(mpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(".claude-plugin/marketplace.json", `{
+		"name": "official-mp",
+		"owner": {"name": "tester"},
+		"plugins": [
+			{"name": "feature-dev", "source": "./plugins/feature-dev"},
+			{"name": "pr-review-toolkit", "source": "./plugins/pr-review-toolkit"}
+		]
+	}`)
+
+	for _, p := range []struct{ id, model, body string }{
+		{"feature-dev", "sonnet", "Review the feature branch."},
+		{"pr-review-toolkit", "opus", "Review the pull request."},
+	} {
+		write("plugins/"+p.id+"/.claude-plugin/plugin.json", `{"name":"`+p.id+`","version":"1.0.0"}`)
+		write("plugins/"+p.id+"/agents/code-reviewer.md",
+			"---\nname: code-reviewer\ndescription: review code\nmodel: "+p.model+"\n---\n"+p.body+"\n")
+		write("plugins/"+p.id+"/skills/code-review/SKILL.md",
+			"---\nname: code-review\ndescription: review code\n---\n"+p.body+"\n")
+		write("plugins/"+p.id+"/commands/review.md",
+			"---\ndescription: review code\n---\n"+p.body+"\n")
+	}
+	return mpDir
+}
+
+// TestApply_CrossPluginCollisionsNamespaceApart is the end-to-end regression for
+// issue #211: two installed plugins each shipping a same-named component made
+// `status` and `apply` exit 1, and every remedy the error named was one the user
+// structurally could not perform — both files live under the marketplace-managed
+// plugin cache, which is overwritten on the next update.
+//
+// The oracle is the ON-DISK RESULT, not the parsed model: a round-trip over a
+// model that cannot represent two same-named components would be trivially
+// "lossless" while dropping one of them. So this asserts the rendered file tree
+// holds both components, at distinct paths, with distinct bodies.
+//
+// Codex is enabled alongside Claude because the two adapters failed differently
+// and BOTH must be fixed — codex refused during Render (its `name` is the agent's
+// identity, so two TOMLs cannot claim one), while Claude emitted two write ops at
+// one destination path and tripped the apply pipeline's divergence guard.
+func TestApply_CrossPluginCollisionsNamespaceApart(t *testing.T) {
+	tmp, env := importTestEnv(t) // inits + enables claude
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings(
+		"official-mp", mpDir, "feature-dev", "pr-review-toolkit",
+	))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// The pre-fix failure was here: `status` exited 1 with "codex subagents
+	// \"code-reviewer\" and \"code-reviewer\" resolve to the same agent name".
+	if out, err := runCLI(t, env, "status"); err != nil {
+		t.Fatalf("status must not fail on a cross-plugin name collision: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply must not fail on a cross-plugin name collision: %v\n%s", err, out)
+	}
+
+	mustContain := func(path, want string) {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected a namespaced component at %s: %v", path, err)
+		}
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("%s should carry %q; got:\n%s", path, want, data)
+		}
+	}
+
+	// Both plugins' subagents survive, at distinct destination paths, each
+	// carrying its OWN body — neither silently overwrote the other.
+	agents := filepath.Join(tmp, ".claude", "agents")
+	mustContain(filepath.Join(agents, "feature-dev-code-reviewer.md"), "Review the feature branch.")
+	mustContain(filepath.Join(agents, "pr-review-toolkit-code-reviewer.md"), "Review the pull request.")
+
+	// The frontmatter `name` follows the rename. Renaming only the file would
+	// leave both still colliding: Claude treats `name` as the agent's identity
+	// (and documents it must be unique across the tree), and Codex prefers the
+	// frontmatter name over the file stem when deriving its TOML `name`.
+	mustContain(filepath.Join(agents, "feature-dev-code-reviewer.md"), "name: feature-dev-code-reviewer")
+	mustContain(filepath.Join(agents, "pr-review-toolkit-code-reviewer.md"), "name: pr-review-toolkit-code-reviewer")
+
+	// The bare pre-namespace name must not exist at all: leaving it would be the
+	// third, ambiguous agent Claude Code would still load.
+	if _, err := os.Stat(filepath.Join(agents, "code-reviewer.md")); err == nil {
+		t.Fatal("the bare colliding name must not be rendered; found .claude/agents/code-reviewer.md")
+	}
+
+	// Codex renders subagents as TOML keyed by `name` — the case that failed
+	// loudest — so assert its on-disk identity too.
+	codexAgents := filepath.Join(tmp, ".codex", "agents")
+	mustContain(filepath.Join(codexAgents, "feature-dev-code-reviewer.toml"), `name = 'feature-dev-code-reviewer'`)
+	mustContain(filepath.Join(codexAgents, "pr-review-toolkit-code-reviewer.toml"), `name = 'pr-review-toolkit-code-reviewer'`)
+
+	// Skills and commands share the failure class — both are name-keyed and
+	// render to a name-derived destination path — so both are namespaced too.
+	skills := filepath.Join(tmp, ".claude", "skills")
+	mustContain(filepath.Join(skills, "feature-dev-code-review", "SKILL.md"), "Review the feature branch.")
+	mustContain(filepath.Join(skills, "pr-review-toolkit-code-review", "SKILL.md"), "Review the pull request.")
+	mustContain(filepath.Join(skills, "feature-dev-code-review", "SKILL.md"), "name: feature-dev-code-review")
+
+	commands := filepath.Join(tmp, ".claude", "commands")
+	mustContain(filepath.Join(commands, "feature-dev-review.md"), "Review the feature branch.")
+	mustContain(filepath.Join(commands, "pr-review-toolkit-review.md"), "Review the pull request.")
+}
+
+// TestApply_HandAuthoredComponentKeepsBareName pins the other half of the
+// contract: namespacing applies to PLUGIN-provided components only. A component
+// the user wrote in ~/.agentsync/ keeps the bare name they chose, even when an
+// installed plugin ships one by the same name — a plugin can never take a name
+// out from under the user, and an upgrade never renames their own files.
+func TestApply_HandAuthoredComponentKeepsBareName(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// A hand-authored subagent whose name matches what the plugin ships.
+	srcDir := filepath.Join(tmp, ".agentsync", "subagents")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "code-reviewer.md"),
+		[]byte("---\nname: code-reviewer\n---\nMy own reviewer.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	agents := filepath.Join(tmp, ".claude", "agents")
+	mine, err := os.ReadFile(filepath.Join(agents, "code-reviewer.md"))
+	if err != nil {
+		t.Fatalf("a hand-authored subagent must keep its bare name: %v", err)
+	}
+	if !strings.Contains(string(mine), "My own reviewer.") {
+		t.Fatalf("the bare name must belong to the USER's subagent; got:\n%s", mine)
+	}
+	if _, err := os.Stat(filepath.Join(agents, "feature-dev-code-reviewer.md")); err != nil {
+		t.Fatalf("the plugin's subagent should still render, namespaced: %v", err)
+	}
+}

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -204,9 +204,19 @@ func TestImport_SkipsPluginProvidedComponents(t *testing.T) {
 
 	// Re-import every text component. The plugin's own output is now sitting in
 	// the native config, and must not be captured back.
+	//
+	// Assert the SKIP is announced, not merely that a file is absent: if ingest
+	// simply stopped seeing the namespaced files, the absence checks below would
+	// be equally green while the filter did nothing. The warning is the positive
+	// control that the filter is what suppressed them.
 	for _, component := range []string{"subagent", "skill", "command"} {
-		if out, err := runCLI(t, env, "import", "claude:"+component); err != nil {
+		out, err := runCLI(t, env, "import", "claude:"+component)
+		if err != nil {
 			t.Fatalf("import claude:%s: %v\n%s", component, err, out)
+		}
+		if !strings.Contains(out, "it is projected from the plugin") {
+			t.Errorf("import claude:%s must announce the skip, not silently omit it; got:\n%s",
+				component, out)
 		}
 	}
 
@@ -316,9 +326,13 @@ func TestReconcile_WriteBackRefusesPluginProvidedComponent(t *testing.T) {
 	}
 
 	// --auto-writeback must refuse this item rather than mint a canonical copy.
+	// Assert the REFUSAL text, not just the plugin name: reconcile echoes the
+	// item label (.claude/agents/feature-dev-code-reviewer.md) on every outcome,
+	// including a successful write-back, so matching "feature-dev" alone would
+	// pass even if the refusal never fired.
 	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
-	if !strings.Contains(out, "feature-dev") {
-		t.Errorf("reconcile should explain that the component comes from a plugin; got:\n%s", out)
+	if !strings.Contains(out, "projected from the plugin") {
+		t.Errorf("reconcile must refuse write-back with its own reason; got:\n%s", out)
 	}
 	captured := filepath.Join(tmp, ".agentsync", "subagents", "feature-dev-code-reviewer.md")
 	if _, err := os.Stat(captured); err == nil {
@@ -327,5 +341,229 @@ func TestReconcile_WriteBackRefusesPluginProvidedComponent(t *testing.T) {
 	}
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply after reconcile must still succeed: %v\n%s", err, out)
+	}
+}
+
+// TestApply_NamespacingMigrationReclaimsPreRenameFiles covers the case every
+// existing user actually hits: the ONE-TIME rename on the first apply after
+// upgrading.
+//
+// It differs materially from a plain removal (which apply_orphan_rename_test.go
+// covers). Here the plan still renders ops into the same directory, so the
+// orphan pass must exclude the freshly-rendered namespaced paths while still
+// reclaiming the bare pre-rename one. Get that wrong in either direction and you
+// either delete the new file or leave the old one — and Claude Code reads every
+// file in its agents directory, so a leftover is a duplicate agent, not a
+// harmless artifact.
+//
+// The pre-rename state is simulated by applying a hand-authored component under
+// the bare name, then handing the same component to a plugin.
+func TestApply_NamespacingMigrationReclaimsPreRenameFiles(t *testing.T) {
+	tmp, env := importTestEnv(t)
+
+	// 1. Pre-upgrade world: the component exists under its BARE name, applied
+	//    and recorded in state exactly as a pre-namespacing apply left it.
+	bare := filepath.Join(tmp, ".agentsync", "subagents", "code-reviewer.md")
+	if err := os.WriteFile(bare, []byte("---\nname: code-reviewer\n---\nReview the feature branch.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("pre-rename apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".claude", "agents", "code-reviewer.md")
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("pre-rename apply did not write the bare name: %v", err)
+	}
+
+	// 2. Upgrade: the component now comes from a plugin, so it renders namespaced.
+	if err := os.Remove(bare); err != nil {
+		t.Fatal(err)
+	}
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("post-rename apply: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(dest); err == nil {
+		t.Fatal("the pre-rename destination file was not reclaimed; it would load as a duplicate agent")
+	}
+	renamed := filepath.Join(tmp, ".claude", "agents", "feature-dev-code-reviewer.md")
+	if _, err := os.Stat(renamed); err != nil {
+		t.Fatalf("the namespaced destination must exist after the rename: %v", err)
+	}
+}
+
+// TestReconcile_WriteBackRefusesPluginSkillBundledFile pins the bundled-file
+// half of the SourceID mapping. A skill is a DIRECTORY: pluginProvidedSourceIDs
+// registers one entry per bundled file (scripts/, references/, assets/), not
+// just SKILL.md. Only covering SKILL.md would leave a hand-edited script
+// capturable — minting a canonical skill directory that collides with the
+// plugin's own.
+func TestReconcile_WriteBackRefusesPluginSkillBundledFile(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeBundledSkillMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("bundle-mp", mpDir, "bundler"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	script := filepath.Join(tmp, ".claude", "skills", "bundler-deploy", "scripts", "run.sh")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("the plugin's bundled file must render under the namespaced skill: %v", err)
+	}
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho HAND EDITED\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := runCLI(t, env, "reconcile", "--auto-writeback")
+	if !strings.Contains(out, "projected from the plugin") {
+		t.Errorf("write-back of a plugin skill's bundled file must be refused; got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agentsync", "skills", "bundler-deploy")); err == nil {
+		t.Fatal("write-back minted a canonical copy of a plugin-provided skill directory")
+	}
+}
+
+// makeBundledSkillMarketplace builds a marketplace with one plugin whose skill
+// carries a bundled script, so the skill-is-a-directory paths are exercised.
+func makeBundledSkillMarketplace(t *testing.T, dir string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "bundle-marketplace")
+	write := func(rel, body string, mode os.FileMode) {
+		t.Helper()
+		p := filepath.Join(mpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".claude-plugin/marketplace.json", `{
+		"name": "bundle-mp",
+		"owner": {"name": "tester"},
+		"plugins": [{"name": "bundler", "source": "./plugins/bundler"}]
+	}`, 0o644)
+	write("plugins/bundler/.claude-plugin/plugin.json", `{"name":"bundler","version":"1.0.0"}`, 0o644)
+	write("plugins/bundler/skills/deploy/SKILL.md",
+		"---\nname: deploy\ndescription: ship it\n---\nSteps.\n", 0o644)
+	write("plugins/bundler/skills/deploy/scripts/run.sh", "#!/bin/sh\necho original\n", 0o755)
+	return mpDir
+}
+
+// TestProjectScope_PluginNamespacingAndImportFilter covers project scope, which
+// the rest of this file's user-scope tests leave untested.
+//
+// Two distinct properties are at stake, and both come from the same rule: the
+// skip set must be exactly the RENDERED set. At project scope every adapter
+// renders from the project-only overlay (`renderC = *c.Project`), never the user
+// canonical — so a project plugin's components are namespaced and refused, while
+// a USER-scope plugin contributes nothing to the project destination and must
+// not shadow a project component that merely shares its derived name.
+func TestProjectScope_PluginNamespacingAndImportFilter(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "init", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install the plugin at USER scope — `import claude:plugin` is user-scope
+	// only, since a plugin is a user-scope concept across every supported
+	// harness — then commit its plugins/<id>.toml into the PROJECT tree. That is
+	// how a project tree actually declares a plugin: the pin travels with the
+	// repo while the fetched cache stays under the user home.
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmpHome, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("user plugin import: %v\n%s", err, out)
+	}
+	pin, err := os.ReadFile(filepath.Join(tmpHome, ".agentsync", "plugins", "feature-dev.toml"))
+	if err != nil {
+		t.Fatalf("the user-scope plugin pin should exist: %v", err)
+	}
+	projPlugins := filepath.Join(proj, ".agentsync", "plugins")
+	if err := os.MkdirAll(projPlugins, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projPlugins, "feature-dev.toml"), pin, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project apply: %v\n%s", err, out)
+	}
+
+	// Namespacing applies at project scope too.
+	renamed := filepath.Join(proj, ".claude", "agents", "feature-dev-code-reviewer.md")
+	if _, err := os.Stat(renamed); err != nil {
+		t.Fatalf("a project-scope plugin's subagent must render namespaced: %v", err)
+	}
+
+	// A hand-authored PROJECT component is still captured — the filter must not
+	// over-refuse just because a plugin is installed at this scope.
+	mine := filepath.Join(proj, ".claude", "agents", "project-only.md")
+	if err := os.WriteFile(mine, []byte("---\nname: project-only\n---\nMine.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:subagent", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project subagent import: %v\n%s", err, out)
+	}
+	captured := filepath.Join(proj, ".agentsync", "subagents", "project-only.md")
+	if _, err := os.Stat(captured); err != nil {
+		t.Fatalf("a hand-authored project subagent must still be captured: %v", err)
+	}
+	// ...and the plugin's own is not.
+	if _, err := os.Stat(filepath.Join(proj, ".agentsync", "subagents", "feature-dev-code-reviewer.md")); err == nil {
+		t.Fatal("import captured a project-scope plugin's subagent into the project source tree")
+	}
+
+	// The project tree must still apply cleanly after the import.
+	if out, err := runCLI(t, env, "apply", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project apply after import: %v\n%s", err, out)
+	}
+}
+
+// TestImport_DryRunSkipsPluginProvidedComponents pins that the preview tells the
+// same story as the real run. A dry-run that listed plugin components as
+// "would import" would be worse than useless — it would advertise a capture the
+// real import refuses.
+func TestImport_DryRunSkipsPluginProvidedComponents(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeCollidingMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	out, err := runCLI(t, env, "import", "claude:subagent", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "would import subagents/feature-dev-code-reviewer.md") {
+		t.Errorf("dry-run must not advertise a capture the real import refuses; got:\n%s", out)
+	}
+	if !strings.Contains(out, "it is projected from the plugin") {
+		t.Errorf("dry-run must report the skip like the real run; got:\n%s", out)
 	}
 }

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -888,3 +888,148 @@ func TestImport_NamedHookEventAllPluginProvided(t *testing.T) {
 		t.Errorf("the error should say why nothing was captured; got: %v", err)
 	}
 }
+
+// TestReconcile_OrphanPromptSaysAutoReclaimKindsAreTemporary pins the prompt
+// wording — and exists because the branch shipped DEAD once already.
+//
+// reconcile's orphan items are built by collectOrphanFileItems, which originally
+// synthesized a FileOp with no SourceID. The wording branch asks a
+// SourceID-keyed question, so it silently answered "not reclaimable" for every
+// orphan and the conditional text could never print. Nothing caught it because
+// no test looked at the prompt.
+//
+// [k]eep is a promise about what happens next. For a subagent, skill, or command
+// the next apply reclaims it, so an unqualified "[k]eep" is a lie.
+func TestReconcile_OrphanPromptSaysAutoReclaimKindsAreTemporary(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	src := filepath.Join(tmp, ".agentsync", "subagents", "reviewer.md")
+	if err := os.WriteFile(src, []byte("---\nname: reviewer\n---\nreview\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	// Remove it from source but leave the destination: an orphan reconcile will
+	// prompt about. (Answer [k]eep so the run does not delete it.)
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := runCLIWithStdin(t, env, "k\n", "reconcile")
+	if !strings.Contains(out, "until the next apply reclaims it") {
+		t.Errorf("a subagent orphan is auto-reclaimed by the next apply, so [k]eep must say "+
+			"it is temporary; got:\n%s", out)
+	}
+}
+
+// TestImport_PluginIdenticalHookDoesNotEraseYourOwn is the data-loss regression.
+//
+// The projected canonical holds the user's handler AND the plugin's, and hooks
+// are keyed by CONTENT — so a plugin shipping a byte-identical handler made the
+// key resolve to the plugin. importHook then dropped the user's handler, and
+// source.WriteHooks REPLACES the whole hooks/<event>.toml, erasing a line the
+// user wrote from a tree that is usually a committed dotfiles repo — while
+// reporting "agentsync already manages it" about it.
+//
+// A plugin author who copies a popular hook gets this for free.
+func TestImport_PluginIdenticalHookDoesNotEraseYourOwn(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeServerMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+
+	// The user's own handler, BYTE-IDENTICAL to what the plugin ships
+	// (PreToolUse / Bash / plugin-guard), plus a second one that is theirs alone
+	// so the event survives and WriteHooks actually rewrites the file.
+	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
+	if err := os.MkdirAll(hooksSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookFile := filepath.Join(hooksSrc, "PreToolUse.toml")
+	if err := os.WriteFile(hookFile, []byte(
+		"[[hook]]\nmatcher = \"Bash\"\ntype = \"command\"\ncommand = \"plugin-guard\"\n"+
+			"[[hook]]\nmatcher = \"Edit\"\ntype = \"command\"\ncommand = \"only-mine\"\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// The canonical file STAYS. That is the whole point: source.WriteHooks
+	// replaces hooks/<event>.toml wholesale, so anything import decides not to
+	// capture is deleted from a file the user already had.
+	if out, err := runCLI(t, env, "import", "claude:hook"); err != nil {
+		t.Fatalf("import claude:hook: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("the event must still be captured: %v", err)
+	}
+	if !strings.Contains(string(data), "plugin-guard") {
+		t.Fatalf("a handler the user ALSO declares must not be treated as the plugin's "+
+			"and dropped — that erases their own line from the canonical source:\n%s", data)
+	}
+	if !strings.Contains(string(data), "only-mine") {
+		t.Fatalf("the user's other handler must survive too:\n%s", data)
+	}
+}
+
+// TestApply_ReclaimsRetiredSubagentSourceID is the end-to-end half of the
+// retired-prefix fix: the unit test proves the delete is SYNTHESIZED, this proves
+// a real apply actually REMOVES the file — which is what the upgrade notice,
+// CHANGELOG, and upgrading.mdx all promise an upgrading user.
+//
+// The state is seeded with the pre-rename "agents/<name>.md" SourceID by hand,
+// because that is exactly the state an upgrading user has and no current code
+// path produces it any more.
+func TestApply_ReclaimsRetiredSubagentSourceID(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	src := filepath.Join(tmp, ".agentsync", "subagents", "code-reviewer.md")
+	if err := os.WriteFile(src, []byte("---\nname: code-reviewer\n---\nreview\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".claude", "agents", "code-reviewer.md")
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("apply did not write the subagent: %v", err)
+	}
+
+	// Rewrite the recorded SourceID to the RETIRED spelling, as a pre-upgrade
+	// state file carries it, then remove the component from source.
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewritten := strings.ReplaceAll(string(data), "subagents/code-reviewer.md", "agents/code-reviewer.md")
+	if rewritten == string(data) {
+		t.Fatal("expected a subagents/ source_id in state to rewrite; the fixture no longer matches")
+	}
+	if err := os.WriteFile(statePath, []byte(rewritten), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply 2: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(dest); err == nil {
+		t.Fatal("a destination recorded under the RETIRED agents/ SourceID must still be " +
+			"reclaimed — that is the pre-rename leftover the upgrade notice promises to remove")
+	}
+}

--- a/internal/cli/plugin_owner_internal_test.go
+++ b/internal/cli/plugin_owner_internal_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
 
 // TestPluginOwnerForKeyItem is the direct unit test for the key-item provenance
 // lookup. The e2e import tests exercise a different code path (import matches by
@@ -33,9 +37,13 @@ func TestPluginOwnerForKeyItem(t *testing.T) {
 		{"generic tier: vscode", "mcp/* (multiple)", "/servers/github", "gh-plugin"},
 		{"generic tier: amp (dotted root)", "mcp/* (multiple)", "/amp.mcpServers/github", "gh-plugin"},
 
-		// Continue renders one file per server, so its op is a whole-file replace
-		// with a per-server SourceID rather than a section-wide one.
-		{"continue per-server SourceID", "mcp/github.toml", "/mcpServers/github", "gh-plugin"},
+		// NOTE: Continue's per-server SourceID ("mcp/<id>.toml") is deliberately
+		// NOT exercised here. Its op is MergeStrategy "replace", so it is a
+		// WHOLE-FILE item that never reaches this function — collectItems looks
+		// it up by SourceID instead. Asserting it here would test a shape that
+		// cannot occur; the real path is covered by
+		// TestPluginProvidedSourceIDs_RegistersBothServerKeyForms and the
+		// Continue e2e in plugin_namespace_test.go.
 
 		{"lsp kind", "lsp/* (multiple)", "/lspServers/gopls", "lsp-plugin"},
 
@@ -83,6 +91,39 @@ func TestUnescapeJSONPointer(t *testing.T) {
 	} {
 		if got := unescapeJSONPointer(tc.in); got != tc.want {
 			t.Errorf("unescapeJSONPointer(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestPluginProvidedSourceIDs_RegistersBothServerKeyForms pins the dual keying
+// that the key-item table above deliberately does not cover.
+//
+// Most adapters fold every MCP server into one config file, so their op carries
+// the section-wide SourceID "mcp/* (multiple)" and only the JSON pointer names
+// the server — that is the "<kind>/<id>" key. Continue instead renders ONE FILE
+// PER SERVER with the per-server SourceID "mcp/<id>.toml", making it a whole-file
+// item that collectItems looks up by SourceID directly. Keying only the bare form
+// left that path unguarded: a plugin-provided server on Continue could still be
+// captured.
+func TestPluginProvidedSourceIDs_RegistersBothServerKeyForms(t *testing.T) {
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "pluginapi", Plugin: "srv"},
+			{ID: "mine"}, // hand-declared: must not appear under either form
+		},
+		LSPServers: []source.LSPServer{{ID: "gopls", Plugin: "srv"}},
+	}
+	got := pluginProvidedSourceIDs(c)
+
+	for _, key := range []string{"mcp/pluginapi", "mcp/pluginapi.toml", "lsp/gopls", "lsp/gopls.toml"} {
+		if got[key] != "srv" {
+			t.Errorf("key %q = %q, want %q — both the key-merge and whole-file "+
+				"lookup shapes must resolve a plugin-owned server", key, got[key], "srv")
+		}
+	}
+	for _, key := range []string{"mcp/mine", "mcp/mine.toml"} {
+		if _, present := got[key]; present {
+			t.Errorf("a hand-declared server must not be registered as plugin-owned; got key %q", key)
 		}
 	}
 }

--- a/internal/cli/pluginowner_internal_test.go
+++ b/internal/cli/pluginowner_internal_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import "testing"
+
+// TestPluginOwnerForKeyItem is the direct unit test for the key-item provenance
+// lookup. The e2e import tests exercise a different code path (import matches by
+// id, never by pointer), so without this the function's whole contract — kind
+// from SourceID, id from the pointer, RFC 6901 decoding — was unwitnessed.
+func TestPluginOwnerForKeyItem(t *testing.T) {
+	owners := map[string]string{
+		"mcp/github":     "gh-plugin",
+		"mcp/with/slash": "slash-plugin",
+		"lsp/gopls":      "lsp-plugin",
+		// A plugin LSP server whose id collides with a common MCP name. This is
+		// the entry that must NOT be reachable from an /mcpServers/ pointer.
+		"lsp/postgres": "lsp-plugin",
+	}
+
+	tests := []struct {
+		name     string
+		sourceID string
+		ptr      string
+		want     string
+	}{
+		// Every MCP root key in the tree resolves the same way, because the kind
+		// comes from the SourceID rather than the root key. The generic tier's
+		// root keys are DATA that grows with every agent added, so a hand-listed
+		// allowlist would silently drop the refusal for each new one.
+		{"claude/cursor/gemini shape", "mcp/* (multiple)", "/mcpServers/github", "gh-plugin"},
+		{"opencode shape", "mcp/* (multiple)", "/mcp/github", "gh-plugin"},
+		{"codex shape", "mcp/* (multiple)", "/mcp_servers/github", "gh-plugin"},
+		{"generic tier: zed", "mcp/* (multiple)", "/context_servers/github", "gh-plugin"},
+		{"generic tier: vscode", "mcp/* (multiple)", "/servers/github", "gh-plugin"},
+		{"generic tier: amp (dotted root)", "mcp/* (multiple)", "/amp.mcpServers/github", "gh-plugin"},
+
+		// Continue renders one file per server, so its op is a whole-file replace
+		// with a per-server SourceID rather than a section-wide one.
+		{"continue per-server SourceID", "mcp/github.toml", "/mcpServers/github", "gh-plugin"},
+
+		{"lsp kind", "lsp/* (multiple)", "/lspServers/gopls", "lsp-plugin"},
+
+		// THE REGRESSION: a plugin LSP server named like a common MCP server must
+		// never be reported as the owner of an MCP pointer. Probing the id
+		// against both kinds would refuse write-back of the user's own MCP server
+		// and blame a plugin that does not own it.
+		{"lsp id must not leak into an mcp pointer", "mcp/* (multiple)", "/mcpServers/postgres", ""},
+
+		// Hooks carry no per-entry provenance for this lookup (hook write-back is
+		// not implemented), so they resolve to "" explicitly rather than falling
+		// through to a server probe.
+		{"hooks resolve to no owner", "hooks/* (multiple)", "/hooks/PreToolUse", ""},
+		{"hook event named like a server", "hooks/* (multiple)", "/hooks/github", ""},
+
+		// RFC 6901: ~1 is '/', ~0 is '~'. An id containing '/' would otherwise
+		// never match its map key.
+		{"escaped slash in id", "mcp/* (multiple)", "/mcpServers/with~1slash", "slash-plugin"},
+
+		{"hand-declared server", "mcp/* (multiple)", "/mcpServers/mine", ""},
+		{"pointer with no id segment", "mcp/* (multiple)", "/mcpServers", ""},
+		{"empty pointer", "mcp/* (multiple)", "", ""},
+		{"unknown kind", "memory/AGENTS.md", "/anything/github", ""},
+		{"deeper pointer still keys on the id", "mcp/* (multiple)", "/mcpServers/github/env/TOKEN", "gh-plugin"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pluginOwnerForKeyItem(tc.sourceID, tc.ptr, owners); got != tc.want {
+				t.Errorf("pluginOwnerForKeyItem(%q, %q) = %q, want %q", tc.sourceID, tc.ptr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUnescapeJSONPointer pins the decode order: ~0 must be decoded LAST, or
+// "~01" would wrongly become "/" instead of the literal "~1".
+func TestUnescapeJSONPointer(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"plain", "plain"},
+		{"with~1slash", "with/slash"},
+		{"with~0tilde", "with~tilde"},
+		{"~01", "~1"},
+		{"~1~0", "/~"},
+		{"", ""},
+	} {
+		if got := unescapeJSONPointer(tc.in); got != tc.want {
+			t.Errorf("unescapeJSONPointer(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -50,7 +50,7 @@ type reconcileItem struct {
 	// pluginOwner is the plugin id providing this component, empty for a
 	// hand-authored one. Write-back is refused for a plugin-provided component:
 	// see writeBackItem. Set for both shapes — whole-file items via the
-	// component SourceID, key-level MCP/LSP items via pluginOwnerForPointer.
+	// component SourceID, key-level MCP/LSP items via pluginOwnerForKeyItem.
 	pluginOwner string
 }
 
@@ -471,7 +471,7 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	//                         server into one config file, so the op carries the
 	//                         section-wide SourceID "mcp/* (multiple)" and only
 	//                         the item's JSON pointer identifies the server).
-	//                         Resolved by pluginOwnerForPointer.
+	//                         Resolved by pluginOwnerForKeyItem.
 	//   "<kind>/<id>.toml"  — the whole-file shape. Continue renders ONE FILE PER
 	//                         SERVER (.continue/mcpServers/<id>.yaml) with the
 	//                         canonical SourceID "mcp/<id>.toml", so its items go
@@ -511,36 +511,51 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	return out
 }
 
-// pluginOwnerForPointer resolves the plugin owning the component a key-level
-// item points at, or "" for a hand-declared one.
+// pluginOwnerForKeyItem resolves the plugin owning the MCP/LSP server a
+// key-level item points at, or "" for a hand-declared one.
 //
-// It deliberately does NOT switch on the pointer's root key. Those keys are
-// per-agent DATA, not a fixed set: alongside /mcpServers (claude, cursor,
-// gemini, …), /mcp (opencode), and /mcp_servers (codex), the generic tier
-// carries `RootKey` in a table that grows with every agent added —
-// /context_servers (Zed), /servers (VS Code), /amp.mcpServers (Amp). A
-// hand-maintained allowlist silently drops the refusal for every key someone
-// forgets to add, which is exactly the failure this guard exists to prevent.
+// The component KIND comes from the op's SourceID, not from the pointer's root
+// key, for two independent reasons:
 //
-// So it identifies the component by its ID — the pointer's second segment — and
-// probes it against each kind. A false positive would need a plugin to provide a
-// server whose id equals an unrelated section's key, and would only ever
-// over-refuse (the safe direction). Segments are JSON-pointer encoded, so ~1/~0
-// are decoded first (RFC 6901 §3) — an id containing '/' would otherwise never
-// match.
-func pluginOwnerForPointer(ptr string, owners map[string]string) string {
+//   - Root keys are per-agent DATA, not a fixed set. Alongside /mcpServers
+//     (claude, cursor, gemini, …), /mcp (opencode) and /mcp_servers (codex), the
+//     generic tier carries `RootKey` in a table that grows with every agent added
+//     (/context_servers, /servers, /amp.mcpServers). A hand-maintained allowlist
+//     silently drops the refusal for each one someone forgets to add.
+//   - Guessing the kind by probing the id against both maps is WRONG, not merely
+//     imprecise. A plugin shipping an LSP server whose id is a common MCP name
+//     ("github", "postgres") would make an /mcpServers/github pointer resolve to
+//     that plugin, refusing write-back of the user's OWN hand-declared MCP server
+//     and blaming a plugin that does not own it. Over-refusal here IS the harm.
+//
+// Every key-merge op carries a section-wide SourceID naming its kind —
+// "mcp/* (multiple)", "hooks/* (multiple)" — so the kind is already unambiguous
+// at the call site.
+//
+// Hooks resolve to "" by construction: hook write-back is not implemented
+// (writeBackKeyItem errors for every non-MCP pointer), so pluginProvidedSourceIDs
+// registers no hook keys for this lookup to find. Import is where plugin hooks
+// are filtered, at handler granularity. Should hook write-back ever be
+// implemented, this returns "" rather than silently permitting the capture — the
+// empty map is the thing to fix, and it is one place.
+//
+// Pointer segments are JSON-pointer encoded, so ~1/~0 are decoded first
+// (RFC 6901 §3) — an id containing '/' would otherwise never match.
+func pluginOwnerForKeyItem(sourceID, ptr string, owners map[string]string) string {
+	var kind string
+	switch {
+	case strings.HasPrefix(sourceID, "mcp/"):
+		kind = "mcp"
+	case strings.HasPrefix(sourceID, "lsp/"):
+		kind = "lsp"
+	default:
+		return "" // hooks, or a shape with no per-entry provenance
+	}
 	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
 	if len(parts) < 2 {
 		return ""
 	}
-	root, id := unescapeJSONPointer(parts[0]), unescapeJSONPointer(parts[1])
-	if root == "hooks" {
-		return owners["hook/"+id]
-	}
-	if p := owners["mcp/"+id]; p != "" {
-		return p
-	}
-	return owners["lsp/"+id]
+	return owners[kind+"/"+unescapeJSONPointer(parts[1])]
 }
 
 // unescapeJSONPointer decodes one JSON-pointer reference token (RFC 6901 §3):
@@ -590,7 +605,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 						srcText:     marshalPretty(getPointerValue(ours, ptr)),
 						dstText:     marshalPretty(getPointerValue(final, ptr)),
 						hasText:     true,
-						pluginOwner: pluginOwnerForPointer(ptr, pluginOwners),
+						pluginOwner: pluginOwnerForKeyItem(op.SourceID, ptr, pluginOwners),
 					})
 				}
 			} else {
@@ -983,7 +998,7 @@ func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 		return fmt.Errorf("write-back for %s is unsafe: this component is projected from the plugin %q, "+
 			"so it has no canonical file to write into. Capturing it would create one that collides with "+
 			"the plugin's own on the next apply. Use [o]verride to restore the plugin's version, change it "+
-			"upstream, or run `agentsync plugin disable %s` to stop projecting it",
+			"upstream, or run `agentsync plugin disable %q` to stop projecting it",
 			what, it.pluginOwner, it.pluginOwner)
 	}
 	if it.ptr != "" {

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -49,7 +49,8 @@ type reconcileItem struct {
 	hasText bool
 	// pluginOwner is the plugin id providing this component, empty for a
 	// hand-authored one. Write-back is refused for a plugin-provided component:
-	// see writeBackFileItem.
+	// see writeBackItem. Set for both shapes — whole-file items via the
+	// component SourceID, key-level MCP/LSP items via pluginOwnerForPointer.
 	pluginOwner string
 }
 
@@ -159,7 +160,15 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 
 	// Collect all items in order, then append orphaned whole-file dests
 	// (owned in state, no longer rendered) for interactive delete/keep.
-	items := collectItems(plan, reg, s, sc, projectRoot, userHome, pluginProvidedSourceIDs(c))
+	// Provenance must come from the SAME canonical the plan rendered from: at
+	// project scope every adapter renders the project-only overlay (`renderC =
+	// *c.Project`), so tagging items from the merged canonical would let a
+	// user-scope plugin claim a project component that merely shares its name.
+	ownerSrc := c
+	if sc == adapter.ScopeProject && c.Project != nil {
+		ownerSrc = *c.Project
+	}
+	items := collectItems(plan, reg, s, sc, projectRoot, userHome, pluginProvidedSourceIDs(ownerSrc))
 	items = append(items, collectOrphanFileItems(plan, reg, s, sc, projectRoot, userHome)...)
 
 	w := p.Out
@@ -455,6 +464,20 @@ func b2i(b bool) int {
 // has to project separately and match by component name.
 func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	out := map[string]string{}
+	// MCP/LSP servers are key-level items, not whole files: their render op
+	// carries the section-wide SourceID "mcp/* (multiple)", so they cannot be
+	// matched by SourceID at all. They are keyed here by "<kind>/<id>", which
+	// pluginOwnerForPointer resolves from the item's JSON pointer.
+	for _, s := range c.MCPServers {
+		if s.Plugin != "" {
+			out["mcp/"+s.ID] = s.Plugin
+		}
+	}
+	for _, s := range c.LSPServers {
+		if s.Plugin != "" {
+			out["lsp/"+s.ID] = s.Plugin
+		}
+	}
 	for _, sk := range c.Skills {
 		if sk.Plugin == "" {
 			continue
@@ -475,6 +498,29 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 		}
 	}
 	return out
+}
+
+// pluginOwnerForPointer resolves the plugin owning the MCP/LSP server a
+// key-level item points at, or "" for a hand-declared server or a pointer that
+// names no server (a hook section, a foreign key). Pointer shapes vary per agent
+// — /mcpServers/<id> (claude, cursor, gemini, …), /mcp/<id> (opencode),
+// /mcp_servers/<id> (codex), /lspServers/<id> — so the top-level key is what
+// says which kind is being addressed.
+func pluginOwnerForPointer(ptr string, owners map[string]string) string {
+	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	var kind string
+	switch parts[0] {
+	case "mcpServers", "mcp", "mcp_servers":
+		kind = "mcp"
+	case "lspServers", "lsp", "lsp_servers":
+		kind = "lsp"
+	default:
+		return ""
+	}
+	return owners[kind+"/"+parts[1]]
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.
@@ -517,6 +563,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 						srcText:     marshalPretty(getPointerValue(ours, ptr)),
 						dstText:     marshalPretty(getPointerValue(final, ptr)),
 						hasText:     true,
+						pluginOwner: pluginOwnerForPointer(ptr, pluginOwners),
 					})
 				}
 			} else {
@@ -889,6 +936,29 @@ func canonicalHookEvents(c source.Canonical) []string {
 }
 
 func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
+	// A plugin-provided component has no canonical file of its own: it is
+	// re-derived from the plugin cache on every load. Writing the destination
+	// back would MINT one under ~/.agentsync/, and the next load would hold two
+	// definitions — the captured copy and the plugin's own projection. For a
+	// name-keyed component that is two writes to one destination path; for an
+	// MCP/LSP server it is a same-id divergence the moment the plugin updates,
+	// which checkProjectedConflicts then refuses. Either way the user is stuck.
+	//
+	// The check sits at the dispatch waist so BOTH shapes are covered — the
+	// whole-file path (skills/subagents/commands) and the key-merge path
+	// (MCP/LSP servers) — rather than being duplicated in each and drifting.
+	// [o]verride restores the plugin's version; the edit belongs upstream.
+	if it.pluginOwner != "" {
+		what := it.op.Path
+		if it.ptr != "" {
+			what = fmt.Sprintf("%s (%s)", it.op.Path, ui.Sanitize(it.ptr))
+		}
+		return fmt.Errorf("write-back for %s is unsafe: this component is projected from the plugin %q, "+
+			"so it has no canonical file to write into. Capturing it would create one that collides with "+
+			"the plugin's own on the next apply. Use [o]verride to restore the plugin's version, change it "+
+			"upstream, or run `agentsync plugin disable %s` to stop projecting it",
+			what, it.pluginOwner, it.pluginOwner)
+	}
 	if it.ptr != "" {
 		return writeBackKeyItem(cmd, home, it)
 	}
@@ -1001,20 +1071,6 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	srcID := it.op.SourceID
 	if srcID == "" {
 		return fmt.Errorf("write-back for %s requires a single source-of-record; the rendering op has no SourceID (this happens for ad-hoc paths) — use [o]verride or [i]gnore", it.op.Path)
-	}
-	// A plugin-provided component has no canonical file of its own: it is
-	// projected from the plugin cache on every load. Writing the destination back
-	// would MINT one under ~/.agentsync/ with the component's (namespaced) name,
-	// and the next load would then hold two components of that name — the captured
-	// copy and the plugin's own projection — rendering to one destination path,
-	// which apply refuses. [o]verride restores the plugin's version; the edit
-	// belongs upstream in the plugin.
-	if it.pluginOwner != "" {
-		return fmt.Errorf("write-back for %s is unsafe: this component is projected from the plugin %q, "+
-			"so it has no canonical file to write into. Capturing it would create one that collides with "+
-			"the plugin's own on the next apply. Use [o]verride to restore the plugin's version, change it "+
-			"upstream, or run `agentsync plugin disable %s` to stop projecting it",
-			it.op.Path, it.pluginOwner, it.pluginOwner)
 	}
 	if strings.HasSuffix(srcID, "(multiple)") {
 		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -464,18 +464,29 @@ func b2i(b bool) int {
 // has to project separately and match by component name.
 func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	out := map[string]string{}
-	// MCP/LSP servers are key-level items, not whole files: their render op
-	// carries the section-wide SourceID "mcp/* (multiple)", so they cannot be
-	// matched by SourceID at all. They are keyed here by "<kind>/<id>", which
-	// pluginOwnerForPointer resolves from the item's JSON pointer.
+	// MCP/LSP servers are keyed under BOTH forms, because the two adapters
+	// families render them differently:
+	//
+	//   "<kind>/<id>"       — the key-merge shape (most adapters fold every
+	//                         server into one config file, so the op carries the
+	//                         section-wide SourceID "mcp/* (multiple)" and only
+	//                         the item's JSON pointer identifies the server).
+	//                         Resolved by pluginOwnerForPointer.
+	//   "<kind>/<id>.toml"  — the whole-file shape. Continue renders ONE FILE PER
+	//                         SERVER (.continue/mcpServers/<id>.yaml) with the
+	//                         canonical SourceID "mcp/<id>.toml", so its items go
+	//                         through the SourceID lookup like a subagent would.
+	//                         Keying only the bare form left that path unguarded.
 	for _, s := range c.MCPServers {
 		if s.Plugin != "" {
 			out["mcp/"+s.ID] = s.Plugin
+			out[filepath.ToSlash(filepath.Join("mcp", s.ID+".toml"))] = s.Plugin
 		}
 	}
 	for _, s := range c.LSPServers {
 		if s.Plugin != "" {
 			out["lsp/"+s.ID] = s.Plugin
+			out[filepath.ToSlash(filepath.Join("lsp", s.ID+".toml"))] = s.Plugin
 		}
 	}
 	for _, sk := range c.Skills {
@@ -500,27 +511,43 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	return out
 }
 
-// pluginOwnerForPointer resolves the plugin owning the MCP/LSP server a
-// key-level item points at, or "" for a hand-declared server or a pointer that
-// names no server (a hook section, a foreign key). Pointer shapes vary per agent
-// — /mcpServers/<id> (claude, cursor, gemini, …), /mcp/<id> (opencode),
-// /mcp_servers/<id> (codex), /lspServers/<id> — so the top-level key is what
-// says which kind is being addressed.
+// pluginOwnerForPointer resolves the plugin owning the component a key-level
+// item points at, or "" for a hand-declared one.
+//
+// It deliberately does NOT switch on the pointer's root key. Those keys are
+// per-agent DATA, not a fixed set: alongside /mcpServers (claude, cursor,
+// gemini, …), /mcp (opencode), and /mcp_servers (codex), the generic tier
+// carries `RootKey` in a table that grows with every agent added —
+// /context_servers (Zed), /servers (VS Code), /amp.mcpServers (Amp). A
+// hand-maintained allowlist silently drops the refusal for every key someone
+// forgets to add, which is exactly the failure this guard exists to prevent.
+//
+// So it identifies the component by its ID — the pointer's second segment — and
+// probes it against each kind. A false positive would need a plugin to provide a
+// server whose id equals an unrelated section's key, and would only ever
+// over-refuse (the safe direction). Segments are JSON-pointer encoded, so ~1/~0
+// are decoded first (RFC 6901 §3) — an id containing '/' would otherwise never
+// match.
 func pluginOwnerForPointer(ptr string, owners map[string]string) string {
 	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
 	if len(parts) < 2 {
 		return ""
 	}
-	var kind string
-	switch parts[0] {
-	case "mcpServers", "mcp", "mcp_servers":
-		kind = "mcp"
-	case "lspServers", "lsp", "lsp_servers":
-		kind = "lsp"
-	default:
-		return ""
+	root, id := unescapeJSONPointer(parts[0]), unescapeJSONPointer(parts[1])
+	if root == "hooks" {
+		return owners["hook/"+id]
 	}
-	return owners[kind+"/"+parts[1]]
+	if p := owners["mcp/"+id]; p != "" {
+		return p
+	}
+	return owners["lsp/"+id]
+}
+
+// unescapeJSONPointer decodes one JSON-pointer reference token (RFC 6901 §3):
+// "~1" is '/' and "~0" is '~'. Order matters — ~0 must be decoded last, or
+// "~01" would wrongly become "/" instead of "~1".
+func unescapeJSONPointer(tok string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(tok, "~1", "/"), "~0", "~")
 }
 
 // collectItems builds the flat reconcile list from a rendered plan + state.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -47,6 +47,10 @@ type reconcileItem struct {
 	srcText string
 	dstText string
 	hasText bool
+	// pluginOwner is the plugin id providing this component, empty for a
+	// hand-authored one. Write-back is refused for a plugin-provided component:
+	// see writeBackFileItem.
+	pluginOwner string
 }
 
 // errDestDroppedServer signals that the destination no longer contains the MCP
@@ -155,7 +159,7 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 
 	// Collect all items in order, then append orphaned whole-file dests
 	// (owned in state, no longer rendered) for interactive delete/keep.
-	items := collectItems(plan, reg, s, sc, projectRoot, userHome)
+	items := collectItems(plan, reg, s, sc, projectRoot, userHome, pluginProvidedSourceIDs(c))
 	items = append(items, collectOrphanFileItems(plan, reg, s, sc, projectRoot, userHome)...)
 
 	w := p.Out
@@ -438,9 +442,46 @@ func b2i(b bool) int {
 	return 0
 }
 
+// pluginProvidedSourceIDs maps each canonical SourceID a plugin provides to the
+// providing plugin's id, for the projected canonical c. Skills contribute one
+// entry per file in the directory (SKILL.md plus every bundled resource), since
+// each renders its own op with its own SourceID.
+//
+// It is reconcile's counterpart to import's pluginProvided(): the same "don't
+// capture agentsync's own output back into the canonical source" rule, keyed the
+// way each caller can match it. Reconcile works from the PROJECTED canonical, so
+// provenance is already on the components and no re-projection is needed; import
+// works from the agent's NATIVE ingest, which carries no provenance at all, so it
+// has to project separately and match by component name.
+func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
+	out := map[string]string{}
+	for _, sk := range c.Skills {
+		if sk.Plugin == "" {
+			continue
+		}
+		out[filepath.ToSlash(filepath.Join("skills", sk.Name, "SKILL.md"))] = sk.Plugin
+		for _, f := range sk.Files {
+			out[filepath.ToSlash(filepath.Join("skills", sk.Name, f.Path))] = sk.Plugin
+		}
+	}
+	for _, sa := range c.Subagents {
+		if sa.Plugin != "" {
+			out[filepath.ToSlash(source.SubagentSourceID(sa.Name))] = sa.Plugin
+		}
+	}
+	for _, cm := range c.Commands {
+		if cm.Plugin != "" {
+			out[filepath.ToSlash(filepath.Join("commands", cm.Name+".md"))] = cm.Plugin
+		}
+	}
+	return out
+}
+
 // collectItems builds the flat reconcile list from a rendered plan + state.
 // userHome (the user's $HOME) is the HomeRelative base for state-key lookups.
-func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot, userHome string) []reconcileItem {
+// pluginOwners (pluginProvidedSourceIDs) tags each item whose component comes
+// from a plugin, so write-back can refuse it.
+func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Targets, sc adapter.Scope, projectRoot, userHome string, pluginOwners map[string]string) []reconcileItem {
 	var items []reconcileItem
 	for _, name := range reg.Names() {
 		res, ok := plan.PerAgent[name]
@@ -500,6 +541,7 @@ func collectItems(plan render.RenderPlan, reg *adapter.Registry, s *state.Target
 					srcText:     string(op.Content),
 					dstText:     string(dstBytes),
 					hasText:     true,
+					pluginOwner: pluginOwners[filepath.ToSlash(op.SourceID)],
 				})
 			}
 		}
@@ -959,6 +1001,20 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	srcID := it.op.SourceID
 	if srcID == "" {
 		return fmt.Errorf("write-back for %s requires a single source-of-record; the rendering op has no SourceID (this happens for ad-hoc paths) — use [o]verride or [i]gnore", it.op.Path)
+	}
+	// A plugin-provided component has no canonical file of its own: it is
+	// projected from the plugin cache on every load. Writing the destination back
+	// would MINT one under ~/.agentsync/ with the component's (namespaced) name,
+	// and the next load would then hold two components of that name — the captured
+	// copy and the plugin's own projection — rendering to one destination path,
+	// which apply refuses. [o]verride restores the plugin's version; the edit
+	// belongs upstream in the plugin.
+	if it.pluginOwner != "" {
+		return fmt.Errorf("write-back for %s is unsafe: this component is projected from the plugin %q, "+
+			"so it has no canonical file to write into. Capturing it would create one that collides with "+
+			"the plugin's own on the next apply. Use [o]verride to restore the plugin's version, change it "+
+			"upstream, or run `agentsync plugin disable %s` to stop projecting it",
+			it.op.Path, it.pluginOwner, it.pluginOwner)
 	}
 	if strings.HasSuffix(srcID, "(multiple)") {
 		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -233,7 +233,15 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 				continue
 			}
 			fmt.Fprintf(w, "\n%s  (orphan — source no longer produces this file)\n", ui.Sanitize(it.op.Path))
-			fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep  [q]uit\n  > ")
+			// [k]eep is honest only for the kinds `apply` does NOT auto-reclaim.
+			// Skills, subagents, and commands are reclaimed on the next apply
+			// (render.orphanReclaimedPrefixes), so "keep" there means "keep until
+			// then" — say so rather than imply it is permanent.
+			if render.OrphanDeleteWillProceed(it.op) {
+				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep (until the next apply reclaims it)  [q]uit\n  > ")
+			} else {
+				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep  [q]uit\n  > ")
+			}
 		orphanPrompt:
 			for {
 				ch, readErr := readChar(br)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -532,6 +532,12 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 // "mcp/* (multiple)", "hooks/* (multiple)" — so the kind is already unambiguous
 // at the call site.
 //
+// The lsp branch is likewise unreachable TODAY — no adapter renders LSP servers
+// in v1 (every one reports them as a Skip), so no op carries an "lsp/" SourceID
+// and the lsp keys pluginProvidedSourceIDs registers are never looked up. It is
+// kept because it is symmetric, free, and correct the day an adapter does render
+// them; without it, that adapter would ship with the refusal silently absent.
+//
 // Hooks resolve to "" by construction: hook write-back is not implemented
 // (writeBackKeyItem errors for every non-MCP pointer), so pluginProvidedSourceIDs
 // registers no hook keys for this lookup to find. Import is where plugin hooks

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -234,10 +234,17 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 			}
 			fmt.Fprintf(w, "\n%s  (orphan — source no longer produces this file)\n", ui.Sanitize(it.op.Path))
 			// [k]eep is honest only for the kinds `apply` does NOT auto-reclaim.
-			// Skills, subagents, and commands are reclaimed on the next apply
-			// (render.orphanReclaimedPrefixes), so "keep" there means "keep until
-			// then" — say so rather than imply it is permanent.
-			if render.OrphanDeleteWillProceed(it.op) {
+			// Skills, subagents, and commands are reclaimed on the next apply, so
+			// "keep" there means "keep until then" — say so rather than imply it
+			// is permanent.
+			//
+			// This asks the KIND question (OrphanIsReclaimable), not the
+			// readability one (OrphanDeleteWillProceed): a reclaimable orphan that
+			// happens to be unreadable right now is retried on every subsequent
+			// apply, so "until the next apply reclaims it" is still the truth for
+			// it. Using the readability predicate here would print the permanent
+			// wording for exactly the file apply keeps coming back to.
+			if render.OrphanIsReclaimable(it.op.SourceID) {
 				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep (until the next apply reclaims it)  [q]uit\n  > ")
 			} else {
 				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep  [q]uit\n  > ")
@@ -472,6 +479,20 @@ func b2i(b bool) int {
 // has to project separately and match by component name.
 func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	out := map[string]string{}
+	// A key the USER also declares is never plugin-provided, even when a plugin
+	// ships an identical component — see pluginProvided (internal/cli/import.go)
+	// for why this is a data-loss guard rather than a nicety.
+	mine := map[string]bool{}
+	claim := func(key, plugin string) {
+		if plugin == "" {
+			mine[key] = true
+			delete(out, key)
+			return
+		}
+		if !mine[key] {
+			out[key] = plugin
+		}
+	}
 	// MCP/LSP servers are keyed under BOTH forms, because the two adapters
 	// families render them differently:
 	//
@@ -486,35 +507,24 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	//                         through the SourceID lookup like a subagent would.
 	//                         Keying only the bare form left that path unguarded.
 	for _, s := range c.MCPServers {
-		if s.Plugin != "" {
-			out["mcp/"+s.ID] = s.Plugin
-			out[filepath.ToSlash(filepath.Join("mcp", s.ID+".toml"))] = s.Plugin
-		}
+		claim("mcp/"+s.ID, s.Plugin)
+		claim(filepath.ToSlash(filepath.Join("mcp", s.ID+".toml")), s.Plugin)
 	}
 	for _, s := range c.LSPServers {
-		if s.Plugin != "" {
-			out["lsp/"+s.ID] = s.Plugin
-			out[filepath.ToSlash(filepath.Join("lsp", s.ID+".toml"))] = s.Plugin
-		}
+		claim("lsp/"+s.ID, s.Plugin)
+		claim(filepath.ToSlash(filepath.Join("lsp", s.ID+".toml")), s.Plugin)
 	}
 	for _, sk := range c.Skills {
-		if sk.Plugin == "" {
-			continue
-		}
-		out[filepath.ToSlash(filepath.Join("skills", sk.Name, "SKILL.md"))] = sk.Plugin
+		claim(filepath.ToSlash(filepath.Join("skills", sk.Name, "SKILL.md")), sk.Plugin)
 		for _, f := range sk.Files {
-			out[filepath.ToSlash(filepath.Join("skills", sk.Name, f.Path))] = sk.Plugin
+			claim(filepath.ToSlash(filepath.Join("skills", sk.Name, f.Path)), sk.Plugin)
 		}
 	}
 	for _, sa := range c.Subagents {
-		if sa.Plugin != "" {
-			out[filepath.ToSlash(source.SubagentSourceID(sa.Name))] = sa.Plugin
-		}
+		claim(filepath.ToSlash(source.SubagentSourceID(sa.Name)), sa.Plugin)
 	}
 	for _, cm := range c.Commands {
-		if cm.Plugin != "" {
-			out[filepath.ToSlash(filepath.Join("commands", cm.Name+".md"))] = cm.Plugin
-		}
+		claim(filepath.ToSlash(filepath.Join("commands", cm.Name+".md")), cm.Plugin)
 	}
 	return out
 }
@@ -690,11 +700,16 @@ func collectOrphanFileItems(plan render.RenderPlan, reg *adapter.Registry, s *st
 				continue
 			}
 			seen[orphan] = true
-			happlied := s.Files[stateFileKey(userHome, name, sc, projectRoot, orphan)].SHA256
+			entry := s.Files[stateFileKey(userHome, name, sc, projectRoot, orphan)]
+			happlied := entry.SHA256
 			hdest := hashFile(orphan)
 			items = append(items, reconcileItem{
-				agentName:   name,
-				op:          adapter.FileOp{Action: "delete", Path: orphan},
+				agentName: name,
+				// SourceID matters: every SourceID-keyed decision downstream — the
+				// reclaimable-kind check behind this item's prompt wording, and
+				// Writer.Delete's backup/prune behaviour if it is ever executed —
+				// silently degrades to "unknown kind" without it.
+				op:          adapter.FileOp{Action: "delete", Path: orphan, SourceID: entry.SourceID, Mode: entry.Mode},
 				cls:         drift.Classify("", happlied, hdest),
 				happlied:    happlied,
 				hdest:       hdest,

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -719,11 +719,13 @@ func collectOrphanFileItems(plan render.RenderPlan, reg *adapter.Registry, s *st
 			hdest := hashFile(orphan)
 			items = append(items, reconcileItem{
 				agentName: name,
-				// SourceID matters: every SourceID-keyed decision downstream — the
-				// reclaimable-kind check behind this item's prompt wording, and
-				// Writer.Delete's backup/prune behaviour if it is ever executed —
-				// silently degrades to "unknown kind" without it.
-				op:          adapter.FileOp{Action: "delete", Path: orphan, SourceID: entry.SourceID, Mode: entry.Mode},
+				// SourceID matters: the reclaimable-KIND check behind this item's
+				// prompt wording is SourceID-keyed and silently degrades to
+				// "unknown kind" without it — which is exactly how that branch
+				// once shipped dead. Mode is deliberately NOT carried: this path
+				// removes via render.BackupFile + os.Remove, never Writer.Delete,
+				// so nothing reads it and setting it would only imply otherwise.
+				op:          adapter.FileOp{Action: "delete", Path: orphan, SourceID: entry.SourceID},
 				cls:         drift.Classify("", happlied, hdest),
 				happlied:    happlied,
 				hdest:       hdest,

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -297,11 +297,25 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 				// file. Writing it back would overwrite the curated source
 				// with foreign content — the worst data-loss path. Refuse to
 				// do that non-interactively; leave it for an explicit choice.
-				if it.cls == drift.ForeignCollision {
+				switch {
+				case it.cls == drift.ForeignCollision:
 					fmt.Fprintf(w, "skipped (foreign-collision, would overwrite source): %s — resolve interactively\n", itemLabelDisp(it))
 					autoSkipped++
 					action = 's'
-				} else {
+				case it.pluginOwner != "":
+					// A plugin-provided component cannot be written back at all —
+					// it has no canonical file of its own. That refusal is
+					// STRUCTURAL and permanent, not a transient failure, so
+					// letting it count as a write-back FAILURE would make
+					// `reconcile --auto-writeback` exit non-zero on every run
+					// forever, breaking any `reconcile && deploy` until the user
+					// disables the plugin. Skip it like a foreign collision — the
+					// same "cannot be resolved non-interactively" shape.
+					fmt.Fprintf(w, "skipped (provided by plugin %q, no canonical file to write into): %s — use [o]verride, or change it upstream\n",
+						ui.Sanitize(it.pluginOwner), itemLabelDisp(it))
+					autoSkipped++
+					action = 's'
+				default:
 					action = 'w'
 				}
 			case autoOR:
@@ -479,17 +493,17 @@ func b2i(b bool) int {
 // has to project separately and match by component name.
 func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	out := map[string]string{}
-	// A key the USER also declares is never plugin-provided, even when a plugin
-	// ships an identical component — see pluginProvided (internal/cli/import.go)
-	// for why this is a data-loss guard rather than a nicety.
-	mine := map[string]bool{}
+	// No co-declaration override here, deliberately. Import needs one for HOOKS,
+	// because source.WriteHooks replaces the whole event file and skipping a
+	// handler the user also declares would ERASE it (see pluginProvided,
+	// internal/cli/import.go). This map registers no hook keys at all — hook
+	// write-back is unimplemented — and for every other kind the override would
+	// be harmful rather than absent: capturing a component the plugin also
+	// provides makes the two DIVERGE, and every later mutating load then fails in
+	// checkProjectedConflicts. Refusing the write-back costs nothing by
+	// comparison, so a plugin-provided key stays the plugin's.
 	claim := func(key, plugin string) {
-		if plugin == "" {
-			mine[key] = true
-			delete(out, key)
-			return
-		}
-		if !mine[key] {
+		if plugin != "" {
 			out[key] = plugin
 		}
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -755,6 +755,15 @@ func hashFile(path string) string {
 		// "this is a symlink now."
 		return "symlink-not-regular-file"
 	}
+	// A FIFO, device, or socket at a destination path would make os.ReadFile
+	// BLOCK forever rather than fail — wedging `status`, which is advertised as
+	// read-only, and reconcile's orphan listing. Neither has a content hash worth
+	// computing, so answer the same "not a regular file" sentinel the symlink
+	// case uses. Shares render's predicate so the destination-read guards cannot
+	// disagree about what is safe to read.
+	if !render.IsRegularOrAbsent(path) {
+		return "symlink-not-regular-file"
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -757,12 +757,14 @@ func hashFile(path string) string {
 	}
 	// A FIFO, device, or socket at a destination path would make os.ReadFile
 	// BLOCK forever rather than fail — wedging `status`, which is advertised as
-	// read-only, and reconcile's orphan listing. Neither has a content hash worth
-	// computing, so answer the same "not a regular file" sentinel the symlink
-	// case uses. Shares render's predicate so the destination-read guards cannot
+	// read-only, and reconcile's orphan listing. None has a content hash worth
+	// computing, so answer a sentinel that can never match one. It is a DIFFERENT
+	// sentinel from the symlink case above so a diagnostic never calls a FIFO a
+	// symlink; both are opaque to callers, which only ever compare hashes for
+	// equality. Shares render's predicate so the destination-read guards cannot
 	// disagree about what is safe to read.
 	if !render.IsRegularOrAbsent(path) {
-		return "symlink-not-regular-file"
+		return "not-a-regular-file"
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/cli/status_fifo_unix_internal_test.go
+++ b/internal/cli/status_fifo_unix_internal_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package cli
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestHashFile_FIFODoesNotBlock covers status's destination-read guard. `status`
+// is advertised as read-only, so a FIFO someone left at a managed destination
+// path must not wedge it: os.ReadFile does not fail on a FIFO, it waits forever
+// for a writer that never comes.
+//
+// It runs under a timeout because the regression is a HANG, not a wrong answer —
+// a plain assertion would never report. The sentinel must also be distinct from
+// the symlink one so a diagnostic never calls a FIFO a symlink.
+//
+// unix-only: syscall.Mkfifo is undefined on Windows.
+func TestHashFile_FIFODoesNotBlock(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "pipe.md")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	var got string
+	done := make(chan struct{})
+	go func() { defer close(done); got = hashFile(fifo) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hashFile BLOCKED on a FIFO — os.ReadFile does not fail on one, it waits " +
+			"for a writer that never comes")
+	}
+
+	if got != "not-a-regular-file" {
+		t.Errorf("a FIFO has no content hash worth computing; want the non-regular sentinel, got %q", got)
+	}
+	if got == "symlink-not-regular-file" {
+		t.Error("a FIFO must not be reported as a symlink")
+	}
+}

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -80,7 +80,7 @@ var upgradeNotices = []upgradeNotice{
 		Actions: []string{
 			"a plugin's component renders as <plugin>-<name>: feature-dev's code-reviewer is now feature-dev-code-reviewer",
 			"invoke plugin agents and commands by the new name (@agent-feature-dev-code-reviewer, /feature-dev-review)",
-			"your own ~/.agentsync/ components are NOT renamed — a plugin can never take a name you chose",
+			"your own ~/.agentsync/ components are NOT renamed; a derived name that clashes with one is reported, not silently resolved",
 			"the next `agentsync apply` removes the old un-namespaced files it wrote; a file you hand-edited is backed up first",
 		},
 		Path: "/reference/upgrading/",

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -73,6 +73,18 @@ var upgradeNotices = []upgradeNotice{
 		},
 		Path: "/reference/upgrading/",
 	},
+	{
+		ID:       "0.11.0-plugin-component-namespacing",
+		Since:    "0.11.0",
+		Headline: "plugin-provided subagents, skills, and commands are now namespaced by their plugin",
+		Actions: []string{
+			"a plugin's component renders as <plugin>-<name>: feature-dev's code-reviewer is now feature-dev-code-reviewer",
+			"invoke plugin agents and commands by the new name (@agent-feature-dev-code-reviewer, /feature-dev-review)",
+			"your own ~/.agentsync/ components are NOT renamed — a plugin can never take a name you chose",
+			"the next `agentsync apply` removes the old un-namespaced files it wrote; a file you hand-edited is backed up first",
+		},
+		Path: "/reference/upgrading/",
+	},
 }
 
 // maybePrintUpgradeNotice shows, at most once per machine, the notices a user

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -85,8 +86,9 @@ func TestUpgradeNotice_ShownOnceOnUpgrade(t *testing.T) {
 	if rec.Version != "0.11.0" {
 		t.Errorf("recorded version = %q, want 0.11.0", rec.Version)
 	}
-	if len(rec.NoticesSeen) != 1 || rec.NoticesSeen[0] != "0.11.0-cli-surface" {
-		t.Fatalf("recorded notice ids = %v, want exactly [0.11.0-cli-surface]", rec.NoticesSeen)
+	wantIDs := []string{"0.11.0-cli-surface", "0.11.0-plugin-component-namespacing"}
+	if !slices.Equal(rec.NoticesSeen, wantIDs) {
+		t.Fatalf("recorded notice ids = %v, want exactly %v", rec.NoticesSeen, wantIDs)
 	}
 
 	// Second run: silent.

--- a/internal/marketplace/iss162_test.go
+++ b/internal/marketplace/iss162_test.go
@@ -42,7 +42,10 @@ func TestLoadProjected_TamperGuardAndBodiesUseSameFs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProjected: %v", err)
 	}
-	if len(c.Skills) != 1 || c.Skills[0].Name != "s" {
+	// Name is the NAMESPACED form: a plugin-provided component is renamed
+	// "<plugin>-<name>" at projection (issue #211), with BaseName keeping the
+	// upstream name.
+	if len(c.Skills) != 1 || c.Skills[0].Name != "p-s" || c.Skills[0].BaseName != "s" {
 		t.Fatalf("skill not projected from the injected fs (bodies read via os.* instead?): %+v", c.Skills)
 	}
 	if !strings.Contains(c.Skills[0].Body, "memfs-only body") {

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -390,8 +390,17 @@ func nameCollisionError[T any](kind, name string, items []T, originOf func(T) (i
 		origins = append(origins, fmt.Sprintf("your own canonical %s %q", kind, name))
 	}
 	if lenient {
-		slog.Warn("component provided by multiple sources with different content; render keeps the last",
-			"kind", kind, "name", name, "from", strings.Join(origins, " and "))
+		// name is projection-derived (a plugin id joined to an upstream component
+		// name) and reaches this log BEFORE render.Plan's ValidateComponentID, so
+		// sanitize it here rather than relying on that waist. The origins are
+		// already %q-quoted by nameCollisionError's callers below.
+		// NOT "render keeps the last" — that is true for MCP/LSP (an id-keyed map,
+		// last write wins) but false here: two name-keyed components rendering to
+		// one destination path make the apply pipeline abort. Lenient callers are
+		// read-only, so they still SHOW state; the next mutating command fails.
+		slog.Warn("component provided by multiple sources with different content; "+
+			"apply will refuse until one is renamed or its plugin disabled",
+			"kind", kind, "name", untrusted.Sanitize(name), "from", strings.Join(origins, " and "))
 		return nil
 	}
 	return fmt.Errorf("%s %q is provided by more than one source with different content — %s. "+

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -164,9 +164,7 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 	if perr != nil {
 		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, perr)
 	}
-	if err := namespaceProjected(&proj, id); err != nil {
-		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, err)
-	}
+	namespaceProjected(&proj, id)
 	return proj, true, nil
 }
 
@@ -200,43 +198,44 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 // keeping the rename last also means the conflict policy still reports the
 // upstream names the user would recognise.
 //
-// Hooks, MCP servers, and LSP servers are deliberately NOT namespaced: hooks
-// have no name key at all, and MCP/LSP are id-keyed with an existing
-// cross-source guard (checkProjectedConflicts) whose hard failure is a
-// deliberate security property — a same-id server from two sources can be a
-// silent endpoint hijack, which is a case to refuse, not to rename apart.
-func namespaceProjected(pr *ProjectionResult, plugin string) error {
+// Hooks, MCP servers, and LSP servers are deliberately NOT renamed: hooks have
+// no name key at all, and MCP/LSP are id-keyed with an existing cross-source
+// guard (checkProjectedConflicts) whose hard failure is a deliberate security
+// property — a same-id server from two sources can be a silent endpoint hijack,
+// which is a case to refuse, not to rename apart.
+//
+// MCP and LSP servers ARE still stamped with provenance, though. They are not
+// renamed, but the dest→source paths still need to know a plugin owns them so
+// import/reconcile refuse to capture one into the canonical source (which would
+// mint a copy that diverges from the plugin's own on its next update).
+func namespaceProjected(pr *ProjectionResult, plugin string) {
 	if plugin == "" {
-		return nil
+		return
+	}
+	for i := range pr.MCPServers {
+		pr.MCPServers[i].Plugin = plugin
+	}
+	for i := range pr.LSPServers {
+		pr.LSPServers[i].Plugin = plugin
 	}
 	for i := range pr.Skills {
-		if err := source.ValidateNamespacedComponentName("skill", plugin, pr.Skills[i].Name); err != nil {
-			return err
-		}
 		pr.Skills[i].Plugin = plugin
 		pr.Skills[i].BaseName = pr.Skills[i].Name
 		pr.Skills[i].Name = source.NamespacedComponentName(plugin, pr.Skills[i].Name)
 		pr.Skills[i].Frontmatter = renameFrontmatter(pr.Skills[i].Frontmatter, pr.Skills[i].Name)
 	}
 	for i := range pr.Subagents {
-		if err := source.ValidateNamespacedComponentName("subagent", plugin, pr.Subagents[i].Name); err != nil {
-			return err
-		}
 		pr.Subagents[i].Plugin = plugin
 		pr.Subagents[i].BaseName = pr.Subagents[i].Name
 		pr.Subagents[i].Name = source.NamespacedComponentName(plugin, pr.Subagents[i].Name)
 		pr.Subagents[i].Frontmatter = renameFrontmatter(pr.Subagents[i].Frontmatter, pr.Subagents[i].Name)
 	}
 	for i := range pr.Commands {
-		if err := source.ValidateNamespacedComponentName("command", plugin, pr.Commands[i].Name); err != nil {
-			return err
-		}
 		pr.Commands[i].Plugin = plugin
 		pr.Commands[i].BaseName = pr.Commands[i].Name
 		pr.Commands[i].Name = source.NamespacedComponentName(plugin, pr.Commands[i].Name)
 		pr.Commands[i].Frontmatter = renameFrontmatter(pr.Commands[i].Frontmatter, pr.Commands[i].Name)
 	}
-	return nil
 }
 
 // renameFrontmatter returns fm with its `name` key set to the namespaced name,
@@ -300,7 +299,102 @@ func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
 		}
 		slog.Warn("lsp server provided by multiple sources with different content; render keeps the last", "id", id)
 	}
+	// Name-keyed text components. Namespacing makes a same-name collision rare,
+	// but it cannot make the mapping injective: plugin "a" shipping "b-c" and
+	// plugin "a-b" shipping "c" both derive "a-b-c", and a user who hand-authors
+	// "feature-dev-code-reviewer" collides with what plugin "feature-dev" derives
+	// for its "code-reviewer". Without this guard those cases reach the render
+	// pipeline, where two DIVERGENT components abort the run with a message that
+	// can name neither origin (a FileOp carries no provenance) — and two
+	// IDENTICAL ones are silently deduped by the shared-path dedup, dropping a
+	// component with no report at all. That silent drop is the bug this guard
+	// exists to prevent; the loud one it merely makes actionable.
+	//
+	// Identical duplicates stay harmless (render dedups them to one byte-identical
+	// write), exactly as for MCP/LSP above.
+	if name, ok := firstDivergentByKey(c.Skills, func(s source.Skill) string { return s.Name },
+		sameSkillRender); ok {
+		if err := nameCollisionError("skill", name, c.Skills, func(s source.Skill) (string, string, string) {
+			return s.Name, s.Plugin, s.BaseName
+		}, lenient); err != nil {
+			return err
+		}
+	}
+	if name, ok := "", false; ok {
+		_ = name
+	} else if name, ok := firstDivergentByKey(c.Subagents, func(s source.Subagent) string { return s.Name },
+		func(a, b source.Subagent) bool { return sameTextRender(a.Frontmatter, a.Body, b.Frontmatter, b.Body) }); ok {
+		if err := nameCollisionError("subagent", name, c.Subagents, func(s source.Subagent) (string, string, string) {
+			return s.Name, s.Plugin, s.BaseName
+		}, lenient); err != nil {
+			return err
+		}
+	}
+	if name, ok := firstDivergentByKey(c.Commands, func(cm source.Command) string { return cm.Name },
+		func(a, b source.Command) bool { return sameTextRender(a.Frontmatter, a.Body, b.Frontmatter, b.Body) }); ok {
+		if err := nameCollisionError("command", name, c.Commands, func(cm source.Command) (string, string, string) {
+			return cm.Name, cm.Plugin, cm.BaseName
+		}, lenient); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// sameTextRender compares the two things a text component renders: its
+// frontmatter and its body. Provenance (Plugin/BaseName) is deliberately
+// excluded — it never reaches a destination file, so two sources differing only
+// on it render identically and are not a collision.
+func sameTextRender(afm map[string]any, abody string, bfm map[string]any, bbody string) bool {
+	if abody != bbody {
+		return false
+	}
+	if len(afm) == 0 && len(bfm) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(afm, bfm)
+}
+
+// sameSkillRender extends sameTextRender with the bundled files, because a skill
+// is a DIRECTORY: two skills with an identical SKILL.md but different scripts/
+// still render different trees.
+func sameSkillRender(a, b source.Skill) bool {
+	if !sameTextRender(a.Frontmatter, a.Body, b.Frontmatter, b.Body) {
+		return false
+	}
+	if len(a.Files) == 0 && len(b.Files) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a.Files, b.Files)
+}
+
+// nameCollisionError reports a same-name divergence between two name-keyed
+// components, naming each side's ORIGIN — which is the whole point, since the
+// colliding pair shares the one thing a bare message would print (the name). It
+// is fatal for the mutating loads and a warning for the lenient read-only ones,
+// matching the MCP/LSP policy directly above.
+func nameCollisionError[T any](kind, name string, items []T, originOf func(T) (itemName, plugin, base string), lenient bool) error {
+	var origins []string
+	for _, it := range items {
+		n, plugin, base := originOf(it)
+		if n != name {
+			continue
+		}
+		if plugin != "" {
+			origins = append(origins, fmt.Sprintf("plugin %q (as %q)", plugin, base))
+			continue
+		}
+		origins = append(origins, fmt.Sprintf("your own %s/%s", kind, name))
+	}
+	if lenient {
+		slog.Warn("component provided by multiple sources with different content; render keeps the last",
+			"kind", kind, "name", name, "from", strings.Join(origins, " and "))
+		return nil
+	}
+	return fmt.Errorf("%s %q is provided by more than one source with different content — %s. "+
+		"Plugin components are namespaced by their plugin, so this is a genuine clash of the derived "+
+		"names: rename your own copy, or run `agentsync plugin disable <id>` for one of the plugins",
+		kind, name, strings.Join(origins, " and "))
 }
 
 // firstDivergentByKey returns the first key shared by two items the sameRender

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -164,7 +164,96 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 	if perr != nil {
 		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, perr)
 	}
+	if err := namespaceProjected(&proj, id); err != nil {
+		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, err)
+	}
 	return proj, true, nil
+}
+
+// namespaceProjected rewrites one plugin's name-keyed components to their
+// namespaced form and stamps their provenance.
+//
+// This is THE fix for cross-plugin name collisions, and it lives here rather
+// than in an adapter for a structural reason: the flattening load appends every
+// plugin's components into one set of flat slices, dropping the origin plugin.
+// By the time any adapter can detect that two components claim one name, the one
+// piece of information needed to resolve it is already gone.
+//
+// Rewriting `Name` — rather than teaching each adapter an "effective name" —
+// is what makes this a small change. `Name` is what every adapter derives its
+// destination path and identity from, so all render sites become correct with no
+// adapter change at all.
+//
+// The frontmatter `name` key is rewritten in step, WHEN PRESENT, because
+// renaming only the struct field would leave the components still colliding:
+// the Codex adapter prefers frontmatter `name` over the file stem when deriving
+// the agent identity (Codex's `name` IS the identity), and Claude's Agent Skills
+// require the frontmatter `name` to match the skill directory. It is left absent
+// when it was absent, so this never invents an identity the upstream artifact
+// did not declare, and a deliberately-divergent name still survives Render →
+// Ingest (issue #144).
+//
+// Ordering matters: this runs AFTER projectWithFuncs' resolveConflicts, whose
+// intra-plugin dedup compares whole components with reflect.DeepEqual. Stamping
+// provenance first would make two otherwise-identical duplicates continue to
+// compare equal (both get the same stamp) but needlessly couples the two steps;
+// keeping the rename last also means the conflict policy still reports the
+// upstream names the user would recognise.
+//
+// Hooks, MCP servers, and LSP servers are deliberately NOT namespaced: hooks
+// have no name key at all, and MCP/LSP are id-keyed with an existing
+// cross-source guard (checkProjectedConflicts) whose hard failure is a
+// deliberate security property — a same-id server from two sources can be a
+// silent endpoint hijack, which is a case to refuse, not to rename apart.
+func namespaceProjected(pr *ProjectionResult, plugin string) error {
+	if plugin == "" {
+		return nil
+	}
+	for i := range pr.Skills {
+		if err := source.ValidateNamespacedComponentName("skill", plugin, pr.Skills[i].Name); err != nil {
+			return err
+		}
+		pr.Skills[i].Plugin = plugin
+		pr.Skills[i].BaseName = pr.Skills[i].Name
+		pr.Skills[i].Name = source.NamespacedComponentName(plugin, pr.Skills[i].Name)
+		pr.Skills[i].Frontmatter = renameFrontmatter(pr.Skills[i].Frontmatter, pr.Skills[i].Name)
+	}
+	for i := range pr.Subagents {
+		if err := source.ValidateNamespacedComponentName("subagent", plugin, pr.Subagents[i].Name); err != nil {
+			return err
+		}
+		pr.Subagents[i].Plugin = plugin
+		pr.Subagents[i].BaseName = pr.Subagents[i].Name
+		pr.Subagents[i].Name = source.NamespacedComponentName(plugin, pr.Subagents[i].Name)
+		pr.Subagents[i].Frontmatter = renameFrontmatter(pr.Subagents[i].Frontmatter, pr.Subagents[i].Name)
+	}
+	for i := range pr.Commands {
+		if err := source.ValidateNamespacedComponentName("command", plugin, pr.Commands[i].Name); err != nil {
+			return err
+		}
+		pr.Commands[i].Plugin = plugin
+		pr.Commands[i].BaseName = pr.Commands[i].Name
+		pr.Commands[i].Name = source.NamespacedComponentName(plugin, pr.Commands[i].Name)
+		pr.Commands[i].Frontmatter = renameFrontmatter(pr.Commands[i].Frontmatter, pr.Commands[i].Name)
+	}
+	return nil
+}
+
+// renameFrontmatter returns fm with its `name` key set to the namespaced name,
+// but ONLY if the key is already present — an absent name is left absent (see
+// namespaceProjected). The map is copied rather than mutated in place: the
+// projection's frontmatter maps can be shared with the caller's parsed
+// artifact, and a rename must not reach back into it.
+func renameFrontmatter(fm map[string]any, name string) map[string]any {
+	if _, ok := fm["name"]; !ok {
+		return fm
+	}
+	out := make(map[string]any, len(fm))
+	for k, v := range fm {
+		out[k] = v
+	}
+	out["name"] = name
+	return out
 }
 
 // aferoReadDirEntries lists dir through the injected fs and adapts the result to

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -199,15 +199,17 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 // upstream names the user would recognise.
 //
 // Hooks, MCP servers, and LSP servers are deliberately NOT renamed: hooks have
-// no name key at all, and MCP/LSP are id-keyed with an existing cross-source
+// no name key at all (a canonical hooks/<event>.toml holds many handlers from
+// many sources), and MCP/LSP are id-keyed with an existing cross-source
 // guard (checkProjectedConflicts) whose hard failure is a deliberate security
 // property — a same-id server from two sources can be a silent endpoint hijack,
 // which is a case to refuse, not to rename apart.
 //
-// MCP and LSP servers ARE still stamped with provenance, though. They are not
-// renamed, but the dest→source paths still need to know a plugin owns them so
-// import/reconcile refuse to capture one into the canonical source (which would
-// mint a copy that diverges from the plugin's own on its next update).
+// All three ARE still stamped with provenance, though. They are not renamed, but
+// the dest→source paths still need to know a plugin owns them so import/reconcile
+// refuse to capture one into the canonical source (which would mint a copy that
+// diverges from the plugin's own on its next update). Hooks are stamped per
+// HANDLER, the granularity import has to filter at.
 func namespaceProjected(pr *ProjectionResult, plugin string) {
 	if plugin == "" {
 		return
@@ -217,6 +219,9 @@ func namespaceProjected(pr *ProjectionResult, plugin string) {
 	}
 	for i := range pr.LSPServers {
 		pr.LSPServers[i].Plugin = plugin
+	}
+	for i := range pr.Hooks {
+		pr.Hooks[i].Plugin = plugin
 	}
 	for i := range pr.Skills {
 		pr.Skills[i].Plugin = plugin
@@ -320,9 +325,7 @@ func checkProjectedConflicts(c *source.Canonical, lenient bool) error {
 			return err
 		}
 	}
-	if name, ok := "", false; ok {
-		_ = name
-	} else if name, ok := firstDivergentByKey(c.Subagents, func(s source.Subagent) string { return s.Name },
+	if name, ok := firstDivergentByKey(c.Subagents, func(s source.Subagent) string { return s.Name },
 		func(a, b source.Subagent) bool { return sameTextRender(a.Frontmatter, a.Body, b.Frontmatter, b.Body) }); ok {
 		if err := nameCollisionError("subagent", name, c.Subagents, func(s source.Subagent) (string, string, string) {
 			return s.Name, s.Plugin, s.BaseName
@@ -384,7 +387,7 @@ func nameCollisionError[T any](kind, name string, items []T, originOf func(T) (i
 			origins = append(origins, fmt.Sprintf("plugin %q (as %q)", plugin, base))
 			continue
 		}
-		origins = append(origins, fmt.Sprintf("your own %s/%s", kind, name))
+		origins = append(origins, fmt.Sprintf("your own canonical %s %q", kind, name))
 	}
 	if lenient {
 		slog.Warn("component provided by multiple sources with different content; render keeps the last",

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -393,7 +393,7 @@ func nameCollisionError[T any](kind, name string, items []T, originOf func(T) (i
 		// name is projection-derived (a plugin id joined to an upstream component
 		// name) and reaches this log BEFORE render.Plan's ValidateComponentID, so
 		// sanitize it here rather than relying on that waist. The origins are
-		// already %q-quoted by nameCollisionError's callers below.
+		// already %q-quoted where this function builds them, just above.
 		// NOT "render keeps the last" — that is true for MCP/LSP (an id-keyed map,
 		// last write wins) but false here: two name-keyed components rendering to
 		// one destination path make the apply pipeline abort. Lenient callers are

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -1,6 +1,9 @@
 package marketplace
 
 import (
+	"bytes"
+	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -170,7 +173,7 @@ func TestCheckProjectedConflicts_NameKeyedComponents(t *testing.T) {
 		if err == nil {
 			t.Fatal("a plugin's derived name colliding with a hand-authored one must be fatal")
 		}
-		if !strings.Contains(err.Error(), "your own subagent/feature-dev-code-reviewer") {
+		if !strings.Contains(err.Error(), `your own canonical subagent "feature-dev-code-reviewer"`) {
 			t.Errorf("error must point at the user's own file; got: %v", err)
 		}
 	})
@@ -190,12 +193,28 @@ func TestCheckProjectedConflicts_NameKeyedComponents(t *testing.T) {
 	// The read-only commands (status/diff/explain) exist to SHOW a problem; they
 	// must not refuse to run on one.
 	t.Run("lenient degrades to a warning", func(t *testing.T) {
+		// Assert the WARNING, not just the absence of an error: "returned nil"
+		// is equally true of a guard that did nothing at all, which is exactly
+		// the regression this subtest is meant to catch.
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+
 		c := source.Canonical{Subagents: []source.Subagent{
 			sub("a-b-c", "a", "b-c", "from a"),
 			sub("a-b-c", "a-b", "c", "from a-b"),
 		}}
 		if err := checkProjectedConflicts(&c, true); err != nil {
 			t.Fatalf("lenient must warn, not fail; got: %v", err)
+		}
+		got := buf.String()
+		// slog's TextHandler escapes the quotes inside the attribute value, so
+		// match the escaped form the warning actually carries.
+		for _, want := range []string{"a-b-c", `plugin \"a\"`, `plugin \"a-b\"`, `(as \"b-c\")`, `(as \"c\")`} {
+			if !strings.Contains(got, want) {
+				t.Errorf("the lenient warning must still name %s; got:\n%s", want, got)
+			}
 		}
 	})
 
@@ -243,9 +262,10 @@ func TestCheckProjectedConflicts_NameKeyedComponents(t *testing.T) {
 // keys) while diagnostics read Plugin/BaseName, so a component whose fields
 // disagree would report an origin that does not match what it rendered.
 //
-// It is asserted reflectively over whatever namespaceProjected produces rather
-// than against a hand-written expectation, so a future component kind added to
-// the rename loop is covered without anyone remembering to extend this test.
+// It walks ProjectionResult by REFLECTION rather than naming each component
+// slice, so a future component kind added to the rename loop is covered without
+// anyone remembering to extend this test — any struct field named Plugin/
+// BaseName/Name is checked wherever it appears.
 func TestProvenanceInvariant(t *testing.T) {
 	pr := ProjectionResult{
 		Skills:    []source.Skill{{Name: "s"}, {Name: "with-hyphen"}},
@@ -255,26 +275,40 @@ func TestProvenanceInvariant(t *testing.T) {
 	const plugin = "my-plugin"
 	namespaceProjected(&pr, plugin)
 
-	check := func(kind, name, gotPlugin, base string) {
-		t.Helper()
-		if gotPlugin != plugin {
-			t.Errorf("%s %q: Plugin = %q, want %q", kind, name, gotPlugin, plugin)
-			return
+	// Reflect over every slice on ProjectionResult, and over every element that
+	// carries all three fields. A component kind with no BaseName (MCP/LSP/hooks
+	// — stamped but never renamed) is skipped by the field check itself, so the
+	// invariant applies exactly where it is meant to.
+	v := reflect.ValueOf(pr)
+	checked := 0
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Kind() != reflect.Slice {
+			continue
 		}
-		if want := source.NamespacedComponentName(gotPlugin, base); name != want {
-			t.Errorf("%s: Name = %q but NamespacedComponentName(%q, %q) = %q — "+
-				"a component's reported origin must match the name it renders as",
-				kind, name, gotPlugin, base, want)
+		kind := v.Type().Field(i).Name
+		for j := 0; j < field.Len(); j++ {
+			el := field.Index(j)
+			nameF, pluginF, baseF := el.FieldByName("Name"), el.FieldByName("Plugin"), el.FieldByName("BaseName")
+			if !nameF.IsValid() || !pluginF.IsValid() || !baseF.IsValid() {
+				continue // not a renamed kind
+			}
+			checked++
+			name, gotPlugin, base := nameF.String(), pluginF.String(), baseF.String()
+			if gotPlugin != plugin {
+				t.Errorf("%s[%d] %q: Plugin = %q, want %q", kind, j, name, gotPlugin, plugin)
+				continue
+			}
+			if want := source.NamespacedComponentName(gotPlugin, base); name != want {
+				t.Errorf("%s[%d]: Name = %q but NamespacedComponentName(%q, %q) = %q — "+
+					"a component's reported origin must match the name it renders as",
+					kind, j, name, gotPlugin, base, want)
+			}
 		}
 	}
-	for _, s := range pr.Skills {
-		check("skill", s.Name, s.Plugin, s.BaseName)
-	}
-	for _, s := range pr.Subagents {
-		check("subagent", s.Name, s.Plugin, s.BaseName)
-	}
-	for _, c := range pr.Commands {
-		check("command", c.Name, c.Plugin, c.BaseName)
+	if checked != 5 {
+		t.Fatalf("expected to check 5 renamed components, checked %d — "+
+			"the reflection walk is not seeing what the fixture provides", checked)
 	}
 
 	// MCP/LSP are stamped but deliberately NOT renamed: their ids are the

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
 // TestNamespaceProjected covers the projection-time rename that resolves
@@ -306,6 +307,29 @@ func TestProvenanceInvariant(t *testing.T) {
 			}
 		}
 	}
+	// Guard the guard: a renamed KIND that the fixture leaves empty would
+	// contribute zero checks and quietly satisfy a bare count. Assert that every
+	// slice whose element type carries BaseName — i.e. every renamed kind, present
+	// and future — was actually populated and walked.
+	renamedKinds := 0
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Kind() != reflect.Slice {
+			continue
+		}
+		if _, ok := field.Type().Elem().FieldByName("BaseName"); !ok {
+			continue
+		}
+		renamedKinds++
+		if field.Len() == 0 {
+			t.Errorf("%s is a renamed kind but the fixture leaves it empty — "+
+				"this test would pass without ever checking it", v.Type().Field(i).Name)
+		}
+	}
+	if renamedKinds != 3 {
+		t.Fatalf("expected 3 renamed kinds (skills, subagents, commands), found %d — "+
+			"a kind was added or removed and this test needs its fixture extended", renamedKinds)
+	}
 	if checked != 5 {
 		t.Fatalf("expected to check 5 renamed components, checked %d — "+
 			"the reflection walk is not seeing what the fixture provides", checked)
@@ -317,6 +341,7 @@ func TestProvenanceInvariant(t *testing.T) {
 	pr2 := ProjectionResult{
 		MCPServers: []source.MCPServer{{ID: "srv"}},
 		LSPServers: []source.LSPServer{{ID: "gopls"}},
+		Hooks:      []source.Hook{{Event: untrusted.Wrap("PreToolUse"), Matcher: "Bash", Type: "command", Command: "guard"}},
 	}
 	namespaceProjected(&pr2, plugin)
 	if pr2.MCPServers[0].ID != "srv" || pr2.MCPServers[0].Plugin != plugin {
@@ -324,5 +349,39 @@ func TestProvenanceInvariant(t *testing.T) {
 	}
 	if pr2.LSPServers[0].ID != "gopls" || pr2.LSPServers[0].Plugin != plugin {
 		t.Errorf("lsp server must be stamped but not renamed; got %+v", pr2.LSPServers[0])
+	}
+	h := pr2.Hooks[0]
+	if h.Event.Unverified() != "PreToolUse" || h.Matcher != "Bash" || h.Command != "guard" {
+		t.Errorf("a hook must not be rewritten by namespacing; got %+v", h)
+	}
+	if h.Plugin != plugin {
+		t.Errorf("a hook must still be stamped so import can filter it per handler; got %+v", h)
+	}
+}
+
+// TestDedupHooks_KeysOnContentNotProvenance pins the rekey. dedupHooks used to
+// key on the whole source.Hook struct; adding a Plugin field would then have made
+// two byte-identical handlers from different plugins survive as duplicates,
+// rendering the same hook twice.
+//
+// Today namespaceProjected stamps provenance AFTER this runs, so every hook here
+// shares one value and the bug could not fire — which is exactly why it is worth
+// pinning: the ordering is not something a future change should have to know.
+func TestDedupHooks_KeysOnContentNotProvenance(t *testing.T) {
+	mk := func(plugin string) source.Hook {
+		return source.Hook{
+			Event: untrusted.Wrap("PreToolUse"), Matcher: "Bash",
+			Type: "command", Command: "guard", Plugin: plugin,
+		}
+	}
+	got := dedupHooks([]source.Hook{mk("a"), mk("b"), mk("a")})
+	if len(got) != 1 {
+		t.Fatalf("identical handlers must collapse regardless of provenance; got %d: %+v", len(got), got)
+	}
+	// Genuinely different handlers still survive.
+	other := mk("a")
+	other.Command = "different"
+	if got := dedupHooks([]source.Hook{mk("a"), other}); len(got) != 2 {
+		t.Fatalf("distinct handlers must not be collapsed; got %d: %+v", len(got), got)
 	}
 }

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -1,6 +1,7 @@
 package marketplace
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/source"
@@ -17,9 +18,7 @@ func TestNamespaceProjected(t *testing.T) {
 			Subagents: []source.Subagent{{Name: "code-reviewer", Frontmatter: map[string]any{"name": "code-reviewer"}}},
 			Commands:  []source.Command{{Name: "review", Frontmatter: map[string]any{"description": "d"}}},
 		}
-		if err := namespaceProjected(&pr, "feature-dev"); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "feature-dev")
 		for _, tc := range []struct{ got, want, field string }{
 			{pr.Skills[0].Name, "feature-dev-code-review", "skill Name"},
 			{pr.Skills[0].BaseName, "code-review", "skill BaseName"},
@@ -45,9 +44,7 @@ func TestNamespaceProjected(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{
 			{Name: "reviewer", Frontmatter: map[string]any{"name": "reviewer", "model": "opus"}},
 		}}
-		if err := namespaceProjected(&pr, "pkg"); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "pkg")
 		if got := pr.Subagents[0].Frontmatter["name"]; got != "pkg-reviewer" {
 			t.Errorf("frontmatter name = %v, want pkg-reviewer", got)
 		}
@@ -63,9 +60,7 @@ func TestNamespaceProjected(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{
 			{Name: "reviewer", Frontmatter: map[string]any{"description": "d"}},
 		}}
-		if err := namespaceProjected(&pr, "pkg"); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "pkg")
 		if _, ok := pr.Subagents[0].Frontmatter["name"]; ok {
 			t.Errorf("namespacing must not invent a frontmatter name; got %v", pr.Subagents[0].Frontmatter)
 		}
@@ -76,9 +71,7 @@ func TestNamespaceProjected(t *testing.T) {
 	t.Run("does not mutate the caller's frontmatter map", func(t *testing.T) {
 		fm := map[string]any{"name": "reviewer"}
 		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer", Frontmatter: fm}}}
-		if err := namespaceProjected(&pr, "pkg"); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "pkg")
 		if fm["name"] != "reviewer" {
 			t.Errorf("the caller's map was mutated in place; got %v", fm)
 		}
@@ -93,22 +86,34 @@ func TestNamespaceProjected(t *testing.T) {
 			MCPServers: []source.MCPServer{{ID: "srv"}},
 			LSPServers: []source.LSPServer{{ID: "gopls"}},
 		}
-		if err := namespaceProjected(&pr, "pkg"); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "pkg")
 		if pr.MCPServers[0].ID != "srv" || pr.LSPServers[0].ID != "gopls" {
 			t.Errorf("id-keyed components must not be namespaced: %+v %+v", pr.MCPServers, pr.LSPServers)
 		}
 	})
 
-	// A plugin id originates from a marketplace, outside agentsync's trust
-	// boundary. A derived name that would escape its destination directory or
-	// smuggle a terminal escape into a diagnostic is refused, not written.
-	t.Run("refuses a derived name the write boundary would reject", func(t *testing.T) {
-		for _, plugin := range []string{"../evil", "a:b", "esc\x1b[31m"} {
+	// Namespacing itself NEVER fails. An earlier revision validated the derived
+	// name here and returned an error, which was a regression: the projection's
+	// own validateProjectedName permits ':' and control runes, so a plugin that
+	// projected fine before started hard-failing — and loadProjected propagates a
+	// projection error regardless of `lenient`, taking down the read-only
+	// commands whose whole design is to degrade and show state.
+	//
+	// The safety property is unchanged because it lives downstream at the single
+	// dispatch waist: render.Plan runs source.ValidateComponentID over every
+	// component id before any of them is joined into a destination path. This
+	// pins BOTH halves — namespacing does not fail, and the derived name is still
+	// caught by the validator that matters.
+	t.Run("hostile plugin ids namespace without error and are caught downstream", func(t *testing.T) {
+		for _, plugin := range []string{"a:b", "esc\x1b[31m"} {
 			pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
-			if err := namespaceProjected(&pr, plugin); err == nil {
-				t.Errorf("plugin id %q should not derive a writable component name", plugin)
+			namespaceProjected(&pr, plugin)
+			got := pr.Subagents[0].Name
+			if got != plugin+"-reviewer" {
+				t.Errorf("plugin %q: derived name = %q", plugin, got)
+			}
+			if err := source.ValidateComponentID("subagent", got); err == nil {
+				t.Errorf("render.Plan's validator must still reject the derived name %q", got)
 			}
 		}
 	})
@@ -117,11 +122,173 @@ func TestNamespaceProjected(t *testing.T) {
 	// flow through the same code path untouched.
 	t.Run("empty plugin is a no-op", func(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
-		if err := namespaceProjected(&pr, ""); err != nil {
-			t.Fatalf("namespaceProjected: %v", err)
-		}
+		namespaceProjected(&pr, "")
 		if pr.Subagents[0].Name != "reviewer" || pr.Subagents[0].Plugin != "" {
 			t.Errorf("an empty plugin id must change nothing; got %+v", pr.Subagents[0])
 		}
 	})
+}
+
+// TestCheckProjectedConflicts_NameKeyedComponents covers the guard that closes
+// the residual namespacing cannot: the derived-name mapping is not injective.
+//
+// Plugin "a" shipping "b-c" and plugin "a-b" shipping "c" both derive "a-b-c",
+// and a user who hand-authors "feature-dev-code-reviewer" collides with what
+// plugin "feature-dev" derives. Without this guard those reach the render
+// pipeline, where DIVERGENT content aborts with a message that can name neither
+// origin, and IDENTICAL content is silently deduped — dropping a component with
+// no report at all.
+func TestCheckProjectedConflicts_NameKeyedComponents(t *testing.T) {
+	sub := func(name, plugin, base, body string) source.Subagent {
+		return source.Subagent{Name: name, Plugin: plugin, BaseName: base, Body: body}
+	}
+
+	t.Run("divergent cross-plugin derived names are fatal and name both origins", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			sub("a-b-c", "a", "b-c", "from a"),
+			sub("a-b-c", "a-b", "c", "from a-b"),
+		}}
+		err := checkProjectedConflicts(&c, false)
+		if err == nil {
+			t.Fatal("two plugins deriving one name with different content must be fatal")
+		}
+		for _, want := range []string{`plugin "a"`, `plugin "a-b"`, `as "b-c"`, `as "c"`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error must carry %s so the user can tell the sides apart; got: %v", want, err)
+			}
+		}
+	})
+
+	// This is the case that contradicted provenance.go's claim that "a plugin can
+	// never take a name the user chose" — it can, via the derived name.
+	t.Run("a plugin colliding with a hand-authored name names the user's file", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			sub("feature-dev-code-reviewer", "", "", "mine"),
+			sub("feature-dev-code-reviewer", "feature-dev", "code-reviewer", "theirs"),
+		}}
+		err := checkProjectedConflicts(&c, false)
+		if err == nil {
+			t.Fatal("a plugin's derived name colliding with a hand-authored one must be fatal")
+		}
+		if !strings.Contains(err.Error(), "your own subagent/feature-dev-code-reviewer") {
+			t.Errorf("error must point at the user's own file; got: %v", err)
+		}
+	})
+
+	// Identical content is harmless: render dedups it to one byte-identical
+	// write, exactly as for MCP/LSP. Erroring here would fail a no-op.
+	t.Run("identical duplicates pass", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			sub("a-b-c", "a", "b-c", "same"),
+			sub("a-b-c", "a-b", "c", "same"),
+		}}
+		if err := checkProjectedConflicts(&c, false); err != nil {
+			t.Fatalf("identical duplicates render identically and must pass; got: %v", err)
+		}
+	})
+
+	// The read-only commands (status/diff/explain) exist to SHOW a problem; they
+	// must not refuse to run on one.
+	t.Run("lenient degrades to a warning", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			sub("a-b-c", "a", "b-c", "from a"),
+			sub("a-b-c", "a-b", "c", "from a-b"),
+		}}
+		if err := checkProjectedConflicts(&c, true); err != nil {
+			t.Fatalf("lenient must warn, not fail; got: %v", err)
+		}
+	})
+
+	// A skill is a DIRECTORY: an identical SKILL.md with different bundled files
+	// still renders a different tree, so it is a divergence.
+	t.Run("skills compare bundled files too", func(t *testing.T) {
+		mk := func(plugin, base string, files []source.SkillFile) source.Skill {
+			return source.Skill{Name: "p-s", Plugin: plugin, BaseName: base, Body: "same", Files: files}
+		}
+		c := source.Canonical{Skills: []source.Skill{
+			mk("p", "s", []source.SkillFile{{Path: "scripts/run.sh", Content: []byte("A"), Mode: 0o755}}),
+			mk("p-s", "", []source.SkillFile{{Path: "scripts/run.sh", Content: []byte("B"), Mode: 0o755}}),
+		}}
+		if err := checkProjectedConflicts(&c, false); err == nil {
+			t.Fatal("skills differing only in a bundled file must be a divergence")
+		}
+	})
+
+	t.Run("commands are covered", func(t *testing.T) {
+		c := source.Canonical{Commands: []source.Command{
+			{Name: "a-b", Plugin: "a", BaseName: "b", Body: "x"},
+			{Name: "a-b", Body: "y"},
+		}}
+		if err := checkProjectedConflicts(&c, false); err == nil {
+			t.Fatal("commands share the failure class and must be guarded")
+		}
+	})
+
+	// Provenance never reaches a destination file, so two sources differing ONLY
+	// on it render identically and are not a collision.
+	t.Run("provenance alone is not a divergence", func(t *testing.T) {
+		c := source.Canonical{Subagents: []source.Subagent{
+			sub("a-b-c", "a", "b-c", "same"),
+			sub("a-b-c", "", "", "same"),
+		}}
+		if err := checkProjectedConflicts(&c, false); err != nil {
+			t.Fatalf("differing only on provenance must not be a collision; got: %v", err)
+		}
+	})
+}
+
+// TestProvenanceInvariant pins the relationship the three fields must hold:
+// when Plugin is set, Name IS the namespaced form of BaseName. Everything
+// downstream reads Name as the effective identity (destination paths, collision
+// keys) while diagnostics read Plugin/BaseName, so a component whose fields
+// disagree would report an origin that does not match what it rendered.
+//
+// It is asserted reflectively over whatever namespaceProjected produces rather
+// than against a hand-written expectation, so a future component kind added to
+// the rename loop is covered without anyone remembering to extend this test.
+func TestProvenanceInvariant(t *testing.T) {
+	pr := ProjectionResult{
+		Skills:    []source.Skill{{Name: "s"}, {Name: "with-hyphen"}},
+		Subagents: []source.Subagent{{Name: "a"}, {Name: "b-c"}},
+		Commands:  []source.Command{{Name: "cmd"}},
+	}
+	const plugin = "my-plugin"
+	namespaceProjected(&pr, plugin)
+
+	check := func(kind, name, gotPlugin, base string) {
+		t.Helper()
+		if gotPlugin != plugin {
+			t.Errorf("%s %q: Plugin = %q, want %q", kind, name, gotPlugin, plugin)
+			return
+		}
+		if want := source.NamespacedComponentName(gotPlugin, base); name != want {
+			t.Errorf("%s: Name = %q but NamespacedComponentName(%q, %q) = %q — "+
+				"a component's reported origin must match the name it renders as",
+				kind, name, gotPlugin, base, want)
+		}
+	}
+	for _, s := range pr.Skills {
+		check("skill", s.Name, s.Plugin, s.BaseName)
+	}
+	for _, s := range pr.Subagents {
+		check("subagent", s.Name, s.Plugin, s.BaseName)
+	}
+	for _, c := range pr.Commands {
+		check("command", c.Name, c.Plugin, c.BaseName)
+	}
+
+	// MCP/LSP are stamped but deliberately NOT renamed: their ids are the
+	// security-relevant key a same-id divergence is refused on, never renamed
+	// apart. The invariant above must not be read as applying to them.
+	pr2 := ProjectionResult{
+		MCPServers: []source.MCPServer{{ID: "srv"}},
+		LSPServers: []source.LSPServer{{ID: "gopls"}},
+	}
+	namespaceProjected(&pr2, plugin)
+	if pr2.MCPServers[0].ID != "srv" || pr2.MCPServers[0].Plugin != plugin {
+		t.Errorf("mcp server must be stamped but not renamed; got %+v", pr2.MCPServers[0])
+	}
+	if pr2.LSPServers[0].ID != "gopls" || pr2.LSPServers[0].Plugin != plugin {
+		t.Errorf("lsp server must be stamped but not renamed; got %+v", pr2.LSPServers[0])
+	}
 }

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -1,0 +1,127 @@
+package marketplace
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestNamespaceProjected covers the projection-time rename that resolves
+// cross-plugin name collisions (issue #211): a plugin-provided component's Name —
+// the thing every adapter derives its destination path and identity from — is
+// rewritten to "<plugin>-<name>", with the upstream name kept in BaseName.
+func TestNamespaceProjected(t *testing.T) {
+	t.Run("renames every name-keyed component and stamps provenance", func(t *testing.T) {
+		pr := ProjectionResult{
+			Skills:    []source.Skill{{Name: "code-review", Frontmatter: map[string]any{"name": "code-review"}}},
+			Subagents: []source.Subagent{{Name: "code-reviewer", Frontmatter: map[string]any{"name": "code-reviewer"}}},
+			Commands:  []source.Command{{Name: "review", Frontmatter: map[string]any{"description": "d"}}},
+		}
+		if err := namespaceProjected(&pr, "feature-dev"); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		for _, tc := range []struct{ got, want, field string }{
+			{pr.Skills[0].Name, "feature-dev-code-review", "skill Name"},
+			{pr.Skills[0].BaseName, "code-review", "skill BaseName"},
+			{pr.Skills[0].Plugin, "feature-dev", "skill Plugin"},
+			{pr.Subagents[0].Name, "feature-dev-code-reviewer", "subagent Name"},
+			{pr.Subagents[0].BaseName, "code-reviewer", "subagent BaseName"},
+			{pr.Subagents[0].Plugin, "feature-dev", "subagent Plugin"},
+			{pr.Commands[0].Name, "feature-dev-review", "command Name"},
+			{pr.Commands[0].BaseName, "review", "command BaseName"},
+			{pr.Commands[0].Plugin, "feature-dev", "command Plugin"},
+		} {
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.field, tc.got, tc.want)
+			}
+		}
+	})
+
+	// Renaming only the struct field would leave the components still colliding:
+	// Codex prefers the frontmatter `name` over the file stem when deriving its
+	// TOML `name` (which IS the agent's identity), and Claude's Agent Skills
+	// require the frontmatter name to match the skill directory.
+	t.Run("rewrites a present frontmatter name", func(t *testing.T) {
+		pr := ProjectionResult{Subagents: []source.Subagent{
+			{Name: "reviewer", Frontmatter: map[string]any{"name": "reviewer", "model": "opus"}},
+		}}
+		if err := namespaceProjected(&pr, "pkg"); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		if got := pr.Subagents[0].Frontmatter["name"]; got != "pkg-reviewer" {
+			t.Errorf("frontmatter name = %v, want pkg-reviewer", got)
+		}
+		if got := pr.Subagents[0].Frontmatter["model"]; got != "opus" {
+			t.Errorf("other frontmatter keys must survive; model = %v", got)
+		}
+	})
+
+	// An absent name stays absent: inventing one would assert an identity the
+	// upstream artifact never declared, and for Claude a subagent's name is
+	// user-visible invocation surface.
+	t.Run("leaves an absent frontmatter name absent", func(t *testing.T) {
+		pr := ProjectionResult{Subagents: []source.Subagent{
+			{Name: "reviewer", Frontmatter: map[string]any{"description": "d"}},
+		}}
+		if err := namespaceProjected(&pr, "pkg"); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		if _, ok := pr.Subagents[0].Frontmatter["name"]; ok {
+			t.Errorf("namespacing must not invent a frontmatter name; got %v", pr.Subagents[0].Frontmatter)
+		}
+	})
+
+	// The frontmatter map can be shared with the caller's parsed artifact, so the
+	// rename copies rather than mutating in place.
+	t.Run("does not mutate the caller's frontmatter map", func(t *testing.T) {
+		fm := map[string]any{"name": "reviewer"}
+		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer", Frontmatter: fm}}}
+		if err := namespaceProjected(&pr, "pkg"); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		if fm["name"] != "reviewer" {
+			t.Errorf("the caller's map was mutated in place; got %v", fm)
+		}
+	})
+
+	// Hooks have no name key; MCP/LSP are id-keyed and guarded by
+	// checkProjectedConflicts, whose hard failure on a same-id divergence is a
+	// deliberate security property (a silent endpoint hijack is a case to refuse,
+	// not to rename apart).
+	t.Run("leaves mcp, lsp, and hooks alone", func(t *testing.T) {
+		pr := ProjectionResult{
+			MCPServers: []source.MCPServer{{ID: "srv"}},
+			LSPServers: []source.LSPServer{{ID: "gopls"}},
+		}
+		if err := namespaceProjected(&pr, "pkg"); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		if pr.MCPServers[0].ID != "srv" || pr.LSPServers[0].ID != "gopls" {
+			t.Errorf("id-keyed components must not be namespaced: %+v %+v", pr.MCPServers, pr.LSPServers)
+		}
+	})
+
+	// A plugin id originates from a marketplace, outside agentsync's trust
+	// boundary. A derived name that would escape its destination directory or
+	// smuggle a terminal escape into a diagnostic is refused, not written.
+	t.Run("refuses a derived name the write boundary would reject", func(t *testing.T) {
+		for _, plugin := range []string{"../evil", "a:b", "esc\x1b[31m"} {
+			pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
+			if err := namespaceProjected(&pr, plugin); err == nil {
+				t.Errorf("plugin id %q should not derive a writable component name", plugin)
+			}
+		}
+	})
+
+	// An empty plugin id means "not plugin-provided" — hand-authored components
+	// flow through the same code path untouched.
+	t.Run("empty plugin is a no-op", func(t *testing.T) {
+		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
+		if err := namespaceProjected(&pr, ""); err != nil {
+			t.Fatalf("namespaceProjected: %v", err)
+		}
+		if pr.Subagents[0].Name != "reviewer" || pr.Subagents[0].Plugin != "" {
+			t.Errorf("an empty plugin id must change nothing; got %+v", pr.Subagents[0])
+		}
+	})
+}

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -197,13 +197,24 @@ func dedupHooks(hooks []source.Hook) []source.Hook {
 	if len(hooks) < 2 {
 		return hooks
 	}
-	seen := make(map[source.Hook]bool, len(hooks))
+	// Key on CONTENT, not the whole struct: provenance (Plugin) is derived state
+	// that never reaches a destination, so two byte-identical handlers must still
+	// collapse to one regardless of which plugin they came from. (Today
+	// namespaceProjected stamps provenance after this runs, so every hook here
+	// shares one value — keying explicitly keeps that ordering from becoming
+	// load-bearing.)
+	type hookContent struct{ event, matcher, typ, command string }
+	key := func(h source.Hook) hookContent {
+		return hookContent{h.Event.Unverified(), h.Matcher, h.Type, h.Command}
+	}
+	seen := make(map[hookContent]bool, len(hooks))
 	out := make([]source.Hook, 0, len(hooks))
 	for _, h := range hooks {
-		if seen[h] {
+		k := key(h)
+		if seen[k] {
 			continue
 		}
-		seen[h] = true
+		seen[k] = true
 		out = append(out, h)
 	}
 	return out

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -432,8 +432,17 @@ func applyPlan(
 		return nil, written, unchanged, wouldChange, fmt.Errorf("render.Apply: nil state")
 	}
 
+	// seen is NOT reset per agent — that is deliberate, since the guard below
+	// exists to catch two agents rendering one shared path differently. But it
+	// means the guard also fires when a SINGLE agent emits two divergent ops for
+	// one path (two canonical components resolving to the same destination), so
+	// seenBy records which agent produced each path and the message distinguishes
+	// the two cases. Before #211 an intra-agent collision was reported as
+	// "different content than an earlier agent", sending the user looking for a
+	// second agent that did not exist.
 	seen := map[string][]byte{}
-	deletedSkillOrphans := map[string]struct{}{}
+	seenBy := map[string]string{}
+	deletedOrphans := map[string]struct{}{}
 	for _, name := range reg.Names() {
 		res, ok := p.PerAgent[name]
 		if !ok {
@@ -483,15 +492,24 @@ func applyPlan(
 					// dropping one agent's bytes would be data loss — so fail
 					// loud rather than pick a winner.
 					if !bytes.Equal(prev, op.Content) {
+						if seenBy[op.Path] == name {
+							return reports, written, unchanged, wouldChange, fmt.Errorf(
+								"agent %q renders two different contents for the same path %s; "+
+									"refusing to silently drop one — two canonical components resolve "+
+									"to one destination file, so rename one of them",
+								name, op.Path,
+							)
+						}
 						return reports, written, unchanged, wouldChange, fmt.Errorf(
-							"agent %q renders different content than an earlier agent for the same path %s; "+
+							"agent %q renders different content than agent %q for the same path %s; "+
 								"refusing to silently drop one (shared paths must render identical bytes)",
-							name, op.Path,
+							name, seenBy[op.Path], op.Path,
 						)
 					}
 					continue
 				}
 				seen[op.Path] = op.Content
+				seenBy[op.Path] = name
 			}
 			deduped = append(deduped, op)
 		}
@@ -499,11 +517,11 @@ func applyPlan(
 		// this agent owns in state but the source no longer renders. Deduped by
 		// path across agents that share a skills dir (claude + opencode →
 		// .claude/skills/), since the first agent's writer already removed it.
-		for _, del := range skillOrphanDeletes(st, userHome, name, scope, project, res.Ops) {
-			if _, done := deletedSkillOrphans[del.Path]; done {
+		for _, del := range orphanDeletes(st, userHome, name, scope, project, res.Ops) {
+			if _, done := deletedOrphans[del.Path]; done {
 				continue
 			}
-			deletedSkillOrphans[del.Path] = struct{}{}
+			deletedOrphans[del.Path] = struct{}{}
 			deduped = append(deduped, del)
 		}
 		var w *Writer

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -194,7 +194,23 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 //
 // Both are flat single files, so they need the backup-if-drifted guarantee but
 // not the empty-directory pruning that skills get; see Writer.Delete.
-var orphanReclaimedPrefixes = []string{"skills/", "subagents/", "commands/"}
+//
+// "agents/" is the RETIRED spelling of the subagent SourceID, and it is listed
+// deliberately. The canonical directory rename (agents/ → subagents/) ships in
+// the same release as namespacing, so an upgrading user's state still holds
+// "agents/<name>.md" entries — and the only rewriter, migrate's
+// rewriteSubagentStateIDs, runs solely from migrateSubagentTree, which returns
+// early when <home>/agents/ holds no files. A user whose subagents come ONLY
+// from plugins has no such directory, so their state is never rewritten.
+//
+// That is exactly the reported scenario (#211: two plugins, no hand-authored
+// subagents). Without this prefix their pre-rename ~/.claude/agents/
+// code-reviewer.md would be unreclaimable AND lose its state entry — left
+// forever beside the two namespaced files, which is MORE duplicates than before
+// and the direct opposite of what the upgrade notice promises. No live SourceID
+// uses this prefix ("subagents/" does not match it), so listing it costs nothing
+// and can be dropped once the retired spelling is out of circulation.
+var orphanReclaimedPrefixes = []string{"skills/", "subagents/", "commands/", "agents/"}
 
 // isOrphanReclaimable reports whether a state SourceID names a component whose
 // destination file `apply` reclaims. It is the single predicate behind both the

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -138,29 +138,61 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 	return out
 }
 
-// SkillOrphanDeletes is the exported view of skillOrphanDeletes: the delete
-// FileOps `apply` will perform to reclaim skill files removed from the source
-// for agent+scope+project against ops. The CLI reads it (before Apply mutates
+// orphanReclaimedPrefixes are the canonical SourceID prefixes whose destination
+// files `apply` reclaims when the source stops rendering them.
+//
+// Skills were the original member: the Agent Skills spec treats a skill as a
+// whole DIRECTORY, so removing one must reclaim the whole tree rather than leave
+// a half-skill behind.
+//
+// Subagents and commands joined them for issue #211. Plugin-provided components
+// are now namespaced by their plugin, which RENAMES every one of them exactly
+// once, on the first apply after upgrading. Without reclamation the pre-rename
+// destination file would linger — and Claude Code reads every file in its agents
+// directory, so a stale ~/.claude/agents/code-reviewer.md sitting beside the two
+// new namespaced files would leave the user with MORE duplicate agents than
+// before, not fewer. The same convergence argument applies to an ordinary
+// removal from the canonical source, which previously left the dest file forever
+// (or until a reconcile).
+//
+// Both are flat single files, so they need the backup-if-drifted guarantee but
+// not the empty-directory pruning that skills get; see Writer.Delete.
+var orphanReclaimedPrefixes = []string{"skills/", "subagents/", "commands/"}
+
+// IsOrphanReclaimable reports whether a state SourceID names a component whose
+// destination file `apply` reclaims. It is the single predicate behind both the
+// delete synthesis here and the writer's backup/prune behavior, so the two can
+// never disagree about what counts as an orphan.
+func IsOrphanReclaimable(sourceID string) bool {
+	for _, p := range orphanReclaimedPrefixes {
+		if strings.HasPrefix(sourceID, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// OrphanDeletes is the exported view of orphanDeletes: the delete FileOps
+// `apply` will perform to reclaim component files removed from the source for
+// agent+scope+project against ops. The CLI reads it (before Apply mutates
 // state) purely to COUNT deletions for the apply summary headline — a pure-delete
 // run must not report "up to date" / "applied: 0 ops". It never writes anything;
 // Apply remains the sole executor (and dedups these across agents itself).
-func SkillOrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) []adapter.FileOp {
-	return skillOrphanDeletes(s, userHome, agent, scope, project, ops)
+func OrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) []adapter.FileOp {
+	return orphanDeletes(s, userHome, agent, scope, project, ops)
 }
 
-// skillOrphanDeletes returns delete FileOps for skill files this agent owns in
-// state — entries whose SourceID is under "skills/" — that the current plan no
-// longer renders. It is how `apply` converges a destination when a whole skill,
-// or a single bundled file within one, is removed from the canonical source:
-// the leftover dest file is removed instead of lingering forever.
+// orphanDeletes returns delete FileOps for files this agent owns in state —
+// entries whose SourceID is under one of orphanReclaimedPrefixes — that the
+// current plan no longer renders. It is how `apply` converges a destination when
+// a component (a whole skill, a single bundled file within one, a subagent, a
+// command) is removed from or renamed in the canonical source: the leftover dest
+// file is removed instead of lingering forever.
 //
-// Scoped deliberately to skills (the Agent Skills spec treats a skill as a whole
-// directory, so removal must reclaim the whole tree). Other replace-strategy
-// components (subagents/commands) keep their established reconcile-driven
-// cleanup. Each op carries the state SourceID + Mode so the writer can back up a
-// drifted dest before deleting and bound empty-directory pruning to the skills
-// root. Sorted deepest-path-first so a directory empties out before it is pruned.
-func skillOrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) []adapter.FileOp {
+// Each op carries the state SourceID + Mode so the writer can back up a drifted
+// dest before deleting and bound empty-directory pruning to the skills root.
+// Sorted deepest-path-first so a directory empties out before it is pruned.
+func orphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) []adapter.FileOp {
 	if s == nil {
 		return nil
 	}
@@ -180,7 +212,7 @@ func skillOrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.
 		if !strings.HasPrefix(key, prefix) {
 			continue
 		}
-		if !strings.HasPrefix(entry.SourceID, "skills/") {
+		if !IsOrphanReclaimable(entry.SourceID) {
 			continue
 		}
 		path := strings.TrimPrefix(key, prefix)

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -64,14 +64,34 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 		}
 	}
 
-	for key := range s.Files {
+	for key, entry := range s.Files {
 		if !strings.HasPrefix(key, prefix) {
 			continue
 		}
 		path := strings.TrimPrefix(key, prefix)
-		if _, ok := currentFiles[path]; !ok {
-			delete(s.Files, key)
+		if _, ok := currentFiles[path]; ok {
+			continue
 		}
+		// Keep tracking a reclaimable destination that is STILL ON DISK.
+		//
+		// apply skips (rather than performs) an orphan delete when it cannot read
+		// the destination first — it cannot rule out an unsynced hand-edit, and
+		// deleting blind would break the never-destroy-unsynced-content
+		// invariant. Pruning the entry anyway would make that skip permanent and
+		// silent: with no state entry, orphanDeletes can never synthesize the
+		// delete again, `status` stops reporting the file, and the one warning
+		// never repeats. The stale file would then live forever — re-creating
+		// exactly the leftover-duplicate failure reclamation exists to prevent.
+		//
+		// So: if the file agentsync owned is still there, agentsync keeps owning
+		// it, and the next apply retries and re-warns. A delete that succeeded
+		// leaves nothing behind, so this is a no-op for the normal path.
+		if isOrphanReclaimable(entry.SourceID) {
+			if _, err := os.Stat(paths.FromHomeRelative(userHome, path)); err == nil {
+				continue
+			}
+		}
+		delete(s.Files, key)
 	}
 	for key := range s.Keys {
 		if !strings.HasPrefix(key, prefix) {

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
 
@@ -210,7 +211,25 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 // and the direct opposite of what the upgrade notice promises. No live SourceID
 // uses this prefix ("subagents/" does not match it), so listing it costs nothing
 // and can be dropped once the retired spelling is out of circulation.
-var orphanReclaimedPrefixes = []string{"skills/", "subagents/", "commands/", "agents/"}
+// The retired entry is spelled via source.LegacySubagentsDir rather than a
+// literal, so the deprecation has ONE owner: when that constant goes, the
+// compiler points here.
+var orphanReclaimedPrefixes = []string{
+	"skills/",
+	source.SubagentsDir + "/",
+	"commands/",
+	source.LegacySubagentsDir + "/",
+}
+
+// OrphanIsReclaimable reports whether `apply` reclaims the destination of a
+// component with this SourceID when the source stops rendering it.
+//
+// It asks only about the KIND. Callers that need to know whether a PARTICULAR
+// destination will actually be removed on this run (it may be skipped as
+// unreadable) want OrphanDeleteWillProceed instead. The CLI uses this one to
+// word reconcile's orphan prompt, which is a statement about what apply does to
+// this class of component — true regardless of whether today's attempt succeeds.
+func OrphanIsReclaimable(sourceID string) bool { return isOrphanReclaimable(sourceID) }
 
 // isOrphanReclaimable reports whether a state SourceID names a component whose
 // destination file `apply` reclaims. It is the single predicate behind both the

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"sort"
 	"strings"
@@ -28,6 +30,12 @@ import (
 // normalize op.Path to its HOME-relative form so state-key lookups match
 // keys written by RecordOpsState. It must NOT be the agentsync home — dest
 // files live under $HOME, not under ~/.agentsync.
+//
+// One exception to the pure ops-vs-state comparison, and the reason this touches
+// the FILESYSTEM: a reclaimable destination that is STILL ON DISK keeps its entry
+// even when the plan no longer renders it. apply skips (rather than performs) an
+// orphan delete it cannot read first, and pruning the entry would make that skip
+// permanent and silent — see the comment at the check itself.
 func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) {
 	if s == nil {
 		return
@@ -87,7 +95,16 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 		// it, and the next apply retries and re-warns. A delete that succeeded
 		// leaves nothing behind, so this is a no-op for the normal path.
 		if isOrphanReclaimable(entry.SourceID) {
-			if _, err := os.Stat(paths.FromHomeRelative(userHome, path)); err == nil {
+			// Keep unless the destination is PROVABLY absent. `err == nil` would be
+			// the wrong polarity: the archetypal reason Delete skips is that the
+			// destination cannot be read, and the archetypal cause of that —
+			// EACCES on the parent directory — also makes Stat fail. Treating a
+			// stat error as "gone" would prune exactly the entries this exists to
+			// preserve, in exactly the case it exists for.
+			// Lstat, not Stat: a DANGLING SYMLINK is a destination that is still
+			// there (os.Remove can clear it) but that Stat reports as absent,
+			// which would prune the entry and strand the link forever.
+			if _, err := os.Lstat(paths.FromHomeRelative(userHome, path)); !errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 		}

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -159,11 +159,11 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 // not the empty-directory pruning that skills get; see Writer.Delete.
 var orphanReclaimedPrefixes = []string{"skills/", "subagents/", "commands/"}
 
-// IsOrphanReclaimable reports whether a state SourceID names a component whose
+// isOrphanReclaimable reports whether a state SourceID names a component whose
 // destination file `apply` reclaims. It is the single predicate behind both the
 // delete synthesis here and the writer's backup/prune behavior, so the two can
 // never disagree about what counts as an orphan.
-func IsOrphanReclaimable(sourceID string) bool {
+func isOrphanReclaimable(sourceID string) bool {
 	for _, p := range orphanReclaimedPrefixes {
 		if strings.HasPrefix(sourceID, p) {
 			return true
@@ -212,7 +212,7 @@ func orphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope
 		if !strings.HasPrefix(key, prefix) {
 			continue
 		}
-		if !IsOrphanReclaimable(entry.SourceID) {
+		if !isOrphanReclaimable(entry.SourceID) {
 			continue
 		}
 		path := strings.TrimPrefix(key, prefix)

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -268,3 +268,84 @@ func TestPruneStaleState_ReclaimableOrphanRetention(t *testing.T) {
 			"a non-reclaimable entry must prune as before")
 	}
 }
+
+// TestPruneStaleState_DanglingSymlinkIsKept is the discriminating case for the
+// guard's PREDICATE, which the test above cannot reach: a present file and an
+// absent one are kept/pruned identically under Stat and Lstat, so neither
+// separates the correct check from the two wrong ones review found.
+//
+// A dangling symlink does. os.Stat follows it and reports ENOENT — so both
+// `Stat() == nil` (the round-3 bug) and `!errors.Is(Stat_err, ErrNotExist)` (the
+// round-4 near-miss) prune the entry and strand the link forever. os.Lstat sees
+// the link itself, so the entry is kept, the delete is retried, and Delete's
+// os.Remove clears it.
+func TestPruneStaleState_DanglingSymlinkIsKept(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "dangling.md")
+	if err := os.Symlink(filepath.Join(tmp, "nonexistent-target"), link); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
+	st := state.New()
+	key := prefix + paths.HomeRelative(tmp, link)
+	st.Files[key] = state.FileEntry{SHA256: "old", SourceID: "subagents/dangling.md"}
+
+	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", nil)
+
+	if _, ok := st.Files[key]; !ok {
+		t.Error("a dangling symlink is still a destination agentsync owns and can remove; " +
+			"pruning its entry strands it forever (the guard must Lstat, not Stat)")
+	}
+}
+
+// TestPruneStaleState_RetiredSubagentSourceIDIsReclaimable pins the prefix that
+// makes the #211 upgrade actually work for the users it targets.
+//
+// The canonical directory rename (agents/ → subagents/) ships in the same release
+// as namespacing, so an upgrading user's state still holds "agents/<name>.md"
+// SourceIDs — and the only rewriter runs from `migrate subagents`, which returns
+// early when <home>/agents/ is empty. A user whose subagents come ONLY from
+// plugins has no such directory, which is exactly the reported scenario. Without
+// the retired prefix their pre-rename destination file is unreclaimable AND loses
+// its state entry: left forever beside the namespaced ones, which is MORE
+// duplicate agents than before and the opposite of what the upgrade notice says.
+func TestPruneStaleState_RetiredSubagentSourceIDIsReclaimable(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(dir, "code-reviewer.md")
+	if err := os.WriteFile(legacy, []byte("pre-rename"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
+	st := state.New()
+	key := prefix + paths.HomeRelative(tmp, legacy)
+	// The RETIRED spelling, as a pre-upgrade state file carries it.
+	st.Files[key] = state.FileEntry{SHA256: "old", SourceID: "agents/code-reviewer.md"}
+
+	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", nil)
+	if _, ok := st.Files[key]; !ok {
+		t.Fatal("a pre-rename subagent entry must stay owned so its destination is reclaimed")
+	}
+
+	deletes := render.OrphanDeletes(st, tmp, "claude", adapter.ScopeUser, "", nil)
+	var found bool
+	for _, d := range deletes {
+		if d.Path == legacy {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("apply must synthesize a delete for the pre-rename destination; got %v", deletes)
+	}
+}

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/spxrogers/agentsync/internal/adapter/noop"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
@@ -347,5 +348,30 @@ func TestPruneStaleState_RetiredSubagentSourceIDIsReclaimable(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("apply must synthesize a delete for the pre-rename destination; got %v", deletes)
+	}
+}
+
+// TestOrphanReclaimedPrefixes_RetiredAliasDoesNotOverMatch guards the one hazard
+// of carrying a retired identifier in a live prefix list: if "agents/" ever
+// becomes a LIVE SourceID prefix again, the alias silently starts matching it.
+//
+// It is asserted against the real producer — source.SubagentSourceID — rather
+// than a literal, so it tracks the constant instead of a copy of it.
+func TestOrphanReclaimedPrefixes_RetiredAliasDoesNotOverMatch(t *testing.T) {
+	live := source.SubagentSourceID("reviewer")
+	if strings.HasPrefix(filepath.ToSlash(live), source.LegacySubagentsDir+"/") {
+		t.Fatalf("the live subagent SourceID (%q) now starts with the RETIRED prefix %q — "+
+			"the alias in orphanReclaimedPrefixes would over-match every live subagent; "+
+			"drop it or re-scope it", live, source.LegacySubagentsDir+"/")
+	}
+	// And the retired spelling is still recognised, which is the point of it.
+	if !render.OrphanIsReclaimable(source.LegacySubagentsDir + "/reviewer.md") {
+		t.Error("the retired agents/ spelling must stay reclaimable until it is out of circulation")
+	}
+	if !render.OrphanIsReclaimable(live) {
+		t.Errorf("the live spelling %q must be reclaimable", live)
+	}
+	if render.OrphanIsReclaimable("memory/AGENTS.md") {
+		t.Error("a non-component SourceID must not be reclaimable")
 	}
 }

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -2,6 +2,7 @@ package render_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,8 +10,10 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	_ "github.com/spxrogers/agentsync/internal/adapter/noop"
+	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
 func TestRecordState_FilesAndKeys(t *testing.T) {
@@ -208,5 +211,60 @@ func TestRecordState_SkipsDeleteOps(t *testing.T) {
 	}
 	if len(s.Files) != 0 || len(s.Keys) != 0 {
 		t.Fatal("delete ops should not create state entries")
+	}
+}
+
+// TestPruneStaleState_ReclaimableOrphanRetention pins both directions of the
+// keep-guard added for the skipped-delete retry.
+//
+// KEEP when the destination survives: apply skips (rather than performs) an
+// orphan delete it cannot read, and pruning the entry would make that skip
+// permanent and silent — orphanDeletes could never synthesize the delete again
+// and the warning would never repeat.
+//
+// PRUNE when it is provably gone: otherwise every successfully-reclaimed file
+// would leak an entry forever and targets.json would grow without bound.
+func TestPruneStaleState_ReclaimableOrphanRetention(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+
+	present := filepath.Join(tmp, ".claude", "agents", "still-here.md")
+	if err := os.MkdirAll(filepath.Dir(present), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(present, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gone := filepath.Join(tmp, ".claude", "agents", "reclaimed.md")
+	// A reclaimable SourceID whose file is gone, plus one that is NOT
+	// reclaimable — the exemption must not widen to every component kind.
+	notReclaimable := filepath.Join(tmp, ".claude", "settings.json")
+	if err := os.WriteFile(notReclaimable, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
+	st := state.New()
+	for path, srcID := range map[string]string{
+		present:        "subagents/still-here.md",
+		gone:           "subagents/reclaimed.md",
+		notReclaimable: "memory/AGENTS.md",
+	} {
+		st.Files[prefix+paths.HomeRelative(tmp, path)] = state.FileEntry{SHA256: "old", SourceID: srcID}
+	}
+
+	// No ops at all: every entry is "no longer rendered".
+	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", nil)
+
+	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, present)]; !ok {
+		t.Error("a reclaimable destination that is still on disk must keep its entry, " +
+			"so a skipped delete is retried rather than forgotten")
+	}
+	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, gone)]; ok {
+		t.Error("a reclaimable destination that is gone must still be pruned")
+	}
+	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, notReclaimable)]; ok {
+		t.Error("the exemption must apply only to reclaimable SourceIDs; " +
+			"a non-reclaimable entry must prune as before")
 	}
 }

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -267,11 +267,11 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 	}
 	orphan := isOrphanReclaimable(op.SourceID)
 	if orphan {
-		preserved, err := w.backupOrphanIfDrifted(op)
+		safeToDelete, err := w.backupOrphanIfDrifted(op)
 		if err != nil {
 			return err
 		}
-		if !preserved {
+		if !safeToDelete {
 			// The destination could not be read, so we cannot tell whether it
 			// holds an unsynced hand-edit. SKIP this one delete rather than
 			// perform it blind — but do NOT fail the run. Refusing the delete is
@@ -296,18 +296,17 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 }
 
 // backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup
-// root iff its on-disk content is not exactly what agentsync last wrote.
-// preserved reports whether the caller may now safely delete: false means the
-// destination could not be READ, so no claim about its contents can be made and
-// the delete must be skipped (not failed — see Delete). An error is returned only
-// when the file WAS readable and drifted but the backup could not be written,
-// which genuinely must stop the run.
+// root iff its on-disk content is not exactly what agentsync last wrote (i.e. the
+// user hand-edited it). A file matching our last-applied hash is our own output
+// and is removed without a backup; anything else is preserved first, so an orphan
+// delete can never silently destroy an unsynced edit.
 //
-// The original contract (i.e.
-// the user hand-edited it). A file matching our last-applied hash is our own
-// output and is removed without a backup; anything else is preserved first so an
-// orphan delete can never silently destroy an unsynced edit.
-func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) (preserved bool, err error) {
+// safeToDelete tells the caller whether it may now remove the file. It is false
+// in exactly one case: the destination could not be READ, so no claim about its
+// contents can be made and the delete must be skipped (skipped, not failed — see
+// Delete). An error is returned only when the file WAS readable and drifted but
+// the backup could not be written, which genuinely must stop the run.
+func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) (safeToDelete bool, err error) {
 	existing, err := os.ReadFile(op.Path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -340,19 +340,17 @@ func OrphanDeleteWillProceed(op adapter.FileOp) bool {
 	if !isOrphanReclaimable(op.SourceID) {
 		return false
 	}
-	// Short-circuit the shapes whose read cannot succeed anyway — a directory,
-	// FIFO, device, or socket. This introduces no divergence from Delete (its
-	// ReadFile fails on every one of them too) and keeps `apply --dry-run`, which
-	// is advertised as read-only, from BLOCKING on an open of a FIFO someone left
-	// at a destination path. Symlinks deliberately fall through, so a dangling one
-	// answers the same way for both (ENOENT → proceeds).
-	if fi, err := os.Lstat(op.Path); err == nil && !fi.Mode().IsRegular() && fi.Mode()&os.ModeSymlink == 0 {
+	if !isRegularOrAbsent(op.Path) {
 		return false
 	}
 	f, err := os.Open(op.Path)
 	if err != nil {
 		// Absent proceeds: nothing to preserve, the remove is a no-op, and the
-		// entry converges away. Anything else (EACCES, ENOTDIR) is the skip.
+		// entry converges away. The IsNotExist test is deliberately kept rather
+		// than a bare `return true`: isRegularOrAbsent above already rejects every
+		// other shape, so ENOENT is the only error reachable HERE today — but that
+		// is a property of the guard above, not of this line, and the two should
+		// not have to be read together to stay correct.
 		return os.IsNotExist(err)
 	}
 	defer func() { _ = f.Close() }()
@@ -367,6 +365,24 @@ func OrphanDeleteWillProceed(op adapter.FileOp) bool {
 	return true
 }
 
+// isRegularOrAbsent reports whether a destination is a regular file, or is not
+// there at all. Anything else — a directory, FIFO, device, socket — is a shape
+// whose content agentsync cannot meaningfully read or preserve.
+//
+// It uses Stat, which FOLLOWS symlinks, so a symlink pointing at a FIFO is
+// caught as well as a bare one. That matters because os.Open on a FIFO with no
+// writer BLOCKS rather than failing: without this, `apply --dry-run` (advertised
+// as read-only) and the real apply's pre-delete read would both hang forever on
+// a FIFO left at a destination path. A dangling symlink reports absent, which is
+// the right answer — the link is removable and carries nothing to preserve.
+func isRegularOrAbsent(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+	return fi.Mode().IsRegular()
+}
+
 // backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup
 // root iff its on-disk content is not exactly what agentsync last wrote (i.e. the
 // user hand-edited it). A file matching our last-applied hash is our own output
@@ -379,6 +395,12 @@ func OrphanDeleteWillProceed(op adapter.FileOp) bool {
 // Delete). An error is returned only when the file WAS readable and drifted but
 // the backup could not be written, which genuinely must stop the run.
 func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) (safeToDelete bool, err error) {
+	// Same shape guard as OrphanDeleteWillProceed, for the same reason: the
+	// os.ReadFile below would BLOCK forever on a FIFO rather than fail. Reporting
+	// "not safe to delete" is the correct answer for every non-regular shape.
+	if !isRegularOrAbsent(op.Path) {
+		return false, nil
+	}
 	existing, err := os.ReadFile(op.Path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -365,6 +365,11 @@ func OrphanDeleteWillProceed(op adapter.FileOp) bool {
 	return true
 }
 
+// IsRegularOrAbsent is the exported view of isRegularOrAbsent, for the sibling
+// destination reads outside this package (internal/cli's hashFile). They face
+// the identical hazard and must not answer it differently.
+func IsRegularOrAbsent(path string) bool { return isRegularOrAbsent(path) }
+
 // isRegularOrAbsent reports whether a destination is a regular file, or is not
 // there at all. Anything else — a directory, FIFO, device, socket — is a shape
 // whose content agentsync cannot meaningfully read or preserve.
@@ -651,6 +656,13 @@ func backupPathFor(src, backupRoot string) string {
 // delete) that must preserve a file before a destructive action so no choice
 // loses content. Returns ("", nil) when path is missing.
 func BackupFile(home, path string) (string, error) {
+	// Same shape guard as the apply-side reads: os.ReadFile BLOCKS forever on a
+	// FIFO rather than failing, and this runs from reconcile's interactive orphan
+	// delete. A non-regular destination has no content to preserve anyway, so
+	// report "nothing backed up" rather than hang.
+	if !isRegularOrAbsent(path) {
+		return "", fmt.Errorf("refusing to back up %s: not a regular file", path)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -301,7 +303,7 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 	return nil
 }
 
-// OrphanDeleteWillProceed reports whether Apply will actually reclaim an
+// OrphanDeleteWillProceed reports whether Apply will actually reclaim this
 // orphaned destination, rather than skip it.
 //
 // Delete skips (with a warning) any orphan it cannot READ first — it cannot rule
@@ -309,20 +311,60 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 // never-destroy-unsynced-content invariant. A caller counting removals for the
 // apply summary has to ask the same question: a permanently-unreadable orphan
 // would otherwise be reported "removed: 1 file(s)" on EVERY run, on the same run
-// that warns it was skipped — two lines that contradict each other. (It reports
-// every run rather than once because the state entry is now deliberately kept so
-// the delete is retried; see PruneStaleState.)
+// that warns it was skipped — two lines that contradict each other. (Every run
+// rather than once, because the state entry is now deliberately kept so the
+// delete is retried; see PruneStaleState.)
 //
-// This is an advisory pre-check for reporting only. Delete's own read is
-// authoritative — the two can disagree if the destination changes in between,
-// which costs a wrong count in a summary line and nothing else. Both use
-// os.ReadFile so they answer the same question about the same thing.
+// # Why a shared predicate rather than a Writer accessor
 //
-// An absent destination proceeds: there is nothing to preserve, the remove is a
+// The obvious alternative — have Delete record what it skipped and expose a
+// SkippedDeletes() accessor, the natural parallel to Unchanged()/WouldChange() —
+// does not work here, and not for cost reasons. removalCounts has TWO callers:
+// the `apply --dry-run` preview and the real apply. Delete returns immediately
+// on dryRun, before any read, so the accessor would be empty in preview: the
+// preview would keep over-counting the exact file the real run under-counts. A
+// preview that disagrees with the apply it previews is the one failure the
+// shared-dryRun design of applyPlan exists to prevent. A pure predicate is the
+// only shape both callers can share.
+//
+// Delete's own read stays authoritative; this can disagree with it if the
+// destination changes in between, or if a read fails only PAST the first byte —
+// either costs a wrong number in a summary line and nothing else. A bare Stat
+// would not do: it answers a different question (a directory stats fine but
+// cannot be read), which is why this opens and reads.
+//
+// A non-reclaimable op is not an orphan delete at all and reports false. An
+// absent destination proceeds: there is nothing to preserve, the remove is a
 // no-op, and the entry converges away.
-func OrphanDeleteWillProceed(path string) bool {
-	_, err := os.ReadFile(path)
-	return err == nil || os.IsNotExist(err)
+func OrphanDeleteWillProceed(op adapter.FileOp) bool {
+	if !isOrphanReclaimable(op.SourceID) {
+		return false
+	}
+	// Short-circuit the shapes whose read cannot succeed anyway — a directory,
+	// FIFO, device, or socket. This introduces no divergence from Delete (its
+	// ReadFile fails on every one of them too) and keeps `apply --dry-run`, which
+	// is advertised as read-only, from BLOCKING on an open of a FIFO someone left
+	// at a destination path. Symlinks deliberately fall through, so a dangling one
+	// answers the same way for both (ENOENT → proceeds).
+	if fi, err := os.Lstat(op.Path); err == nil && !fi.Mode().IsRegular() && fi.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	f, err := os.Open(op.Path)
+	if err != nil {
+		// Absent proceeds: nothing to preserve, the remove is a no-op, and the
+		// entry converges away. Anything else (EACCES, ENOTDIR) is the skip.
+		return os.IsNotExist(err)
+	}
+	defer func() { _ = f.Close() }()
+	// One byte is enough to separate "readable" from EACCES/EIO at offset 0
+	// without buffering a large bundled skill asset twice per apply (Delete reads
+	// the whole file again immediately after). io.EOF means an empty but readable
+	// file, which Delete handles fine.
+	var probe [1]byte
+	if _, rerr := f.Read(probe[:]); rerr != nil && !errors.Is(rerr, io.EOF) {
+		return false
+	}
+	return true
 }
 
 // backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -248,19 +248,24 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 
 // Delete satisfies adapter.DestWriter. Idempotent on missing files.
 //
-// Skill-orphan deletes (op.SourceID under "skills/", synthesized by Apply when a
-// skill or bundled file is removed from source) get two extra guarantees: a dest
-// that drifted from what agentsync last wrote is backed up before removal (the
-// never-destroy-unsynced-content invariant the write path enforces), and empty
-// skill directories left behind are pruned up to — but never including — the
-// agent's skills root. Other delete callers (agent disable --purge, reconcile
-// orphan removal) pass an empty SourceID and keep the plain idempotent remove.
+// Orphan deletes (op.SourceID under a reclaimed prefix — see
+// IsOrphanReclaimable — synthesized by Apply when a component is removed from or
+// renamed in the source) get a dest that drifted from what agentsync last wrote
+// backed up before removal, honouring the never-destroy-unsynced-content
+// invariant the write path enforces. Other delete callers (agent disable
+// --purge, reconcile orphan removal) pass an empty SourceID and keep the plain
+// idempotent remove.
+//
+// Empty-directory pruning is additionally applied to SKILLS only: a skill is a
+// directory, so reclaiming one must not leave the husk behind. Subagents and
+// commands are flat files in a directory the agent always owns, so there is
+// nothing to prune — and walking up from one would target that shared directory.
 func (w *Writer) Delete(op adapter.FileOp) error {
 	if w.dryRun {
 		return nil
 	}
-	skillOrphan := strings.HasPrefix(op.SourceID, "skills/")
-	if skillOrphan {
+	orphan := IsOrphanReclaimable(op.SourceID)
+	if orphan {
 		if err := w.backupOrphanIfDrifted(op); err != nil {
 			return err
 		}
@@ -268,13 +273,13 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 	if err := os.Remove(op.Path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete %s: %w", op.Path, err)
 	}
-	if skillOrphan {
+	if orphan && strings.HasPrefix(op.SourceID, "skills/") {
 		pruneEmptySkillDirs(op.Path, op.SourceID)
 	}
 	return nil
 }
 
-// backupOrphanIfDrifted copies a soon-to-be-deleted skill file to the backup
+// backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup
 // root iff its on-disk content is not exactly what agentsync last wrote (i.e.
 // the user hand-edited it). A file matching our last-applied hash is our own
 // output and is removed without a backup; anything else is preserved first so an

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -249,7 +249,7 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 // Delete satisfies adapter.DestWriter. Idempotent on missing files.
 //
 // Orphan deletes (op.SourceID under a reclaimed prefix — see
-// IsOrphanReclaimable — synthesized by Apply when a component is removed from or
+// isOrphanReclaimable — synthesized by Apply when a component is removed from or
 // renamed in the source) get a dest that drifted from what agentsync last wrote
 // backed up before removal, honouring the never-destroy-unsynced-content
 // invariant the write path enforces. Other delete callers (agent disable
@@ -264,7 +264,7 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 	if w.dryRun {
 		return nil
 	}
-	orphan := IsOrphanReclaimable(op.SourceID)
+	orphan := isOrphanReclaimable(op.SourceID)
 	if orphan {
 		if err := w.backupOrphanIfDrifted(op); err != nil {
 			return err
@@ -287,7 +287,16 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) error {
 	existing, err := os.ReadFile(op.Path)
 	if err != nil {
-		return nil // already gone (or unreadable): nothing to preserve
+		if os.IsNotExist(err) {
+			return nil // already gone: nothing to preserve
+		}
+		// Any OTHER read failure (EACCES, EIO, EISDIR) means we cannot tell
+		// whether this destination holds an unsynced user edit — and the caller
+		// deletes immediately after. Treating that as "nothing to preserve" would
+		// destroy a drifted file with no backup, which is exactly what the
+		// never-destroy-unsynced-content invariant forbids. Refuse the delete
+		// instead; a reclaim is convergence, never worth data loss.
+		return fmt.Errorf("cannot verify %s before reclaiming it (a hand-edit could be lost): %w", op.Path, err)
 	}
 	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
 		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -266,8 +267,23 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 	}
 	orphan := isOrphanReclaimable(op.SourceID)
 	if orphan {
-		if err := w.backupOrphanIfDrifted(op); err != nil {
+		preserved, err := w.backupOrphanIfDrifted(op)
+		if err != nil {
 			return err
+		}
+		if !preserved {
+			// The destination could not be read, so we cannot tell whether it
+			// holds an unsynced hand-edit. SKIP this one delete rather than
+			// perform it blind — but do NOT fail the run. Refusing the delete is
+			// what protects the data; refusing the whole apply would let a single
+			// unreadable destination (a stray directory at the path, a
+			// permissions mishap) wedge every other agent's writes with no way
+			// past it, and a lingering orphan is not data loss. The warning is
+			// how the user learns to clean it up.
+			slog.Warn("skipped reclaiming an orphaned destination: it could not be read, "+
+				"so agentsync cannot rule out an unsynced edit; remove it by hand once you have checked it",
+				"path", op.Path, "agent", w.agent)
+			return nil
 		}
 	}
 	if err := os.Remove(op.Path); err != nil && !os.IsNotExist(err) {
@@ -280,38 +296,48 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 }
 
 // backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup
-// root iff its on-disk content is not exactly what agentsync last wrote (i.e.
+// root iff its on-disk content is not exactly what agentsync last wrote.
+// preserved reports whether the caller may now safely delete: false means the
+// destination could not be READ, so no claim about its contents can be made and
+// the delete must be skipped (not failed — see Delete). An error is returned only
+// when the file WAS readable and drifted but the backup could not be written,
+// which genuinely must stop the run.
+//
+// The original contract (i.e.
 // the user hand-edited it). A file matching our last-applied hash is our own
 // output and is removed without a backup; anything else is preserved first so an
 // orphan delete can never silently destroy an unsynced edit.
-func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) error {
+func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) (preserved bool, err error) {
 	existing, err := os.ReadFile(op.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // already gone: nothing to preserve
+			return true, nil // already gone: nothing to preserve, safe to proceed
 		}
 		// Any OTHER read failure (EACCES, EIO, EISDIR) means we cannot tell
 		// whether this destination holds an unsynced user edit — and the caller
 		// deletes immediately after. Treating that as "nothing to preserve" would
 		// destroy a drifted file with no backup, which is exactly what the
-		// never-destroy-unsynced-content invariant forbids. Refuse the delete
-		// instead; a reclaim is convergence, never worth data loss.
-		return fmt.Errorf("cannot verify %s before reclaiming it (a hand-edit could be lost): %w", op.Path, err)
+		// never-destroy-unsynced-content invariant forbids. Report "not
+		// preserved" so the caller skips the delete; the read error itself is not
+		// returned, because it is not a reason to fail the run (see Delete).
+		return false, nil
 	}
 	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
 		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
 	if entry, owned := w.state.Files[stateKey]; owned {
 		sum := sha256.Sum256(existing)
 		if hex.EncodeToString(sum[:]) == entry.SHA256 {
-			return nil // unchanged since our last apply — safe to delete
+			return true, nil // unchanged since our last apply — safe to delete
 		}
 	}
-	dest, err := w.backup(op.Path, existing)
-	if err != nil {
-		return err
+	dest, berr := w.backup(op.Path, existing)
+	if berr != nil {
+		// A backup we cannot write IS a reason to fail: proceeding would delete
+		// a known-drifted file with nothing preserved.
+		return false, berr
 	}
 	w.reports = append(w.reports, CollisionReport{Agent: w.agent, Path: op.Path, BackupTo: dest})
-	return nil
+	return true, nil
 }
 
 // pruneEmptySkillDirs removes now-empty directories left after deleting a skill

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -658,8 +658,11 @@ func backupPathFor(src, backupRoot string) string {
 func BackupFile(home, path string) (string, error) {
 	// Same shape guard as the apply-side reads: os.ReadFile BLOCKS forever on a
 	// FIFO rather than failing, and this runs from reconcile's interactive orphan
-	// delete. A non-regular destination has no content to preserve anyway, so
-	// report "nothing backed up" rather than hang.
+	// delete. Returning an ERROR (not the ("", nil) "nothing to back up" answer
+	// the missing-file case gives) is deliberate: the caller removes the file
+	// only if the backup succeeded, so erroring here refuses the removal too.
+	// A non-regular destination is one agentsync cannot preserve, and refusing
+	// to delete what it cannot preserve is the same rule the apply path follows.
 	if !isRegularOrAbsent(path) {
 		return "", fmt.Errorf("refusing to back up %s: not a regular file", path)
 	}

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -280,8 +280,14 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 			// permissions mishap) wedge every other agent's writes with no way
 			// past it, and a lingering orphan is not data loss. The warning is
 			// how the user learns to clean it up.
+			// Note for skills specifically: reclamation is per FILE, so skipping
+			// one file of a skill directory can leave a partial tree (scripts/
+			// without SKILL.md). That converges — the state entry is kept, so the
+			// next apply retries this file — and the alternative, deleting a file
+			// we cannot read, is the one outcome that is not recoverable.
 			slog.Warn("skipped reclaiming an orphaned destination: it could not be read, "+
-				"so agentsync cannot rule out an unsynced edit; remove it by hand once you have checked it",
+				"so agentsync cannot rule out an unsynced edit; it will be retried on the "+
+				"next apply — remove it by hand once you have checked it",
 				"path", op.Path, "agent", w.agent)
 			return nil
 		}
@@ -293,6 +299,30 @@ func (w *Writer) Delete(op adapter.FileOp) error {
 		pruneEmptySkillDirs(op.Path, op.SourceID)
 	}
 	return nil
+}
+
+// OrphanDeleteWillProceed reports whether Apply will actually reclaim an
+// orphaned destination, rather than skip it.
+//
+// Delete skips (with a warning) any orphan it cannot READ first — it cannot rule
+// out an unsynced hand-edit, and deleting blind would break the
+// never-destroy-unsynced-content invariant. A caller counting removals for the
+// apply summary has to ask the same question: a permanently-unreadable orphan
+// would otherwise be reported "removed: 1 file(s)" on EVERY run, on the same run
+// that warns it was skipped — two lines that contradict each other. (It reports
+// every run rather than once because the state entry is now deliberately kept so
+// the delete is retried; see PruneStaleState.)
+//
+// This is an advisory pre-check for reporting only. Delete's own read is
+// authoritative — the two can disagree if the destination changes in between,
+// which costs a wrong count in a summary line and nothing else. Both use
+// os.ReadFile so they answer the same question about the same thing.
+//
+// An absent destination proceeds: there is nothing to preserve, the remove is a
+// no-op, and the entry converges away.
+func OrphanDeleteWillProceed(path string) bool {
+	_, err := os.ReadFile(path)
+	return err == nil || os.IsNotExist(err)
 }
 
 // backupOrphanIfDrifted copies a soon-to-be-deleted component file to the backup

--- a/internal/render/writer_fifo_unix_test.go
+++ b/internal/render/writer_fifo_unix_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package render_test
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/render"
+)
+
+// TestOrphanDeleteWillProceed_FIFO covers the non-regular short-circuit, which
+// exists ONLY for shapes whose open BLOCKS rather than fails — a FIFO is the
+// reachable one. A directory answers false via the read anyway, so without this
+// case the whole branch could be deleted with the main table still green.
+//
+// It runs under a timeout because the regression is a HANG, not a wrong answer:
+// a plain assertion would never report. `apply --dry-run` is advertised as
+// read-only, so wedging it on a FIFO someone left at a destination path is the
+// failure this prevents.
+//
+// unix-only: syscall.Mkfifo is undefined on Windows.
+func TestOrphanDeleteWillProceed_FIFO(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "pipe.md")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	op := adapter.FileOp{Action: "delete", Path: fifo, SourceID: "subagents/pipe.md"}
+
+	done := make(chan bool, 1) // buffered so the goroutine cannot leak on timeout
+	go func() { done <- render.OrphanDeleteWillProceed(op) }()
+	select {
+	case got := <-done:
+		if got {
+			t.Error("a FIFO cannot be read or preserved; it must not be reported as reclaimable")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("OrphanDeleteWillProceed BLOCKED on a FIFO — `apply --dry-run` is advertised " +
+			"as read-only and would hang forever")
+	}
+}

--- a/internal/render/writer_fifo_unix_test.go
+++ b/internal/render/writer_fifo_unix_test.go
@@ -3,6 +3,7 @@
 package render_test
 
 import (
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -10,7 +11,31 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/state"
 )
+
+// withinTimeout runs fn and fails if it has not returned within 5s. Every guard
+// in this file defends against a HANG rather than a wrong answer, so a plain
+// assertion would never report — the test would just never finish.
+func withinTimeout(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { defer close(done); fn() }() // buffered by close, cannot leak
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s BLOCKED on a FIFO — os.ReadFile does not fail on one, it waits "+
+			"for a writer that never comes", what)
+	}
+}
+
+// mkfifo creates a FIFO or skips the test where that is unsupported.
+func mkfifo(t *testing.T, path string) {
+	t.Helper()
+	if err := syscall.Mkfifo(path, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+}
 
 // TestOrphanDeleteWillProceed_FIFO covers the non-regular short-circuit, which
 // exists ONLY for shapes whose open BLOCKS rather than fails — a FIFO is the
@@ -25,20 +50,60 @@ import (
 // unix-only: syscall.Mkfifo is undefined on Windows.
 func TestOrphanDeleteWillProceed_FIFO(t *testing.T) {
 	fifo := filepath.Join(t.TempDir(), "pipe.md")
-	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
-		t.Skipf("mkfifo unsupported here: %v", err)
-	}
+	mkfifo(t, fifo)
 	op := adapter.FileOp{Action: "delete", Path: fifo, SourceID: "subagents/pipe.md"}
-
-	done := make(chan bool, 1) // buffered so the goroutine cannot leak on timeout
-	go func() { done <- render.OrphanDeleteWillProceed(op) }()
-	select {
-	case got := <-done:
-		if got {
+	withinTimeout(t, "OrphanDeleteWillProceed", func() {
+		if render.OrphanDeleteWillProceed(op) {
 			t.Error("a FIFO cannot be read or preserved; it must not be reported as reclaimable")
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("OrphanDeleteWillProceed BLOCKED on a FIFO — `apply --dry-run` is advertised " +
-			"as read-only and would hang forever")
+	})
+}
+
+// TestWriterDelete_FIFODoesNotBlock covers the guard that matters MOST, and the
+// one a summary predicate cannot stand in for: OrphanDeleteWillProceed only
+// decides a COUNT, while Writer.Delete is the call a real `apply` makes. Its
+// pre-delete read is the one that would wedge the run.
+//
+// The FIFO must also survive: agentsync cannot read it, so it cannot rule out
+// content worth preserving, so it must not remove it.
+func TestWriterDelete_FIFODoesNotBlock(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
 	}
+	fifo := filepath.Join(tmp, "pipe.md")
+	mkfifo(t, fifo)
+
+	w := render.NewWriter(state.New(), home, tmp, adapter.ScopeUser, "", "claude")
+	op := adapter.FileOp{Action: "delete", Path: fifo, SourceID: "subagents/pipe.md"}
+	withinTimeout(t, "Writer.Delete", func() {
+		if err := w.Delete(op); err != nil {
+			t.Errorf("a non-regular destination must be SKIPPED, not error the run: %v", err)
+		}
+	})
+	if _, err := os.Lstat(fifo); err != nil {
+		t.Error("agentsync cannot read a FIFO, so it cannot rule out content worth " +
+			"preserving — it must not remove it")
+	}
+}
+
+// TestBackupFile_FIFODoesNotBlock covers reconcile's interactive orphan delete,
+// which backs up before removing. Erroring is the point: the caller removes only
+// if the backup succeeded, so refusing to back up also refuses the removal.
+func TestBackupFile_FIFODoesNotBlock(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(tmp, "pipe.md")
+	mkfifo(t, fifo)
+
+	withinTimeout(t, "render.BackupFile", func() {
+		if _, err := render.BackupFile(home, fifo); err == nil {
+			t.Error("a destination agentsync cannot preserve must not report a successful " +
+				"backup — the caller would then delete it")
+		}
+	})
 }

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -760,3 +760,54 @@ func TestApply_UnreadableOrphanIsSkippedNotDeleted(t *testing.T) {
 		t.Fatal("once the destination is readable again, the retry must reclaim it")
 	}
 }
+
+// TestOrphanDeleteWillProceed pins the predicate the apply summary counts with.
+// It must answer the same question Delete does, or a permanently-unreadable
+// orphan is reported "removed: N" on every run — on the same run that warns it
+// was skipped, and forever, because the state entry is deliberately kept so the
+// delete is retried.
+func TestOrphanDeleteWillProceed(t *testing.T) {
+	tmp := t.TempDir()
+	op := func(name, sourceID string) adapter.FileOp {
+		return adapter.FileOp{Action: "delete", Path: filepath.Join(tmp, name), SourceID: sourceID}
+	}
+
+	readable := filepath.Join(tmp, "readable.md")
+	if err := os.WriteFile(readable, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	empty := filepath.Join(tmp, "empty.md")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A directory at a file path: the root-safe way to make a destination
+	// unreadable (chmod does not stop root, which is how CI runs).
+	if err := os.MkdirAll(filepath.Join(tmp, "isdir.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(tmp, "no-such-target"), filepath.Join(tmp, "dangling.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		op   adapter.FileOp
+		want bool
+	}{
+		{"readable regular file", op("readable.md", "subagents/readable.md"), true},
+		{"empty but readable", op("empty.md", "subagents/empty.md"), true},
+		{"absent destination converges away", op("gone.md", "subagents/gone.md"), true},
+		// Delete's ReadFile fails EISDIR here, so it skips — the count must agree.
+		{"directory at the path", op("isdir.md", "subagents/isdir.md"), false},
+		// Delete's ReadFile gets ENOENT and removes the link, so this proceeds.
+		{"dangling symlink", op("dangling.md", "subagents/dangling.md"), true},
+		// Not an orphan delete at all.
+		{"non-reclaimable SourceID", op("readable.md", "memory/AGENTS.md"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := render.OrphanDeleteWillProceed(tc.op); got != tc.want {
+				t.Errorf("OrphanDeleteWillProceed(%s) = %v, want %v", tc.op.SourceID, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -2,12 +2,14 @@ package render_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -685,5 +687,50 @@ func TestWriter_JSONCFallbackBacksUpWholeFile(t *testing.T) {
 	got, _ := os.ReadFile(reports[0].BackupTo)
 	if !strings.Contains(string(got), "old") {
 		t.Fatalf("JSONC-fallback backup missing original content: %s", got)
+	}
+}
+
+// TestApply_UnreadableOrphanIsSkippedNotDeleted pins the two-sided contract on
+// reclaiming a destination agentsync cannot read.
+//
+// Refusing the DELETE is required: without reading the file, agentsync cannot
+// rule out an unsynced hand-edit, and deleting it would break the
+// never-destroy-unsynced-content invariant. Refusing the RUN is not: a lingering
+// orphan is not data loss, and failing would let one unreadable destination (a
+// stray directory at the path, a permissions mishap) wedge every other agent's
+// writes with no flag to get past it. So: skip that one delete, keep going.
+//
+// A directory at the destination path yields EISDIR from os.ReadFile without
+// needing to manipulate permissions, which would not work as root in CI.
+func TestApply_UnreadableOrphanIsSkippedNotDeleted(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+
+	// The "orphan": owned in state, no longer rendered, and unreadable.
+	orphan := filepath.Join(tmp, ".claude", "agents", "gone.md")
+	_ = os.MkdirAll(orphan, 0o755) // a DIRECTORY at the file path → EISDIR
+	// A second, ordinary op that must still be applied.
+	live := filepath.Join(tmp, ".claude", "agents", "live.md")
+
+	st := state.New()
+	st.Files[fmt.Sprintf("claude:user:%s:%s", paths.HomeRelative(tmp, ""), paths.HomeRelative(tmp, orphan))] = state.FileEntry{SHA256: "stale", SourceID: "subagents/gone.md", Mode: 0o644}
+
+	reg := adapter.NewRegistry()
+	_ = reg.Register(&fakeJSONApply{name: "claude"})
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{
+			{Action: "write", Path: live, Content: []byte("live"), Mode: 0o644, SourceID: "subagents/live.md"},
+		}},
+	}}
+
+	if _, _, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("an unreadable orphan must not fail the whole apply: %v", err)
+	}
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("the unreadable orphan must NOT be deleted (it could hold an unsynced edit): %v", err)
+	}
+	if data, err := os.ReadFile(live); err != nil || string(data) != "live" {
+		t.Fatalf("the rest of the apply must still land; got %q err=%v", data, err)
 	}
 }

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -733,4 +733,30 @@ func TestApply_UnreadableOrphanIsSkippedNotDeleted(t *testing.T) {
 	if data, err := os.ReadFile(live); err != nil || string(data) != "live" {
 		t.Fatalf("the rest of the apply must still land; got %q err=%v", data, err)
 	}
+
+	// The skip must be RETRIED, not forgotten. PruneStaleState drops the state
+	// entry for anything the plan no longer renders, and delete ops are never in
+	// its rendered set — so without the still-on-disk exemption the entry would
+	// vanish here, orphanDeletes could never synthesize the delete again, and the
+	// one warning would never repeat. The stale file would live forever, which is
+	// the leftover-duplicate failure reclamation exists to prevent.
+	stateKey := fmt.Sprintf("claude:user:%s:%s", paths.HomeRelative(tmp, ""), paths.HomeRelative(tmp, orphan))
+	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", plan.PerAgent["claude"].Ops)
+	if _, stillOwned := st.Files[stateKey]; !stillOwned {
+		t.Fatal("a skipped orphan must keep its state entry so the next apply retries and re-warns")
+	}
+
+	// And once the obstruction is gone, the retry converges: the delete happens.
+	if err := os.Remove(orphan); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(orphan, []byte("now readable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("retry apply: %v", err)
+	}
+	if _, err := os.Stat(orphan); err == nil {
+		t.Fatal("once the destination is readable again, the retry must reclaim it")
+	}
 }

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
@@ -803,6 +805,9 @@ func TestOrphanDeleteWillProceed(t *testing.T) {
 		{"dangling symlink", op("dangling.md", "subagents/dangling.md"), true},
 		// Not an orphan delete at all.
 		{"non-reclaimable SourceID", op("readable.md", "memory/AGENTS.md"), false},
+		// A path THROUGH a regular file: Stat fails ENOTDIR, which is neither
+		// "regular" nor "absent", so the shape guard rejects it before any open.
+		{"path through a file", op(filepath.Join("readable.md", "child.md"), "subagents/child.md"), false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := render.OrphanDeleteWillProceed(tc.op); got != tc.want {
@@ -810,4 +815,32 @@ func TestOrphanDeleteWillProceed(t *testing.T) {
 			}
 		})
 	}
+
+	// The non-regular short-circuit exists ONLY for shapes whose open blocks
+	// rather than fails — a FIFO is the reachable one. A directory returns false
+	// via the read anyway, so without this case the whole branch could be deleted
+	// with the table still green. The call is run under a timeout because the
+	// regression is a HANG, not a wrong answer: a plain assertion would never
+	// report.
+	t.Run("fifo does not block", func(t *testing.T) {
+		fifo := filepath.Join(tmp, "pipe.md")
+		if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+			t.Skipf("mkfifo unsupported here: %v", err)
+		}
+		done := make(chan bool, 1)
+		go func() {
+			done <- render.OrphanDeleteWillProceed(
+				adapter.FileOp{Action: "delete", Path: fifo, SourceID: "subagents/pipe.md"},
+			)
+		}()
+		select {
+		case got := <-done:
+			if got {
+				t.Error("a FIFO cannot be read or preserved; it must not be reported as reclaimable")
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("OrphanDeleteWillProceed BLOCKED on a FIFO — `apply --dry-run` is advertised " +
+				"as read-only and would hang forever")
+		}
+	})
 }

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -6,9 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/paths"
@@ -816,31 +814,7 @@ func TestOrphanDeleteWillProceed(t *testing.T) {
 		})
 	}
 
-	// The non-regular short-circuit exists ONLY for shapes whose open blocks
-	// rather than fails — a FIFO is the reachable one. A directory returns false
-	// via the read anyway, so without this case the whole branch could be deleted
-	// with the table still green. The call is run under a timeout because the
-	// regression is a HANG, not a wrong answer: a plain assertion would never
-	// report.
-	t.Run("fifo does not block", func(t *testing.T) {
-		fifo := filepath.Join(tmp, "pipe.md")
-		if err := syscall.Mkfifo(fifo, 0o644); err != nil {
-			t.Skipf("mkfifo unsupported here: %v", err)
-		}
-		done := make(chan bool, 1)
-		go func() {
-			done <- render.OrphanDeleteWillProceed(
-				adapter.FileOp{Action: "delete", Path: fifo, SourceID: "subagents/pipe.md"},
-			)
-		}()
-		select {
-		case got := <-done:
-			if got {
-				t.Error("a FIFO cannot be read or preserved; it must not be reported as reclaimable")
-			}
-		case <-time.After(5 * time.Second):
-			t.Fatal("OrphanDeleteWillProceed BLOCKED on a FIFO — `apply --dry-run` is advertised " +
-				"as read-only and would hang forever")
-		}
-	})
+	// The non-regular short-circuit is exercised by TestOrphanDeleteWillProceed_FIFO
+	// in writer_fifo_unix_test.go — syscall.Mkfifo does not exist on Windows, so it
+	// lives behind a build tag rather than breaking `go test ./...` there.
 }

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -468,6 +468,44 @@ func TestRenderApply_SharedWriteDivergence(t *testing.T) {
 	})
 }
 
+// TestRenderApply_IntraAgentDivergenceMessage pins that the shared-write guard
+// tells the truth about WHO collided.
+//
+// The `seen` map is deliberately not reset per agent — that is what lets the
+// guard catch two agents rendering one shared path differently. But it means the
+// guard also fires when a SINGLE agent emits two divergent ops for one path,
+// which is exactly what two same-named canonical components produce (issue
+// #211: two plugins each shipping agents/code-reviewer.md made Claude render two
+// ops at ~/.claude/agents/code-reviewer.md). That case was reported as
+// "different content than an earlier agent", sending the user looking for a
+// second agent that did not exist.
+func TestRenderApply_IntraAgentDivergenceMessage(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	_ = os.MkdirAll(home, 0o755)
+	dest := filepath.Join(tmp, ".claude", "agents", "code-reviewer.md")
+	_ = os.MkdirAll(filepath.Dir(dest), 0o755)
+	reg := adapter.NewRegistry()
+	_ = reg.Register(&fakeJSONApply{name: "claude"})
+
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{
+			{Action: "write", Path: dest, Content: []byte("from plugin A"), Mode: 0o644, SourceID: "subagents/code-reviewer.md"},
+			{Action: "write", Path: dest, Content: []byte("from plugin B"), Mode: 0o644, SourceID: "subagents/code-reviewer.md"},
+		}},
+	}}
+	_, _, _, err := render.Apply(plan, reg, state.New(), home, tmp, adapter.ScopeUser, "")
+	if err == nil {
+		t.Fatal("one agent rendering two divergent ops for a path must fail loud")
+	}
+	if strings.Contains(err.Error(), "earlier agent") {
+		t.Fatalf("an intra-agent collision must not be blamed on a second agent; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "two canonical components") {
+		t.Fatalf("the message should point at the real cause; got: %v", err)
+	}
+}
+
 // TestPreviewApply_SharedWriteDivergence ensures `apply --dry-run`'s preview
 // fails loud on divergent shared-path content, matching Apply — so the dry-run
 // can't show a clean preview that the real apply then aborts on.

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -40,9 +40,17 @@ var walkerCovered = map[string]map[string]bool{
 	},
 	"MCPServer": {
 		"ID": false, // filename identifier, never a secret
+		// Plugin is derived provenance stamped at projection (the id of the
+		// plugin that supplied this server). It never round-trips through a
+		// native config, is never serialized to the canonical source, and holds
+		// a plugin's filesystem id — a marketplace-derived name, not a
+		// credential. It exists so import/reconcile can refuse to capture a
+		// plugin-owned server; nothing resolves or re-references it.
+		"Plugin": false,
 	},
 	"LSPServer": {
-		"ID": false, // filename identifier, never a secret
+		"ID":     false, // filename identifier, never a secret
+		"Plugin": false, // derived provenance; see MCPServer.Plugin above
 	},
 }
 

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -29,6 +29,7 @@ var walkerCovered = map[string]map[string]bool{
 		"Event":   false, // event name (e.g. PreToolUse)
 		"Matcher": false, // glob/regex, not a credential
 		"Type":    false, // always "command"
+		"Plugin":  false, // derived provenance; see MCPServer.Plugin below
 	},
 	"LSPServerSpec": {
 		"Command": true,

--- a/internal/source/provenance.go
+++ b/internal/source/provenance.go
@@ -73,28 +73,12 @@ func NamespacedComponentName(plugin, base string) string {
 	return plugin + ComponentNamespaceSeparator + base
 }
 
-// NOTE ON VALIDATION — deliberately absent here.
-//
-// An earlier revision validated the DERIVED name against ValidateComponentID at
-// projection time and returned an error. That was wrong twice over:
-//
-//   - It was a SECOND, stricter rune set than the projection's own
-//     validateProjectedName (which permits ':' and control runes), so a plugin
-//     whose component name contained one projected fine before and hard-failed
-//     after — a regression, not a guard.
-//   - loadProjected propagates a projection error regardless of `lenient`, so
-//     that failure aborted the whole load for the read-only commands
-//     (status/diff/explain) whose entire design is to degrade and SHOW state
-//     rather than refuse.
-//
-// The check was also redundant: render.Plan already runs ValidateComponentID
-// over every component id at the single dispatch waist, before any id is joined
-// into a destination path, and source.Write*/capture guard the write boundary.
-// Adding a copy here bought nothing and could only drift from those. Namespacing
-// prepends a prefix; it cannot make a valid name invalid unless the plugin id
-// itself is malformed, and projectOnePlugin already rejects a plugin id with a
-// path separator or traversal component before any of this runs.
-//
-// Diagnostics that interpolate a derived name use %q, which escapes control and
-// bidi runes, so an unvalidated name cannot smuggle a terminal escape through an
-// error or warning either.
+// Namespacing performs NO validation of the derived name, deliberately. An
+// earlier revision did, and it was a regression: the check used a stricter rune
+// set than the projection's own validateProjectedName, and loadProjected
+// propagates a projection error regardless of `lenient`, so it took down the
+// read-only commands whose whole design is to degrade and show state. The name
+// safety lives downstream at the single dispatch waist, where render.Plan runs
+// ValidateComponentID over every component id before any of them is joined into
+// a destination path. See the "Amendments after review" section of
+// docs/superpowers/specs/2026-07-28-plugin-component-namespacing-design.md.

--- a/internal/source/provenance.go
+++ b/internal/source/provenance.go
@@ -1,7 +1,5 @@
 package source
 
-import "fmt"
-
 // ComponentNamespaceSeparator joins a plugin id to a component name.
 //
 // It is a HYPHEN, and that is forced rather than chosen. Claude Code documents a
@@ -37,10 +35,26 @@ const ComponentNamespaceSeparator = "-"
 // # The provenance fields
 //
 // A namespaced component records `Plugin` (the providing plugin's filesystem
-// id) and `BaseName` (the pre-namespace name) so a report, `plugin explain`, or
-// a collision error can say where it came from and what it was called upstream.
-// Both are empty for a hand-authored component loaded from ~/.agentsync/, which
-// is NEVER renamed — a plugin can therefore never take a name the user chose.
+// id) and `BaseName` (the pre-namespace name). `Plugin` drives real behaviour:
+// the dest→source paths refuse to capture a plugin-owned component, and the
+// collision guards name the providing plugin. `BaseName` exists ONLY so those
+// diagnostics can also say what the component was called upstream — it is
+// never matched on, and nothing derives a path from it. Both are empty for a
+// hand-authored component loaded from ~/.agentsync/, which is never renamed.
+//
+// A hand-authored component is never renamed, but note the converse is NOT a
+// guarantee that a plugin can never occupy a name the user chose: the derived
+// name is not injective. A user's own `feature-dev-code-reviewer` collides with
+// what plugin `feature-dev` derives for its `code-reviewer`, and plugin `a`
+// shipping `b-c` collides with plugin `a-b` shipping `c`. Those residual cases
+// are caught by marketplace.checkProjectedConflicts, which reports both origins
+// rather than letting one silently win.
+//
+// INVARIANT: when Plugin is non-empty, Name == NamespacedComponentName(Plugin,
+// BaseName). Everything downstream reads Name as the effective identity while
+// diagnostics read the other two, so a component whose three fields disagree
+// would report an origin that does not match what it rendered. Pinned by
+// TestProvenanceInvariant (internal/marketplace).
 //
 // Neither field is ever serialized. Skills, subagents, and commands are
 // FILE-backed components whose canonical form is a file on disk, and a projected
@@ -59,18 +73,28 @@ func NamespacedComponentName(plugin, base string) string {
 	return plugin + ComponentNamespaceSeparator + base
 }
 
-// ValidateNamespacedComponentName checks that a derived name is writable and
-// safe to display, reusing the SAME rules ValidateComponentID enforces at the
-// canonical write boundary (no path separator, no "..", no ':', no control or
-// deceptive formatting rune). A plugin id originates from a marketplace, so it
-// is outside agentsync's trust boundary: without this, a hostile id could derive
-// a component name that escapes its destination directory or smuggles a
-// terminal escape into a diagnostic. The error names both halves so the user can
-// tell which one is at fault.
-func ValidateNamespacedComponentName(kind, plugin, base string) error {
-	name := NamespacedComponentName(plugin, base)
-	if err := ValidateComponentID(kind, name); err != nil {
-		return fmt.Errorf("plugin %q provides %s %q: %w", plugin, kind, base, err)
-	}
-	return nil
-}
+// NOTE ON VALIDATION — deliberately absent here.
+//
+// An earlier revision validated the DERIVED name against ValidateComponentID at
+// projection time and returned an error. That was wrong twice over:
+//
+//   - It was a SECOND, stricter rune set than the projection's own
+//     validateProjectedName (which permits ':' and control runes), so a plugin
+//     whose component name contained one projected fine before and hard-failed
+//     after — a regression, not a guard.
+//   - loadProjected propagates a projection error regardless of `lenient`, so
+//     that failure aborted the whole load for the read-only commands
+//     (status/diff/explain) whose entire design is to degrade and SHOW state
+//     rather than refuse.
+//
+// The check was also redundant: render.Plan already runs ValidateComponentID
+// over every component id at the single dispatch waist, before any id is joined
+// into a destination path, and source.Write*/capture guard the write boundary.
+// Adding a copy here bought nothing and could only drift from those. Namespacing
+// prepends a prefix; it cannot make a valid name invalid unless the plugin id
+// itself is malformed, and projectOnePlugin already rejects a plugin id with a
+// path separator or traversal component before any of this runs.
+//
+// Diagnostics that interpolate a derived name use %q, which escapes control and
+// bidi runes, so an unvalidated name cannot smuggle a terminal escape through an
+// error or warning either.

--- a/internal/source/provenance.go
+++ b/internal/source/provenance.go
@@ -1,0 +1,76 @@
+package source
+
+import "fmt"
+
+// ComponentNamespaceSeparator joins a plugin id to a component name.
+//
+// It is a HYPHEN, and that is forced rather than chosen. Claude Code documents a
+// subagent's `name` as a "Unique identifier using lowercase letters and
+// hyphens", so ':' is not available — the familiar `plugin:agent` form is a
+// scoped identifier Claude Code DERIVES from the plugin directory for its own
+// picker and hook matchers, never a value written into a `name` field. Codex
+// states no charset rule and treats `name` as the agent's identity
+// (learn.chatgpt.com/docs/agent-configuration/subagents), so a hyphenated name
+// is equally valid there. A ':' would also be rejected by ValidateComponentID,
+// which bans it because the id becomes a filename and a colon is illegal on
+// Windows.
+const ComponentNamespaceSeparator = "-"
+
+// NamespacedComponentName derives the effective name of a plugin-provided
+// component: "<plugin>-<base>".
+//
+// # Why components are namespaced at all
+//
+// agentsync flattens every enabled plugin's components into one canonical model
+// and renders them to the agent's native paths. Two plugins shipping a
+// same-named component (the reported case: feature-dev and pr-review-toolkit
+// each ship agents/code-reviewer.md) therefore rendered two files at one
+// destination path, which apply refused — correctly, since silently keeping one
+// is data loss. But BOTH files live under the marketplace-managed plugin cache,
+// so the remedy the error named ("rename one") was one the user structurally
+// could not perform. Namespacing removes the collision instead of reporting it.
+//
+// Claude Code reaches the same end natively, addressing a plugin's agent as
+// `plugin:agent`; agentsync uses a hyphen for the reasons on
+// ComponentNamespaceSeparator.
+//
+// # The provenance fields
+//
+// A namespaced component records `Plugin` (the providing plugin's filesystem
+// id) and `BaseName` (the pre-namespace name) so a report, `plugin explain`, or
+// a collision error can say where it came from and what it was called upstream.
+// Both are empty for a hand-authored component loaded from ~/.agentsync/, which
+// is NEVER renamed — a plugin can therefore never take a name the user chose.
+//
+// Neither field is ever serialized. Skills, subagents, and commands are
+// FILE-backed components whose canonical form is a file on disk, and a projected
+// component is never written back into the canonical source, so provenance is
+// derived state that lives only for the duration of a load.
+//
+// Both are also outside the secret machinery by construction: these are text
+// components walkSecretFields deliberately never visits (internal/secrets/walk.go),
+// so neither can carry a ${secret:…} reference or a resolved value.
+//
+// An empty plugin returns base unchanged, so callers need no branch.
+func NamespacedComponentName(plugin, base string) string {
+	if plugin == "" {
+		return base
+	}
+	return plugin + ComponentNamespaceSeparator + base
+}
+
+// ValidateNamespacedComponentName checks that a derived name is writable and
+// safe to display, reusing the SAME rules ValidateComponentID enforces at the
+// canonical write boundary (no path separator, no "..", no ':', no control or
+// deceptive formatting rune). A plugin id originates from a marketplace, so it
+// is outside agentsync's trust boundary: without this, a hostile id could derive
+// a component name that escapes its destination directory or smuggles a
+// terminal escape into a diagnostic. The error names both halves so the user can
+// tell which one is at fault.
+func ValidateNamespacedComponentName(kind, plugin, base string) error {
+	name := NamespacedComponentName(plugin, base)
+	if err := ValidateComponentID(kind, name); err != nil {
+		return fmt.Errorf("plugin %q provides %s %q: %w", plugin, kind, base, err)
+	}
+	return nil
+}

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -120,6 +120,16 @@ type SecretsConfig struct {
 type MCPServer struct {
 	ID     string        `toml:"-"` // filename minus .toml
 	Server MCPServerSpec `toml:"server"`
+	// Plugin is the id of the plugin providing this server, empty when the user
+	// declared it in mcp/<id>.toml. Unlike a skill/subagent/command, an MCP
+	// server's ID is NOT namespaced — two sources claiming one id can be a silent
+	// endpoint hijack, which checkProjectedConflicts refuses rather than renames
+	// apart. Provenance is carried only so the dest→source paths (import,
+	// reconcile write-back) can refuse to capture a server the plugin owns. It is
+	// derived state, never serialized, and never secret-bearing — see
+	// NamespacedComponentName (provenance.go) and walkerCovered
+	// (internal/secrets/walk_test.go).
+	Plugin string `toml:"-"`
 }
 
 type MCPServerSpec struct {
@@ -272,6 +282,9 @@ type Hook struct {
 type LSPServer struct {
 	ID   string
 	Spec LSPServerSpec
+	// Plugin mirrors MCPServer.Plugin — provenance only, never namespaced, never
+	// serialized, never secret-bearing. See MCPServer.Plugin.
+	Plugin string `toml:"-"`
 }
 
 // LSPServerSpec holds the server configuration for an LSP server.

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -276,6 +276,14 @@ type Hook struct {
 	Matcher string         // glob/regex string
 	Type    string         // "command"
 	Command string         // shell command
+	// Plugin is the id of the plugin providing this handler, empty when the user
+	// declared it in hooks/<event>.toml. Hooks are neither namespaced nor
+	// id-keyed — a canonical hooks/<event>.toml holds MANY handlers from many
+	// sources — so provenance is carried per HANDLER, which is the granularity
+	// import must filter at: refusing a whole event would drop the user's own
+	// handlers alongside the plugin's. Never serialized (WriteHooks emits an
+	// explicit hookEntryOut), never secret-bearing — see MCPServer.Plugin.
+	Plugin string
 }
 
 // LSPServer mirrors lsp/<id>.toml.

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -147,10 +147,15 @@ type MCPServerSpec struct {
 // nested files. Files captures everything in the directory other than SKILL.md
 // so apply/import/reconcile are not lossy for those resources.
 type Skill struct {
-	Name        string         `toml:"-"` // dirname
+	Name        string         `toml:"-"` // dirname (namespaced when Plugin is set)
 	Frontmatter map[string]any `toml:"-"` // YAML frontmatter parsed
 	Body        string         `toml:"-"` // markdown body
 	Files       []SkillFile    `toml:"-"` // bundled files other than SKILL.md
+
+	// Plugin / BaseName carry plugin provenance; see NamespacedComponentName
+	// (provenance.go) for what they mean and why they are never serialized.
+	Plugin   string `toml:"-"`
+	BaseName string `toml:"-"`
 }
 
 // SkillFile is one bundled resource inside a skill directory (e.g.
@@ -225,17 +230,27 @@ type MarketplaceSpec struct {
 // Subagent mirrors subagents/<name>.md (frontmatter + body).
 // Subagents in Claude live at ~/.claude/agents/<name>.md.
 type Subagent struct {
-	Name        string         // filename without .md extension
+	Name        string         // filename without .md extension (namespaced when Plugin is set)
 	Frontmatter map[string]any // YAML frontmatter (description, tools, model, color, etc.)
 	Body        string         // markdown body
+
+	// Plugin / BaseName carry plugin provenance; see NamespacedComponentName
+	// (provenance.go) for what they mean and why they are never serialized.
+	Plugin   string
+	BaseName string
 }
 
 // Command mirrors commands/<name>.md (frontmatter + body).
 // Slash commands in Claude live at ~/.claude/commands/<name>.md.
 type Command struct {
-	Name        string         // filename without .md extension
+	Name        string         // filename without .md extension (namespaced when Plugin is set)
 	Frontmatter map[string]any // YAML frontmatter
 	Body        string         // markdown body
+
+	// Plugin / BaseName carry plugin provenance; see NamespacedComponentName
+	// (provenance.go) for what they mean and why they are never serialized.
+	Plugin   string
+	BaseName string
 }
 
 // Hook represents a single hook entry for an event.

--- a/test/bdd/features/06_marketplace_plugins.feature
+++ b/test/bdd/features/06_marketplace_plugins.feature
@@ -46,11 +46,13 @@ Feature: Marketplaces and plugins
     Then the command succeeds
     When I run "agentsync apply"
     Then the command succeeds
-    And the file ".claude/skills/proj-skill/SKILL.md" exists
-    And the file ".claude/skills/proj-skill/SKILL.md" contains "BODY_TOKEN_skill_proj-skill"
-    And the file ".claude/skills/proj-skill/scripts/run.sh" exists
-    And the file ".claude/skills/proj-skill/scripts/run.sh" contains "BODY_TOKEN_skill_script"
-    And the file ".claude/agents/proj-agent.md" exists
-    And the file ".claude/agents/proj-agent.md" contains "BODY_TOKEN_agent_proj-agent"
-    And the file ".claude/commands/proj-cmd.md" exists
-    And the file ".claude/commands/proj-cmd.md" contains "BODY_TOKEN_cmd_proj-cmd"
+    # Destination names are namespaced by the providing plugin (issue #211), so
+    # "proj-skill" from plugin "proj-plugin" lands as "proj-plugin-proj-skill".
+    And the file ".claude/skills/proj-plugin-proj-skill/SKILL.md" exists
+    And the file ".claude/skills/proj-plugin-proj-skill/SKILL.md" contains "BODY_TOKEN_skill_proj-skill"
+    And the file ".claude/skills/proj-plugin-proj-skill/scripts/run.sh" exists
+    And the file ".claude/skills/proj-plugin-proj-skill/scripts/run.sh" contains "BODY_TOKEN_skill_script"
+    And the file ".claude/agents/proj-plugin-proj-agent.md" exists
+    And the file ".claude/agents/proj-plugin-proj-agent.md" contains "BODY_TOKEN_agent_proj-agent"
+    And the file ".claude/commands/proj-plugin-proj-cmd.md" exists
+    And the file ".claude/commands/proj-plugin-proj-cmd.md" contains "BODY_TOKEN_cmd_proj-cmd"

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -34,6 +34,49 @@ newest first. It is what the CLI's one-time upgrade notice links to.
 
 ## 0.11.0
 
+### Plugin-provided components are namespaced by their plugin
+
+A subagent, skill, or slash command that comes from an installed plugin now
+renders under `<plugin>-<name>`. `feature-dev`'s `code-reviewer` becomes
+`feature-dev-code-reviewer`; its `code-review` skill becomes
+`feature-dev-code-review`.
+
+This is what makes two plugins shipping the same component name work. Before,
+`feature-dev` and `pr-review-toolkit` — both stock official plugins, both
+shipping `agents/code-reviewer.md` — made `agentsync status` and `agentsync
+apply` exit 1, and there was no way to resolve it: both files live in the
+marketplace-managed plugin cache, so you could not rename either one.
+
+| Before | After |
+|---|---|
+| `~/.claude/agents/code-reviewer.md` *(collision — apply failed)* | `~/.claude/agents/feature-dev-code-reviewer.md` and `~/.claude/agents/pr-review-toolkit-code-reviewer.md` |
+| `/review` | `/feature-dev-review` |
+| `@agent-code-reviewer` | `@agent-feature-dev-code-reviewer` |
+
+**What you need to do:** invoke plugin-provided agents and commands by their new
+names. If you have scripts, hooks, or `--agent` flags naming a plugin
+component, update them.
+
+**Components you wrote yourself are not renamed.** Only components projected
+from a plugin are namespaced — anything in your own `~/.agentsync/` tree keeps
+the name you gave it, and a plugin can never take that name from you.
+
+**The old files are cleaned up for you.** The next `agentsync apply` removes the
+un-namespaced destination files agentsync previously wrote, so you are not left
+with duplicate agents. A file you hand-edited since the last apply is backed up
+under `~/.agentsync/.state/backups/` before removal, never silently discarded.
+
+<Aside type="tip" title="Why a hyphen and not a colon">
+	Claude Code addresses a plugin's agent as `plugin:agent`, but that is a
+	*scoped identifier* it derives from the plugin directory — not something
+	written into the file. Claude Code documents a subagent's `name` as a "Unique
+	identifier using lowercase letters and hyphens", so a colon is not a legal
+	`name` value (and would be an illegal filename on Windows). A hyphen is valid
+	for both Claude Code and Codex, whose `name` field is the agent's identity.
+</Aside>
+
+### The v1.x CLI surface
+
 The v1.x CLI surface was locked in this release, so several names moved. All of
 them are **hard renames with no aliases** — the old spellings fail, loudly,
 rather than working quietly for a while. Scripts and CI pipelines need updating.

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -59,7 +59,12 @@ component, update them.
 
 **Components you wrote yourself are not renamed.** Only components projected
 from a plugin are namespaced — anything in your own `~/.agentsync/` tree keeps
-the name you gave it, and a plugin can never take that name from you.
+the name you gave it.
+
+In the rare case where a plugin's *derived* name lands on one of yours — you
+wrote `feature-dev-code-reviewer` and the `feature-dev` plugin ships
+`code-reviewer` — agentsync tells you, naming both sides, instead of picking a
+winner. Rename your copy or disable the plugin to resolve it.
 
 **The old files are cleaned up for you.** The next `agentsync apply` removes the
 un-namespaced destination files agentsync previously wrote, so you are not left


### PR DESCRIPTION
## Summary

Closes #211.

Two stock official plugins — `feature-dev` and `pr-review-toolkit` — each ship `agents/code-reviewer.md`. Installing both made `agentsync status` and `agentsync apply` exit 1, and every remedy the error named was one the user **structurally could not perform**: both files live under the marketplace-managed plugin cache, so "rename one" is not a thing they can do.

Plugin-provided subagents, skills, and commands are now renamed to `<plugin>-<name>` at **projection** time (`marketplace.namespaceProjected`), which also stamps the providing plugin id and the upstream base name onto the component.

The fix cannot live in an adapter. `loadProjected` appends every plugin's components into flat slices, so by the time an adapter can *detect* a collision, the provenance needed to *resolve* it is already gone. Rewriting `Name` — what every adapter derives its destination path and identity from — is also what makes every render site correct with no adapter change.

MCP and LSP servers keep their ids. A same-id divergence across sources can be a silent endpoint hijack rather than a naming clash, so it stays a hard failure rather than being renamed apart.

Design decisions taken from the issue discussion: always namespace (not only-on-collision); subagents/skills/commands (not MCP/LSP); rename every participant; the canonical-side override knob is deferred to a follow-up.

Scope folded in during implementation: `import` and `reconcile` write-back previously **re-captured** plugin-projected components, minting a canonical copy that renders identically today and diverges the moment the plugin updates — at which point every load refuses. Both dest→source entry points now refuse, across all six component kinds.

This branch also carries `c71be07` (a #210 follow-up on the `AtomicWrite` concurrency claim and the upgrade-notice `ID→Since` pin) that was already in flight when the branch was cut.

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Review-loop findings and fixes, round by round

Eight rounds of four-lens adversarial review (correctness, adversarial, api-design, test-rigor), under an explicit "make it bulletproof" mandate — take the more defensive side on every reviewer disagreement, including from a minority of one.

Every round found something real. The rounds that found the most were the ones reviewing *previous rounds' fixes*.

### Round 1 — four convergent findings (2+ lenses each)

- **No guard on the *namespaced* names, and identical bytes silently dropped.** Namespacing makes the common case work, but the derived name is not injective: plugin `a` shipping `b-c` and plugin `a-b` shipping `c` both derive `a-b-c`. Those reached the render pipeline, where divergent content aborted with a message naming neither origin (a `FileOp` carries no provenance) and **identical** content was silently deduped — a component dropped with no report at all. `checkProjectedConflicts` now guards name-keyed components exactly as it guards MCP/LSP ids. The silent drop is why the guard exists; the loud one it merely makes actionable.
- **Namespacing introduced a new fatal load path.** The derived-name validation used a stricter rune set than the projection's own `validateProjectedName`, so a plugin that projected fine before started hard-failing — and `loadProjected` propagates a projection error regardless of `lenient`, taking down `status`/`diff`/`explain`, whose whole design is to degrade and show state. It was also redundant with `render.Plan`'s `ValidateComponentID` at the single dispatch waist. Removed.
- **The capture refusal covered file components only** — a plugin-provided MCP or LSP server was still capturable.
- **The skip set did not match the rendered set at project scope** (project render uses the project-only overlay; unioning the user home over-refused).

Plus: `import` failed **open** when the projection failed (plugin data can trigger that) — now fail-closed; `backupOrphanIfDrifted` swallowed EACCES/EIO and deleted anyway, destroying a hand-edit with no backup.

### Round 2 — the capture refusal had two holes, one exploitable

- **Continue was unguarded.** It is the only adapter rendering MCP as a whole-file op (`SourceID: "mcp/<id>.toml"`), and the provenance map keyed servers as `mcp/<id>` with no suffix. A plugin MCP server on Continue could still be captured. Registered under both forms.
- **Dead scaffolding shipped in round 1** (`if name, ok := "", false; ok {…} else if`) — an editing artifact from a break-verify. It compiled, vetted and gofmt'd clean, so nothing caught it.
- **The round-1 backup fix over-corrected.** Refusing the *delete* is right; refusing the *run* is not. One unreadable destination wedged every other agent's writes — right as the reclaim set widened from skills to subagents+commands. Now skips that one delete and warns.
- **Hooks were uncovered by both refusals while the docs claimed otherwise.** Plugin hooks *are* projected, so `import` duplicated every one. Filtering has to be per **handler**, not per event: a canonical `hooks/<event>.toml` holds handlers from many sources.

A test written in round 1 **could not fail on the fix it was written for** (it put the plugin in the project tree, so old and new logic gave the same skip set). Replaced with the real over-refusal case.

### Round 3 — a lookup that was wrong, not merely imprecise

- **Provenance lookup for key items probed the id against both maps.** A plugin shipping an LSP server whose id is a common MCP name (`github`, `postgres`) made an `/mcpServers/github` pointer resolve to that plugin — **refusing write-back of the user's own hand-declared MCP server and blaming a plugin that does not own it.** Over-refusal *is* the harm here, so the "only ever over-refuses, the safe direction" comment was wrong too. The kind now comes from the op's `SourceID`, which also makes the lookup immune to the generic tier's growing `RootKey` table.
- **A skipped orphan delete was forgotten rather than retried.** `PruneStaleState` dropped the entry unconditionally, so the file agentsync declined to delete became unowned — re-creating exactly the leftover-duplicate failure reclamation exists to prevent.
- **"A plugin can never take a name you chose" was false** and appeared in four places. `provenance.go` itself refutes it: derived names are not injective. Qualified everywhere.

### Round 4 — the round-3 fix had the wrong polarity

- The orphan-retry fix kept a state entry only when `os.Stat` **succeeded** — but `Delete` skips on any non-ENOENT read failure, and the archetypal cause (EACCES on the parent directory) *also* makes `Stat` fail. The entry was still pruned in exactly the case the fix existed for. Now: keep unless **provably absent**, via `Lstat`.
- Keeping the entry made the apply summary contradict itself — `removalCounts` reads pre-apply state, so a permanently-unreadable orphan printed `removed: 1 file(s)` on **every** run, on the same run that warned it was skipped.
- **The doc retraction missed the two most user-visible sites** — `CHANGELOG.md` and `upgrading.mdx`, the latter being the exact page the upgrade notice deep-links, so the notice contradicted its own destination.
- A test corrected an **overclaim in the round-3 commit message**: the "Continue per-server SourceID" pointer case tested a shape that cannot occur (Continue's MCP op is `MergeStrategy: "replace"`, so it never reaches that lookup).

### Round 5 — a blocker for the exact users #211 targets

- **The un-namespaced leftover was not reclaimed for plugin-only users.** `orphanReclaimedPrefixes` listed `skills/`, `subagents/`, `commands/` — but the canonical `agents/` → `subagents/` rename ships in this same release, so an upgrading user's state still holds `agents/<name>.md` SourceIDs. The only rewriter runs from `migrate subagents`, which returns early when `<home>/agents/` is empty — and a user whose subagents come **only** from plugins has no such directory. **That is the reported scenario.** Their pre-rename `~/.claude/agents/code-reviewer.md` was unreclaimable *and* lost its state entry: **more** duplicate agents than before, the direct opposite of what the notice, CHANGELOG, upgrading.mdx and architecture §7 all promise.
- **The round-4 `Lstat` fix was entirely unpinned** — reverting it to either prior form passed the whole suite. A dangling symlink is the discriminating case. A fix whose bug review found twice should not be invisible to the suite a third time.
- `OrphanDeleteWillProceed` buffered a large bundled skill asset twice per apply, now also on dry-run. Reads one byte.

### Round 6 — data loss

- **Hooks are keyed by content**, and the projected canonical holds the user's handler *and* the plugin's with no cross-source dedup — so **a plugin shipping a byte-identical handler made the key resolve to the plugin**. `importHook` dropped it, and `source.WriteHooks` replaces `hooks/<event>.toml` wholesale, so **the user's own hand-authored handler was erased from a tree that is usually a committed dotfiles repo** — while the warning said "agentsync already manages it" about a line they wrote. A plugin author who copies a popular hook gets this for free.
- **The round-5 reconcile-prompt fix was dead code**, flagged by three lenses. `collectOrphanFileItems` synthesized a `FileOp` with no `SourceID`, and round 5's own new first line asserts `isOrphanReclaimable(SourceID)` — so the branch could never fire.
- **The FIFO guard was half a fix**: it used `Lstat`, so a symlink to a FIFO still blocked, and `backupOrphanIfDrifted` kept a bare `ReadFile`, so the **real apply hung** where the predicate said otherwise.

### Round 7 — the round-6 fix was itself a regression

- The co-declaration guard ("a component the user also declares is never plugin-provided") was **right for hooks and wrong for everything else**. `checkProjectedConflicts` only fails on *divergent* duplicates, so a user `mcp/foo.toml` byte-identical to a plugin's projects cleanly; round 6 then made that id the user's, so `import claude:mcp:foo` captured the **drifted** native content, the two copies diverged, and every later mutating load hard-failed. **A protective refusal became a permanent wedge.**
- The distinguishing fact is what *skipping* does, and it differs by writer: `WriteHooks` **replaces the whole file**, so a declined handler is erased — the user's claim must win. `WriteMCP`/`WriteSkill`/`WriteSubagent`/`WriteCommand` write **one file per component**, so a refusal deletes nothing. Narrowed to hooks alone.
- **`reconcile --auto-writeback` exited non-zero forever** on a plugin-provided item. The refusal is structural and permanent, not transient, so counting it as a failure broke `reconcile && deploy` until the plugin was disabled.
- **The FIFO class was declared closed one round early**: `hashFile` (which feeds `status` *and* reconcile's orphan listing) and `render.BackupFile` both kept a bare `os.ReadFile`, which **blocks** rather than fails on a FIFO.
- The FIFO test moved behind `//go:build unix` — `syscall.Mkfifo` is undefined on Windows, so `go test ./...` no longer fails to compile there.

### Round 8 — the FIFO fix was untested

Deleting either round-7 guard left the whole suite green — precisely the CLAUDE.md "a prose capability claim must point at the test" rule. Four timeout-wrapped cases now cover every destination read a FIFO reaches (`Writer.Delete`, `BackupFile`, `OrphanDeleteWillProceed`, `hashFile`), each **break-verified individually**: deleting a guard fails exactly its own test and no other.

`Writer.Delete` is the one that matters — the others are a count and a diagnostic. It asserts both halves: the run is not errored, **and** the FIFO survives (agentsync cannot read it, so it cannot rule out content worth preserving, so it must not remove it).

Also corrected three comments that had drifted from their code, including a `Mode` removal the round-7 commit message claimed but whose working-tree change had been lost.

## Test plan

- [x] `go test -race ./...` green
- [x] `go test -tags=e2e ./test/e2e/...` green
- [x] `go test -tags=bdd ./test/bdd/...` green
- [x] `golangci-lint run ./...` — 0 issues; `gofmt`/`gofumpt` clean; `go mod tidy` a no-op
- [x] `GOOS=windows go vet ./...` clean (the FIFO tests are `//go:build unix`); `GOOS=darwin go build ./...` clean

Tests are **artifact-anchored** per the CLAUDE.md fidelity rule — spec-complete on-disk fixtures (skills with bundled `scripts/`/`references/`, MCP servers with unmodeled native keys), asserting the on-disk result rather than the parsed model.

Load-bearing fixes were **break-verified**: temporarily re-induce the bug, confirm the new test fails cleanly, restore. This caught several tests that could not fail on the fix they were written for — the round-1 project-scope test, the round-4 `Lstat` fix, and the round-5 prompt wording, which shipped unpinned twice.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] Touches `internal/capture` boundaries and `source.Write*` paths — re-read the secret-handling invariants and did not weaken them. `MCPServer`/`LSPServer`/`Hook` gained a `Plugin` provenance field; `TestNewSecretFieldGuard` fired on the addition and the fields are classified as non-secret-bearing. Provenance fields are `toml:"-"` derived state, never serialized. No new dest→source write bypasses `capture.Capture`.
- [x] Docs updated: `concepts.md`, `architecture.md`, `components.md`, `capability-matrix.md`, `user-guide.md`, `CHANGELOG.md`, `website/.../upgrading.mdx`, the upgrade notice, and the design spec (with an "Amendments after review" section recording the two design points review overturned).

## Known residuals

All deliberate and documented — none blocking:

- **The canonical-side override knob is deferred to a follow-up** (your design decision on the issue).
- **#213** — reconcile write-back picks the MCP dialect from the JSON root key, corrupting crush. **Pre-existing**, found during this review and filed separately.
- reconcile's `[r]` leaves an empty skill directory behind.
- An `mcp/x.toml` key-namespace over-refusal: contrived to reach, and it fails **closed** — it refuses a write it could have allowed, never the reverse. A `keyItemLookupKey` fix was started and reverted; the adversarial lens agreed the fix carried more risk than the residual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2A2z2qF2JFQmyiyb6NqP5)_