### PR TITLE
feat(ui): label every diagnostic and lead success lines with an emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   nothing marking which was the failure.
   ([#211](https://github.com/spxrogers/agentsync/issues/211#issuecomment-5108532310))
   - Diagnostics — anything that is a notice *about* the run — render as
-    `✗ ERROR` / `⚠ WARN` / `ℹ INFO` / `• DEBUG` on **stderr**, with message text
+    `✗ ERROR` / `⚠ WARN` / `ℹ INFO` on **stderr**, with message text
     starting at a fixed column so stacked lines align and detail lines hang
     under their label. The glyph and the level word are content, not decoration:
     piped, redirected, under `NO_COLOR`, or `--color never`, severity still
@@ -34,7 +34,7 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   - Success outcomes carry **no** level word — an `INFO` on `added agent: claude`
     is noise that dilutes the labels that matter — and instead lead with an emoji
     chosen by what happened: `🎉 applied: 12 ops`, `✅ added agent: claude`,
-    `🧹 removed mcp server: github`, `📥 imported 4 skills…`, `🔙 reverted…`,
+    `🧹 removed mcp server: github`, `📥 imported 4 items from claude`, `🔙 reverted…`,
     `✨ …initialized`. Command *results* (a `--json` payload, a `status` table, a
     `diff`, a `list`) are unchanged and unlabeled.
   - Several warnings that had been printing to **stdout** — `plugin outdated` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ## [Unreleased]
 
+### Changed
+
+- **Every diagnostic across the CLI now carries a severity label, and success
+  lines lead with an emoji.** The formatting of `agentsync`'s output was the
+  reason a correct, deliberate fatal error read as a broken tool: it printed as
+  a flat, uncolored, unlabeled `agentsync: render codex: …` sitting directly
+  beneath a `2026/07/28 15:03:45 WARN …` line from a different subsystem, with
+  nothing marking which was the failure.
+  ([#211](https://github.com/spxrogers/agentsync/issues/211#issuecomment-5108532310))
+  - Diagnostics — anything that is a notice *about* the run — render as
+    `✗ ERROR` / `⚠ WARN` / `ℹ INFO` / `• DEBUG` on **stderr**, with message text
+    starting at a fixed column so stacked lines align and detail lines hang
+    under their label. The glyph and the level word are content, not decoration:
+    piped, redirected, under `NO_COLOR`, or `--color never`, severity still
+    reaches the log file. With color on, the label is bold red / yellow / cyan.
+  - The terminal error line is one of them. `agentsync: <err>` is now
+    `✗ ERROR  <err>`; the redundant program prefix is gone. The quiet
+    `--exit-code` sentinel still prints nothing and keeps its own exit code.
+  - Library-side `slog` calls (`internal/render`, `internal/marketplace`) render
+    identically. No slog handler had ever been installed, so those warnings fell
+    through to the standard library's default and printed with a wall-clock
+    timestamp in a shape nothing else in the CLI used. The timestamp is gone.
+  - Success outcomes carry **no** level word — an `INFO` on `added agent: claude`
+    is noise that dilutes the labels that matter — and instead lead with an emoji
+    chosen by what happened: `🎉 applied: 12 ops`, `✅ added agent: claude`,
+    `🧹 removed mcp server: github`, `📥 imported 4 skills…`, `🔙 reverted…`,
+    `✨ …initialized`. Command *results* (a `--json` payload, a `status` table, a
+    `diff`, a `list`) are unchanged and unlabeled.
+  - Several warnings that had been printing to **stdout** — `plugin outdated` /
+    `plugin upgrade --all`'s marketplace re-fetch, SHA-drift, and lossless-bump
+    diagnostics — moved to stderr, where they no longer interleave with the
+    command's own output.
+  - Scripts that grep agentsync's human-readable output for `warning:`, `note:`,
+    `agentsync:`, or `ok:` need updating; `--json` payloads are unaffected.
+
 ### Fixed
 
 - **Two plugins shipping a same-named component no longer break `status` and

--- a/cmd/agentsync/main.go
+++ b/cmd/agentsync/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"os"
 
 	"github.com/spxrogers/agentsync/internal/cli"
@@ -19,16 +17,13 @@ func main() {
 	cli.Commit = commit
 	cli.Date = date
 
-	if err := cli.Execute(); err != nil {
-		// A quiet exit-code sentinel (status/diff --exit-code) carries its own
-		// process exit code and an empty message: map it to that code and print
-		// nothing, so a CI gate gets a stable non-zero exit with no spurious
-		// "agentsync:" line. Every other error exits 1 with its message.
-		var ec cli.ExitCoder
-		if errors.As(err, &ec) {
-			os.Exit(ec.ExitCode())
-		}
-		fmt.Fprintln(os.Stderr, "agentsync:", err)
-		os.Exit(1)
+	// ReportError owns the whole terminal-diagnostic decision — the quiet
+	// exit-code sentinel (status/diff --exit-code), the ✗ ERROR label, the
+	// color resolution — so the last line a failing run prints goes through
+	// the same vocabulary as every other diagnostic in the CLI. It lives in
+	// internal/cli rather than here because that is where the --color flag was
+	// resolved and where ExitCoder is defined.
+	if code := cli.ReportError(cli.Execute()); code != 0 {
+		os.Exit(code)
 	}
 }

--- a/cmd/agentsync/main.go
+++ b/cmd/agentsync/main.go
@@ -17,13 +17,9 @@ func main() {
 	cli.Commit = commit
 	cli.Date = date
 
-	// ReportError owns the whole terminal-diagnostic decision — the quiet
-	// exit-code sentinel (status/diff --exit-code), the ✗ ERROR label, the
-	// color resolution — so the last line a failing run prints goes through
-	// the same vocabulary as every other diagnostic in the CLI. It lives in
-	// internal/cli rather than here because that is where the --color flag was
-	// resolved and where ExitCoder is defined.
-	if code := cli.ReportError(cli.Execute()); code != 0 {
-		os.Exit(code)
-	}
+	// cli.Execute owns the whole invocation and returns the exit code: the quiet
+	// exit-code sentinel (status/diff --exit-code), the ✗ ERROR label, and the
+	// --color resolution all live there, where the flag was parsed and where
+	// ExitCoder is defined. main stays a three-line shim on purpose.
+	os.Exit(cli.Execute())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1077,7 +1077,7 @@ three unrelated renderings coexisting —
 All three now converge. `ui.Level` owns the label; `ui.SlogHandler` renders slog
 records through it and `internal/log` installs it as the process default from the
 root `PersistentPreRunE`; `cli.Execute` returns the process exit code and prints the
-terminal error as an `ERROR` diagnostic through `ReportErrorTo` — owning the whole
+terminal error as an `ERROR` diagnostic — owning the whole
 invocation is what lets it read the resolved `--color` flag off the still-in-scope
 root command instead of carrying it across the `main` boundary in package state. A `slog.Warn` from `internal/marketplace`, an adapter's
 `warning: ` line through `ui.WarnWriter`, and a command's `p.Warnf` produce

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1076,8 +1076,10 @@ three unrelated renderings coexisting —
 
 All three now converge. `ui.Level` owns the label; `ui.SlogHandler` renders slog
 records through it and `internal/log` installs it as the process default from the
-root `PersistentPreRunE`; `cli.ReportError` prints the terminal error as an
-`ERROR` diagnostic. A `slog.Warn` from `internal/marketplace`, an adapter's
+root `PersistentPreRunE`; `cli.Execute` returns the process exit code and prints the
+terminal error as an `ERROR` diagnostic through `ReportErrorTo` — owning the whole
+invocation is what lets it read the resolved `--color` flag off the still-in-scope
+root command instead of carrying it across the `main` boundary in package state. A `slog.Warn` from `internal/marketplace`, an adapter's
 `warning: ` line through `ui.WarnWriter`, and a command's `p.Warnf` produce
 byte-identical output.
 
@@ -1086,6 +1088,16 @@ byte-identical output.
 - *The glyph and the level word are content, not decoration.* Color is a second
   signal only. Piped, redirected, under `NO_COLOR`, or `--color never`, severity
   still reaches a log file — which is where CI reads it.
+- *Color is resolved PER STREAM, not per Printer.* `auto` asks whether the
+  destination is a terminal, and stdout and stderr are different destinations:
+  `agentsync apply 2>err.log` from a terminal has a TTY stdout and a file stderr.
+  One decision taken off `Out` and reused for `Err` wrote ANSI into that file —
+  the exact leak this rule forbids — and since every diagnostic goes to `Err`,
+  that was the common path, not a corner case. `ui.Printer` therefore holds two
+  decisions, and the writers that take an explicit `io.Writer` style for the
+  stream they actually target. The two fallbacks for an unrecognized writer are
+  deliberately opposite: a diagnostic takes the `Err` decision, a success line
+  takes `Out`'s.
 - *A command's machine-readable stdout is never polluted by a diagnostic.* This
   is the guarantee that matters and the one that is asserted end-to-end
   (`TestSlogWarningNeverEntersAJSONPayload` drives a real `status --json` with a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1137,9 +1137,13 @@ vacuous, and passing green proves neither is absent.**
 
 1. *Wrong files.* The sweep first globbed `*.go` relative to the working
    directory — but `internal/cli`'s `TestMain` chdirs to a scratch dir, so it
-   matched nothing. It now resolves the repo root from `runtime.Caller`, requires
-   every swept directory to be non-empty, and asserts a floor on the total file
-   count.
+   matched nothing. It now resolves the repo root from `runtime.Caller` and holds a
+   PER-DIRECTORY file-count floor. Per-directory matters: an aggregate floor cannot
+   defend this list, because `internal/cli` has ~31 non-test files and
+   `cmd/agentsync` has one — deleting the `cmd/agentsync` entry left 31 files and
+   cleared any total-count floor, silently reopening the hole below.
+   `TestSweptDirsCoverTheEmitters` pins the directory set itself, since a floor
+   catches a directory going empty but not an entry being removed.
 2. *Wrong matcher.* Even after that, it compared literals for *equality*, so it
    passed with the verbatim #211 emitter —
    `fmt.Fprintln(os.Stderr, "agentsync:", err)` — restored to `main()`: that file

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1081,7 +1081,11 @@ terminal error as an `ERROR` diagnostic — owning the whole
 invocation is what lets it read the resolved `--color` flag off the still-in-scope
 root command instead of carrying it across the `main` boundary in package state. A `slog.Warn` from `internal/marketplace`, an adapter's
 `warning: ` line through `ui.WarnWriter`, and a command's `p.Warnf` produce
-byte-identical output.
+byte-identical output — for a sanitize-clean, single-line message, which is what a
+real diagnostic is. The three paths deliberately differ on hostile input:
+`SlogHandler` and `WarnWriter` sanitize, because their inputs are assembled by
+packages that cannot, while `Diagf` does not, because its callers may hand it
+pre-styled text. `TestWarnPathsAreByteIdentical` pins the clean case.
 
 **Three load-bearing rules.**
 
@@ -1191,7 +1195,7 @@ flowchart TD
     INFRA["internal/iox · paths · jsonkeys · untrusted"]
 
     CLI --> REN & CAP & AD & SRC & SEC & MKT & PRJ & DRF & ST & GIT & UI & LOG
-    REN --> AD & SEC & SRC & ST & DRF & UI & INFRA
+    REN --> AD & SEC & SRC & ST & UI & INFRA
     CAP --> SRC & SEC & INFRA
     AD --> SRC & SEC & INFRA
     AD -. "opencode ingest ownership only (issue #148)" .-> ST

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1135,37 +1135,32 @@ mechanical guard. `TestNoAdHocDiagnosticPrefixes` parses the non-test sources of
 **both `internal/cli` and `cmd/agentsync`** and fails on a reintroduced
 `"agentsync:"` / `"note:"` prefix, or a bare `"warning:"` label token.
 
-Both halves of that scoping were learned the hard way, and the lesson generalizes
-past this one test: **a source-sweeping guard has two independent ways to be
-vacuous, and passing green proves neither is absent.**
+Both halves of that scoping are load-bearing, and generalize past this test: **a
+source sweep has two independent ways to be vacuous, and green proves neither is
+absent.**
 
-1. *Wrong files.* The sweep first globbed `*.go` relative to the working
-   directory — but `internal/cli`'s `TestMain` chdirs to a scratch dir, so it
-   matched nothing. It now resolves the repo root from `runtime.Caller` and holds a
-   PER-DIRECTORY file-count floor. Per-directory matters: an aggregate floor cannot
-   defend this list, because `internal/cli` has ~31 non-test files and
-   `cmd/agentsync` has one — deleting the `cmd/agentsync` entry left 31 files and
-   cleared any total-count floor, silently reopening the hole below.
-   `TestSweptDirsCoverTheEmitters` pins the directory set itself, since a floor
-   catches a directory going empty but not an entry being removed.
-2. *Wrong matcher.* Even after that, it compared literals for *equality*, so it
-   passed with the verbatim #211 emitter —
-   `fmt.Fprintln(os.Stderr, "agentsync:", err)` — restored to `main()`: that file
-   sat outside the swept set, and `"agentsync: %v\n"` would have slipped past the
-   matcher regardless. It now `strconv.Unquote`s each literal (so a raw backtick
-   string is compared as the text a terminal would receive) and matches by prefix.
+1. *Wrong files.* The sweep first globbed `*.go` relative to the working directory,
+   but `internal/cli`'s `TestMain` chdirs to a scratch dir, so it matched nothing.
+   It now resolves the repo root from `runtime.Caller` and holds a **per-directory**
+   file-count floor — aggregate floors cannot defend a one-file entry, since
+   dropping `cmd/agentsync` still left ~31 files from `internal/cli`.
+   `TestSweptDirsCoverTheEmitters` pins the directory set, because a floor catches a
+   directory going empty but not an entry being deleted.
+2. *Wrong matcher.* It then compared literals for *equality*, so the verbatim #211
+   emitter (`fmt.Fprintln(os.Stderr, "agentsync:", err)`) passed once restored to
+   `main()`, and `"agentsync: %v\n"` would have slipped regardless. It now
+   `strconv.Unquote`s each literal — so a raw backtick string is compared as the
+   text a terminal receives — and matches by prefix.
 
-`"warning:"` is matched differently from the other two, deliberately: the
-`warning: <message>` sentinel is a *contract* with the packages that cannot import
-`ui`, so only the bare label forms are banned. The one legitimate `agentsync:`
-literal — a `panic` value in `registry_internal.go`, which surfaces through Go's
-own panic output rather than as a diagnostic line — is an explicit, commented
-entry in an exemption map rather than a loosened pattern.
+`"warning:"` is matched differently on purpose: the `warning: <message>` sentinel
+is a contract with the packages that cannot import `ui`, so only the bare label
+forms are banned. The one legitimate `agentsync:` literal — a `panic` value in
+`registry_internal.go`, which surfaces through Go's own panic output — is a
+commented entry in an exemption map, not a loosened pattern.
 
-Beyond that, the guard stays deliberately narrow in *which* prefixes it lists: a
-broader set (e.g. `scope:`, `ok:`) would also flag legitimate field labels inside
-a report body, where no level belongs — `explain` prints `scope: user` as a data
-row, not as a notice.
+The prefix list stays narrow: a broader one (`scope:`, `ok:`) would flag legitimate
+field labels in a report body, where no level belongs — `explain` prints
+`scope: user` as a data row, not a notice.
 
 **Test isolation.** The installation is process-global, so `internal/log` exposes
 `Detach()` and the CLI test harness calls it via `t.Cleanup` on every invocation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1050,7 +1050,67 @@ forgotten in the others.
 
 ---
 
-## 11. Package layering
+## 11. Output — one diagnostic vocabulary
+
+Everything agentsync prints is one of two things, and `internal/ui` is the only
+place that decides how either looks.
+
+| | What it is | Stream | Rendering |
+| --- | --- | --- | --- |
+| **Diagnostic** | a notice *about* the run | stderr | `✗ ERROR` / `⚠ WARN` / `ℹ INFO` / `• DEBUG`; message at column 9 |
+| **Result** | what the command was asked to produce | stdout | no level label; a success outcome leads with a curated emoji |
+
+**Why this is an architectural concern and not styling.** Issue #211 reported a
+correct, deliberate fatal error that read as a broken tool, and the formatting
+was the reason: `agentsync: render codex: …` printed flush-left, uncolored and
+unlabeled, directly beneath a `2026/07/28 15:03:45 WARN …` line from a different
+subsystem. Nothing distinguished the fatal from the advisory. The cause was
+three unrelated renderings coexisting —
+
+1. commands hand-rolled their own prefixes (`p.Yellow("agentsync:")`,
+   `p.Cyan("note:")`, `p.Yellow("warning:")`, a bare `•`);
+2. library packages called `slog.Warn`, and **no handler was ever installed**, so
+   those fell through to the stdlib default and printed with a wall-clock
+   timestamp in a shape nothing else used;
+3. `main` printed the terminal error itself, bypassing `ui` entirely.
+
+All three now converge. `ui.Level` owns the label; `ui.SlogHandler` renders slog
+records through it and `internal/log` installs it as the process default from the
+root `PersistentPreRunE`; `cli.ReportError` prints the terminal error as an
+`ERROR` diagnostic. A `slog.Warn` from `internal/marketplace`, an adapter's
+`warning: ` line through `ui.WarnWriter`, and a command's `p.Warnf` produce
+byte-identical output.
+
+**Three load-bearing rules.**
+
+- *The glyph and the level word are content, not decoration.* Color is a second
+  signal only. Piped, redirected, under `NO_COLOR`, or `--color never`, severity
+  still reaches a log file — which is where CI reads it.
+- *Diagnostics never touch stdout.* That is what keeps `status --json` a clean
+  payload while its warnings still reach the user, and it is asserted end-to-end.
+- *Success carries no level word.* An `INFO` on `added agent: claude` is noise
+  that trains the eye to skip labels; the emoji says both "this worked" and
+  "this is the outcome line". Chosen by what happened, not by which command ran.
+
+**The emitter-side sentinel.** Adapters and `internal/capture` must not depend on
+`ui` (they are below it in the layering), so they emit the plain `warning: ` line
+prefix into an `io.Writer` they were handed, and `ui.WarnWriter` rewrites it into
+the WARN label at the one point that knows whether this terminal gets color. That
+split is a contract between two packages that share no types — rename it on one
+side and warnings silently stop being labeled, with nothing failing to compile —
+so both halves are pinned by `TestWarnSentinelStaysWiredToTheWarnLabel`.
+
+**The regression fence.** A hand-rolled prefix compiles, reads like "just a
+`Fprintf`" in review, and breaks no test — the exact failure class that needs a
+mechanical guard. `TestNoAdHocDiagnosticPrefixes` parses every non-test source in
+`internal/cli` and fails on a reintroduced `"agentsync:"` / `"warning:"` /
+`"note:"` string literal. It is deliberately narrow: a broader list would also
+flag legitimate field labels inside a report body, where no level belongs
+(`explain` prints `scope: user` as a data row, not as a notice).
+
+---
+
+## 12. Package layering
 
 ```mermaid
 flowchart TD
@@ -1080,10 +1140,10 @@ flowchart TD
 ```
 
 `internal/drift`, `internal/git`, `internal/iox`, `internal/jsonkeys`,
-`internal/paths`, `internal/log`, and `internal/untrusted` have no internal
+`internal/paths`, and `internal/untrusted` have no internal
 dependencies — they're the leaves (`internal/git` is reached only from `cli` —
 `internal/cli/gitbackup.go`, `doctor.go`, and `revert.go`); `internal/ui` builds
-only on `internal/untrusted`.
+only on `internal/untrusted`, and `internal/log` only on `internal/ui`.
 See the [component map](components.md) for what each package contains.
 
 **Documented layering exception (`opencode → state`).** Adapters otherwise depend

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1086,8 +1086,21 @@ byte-identical output.
 - *The glyph and the level word are content, not decoration.* Color is a second
   signal only. Piped, redirected, under `NO_COLOR`, or `--color never`, severity
   still reaches a log file — which is where CI reads it.
-- *Diagnostics never touch stdout.* That is what keeps `status --json` a clean
-  payload while its warnings still reach the user, and it is asserted end-to-end.
+- *A command's machine-readable stdout is never polluted by a diagnostic.* This
+  is the guarantee that matters and the one that is asserted end-to-end
+  (`TestSlogWarningNeverEntersAJSONPayload` drives a real `status --json` with a
+  library `slog.Warn` in flight, parses the payload, and rejects any level word
+  in it). `Errorf`/`Warnf`/`Infof` all write to stderr, so this holds by
+  construction for every command.
+
+  It is **not** the same as "no diagnostic is ever written to stdout", and that
+  stronger claim would be false: `reconcile`'s interactive loop deliberately
+  routes its labeled write-back failures through `Fdiagf` onto `p.Out`, the same
+  stream as the prompt they answer. Splitting a keystroke-driven conversation
+  across two streams would break the transcript for the sake of a rule that buys
+  nothing there — `reconcile` is interactive and emits no machine-readable
+  payload. `Fdiagf` exists for exactly that case, which is why it takes an
+  explicit writer while `Diagf` does not.
 - *Success carries no level word.* An `INFO` on `added agent: claude` is noise
   that trains the eye to skip labels; the emoji says both "this worked" and
   "this is the outcome line". Chosen by what happened, not by which command ran.
@@ -1102,11 +1115,43 @@ so both halves are pinned by `TestWarnSentinelStaysWiredToTheWarnLabel`.
 
 **The regression fence.** A hand-rolled prefix compiles, reads like "just a
 `Fprintf`" in review, and breaks no test — the exact failure class that needs a
-mechanical guard. `TestNoAdHocDiagnosticPrefixes` parses every non-test source in
-`internal/cli` and fails on a reintroduced `"agentsync:"` / `"warning:"` /
-`"note:"` string literal. It is deliberately narrow: a broader list would also
-flag legitimate field labels inside a report body, where no level belongs
-(`explain` prints `scope: user` as a data row, not as a notice).
+mechanical guard. `TestNoAdHocDiagnosticPrefixes` parses the non-test sources of
+**both `internal/cli` and `cmd/agentsync`** and fails on a reintroduced
+`"agentsync:"` / `"note:"` prefix, or a bare `"warning:"` label token.
+
+Both halves of that scoping were learned the hard way, and the lesson generalizes
+past this one test: **a source-sweeping guard has two independent ways to be
+vacuous, and passing green proves neither is absent.**
+
+1. *Wrong files.* The sweep first globbed `*.go` relative to the working
+   directory — but `internal/cli`'s `TestMain` chdirs to a scratch dir, so it
+   matched nothing. It now resolves the repo root from `runtime.Caller`, requires
+   every swept directory to be non-empty, and asserts a floor on the total file
+   count.
+2. *Wrong matcher.* Even after that, it compared literals for *equality*, so it
+   passed with the verbatim #211 emitter —
+   `fmt.Fprintln(os.Stderr, "agentsync:", err)` — restored to `main()`: that file
+   sat outside the swept set, and `"agentsync: %v\n"` would have slipped past the
+   matcher regardless. It now `strconv.Unquote`s each literal (so a raw backtick
+   string is compared as the text a terminal would receive) and matches by prefix.
+
+`"warning:"` is matched differently from the other two, deliberately: the
+`warning: <message>` sentinel is a *contract* with the packages that cannot import
+`ui`, so only the bare label forms are banned. The one legitimate `agentsync:`
+literal — a `panic` value in `registry_internal.go`, which surfaces through Go's
+own panic output rather than as a diagnostic line — is an explicit, commented
+entry in an exemption map rather than a loosened pattern.
+
+Beyond that, the guard stays deliberately narrow in *which* prefixes it lists: a
+broader set (e.g. `scope:`, `ok:`) would also flag legitimate field labels inside
+a report body, where no level belongs — `explain` prints `scope: user` as a data
+row, not as a notice.
+
+**Test isolation.** The installation is process-global, so `internal/log` exposes
+`Detach()` and the CLI test harness calls it via `t.Cleanup` on every invocation.
+Without it, each `runCLI` leaves `slog.Default()` bound to a finished test's
+`bytes.Buffer` — invisible today, and a data race the moment a test there adopts
+`t.Parallel`.
 
 ---
 
@@ -1125,10 +1170,12 @@ flowchart TD
     DRF["internal/drift — 3-way classifier (pure)"]
     ST["internal/state — targets.json"]
     GIT["internal/git — local-only go-git wrapper (no push surface)"]
-    INFRA["internal/iox · paths · jsonkeys · log · untrusted · ui"]
+    UI["internal/ui — presentation: color · glyphs · diagnostics"]
+    LOG["internal/log — slog wiring (installs ui.SlogHandler)"]
+    INFRA["internal/iox · paths · jsonkeys · untrusted"]
 
-    CLI --> REN & CAP & AD & SRC & SEC & MKT & PRJ & DRF & ST & GIT
-    REN --> AD & SEC & SRC & ST & DRF & INFRA
+    CLI --> REN & CAP & AD & SRC & SEC & MKT & PRJ & DRF & ST & GIT & UI & LOG
+    REN --> AD & SEC & SRC & ST & DRF & UI & INFRA
     CAP --> SRC & SEC & INFRA
     AD --> SRC & SEC & INFRA
     AD -. "opencode ingest ownership only (issue #148)" .-> ST
@@ -1137,7 +1184,18 @@ flowchart TD
     SRC --> INFRA
     SEC --> SRC & INFRA
     ST --> INFRA
+    LOG --> UI
+    UI --> INFRA
 ```
+
+`internal/ui` is drawn as its own node rather than folded into `INFRA` because
+the distinction is load-bearing, not cosmetic: **`internal/adapter` and
+`internal/capture` must not depend on `ui`**, and an `AD --> INFRA` edge into a
+node containing `ui` asserted exactly the dependency §11 forbids. That constraint
+is why an adapter emits the plain `warning: ` sentinel into an `io.Writer` it was
+handed instead of formatting a label itself. `internal/render` *does* depend on
+`ui` (its translation report renders through a `*Printer`), and `internal/log`
+depends on it too — so `log` is no longer a leaf.
 
 `internal/drift`, `internal/git`, `internal/iox`, `internal/jsonkeys`,
 `internal/paths`, and `internal/untrusted` have no internal

--- a/docs/components.md
+++ b/docs/components.md
@@ -520,13 +520,24 @@ line, which must not interleave) and returns write errors rather than swallowing
 them. The `slog.Warn` / `WarnWriter` / `p.Warnf` triple being byte-identical is
 pinned by `TestWarnPathsAreByteIdentical`.
 
-**Who sanitizes.** `SlogHandler.Handle` and `cli.ReportError` sanitize their own
-input, because neither has a call site that could: a log record and a wrapped
-error chain are both assembled elsewhere. Everywhere else the **caller** applies
-`ui.Sanitize` at the display boundary, as the rest of this codebase does — the
-`Diagf`/`Detailf`/`Successf` family deliberately does not, so a caller can pass
-pre-styled text (the upgrade-notice banner composes `p.Bold`/`p.Yellow` fragments
-into a `Warnf`) without having its own escape codes stripped.
+**Who sanitizes.** `SlogHandler.Handle` and `cli.Execute`'s terminal error line
+sanitize their own input, because neither has a call site that could: a log record
+and a wrapped error chain are both assembled elsewhere. Everywhere else the
+**caller** applies `ui.Sanitize` at the display boundary, as the rest of this
+codebase does — the `Diagf`/`Detailf`/`Successf` family deliberately does not, so a
+caller can pass pre-styled text (the upgrade-notice banner composes
+`p.Bold`/`p.Yellow` fragments into a `Warnf`) without having its own escape codes
+stripped.
+
+`WarnWriter` sits between those two cases and is worth naming explicitly, because
+it looks like the first and behaves like the second: its input comes from the
+adapter and capture packages, which *cannot* call `ui.Sanitize` (they must not
+import `ui` — that constraint is the reason the `warning: ` sentinel exists). It
+does not sanitize. What holds today is that every adapter emitter interpolates
+untrusted values with `%q`, which escapes control bytes — a real mitigation, but an
+incidental one. A new emitter that used `%s` for a config-derived value would open
+a hole, so **an emitter writing into a `WarnWriter` must use `%q` for anything
+config-derived.**
 - **Key:** `Printer` (`New`, `Color`, `Section`, colour helpers; color is resolved
   per stream, and the diagnostic writers style for the stream they target);
   `Level` + `Label`; `Errorf`/`Warnf`/`Infof`/`Diagf`/`Fdiagf`;

--- a/docs/components.md
+++ b/docs/components.md
@@ -27,8 +27,8 @@ internal/
 ├── iox/              # atomic write + file lock
 ├── jsonkeys/         # per-key JSON-pointer merge (preserve foreign keys)
 ├── paths/            # AGENTSYNC_HOME / TARGET_ROOT / HOME resolution
-├── ui/               # presentation: Printer · color · glyphs · WarnWriter
-├── log/              # slog setup
+├── ui/               # presentation: Printer · color · glyphs · diagnostics · WarnWriter
+├── log/              # slog setup (installs ui.SlogHandler as the default)
 └── testenv/          # hermetic-container test guard
 ```
 
@@ -465,7 +465,12 @@ absolute and `${HOME}`-relative forms for portable state.
 - **Files:** `paths.go`.
 
 ### `internal/log`
-slog setup. **Key:** `New(w, verbose) *slog.Logger`. **Files:** `log.go`.
+slog setup. Builds a logger over `ui.SlogHandler` and installs it as the
+process-wide default from the root command's `PersistentPreRunE`, which is what
+routes library-side `slog` calls (`internal/render`, `internal/marketplace`) into
+the CLI's diagnostic vocabulary instead of the stdlib default's timestamped
+lines. **Key:** `New(w, p, verbose) *slog.Logger`; `Install(w, p, verbose) func()`
+(returns a restore, for tests). **Depends on:** ui. **Files:** `log.go`.
 
 ### `internal/untrusted`
 The display trust boundary for fetched/native metadata. Owns `Sanitize` (strip
@@ -480,15 +485,41 @@ here. See [architecture §7](architecture.md#7-safety-primitives) and `SECURITY.
 ### `internal/ui`
 The presentation layer — every command renders styled output through a `*Printer`
 so color, glyph, and spacing decisions live in one place. Owns the curated glyph
-vocabulary (`✓`/`◐`/`✗`/`⚠`/`•`/`→`), the `--color` mode resolution, and a
-`WarnWriter` that restyles `warning:` line prefixes. `Sanitize` delegates to
+vocabulary (`✓`/`◐`/`✗`/`⚠`/`•`/`→`), the `--color` mode resolution, the
+**diagnostic vocabulary** (below), and a `WarnWriter` that rewrites the
+`warning: ` emitter sentinel into the shared WARN label. `Sanitize` delegates to
 `internal/untrusted`, so untrusted metadata printed through `ui` is stripped of
 terminal-control and deceptive-format runes by construction.
-- **Key:** `Printer` (`New`, `Color`, `Section`, colour helpers); the
-  package-level `Pad` helper; `ColorMode`/`ParseColorMode`; the `Glyph*`
-  vocabulary; `WarnWriter` (`NewWarnWriter`, `RouteTo`, `Flush`); `Sanitize`.
+
+**Diagnostics vs results.** Output splits in two, and every `ui` API belongs to
+one side:
+
+| | What it is | Stream | Rendering |
+| --- | --- | --- | --- |
+| **Diagnostic** | a notice *about* the run | stderr | `✗ ERROR` / `⚠ WARN` / `ℹ INFO` / `• DEBUG`, message at column 9 |
+| **Result** | what the command was asked to produce | stdout | no level label; a success outcome leads with a curated emoji |
+
+The level label is `<glyph> <WORD padded to 5>` plus a two-column gutter, so
+messages start at the same column for every level and `Detailf` continuation
+lines hang under them. Success lines carry **no** level word — an `INFO` on
+`added agent: claude` is noise that dilutes the labels that matter — and instead
+use `EmojiSuccess ✅` / `EmojiApplied 🎉` / `EmojiRemoved 🧹` / `EmojiImported 📥`
+/ `EmojiReverted 🔙` / `EmojiInit ✨`, chosen by what happened rather than by
+which command ran.
+
+`SlogHandler` renders `log/slog` records through the same vocabulary and is
+installed as the process-wide default by the root command, so a `slog.Warn` from
+`internal/render` or `internal/marketplace` is byte-identical to a command's own
+`p.Warnf`. Record timestamps are dropped: these are user-facing CLI diagnostics,
+not a log stream anyone greps by time.
+- **Key:** `Printer` (`New`, `Color`, `ColorMode`, `Section`, colour helpers);
+  `Level` + `Label`; `Errorf`/`Warnf`/`Infof`/`Diagf`/`Fdiagf`;
+  `Detailf`/`Fdetailf`; `Successf`/`Fsuccessf` + the `Emoji*` vocabulary;
+  `SlogHandler`/`NewSlogHandler`; the package-level `Pad` helper;
+  `ColorMode`/`ParseColorMode`; the `Glyph*` vocabulary; `WarnWriter`
+  (`NewWarnWriter`, `RouteTo`, `Flush`); `Sanitize`.
 - **Depends on:** untrusted.
-- **Files:** `ui.go`, `spinner.go`.
+- **Files:** `ui.go`, `diag.go`, `slog.go`, `spinner.go`.
 
 ### `internal/testenv`
 Guards FS-touching tests so they only run in the hermetic container.
@@ -505,7 +536,8 @@ Guards FS-touching tests so they only run in the hermetic container.
 packages (`iox`, `jsonkeys`, `paths`, and — for the canonical plugin/marketplace
 identity fields typed `untrusted.Text` — `untrusted`). `git` (destination
 rollback history, reached only from `cli`) is likewise a leaf. `drift`, `git`,
-`iox`, `jsonkeys`, `paths`, `log`, and `untrusted` depend on nothing internal —
-they're the foundation; `ui` (presentation) builds only on `untrusted`. See the
+`iox`, `jsonkeys`, `paths`, and `untrusted` depend on nothing internal —
+they're the foundation; `ui` (presentation) builds only on `untrusted`, and
+`log` only on `ui` (it wires `ui.SlogHandler` in as the slog default). See the
 rendered dependency graph in
-[architecture §11](architecture.md#11-package-layering).
+[architecture §12](architecture.md#12-package-layering).

--- a/docs/components.md
+++ b/docs/components.md
@@ -512,7 +512,19 @@ installed as the process-wide default by the root command, so a `slog.Warn` from
 `internal/render` or `internal/marketplace` is byte-identical to a command's own
 `p.Warnf`. Record timestamps are dropped: these are user-facing CLI diagnostics,
 not a log stream anyone greps by time.
-- **Key:** `Printer` (`New`, `Color`, `ColorMode`, `Section`, colour helpers);
+`Handle` locks its writer (a record is a label line plus an optional attribute
+line, which must not interleave) and returns write errors rather than swallowing
+them. The `slog.Warn` / `WarnWriter` / `p.Warnf` triple being byte-identical is
+pinned by `TestWarnPathsAreByteIdentical`.
+
+**Who sanitizes.** `SlogHandler.Handle` and `cli.ReportError` sanitize their own
+input, because neither has a call site that could: a log record and a wrapped
+error chain are both assembled elsewhere. Everywhere else the **caller** applies
+`ui.Sanitize` at the display boundary, as the rest of this codebase does — the
+`Diagf`/`Detailf`/`Successf` family deliberately does not, so a caller can pass
+pre-styled text (the upgrade-notice banner composes `p.Bold`/`p.Yellow` fragments
+into a `Warnf`) without having its own escape codes stripped.
+- **Key:** `Printer` (`New`, `Color`, `ColorErr`, `ColorMode`, `Section`, colour helpers);
   `Level` + `Label`; `Errorf`/`Warnf`/`Infof`/`Diagf`/`Fdiagf`;
   `Detailf`/`Fdetailf`; `Successf`/`Fsuccessf` + the `Emoji*` vocabulary;
   `SlogHandler`/`NewSlogHandler`; the package-level `Pad` helper;

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,7 +43,8 @@ The binary's `main`. Injects `Version`/`Commit`/`Date` via `-ldflags` and calls
 ### `internal/cli`
 Wires every cobra subcommand into the root tree and dispatches to handlers; this
 is the only package that depends on nearly all the others.
-- **Key:** `NewRoot() *cobra.Command`, `Execute() error`, `Version`/`Commit`/`Date`.
+- **Key:** `NewRoot() *cobra.Command`, `Execute() int` (returns the process exit
+  code; owns the terminal `✗ ERROR` line via `ReportErrorTo`), `Version`/`Commit`/`Date`.
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
   `revert`, `status`, `diff`, `reconcile`, `import`, `doctor`, `check`,
   `mcp {add,remove,list,enable,disable}`,
@@ -469,8 +470,10 @@ slog setup. Builds a logger over `ui.SlogHandler` and installs it as the
 process-wide default from the root command's `PersistentPreRunE`, which is what
 routes library-side `slog` calls (`internal/render`, `internal/marketplace`) into
 the CLI's diagnostic vocabulary instead of the stdlib default's timestamped
-lines. **Key:** `New(w, p, verbose) *slog.Logger`; `Install(w, p, verbose) func()`
-(returns a restore, for tests). **Depends on:** ui. **Files:** `log.go`.
+lines. **Key:** `New(w, p, verbose) *slog.Logger`; `Install(w, p, verbose)`;
+`Detach()` (unbinds the process default to a discarding handler — the seam test
+binaries need, since each `Execute()` otherwise leaves `slog.Default()` pointed at
+a finished test's buffer). **Depends on:** ui. **Files:** `log.go`.
 
 ### `internal/untrusted`
 The display trust boundary for fetched/native metadata. Owns `Sanitize` (strip
@@ -524,7 +527,8 @@ error chain are both assembled elsewhere. Everywhere else the **caller** applies
 `Diagf`/`Detailf`/`Successf` family deliberately does not, so a caller can pass
 pre-styled text (the upgrade-notice banner composes `p.Bold`/`p.Yellow` fragments
 into a `Warnf`) without having its own escape codes stripped.
-- **Key:** `Printer` (`New`, `Color`, `ColorErr`, `ColorMode`, `Section`, colour helpers);
+- **Key:** `Printer` (`New`, `Color`, `Section`, colour helpers; color is resolved
+  per stream, and the diagnostic writers style for the stream they target);
   `Level` + `Label`; `Errorf`/`Warnf`/`Infof`/`Diagf`/`Fdiagf`;
   `Detailf`/`Fdetailf`; `Successf`/`Fsuccessf` + the `Emoji*` vocabulary;
   `SlogHandler`/`NewSlogHandler`; the package-level `Pad` helper;

--- a/docs/components.md
+++ b/docs/components.md
@@ -520,9 +520,9 @@ line, which must not interleave) and returns write errors rather than swallowing
 them. The `slog.Warn` / `WarnWriter` / `p.Warnf` triple being byte-identical is
 pinned by `TestWarnPathsAreByteIdentical`.
 
-**Who sanitizes.** `SlogHandler.Handle` and `cli.Execute`'s terminal error line
-sanitize their own input, because neither has a call site that could: a log record
-and a wrapped error chain are both assembled elsewhere. Everywhere else the
+**Who sanitizes.** `SlogHandler.Handle` and `reportErrorTo`'s terminal error line
+(via `sanitizeLines`) sanitize their own input, because neither has a call site that
+could: a log record and a wrapped error chain are both assembled elsewhere. Everywhere else the
 **caller** applies `ui.Sanitize` at the display boundary, as the rest of this
 codebase does — the `Diagf`/`Detailf`/`Successf` family deliberately does not, so a
 caller can pass pre-styled text (the upgrade-notice banner composes
@@ -537,13 +537,16 @@ sanitizes the message **body** only; the passthrough branch stays verbatim becau
 that branch carries agentsync's own already-styled lines, whose ANSI sanitizing
 would strip.
 
-This was briefly documented the other way round — as a *requirement* that every
-emitter interpolate untrusted values with `%q`. That was the wrong disposition, and
-demonstrably so: the convention was **already violated when it was written down**
-(`internal/adapter/continuedev/ingest.go` quoted a native-config MCP id with `%q`
-twice and `%s` once on the same line). A rule that every future emitter must
-remember is not a control; the backstop is. `%q` at the emitters is still good
-practice for legibility, but it is no longer load-bearing.
+That backstop does not replace `%q` at the emitters, and its bound is worth stating
+exactly, because the asymmetry above is easy to over-read. `WarnWriter.Write` splits
+on `\n` *before* `emit` runs, so a sanitized body never contains an interior
+newline. An emitter that interpolates a raw newline into a `warning: ` line puts
+lines 2..n through the **passthrough** branch — unlabeled and unsanitized — so for
+the newline case `%q` (which escapes it) is still the control. Nearly every emitter
+already uses `%q` for the untrusted identifier; the residual is the handful of
+`%v`-of-error sites, where a multi-line wrapped error could carry native-config text
+into the passthrough branch. Pre-existing; not introduced by the diagnostic
+vocabulary, and not closed by it.
 
 Note that `%s` on an `untrusted.Text` value — which is how plugin and marketplace
 identity fields are typed — was never a hole: `Text.String()` sanitizes by

--- a/docs/components.md
+++ b/docs/components.md
@@ -44,7 +44,7 @@ The binary's `main`. Injects `Version`/`Commit`/`Date` via `-ldflags` and calls
 Wires every cobra subcommand into the root tree and dispatches to handlers; this
 is the only package that depends on nearly all the others.
 - **Key:** `NewRoot() *cobra.Command`, `Execute() int` (returns the process exit
-  code; owns the terminal `✗ ERROR` line via `ReportErrorTo`), `Version`/`Commit`/`Date`.
+  code and owns the terminal `✗ ERROR` line), `Version`/`Commit`/`Date`.
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
   `revert`, `status`, `diff`, `reconcile`, `import`, `doctor`, `check`,
   `mcp {add,remove,list,enable,disable}`,
@@ -529,15 +529,25 @@ caller can pass pre-styled text (the upgrade-notice banner composes
 `p.Bold`/`p.Yellow` fragments into a `Warnf`) without having its own escape codes
 stripped.
 
-`WarnWriter` sits between those two cases and is worth naming explicitly, because
-it looks like the first and behaves like the second: its input comes from the
-adapter and capture packages, which *cannot* call `ui.Sanitize` (they must not
-import `ui` — that constraint is the reason the `warning: ` sentinel exists). It
-does not sanitize. What holds today is that every adapter emitter interpolates
-untrusted values with `%q`, which escapes control bytes — a real mitigation, but an
-incidental one. A new emitter that used `%s` for a config-derived value would open
-a hole, so **an emitter writing into a `WarnWriter` must use `%q` for anything
-config-derived.**
+`WarnWriter` is the third self-sanitizing site, for the same reason as the other
+two: its input comes from the adapter and capture packages, which *cannot* call
+`ui.Sanitize` (they must not import `ui` — that constraint is the reason the
+`warning: ` sentinel exists), so if `ui` does not sanitize, nothing does. It
+sanitizes the message **body** only; the passthrough branch stays verbatim because
+that branch carries agentsync's own already-styled lines, whose ANSI sanitizing
+would strip.
+
+This was briefly documented the other way round — as a *requirement* that every
+emitter interpolate untrusted values with `%q`. That was the wrong disposition, and
+demonstrably so: the convention was **already violated when it was written down**
+(`internal/adapter/continuedev/ingest.go` quoted a native-config MCP id with `%q`
+twice and `%s` once on the same line). A rule that every future emitter must
+remember is not a control; the backstop is. `%q` at the emitters is still good
+practice for legibility, but it is no longer load-bearing.
+
+Note that `%s` on an `untrusted.Text` value — which is how plugin and marketplace
+identity fields are typed — was never a hole: `Text.String()` sanitizes by
+construction. The gap was only ever plain `string` values read out of native config.
 - **Key:** `Printer` (`New`, `Color`, `Section`, colour helpers; color is resolved
   per stream, and the diagnostic writers style for the stream they target);
   `Level` + `Label`; `Errorf`/`Warnf`/`Infof`/`Diagf`/`Fdiagf`;

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -870,7 +870,14 @@ reason** rather than accepting and ignoring them.
 expands each collapsed skill directory back to one row per bundled file).
 `--color=auto|always|never` controls whether output is styled with ANSI color
 and bold (default `auto` — on for a TTY, off when piped/redirected; honors
-`NO_COLOR`). `--agents <list>` is the **one** way to say which agents a command
+`NO_COLOR`). Color is a *second* signal, never the only one: every diagnostic
+also carries a level label — `✗ ERROR`, `⚠ WARN`, `ℹ INFO`, `• DEBUG` — on
+**stderr**, so severity survives being piped into a file or a CI log. Command
+*results* (a `--json` payload, a `status` table, a `diff`, a `list`) go to
+stdout with no label, and a success outcome leads with an emoji instead —
+`🎉 applied: 12 ops`, `✅ added agent: claude`, `🧹 removed mcp server: github`,
+`📥 imported 4 skills…`, `🔙 reverted…`, `✨ …initialized`. That split is why a
+warning never lands in the middle of `status --json`. `--agents <list>` is the **one** way to say which agents a command
 acts on: `apply`, `status`, `diff`, `reconcile`, and `revert` all take it, with
 identical parsing and the same `*` = all-enabled convention (an empty or unknown
 value is rejected identically by all five). On `revert` it is a spelling of the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -871,12 +871,13 @@ expands each collapsed skill directory back to one row per bundled file).
 `--color=auto|always|never` controls whether output is styled with ANSI color
 and bold (default `auto` — on for a TTY, off when piped/redirected; honors
 `NO_COLOR`). Color is a *second* signal, never the only one: every diagnostic
-also carries a level label — `✗ ERROR`, `⚠ WARN`, `ℹ INFO`, `• DEBUG` — on
+also carries a level label — `✗ ERROR`, `⚠ WARN`, `ℹ INFO` (and a reserved
+`• DEBUG`, which nothing emits today) — on
 **stderr**, so severity survives being piped into a file or a CI log. Command
 *results* (a `--json` payload, a `status` table, a `diff`, a `list`) go to
 stdout with no label, and a success outcome leads with an emoji instead —
 `🎉 applied: 12 ops`, `✅ added agent: claude`, `🧹 removed mcp server: github`,
-`📥 imported 4 skills…`, `🔙 reverted…`, `✨ …initialized`. That split is why a
+`📥 imported 4 items from claude`, `🔙 reverted…`, `✨ …initialized`. That split is why a
 warning never lands in the middle of `status --json`. `--agents <list>` is the **one** way to say which agents a command
 acts on: `apply`, `status`, `diff`, `reconcile`, and `revert` all take it, with
 identical parsing and the same `*` = all-enabled convention (an empty or unknown

--- a/internal/adapter/continuedev/ingest.go
+++ b/internal/adapter/continuedev/ingest.go
@@ -72,7 +72,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 				// original (now-foreign) block, and Continue would load both.
 				// Capture it, but tell the user about the duplicate hazard.
 				if id != fallbackID || len(servers) > 1 {
-					fmt.Fprintf(warn, "warning: MCP server %q in block %q: apply renders one %s.yaml per server; remove the original block after import to avoid duplicate definitions\n", id, e.Name(), id)
+					fmt.Fprintf(warn, "warning: MCP server %q in block %q: apply renders one %q.yaml per server; remove the original block after import to avoid duplicate definitions\n", id, e.Name(), id)
 				}
 				spec := IngestMCPSpec(srv)
 				applyBlockHeader(&spec, blockVersion, blockSchema)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -438,7 +438,13 @@ func agentRemoveRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if _, ok := agents[name]; !ok {
-		diag(cmd, ui.LevelInfo, "agent %s not registered", name)
+		// A RESULT, not a diagnostic — and on the same stream as `add`'s
+		// already-registered line, which is its exact mirror. Both are the
+		// idempotent no-op case: the desired state already holds, the command
+		// succeeded, and nothing about the run needs flagging. Splitting the two
+		// across stdout and stderr (as this briefly did) means a script that reads
+		// one has to read the other from somewhere else.
+		success(cmd, ui.EmojiSuccess, "agent %s not registered; nothing to remove", name)
 		return nil
 	}
 	delete(agents, name)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -395,7 +395,7 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if _, ok := agents[name]; ok {
-		fmt.Fprintf(cmd.OutOrStdout(), "agent %s already registered\n", name)
+		success(cmd, ui.EmojiSuccess, "agent %s already registered", name)
 		return nil
 	}
 	entry := map[string]any{"enabled": true}
@@ -408,7 +408,7 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 	if err := writeAgents(p, raw, agents); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "added agent: %s\n", name)
+	success(cmd, ui.EmojiSuccess, "added agent: %s", name)
 
 	// Warn (don't fail) if the agent's binary is not on PATH. The user
 	// may be authoring config on machine A to apply on machine B, so we
@@ -417,10 +417,10 @@ func agentAddRun(cmd *cobra.Command, args []string) error {
 	// anything?" later.
 	if bin := agentBinary(name); bin != "" {
 		if _, err := exec.LookPath(bin); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"warning: %s binary not found on PATH; "+
+			diag(cmd, ui.LevelWarn,
+				"%s binary not found on PATH; "+
 					"agentsync will still write config to its destination dirs "+
-					"but %s itself must be installed to read it\n",
+					"but %s itself must be installed to read it",
 				bin, name)
 		}
 	}
@@ -438,14 +438,14 @@ func agentRemoveRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if _, ok := agents[name]; !ok {
-		fmt.Fprintf(cmd.OutOrStdout(), "agent %s not registered\n", name)
+		diag(cmd, ui.LevelInfo, "agent %s not registered", name)
 		return nil
 	}
 	delete(agents, name)
 	if err := writeAgents(p, raw, agents); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "removed agent: %s\n", name)
+	success(cmd, ui.EmojiRemoved, "removed agent: %s", name)
 	return nil
 }
 
@@ -550,7 +550,7 @@ func agentEnableRun(cmd *cobra.Command, args []string) error {
 	if err := writeAgents(p, raw, agents); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "enabled agent: %s\n", name)
+	success(cmd, ui.EmojiSuccess, "enabled agent: %s", name)
 	return nil
 }
 
@@ -587,7 +587,7 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	if err := writeAgents(p, raw, agents); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "disabled agent: %s\n", name)
+	success(cmd, ui.EmojiSuccess, "disabled agent: %s", name)
 
 	if !purge {
 		return nil
@@ -779,7 +779,7 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 		return fmt.Errorf("save state: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "purged agent %s: deleted %d file(s), pruned owned keys from %d shared file(s)\n", name, deletedFiles, prunedFiles)
+	success(cmd, ui.EmojiRemoved, "purged agent %s: deleted %d file(s), pruned owned keys from %d shared file(s)", name, deletedFiles, prunedFiles)
 	if sharedKept > 0 {
 		fmt.Fprintf(cmd.OutOrStdout(), "  kept %d shared path(s) still owned by another agent\n", sharedKept)
 	}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -302,6 +302,9 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 	//   - a genuine clean re-apply (every dest already held our exact bytes,
 	//     nothing removed) → "up to date" (unchanged detection preserved).
 	//   - normal writes → "applied: N ops".
+	//   - a zero-op plan (no agent renders anything yet) → a plain ✅, not 🎉:
+	//     celebrating an apply that did nothing reads as a tool that does not
+	//     know what it did.
 	switch {
 	case removed > 0 && appliedOps == 0:
 		p.Fsuccessf(w, ui.EmojiRemoved, "removed: %s", removedLabel(removedKeys, removedFiles))

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -80,9 +80,9 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 	// Announce the effective scope so a project-scoped apply is never silent
 	// about writing to a repo tree instead of the user's machine-wide config.
 	if sc == adapter.ScopeProject {
-		fmt.Fprintf(p.Err, "%s project (%s)\n", p.Faint("scope:"), projectRoot)
+		p.Infof("scope: project (%s)", projectRoot)
 	} else {
-		fmt.Fprintf(p.Err, "%s user\n", p.Faint("scope:"))
+		p.Infof("scope: user")
 	}
 
 	// Resolve ${secret:...} and ${env:...} references before rendering. The
@@ -121,13 +121,11 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 		// project tree's [agents] table resolving to nothing enabled, so
 		// point there instead of at `agent add`.
 		if sc == adapter.ScopeProject {
-			fmt.Fprintf(p.Err,
-				"%s no agents are enabled at project scope (%s); nothing to apply.\n"+
-					"  Check the [agents] table in %s.\n", p.Yellow("agentsync:"), projectRoot, project.Home(projectRoot))
+			p.Warnf("no agents are enabled at project scope (%s); nothing to apply.", projectRoot)
+			p.Detailf("Check the [agents] table in %s.", project.Home(projectRoot))
 		} else {
-			fmt.Fprintf(p.Err,
-				"%s no agents are enabled in agentsync.toml; nothing to apply.\n"+
-					"  Run `agentsync agent add claude` (or opencode) to register an agent.\n", p.Yellow("agentsync:"))
+			p.Warnf("no agents are enabled in agentsync.toml; nothing to apply.")
+			p.Detailf("Run `agentsync agent add claude` (or opencode) to register an agent.")
 		}
 		return nil
 	}
@@ -235,10 +233,9 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 
 	collisions, written, unchanged, applyErr := render.Apply(plan, reg, s, home, userHome, sc, projectRoot)
 	if len(collisions) > 0 {
-		fmt.Fprintf(p.Err, "%s backed up %d pre-existing target(s) before overwriting:\n",
-			p.Yellow("agentsync:"), len(collisions))
+		p.Warnf("backed up %d pre-existing target(s) before overwriting:", len(collisions))
 		for _, r := range collisions {
-			fmt.Fprintf(p.Err, "  %s\n", r.String())
+			p.Detailf("%s", r.String())
 		}
 	}
 
@@ -294,7 +291,7 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 	// is the SAME session that took the pre-apply baseline above, so a fresh dir it
 	// inited is committed into here without a second prompt.
 	if err := gb.checkpoint(written); err != nil {
-		fmt.Fprintf(p.Err, "%s destination git backup: %v\n", p.Yellow("agentsync:"), err)
+		p.Warnf("destination git backup: %v", err)
 	}
 
 	w := p.Out
@@ -307,13 +304,19 @@ func applyRun(cmd *cobra.Command, home string, dryRun, noGitBackup bool, agentsC
 	//   - normal writes → "applied: N ops".
 	switch {
 	case removed > 0 && appliedOps == 0:
-		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green("removed: "+removedLabel(removedKeys, removedFiles)))
+		p.Fsuccessf(w, ui.EmojiRemoved, "removed: %s", removedLabel(removedKeys, removedFiles))
 	case removed > 0:
-		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("applied: %d ops, removed: %s", appliedOps, removedLabel(removedKeys, removedFiles))))
+		p.Fsuccessf(w, ui.EmojiApplied, "applied: %d ops, removed: %s", appliedOps, removedLabel(removedKeys, removedFiles))
 	case len(written) > 0 && len(unchanged) == len(written):
-		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("up to date: %d ops, no changes", plan.Total())))
+		// Nothing changed, so this is not a celebration — a plain ✅ says
+		// "checked, all good" without implying work was done.
+		p.Fsuccessf(w, ui.EmojiSuccess, "up to date: %d ops, no changes", plan.Total())
+	case plan.Total() == 0:
+		// Nothing to do at all (no agents render anything yet). Celebrating a
+		// zero-op apply reads as a tool that doesn't know what it did.
+		p.Fsuccessf(w, ui.EmojiSuccess, "applied: 0 ops")
 	default:
-		fmt.Fprintf(w, "%s %s\n", p.Green(ui.GlyphOK), p.Green(fmt.Sprintf("applied: %d ops", plan.Total())))
+		p.Fsuccessf(w, ui.EmojiApplied, "applied: %d ops", plan.Total())
 	}
 	report := render.BuildReport(reportCanonical(c, sc), plan, agents)
 	if len(report.Rows) > 0 {
@@ -749,10 +752,11 @@ func promptScopeChoice(cmd *cobra.Command, projectRoot, userHome string) (adapte
 	// prompt to stdout would corrupt the machine-readable output a caller is
 	// piping. stdin is still read from InOrStdin so the keystroke reaches us.
 	w := cmd.ErrOrStderr()
+	p := printerOn(cmd, w)
 	r := bufio.NewReader(cmd.InOrStdin())
-	fmt.Fprintf(w, "ℹ this repo has a .agentsync/ project tree.\n")
-	fmt.Fprintf(w, "  [1] project scope (%s)\n", projectRoot)
-	fmt.Fprintf(w, "  [2] user scope (%s)\n", userHome)
+	p.Fdiagf(w, ui.LevelInfo, "this repo has a .agentsync/ project tree.")
+	p.Fdetailf(w, "[1] project scope (%s)", projectRoot)
+	p.Fdetailf(w, "[2] user scope (%s)", userHome)
 	for attempts := 0; attempts < 5; attempts++ {
 		fmt.Fprintf(w, "run `agentsync %s` at which scope? [1/2]: ", cmd.Name())
 		line, err := r.ReadString('\n')
@@ -766,7 +770,7 @@ func promptScopeChoice(cmd *cobra.Command, projectRoot, userHome string) (adapte
 			// EOF / closed stdin with no valid choice — don't loop forever.
 			return adapter.ScopeUser, "", fmt.Errorf("no scope selected (input closed); pass --scope user|project")
 		}
-		fmt.Fprintf(w, "  please enter 1 (project) or 2 (user).\n")
+		p.Fdetailf(w, "please enter 1 (project) or 2 (user).")
 	}
 	return adapter.ScopeUser, "", fmt.Errorf("no valid scope selected after 5 attempts; pass --scope user|project")
 }

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
 	"github.com/spxrogers/agentsync/internal/untrusted"
 )
 
@@ -134,9 +135,9 @@ wrong, and check when something is written wrong.`,
 				}
 			}
 			if offline {
-				fmt.Fprintln(cmd.OutOrStdout(), "ok: schema valid; reference shapes valid (offline — resolvability not checked)")
+				success(cmd, ui.EmojiSuccess, "schema valid; reference shapes valid (offline — resolvability not checked)")
 			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), "ok: schema valid; all references resolve")
+				success(cmd, ui.EmojiSuccess, "schema valid; all references resolve")
 			}
 			return nil
 		},

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // TestCheck_UninitializedHomeErrors is the regression for check printing a
@@ -54,8 +56,8 @@ func TestCheck_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check on empty home: %v", err)
 	}
-	if !strings.Contains(out, "ok") {
-		t.Fatalf("check output missing 'ok': %s", out)
+	if !strings.Contains(out, ui.EmojiSuccess) || !strings.Contains(out, "schema valid") {
+		t.Fatalf("check output missing the success line: %s", out)
 	}
 }
 
@@ -180,8 +182,8 @@ func TestCheck_ProjectScope_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("check --project: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "ok") {
-		t.Fatalf("check --project output missing 'ok': %s", out)
+	if !strings.Contains(out, ui.EmojiSuccess) || !strings.Contains(out, "schema valid") {
+		t.Fatalf("check --project output missing the success line: %s", out)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -107,11 +107,15 @@ func newDoctorCmd() *cobra.Command {
 
 			fmt.Fprintln(p.Out, "")
 			if fails > 0 {
+				// The summary is part of doctor's REPORT (stdout, where the
+				// per-check lines went), so it keeps the report's ✗ rather than
+				// becoming a stderr ERROR diagnostic. The returned error is what
+				// reaches the terminal ERROR line, one level up.
 				fmt.Fprintf(p.Out, "%s %s\n", p.Red(ui.GlyphErr),
 					p.Red(fmt.Sprintf("%d issue(s) detected — fix before running `agentsync apply`", fails)))
 				return fmt.Errorf("doctor: %d issue(s) detected", fails)
 			}
-			fmt.Fprintf(p.Out, "%s %s\n", p.Green(ui.GlyphOK), p.Green("all checks passed"))
+			p.Successf(ui.EmojiSuccess, "all checks passed")
 			return nil
 		},
 	}

--- a/internal/cli/gitbackup.go
+++ b/internal/cli/gitbackup.go
@@ -49,10 +49,11 @@ type gitBackupSession struct {
 }
 
 // gitPermWarn returns the callback EnsureDirSecure reports through — a loosened
-// .git-history warning to stderr with the existing agentsync yellow prefix.
+// .git-history permission warning, emitted as a WARN diagnostic on stderr like
+// every other warning in the CLI.
 func (s *gitBackupSession) gitPermWarn() func(string) {
 	return func(msg string) {
-		fmt.Fprintf(s.p.Err, "%s %s\n", s.p.Yellow("agentsync:"), msg)
+		s.p.Warnf("%s", msg)
 	}
 }
 
@@ -96,8 +97,7 @@ func (s *gitBackupSession) resolveBackupRepo(root string, st agit.State, hasWrit
 		// The user already source-controls this dir — stay out of their way.
 		if hasWrites && !s.handled[root] {
 			s.handled[root] = true
-			fmt.Fprintf(s.p.Err, "%s %s is under your own source control; skipping agentsync git backup.\n",
-				s.p.Faint(ui.GlyphInfo), root)
+			s.p.Infof("%s is under your own source control; skipping agentsync git backup.", root)
 		}
 		return nil, nil
 	case agit.StateAgentsyncOwned:
@@ -155,7 +155,7 @@ func (s *gitBackupSession) baseline(planned map[string]bool) {
 		}
 		st, err := agit.Detect(root)
 		if err != nil {
-			fmt.Fprintf(s.p.Err, "%s git baseline: %v\n", s.p.Yellow("agentsync:"), err)
+			s.p.Warnf("git baseline: %v", err)
 			continue
 		}
 		repo, err := s.resolveBackupRepo(root, st, true)
@@ -218,8 +218,7 @@ func (s *gitBackupSession) baseline(planned map[string]bool) {
 			continue
 		}
 		if h != "" {
-			fmt.Fprintf(s.p.Err, "%s %s\n", s.p.Faint(ui.GlyphInfo),
-				s.p.Faint(fmt.Sprintf("git backup: pre-apply baseline of %s", root)))
+			s.p.Infof("git backup: pre-apply baseline of %s", root)
 			s.cautionCleartextOnce()
 		}
 	}
@@ -239,8 +238,7 @@ func (s *gitBackupSession) cautionCleartextOnce() {
 		return
 	}
 	s.warnedCleartext = true
-	fmt.Fprintf(s.p.Err, "%s that baseline is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.\n",
-		s.p.Faint(ui.GlyphInfo))
+	s.p.Infof("that baseline is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.")
 }
 
 // warnFirstApplyUnrevertible tells the user, loudly, that a pre-apply baseline could
@@ -248,12 +246,10 @@ func (s *gitBackupSession) cautionCleartextOnce() {
 // documented failure policy of the baseline pass (it warns but never aborts apply).
 func (s *gitBackupSession) warnFirstApplyUnrevertible(root string, err error) {
 	if err != nil {
-		fmt.Fprintf(s.p.Err, "%s could not take a pre-apply baseline of %s (%v); the first apply to it will not be revertible.\n",
-			s.p.Yellow("agentsync:"), root, err)
+		s.p.Warnf("could not take a pre-apply baseline of %s (%v); the first apply to it will not be revertible.", root, err)
 		return
 	}
-	fmt.Fprintf(s.p.Err, "%s could not take a pre-apply baseline of %s; the first apply to it will not be revertible.\n",
-		s.p.Yellow("agentsync:"), root)
+	s.p.Warnf("could not take a pre-apply baseline of %s; the first apply to it will not be revertible.", root)
 }
 
 // checkpoint records the POST-APPLY checkpoint for each version root that received
@@ -276,12 +272,12 @@ func (s *gitBackupSession) checkpoint(written map[string]bool) error {
 
 		st, err := agit.Detect(root)
 		if err != nil {
-			fmt.Fprintf(s.p.Err, "%s git backup: %v\n", s.p.Yellow("agentsync:"), err)
+			s.p.Warnf("git backup: %v", err)
 			continue
 		}
 		repo, err := s.resolveBackupRepo(root, st, len(rels) > 0)
 		if err != nil {
-			fmt.Fprintf(s.p.Err, "%s git backup for %s: %v\n", s.p.Yellow("agentsync:"), root, err)
+			s.p.Warnf("git backup for %s: %v", root, err)
 			continue
 		}
 		if repo == nil {
@@ -314,7 +310,7 @@ func (s *gitBackupSession) checkpoint(written map[string]bool) error {
 		// anyway (CommitStaged returns "" on a clean index), so nothing is lost.
 		deleted, err := repo.StageTrackedDeletions()
 		if err != nil {
-			fmt.Fprintf(s.p.Err, "%s git backup for %s: %v\n", s.p.Yellow("agentsync:"), root, err)
+			s.p.Warnf("git backup for %s: %v", root, err)
 			continue
 		}
 		if len(rels) == 0 && len(deleted) == 0 {
@@ -327,19 +323,18 @@ func (s *gitBackupSession) checkpoint(written map[string]bool) error {
 		toStage = append(toStage, rels...)
 		toStage = append(toStage, agit.NoticeFile)
 		if err := repo.Stage(toStage); err != nil {
-			fmt.Fprintf(s.p.Err, "%s git backup for %s: %v\n", s.p.Yellow("agentsync:"), root, err)
+			s.p.Warnf("git backup for %s: %v", root, err)
 			continue
 		}
 		staged := dedupeSorted(append(toStage, deleted...))
 		msg := checkpointMessage(root, staged)
 		h, err := repo.CommitStaged(msg, s.id)
 		if err != nil {
-			fmt.Fprintf(s.p.Err, "%s git backup for %s: %v\n", s.p.Yellow("agentsync:"), root, err)
+			s.p.Warnf("git backup for %s: %v", root, err)
 			continue
 		}
 		if h != "" {
-			fmt.Fprintf(s.p.Err, "%s %s\n", s.p.Faint(ui.GlyphInfo),
-				s.p.Faint(fmt.Sprintf("git backup: checkpointed %s", root)))
+			s.p.Infof("git backup: checkpointed %s", root)
 		}
 	}
 	return nil
@@ -526,11 +521,10 @@ func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mo
 			// cleartext caution clause, gated by warnedCleartext (shared with the
 			// baseline-snapshot caution) so the warning doesn't repeat per dir.
 			if *warnedCleartext {
-				fmt.Fprintf(p.Err, "%s started a %s git backup of %s.\n",
-					p.Faint(ui.GlyphInfo), p.Bold("local-only"), dir)
+				p.Infof("started a %s git backup of %s.", p.Bold("local-only"), dir)
 			} else {
-				fmt.Fprintf(p.Err, "%s started a %s git backup of %s; like the files it versions, its history may contain secrets in cleartext (it is never pushed).\n",
-					p.Faint(ui.GlyphInfo), p.Bold("local-only"), dir)
+				p.Infof("started a %s git backup of %s; like the files it versions, its history may contain secrets in cleartext (it is never pushed).",
+					p.Bold("local-only"), dir)
 				*warnedCleartext = true
 			}
 		}
@@ -549,25 +543,24 @@ func ensureUntrackedRepo(cmd *cobra.Command, p *ui.Printer, dir, home string, mo
 				// warned why), yet the user said "yes" — surface that the global
 				// switch is flipping on regardless, so the persisted mode=on below
 				// is not a silent change.
-				fmt.Fprintf(p.Err, "%s this directory was skipped, but auto-backup is now enabled for future directories and applies.\n",
-					p.Faint(ui.GlyphInfo))
+				p.Infof("this directory was skipped, but auto-backup is now enabled for future directories and applies.")
 			}
 			if perr := setDestinationGitBackupMode(home, source.GitBackupModeOn); perr != nil {
-				fmt.Fprintf(p.Err, "%s could not persist git-backup mode: %v\n", p.Yellow("agentsync:"), perr)
+				p.Warnf("could not persist git-backup mode: %v", perr)
 			}
 			*mode = source.GitBackupModeOn
 			return repo, nil
 		case promptNever:
 			if perr := setDestinationGitBackupMode(home, source.GitBackupModeOff); perr != nil {
-				fmt.Fprintf(p.Err, "%s could not persist git-backup mode: %v\n", p.Yellow("agentsync:"), perr)
+				p.Warnf("could not persist git-backup mode: %v", perr)
 			}
 			*mode = source.GitBackupModeOff
-			fmt.Fprintf(p.Err, "%s destination git backup disabled; re-enable later by setting mode in agentsync.toml.\n", p.Faint(ui.GlyphInfo))
+			p.Infof("destination git backup disabled; re-enable later by setting mode in agentsync.toml.")
 			return nil, nil
 		case promptUnavailable:
 			if !*hintedUnavailable {
-				fmt.Fprintf(p.Err, "%s destination git backup is available — run `agentsync apply` interactively to enable it, "+
-					"or set [destination_directory_git_backup] mode = \"on\" in agentsync.toml.\n", p.Faint(ui.GlyphInfo))
+				p.Infof("destination git backup is available — run `agentsync apply` interactively to enable it, " +
+					"or set [destination_directory_git_backup] mode = \"on\" in agentsync.toml.")
 				*hintedUnavailable = true
 			}
 			return nil, nil
@@ -598,9 +591,8 @@ func initGuarded(p *ui.Printer, dir string) (*agit.Repo, error) {
 		return nil, err
 	}
 	if nested {
-		fmt.Fprintf(p.Err, "%s %s contains a nested git repository; skipping agentsync git backup here "+
-			"to avoid a repo inside a repo (remove the inner .git or reconcile to merge).\n",
-			p.Yellow("agentsync:"), dir)
+		p.Warnf("%s contains a nested git repository; skipping agentsync git backup here "+
+			"to avoid a repo inside a repo (remove the inner .git or reconcile to merge).", dir)
 		return nil, nil
 	}
 	return agit.Init(dir)
@@ -618,10 +610,9 @@ func warnNestedForeignRepoOnCommit(p *ui.Printer, root string) {
 	if err != nil || !nested {
 		return
 	}
-	fmt.Fprintf(p.Err, "%s a nested git repository now lives below the agentsync-owned dir %s; "+
+	p.Warnf("a nested git repository now lives below the agentsync-owned dir %s; "+
 		"`agentsync revert` of this root will refuse as a precaution until the inner repo is "+
-		"removed or reconciled.\n",
-		p.Yellow("agentsync:"), root)
+		"removed or reconciled.", root)
 }
 
 // managedRelsUnder returns the slash-relative paths of every written file that

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -227,10 +227,10 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		return perr
 	}
 	// Wrap stderr once so every "warning: …" line — ours, the adapter's
-	// Ingest, capture's re-reference, etc. — picks up the same bold-yellow
-	// "⚠️ warning:" styling. Lines that don't start with "warning: " pass
-	// through unchanged, so indented continuations and "agentsync:" notes
-	// look the same as before.
+	// Ingest, capture's re-reference, etc. — picks up the same "⚠ WARN" label.
+	// Lines that don't start with "warning: " pass through unchanged, which is
+	// what lets already-labeled diagnostics (INFO notes, aligned continuation
+	// lines) reach the terminal untouched.
 	warnW := ui.NewWarnWriter(p.Err, p)
 	io := &importIO{p: p, out: p.Out, err: warnW, dryRun: dryRun}
 
@@ -242,7 +242,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	srcHome := agentsyncHome
 	if sc == adapter.ScopeProject {
 		srcHome = project.Home(projectRoot)
-		fmt.Fprintf(p.Err, "%s project (%s)\n", p.Faint("scope:"), projectRoot)
+		p.Infof("scope: project (%s)", projectRoot)
 	}
 	reg := registryFactory()
 	a := reg.Lookup(agentName)
@@ -376,9 +376,9 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 		for _, w := range warnings {
 			// w is <op.Path>#<pointer> harvested from the native config; the
 			// pointer can hold control bytes, so sanitize on display (#93/#171).
-			fmt.Fprintf(io.err, "  %s\n", ui.Sanitize(w))
+			io.detailf("%s", ui.Sanitize(w))
 		}
-		fmt.Fprintln(io.err, "  agentsync will leave them alone on apply (it only writes keys it owns). Import an item by name if you want agentsync to manage it.")
+		io.detailf("agentsync will leave them alone on apply (it only writes keys it owns). Import an item by name if you want agentsync to manage it.")
 	}
 	// Surface a partial-import error after seeding so the command still exits
 	// non-zero, but the components that were written are now owned.
@@ -905,21 +905,18 @@ func (i *importIO) flushSection() {
 	i.sectionShown = true
 }
 
-// warn emits a "warning: …" line. Styling (bold-yellow "⚠️ warning:") is
-// applied by the ui.WarnWriter wrapping i.err — emitting the plain prefix
-// here means adapter Ingest, capture, and importIO all share one styling
-// point, and no caller has to know about it. msg should not include a
-// trailing newline; warn appends one.
+// warn emits a "warning: …" line. The WARN label is applied by the
+// ui.WarnWriter wrapping i.err — emitting the plain sentinel here means adapter
+// Ingest, capture, and importIO all share one styling point, and no caller has
+// to know about it. msg should not include a trailing newline; warn appends one.
 func (i *importIO) warn(msg string) {
 	fmt.Fprintf(i.err, "warning: %s\n", msg)
 }
 
-// note prints a cyan "note:" prefix followed by msg, for informational lines
-// that aren't problems — matches the styling status.go uses for the same
-// "this is FYI, not a warning" tier. msg should not include a trailing
-// newline; note appends one.
+// note emits an INFO diagnostic — the "this is FYI, not a problem" tier. msg
+// should not include a trailing newline; note appends one.
 func (i *importIO) note(msg string) {
-	fmt.Fprintf(i.err, "%s %s\n", i.p.Cyan("note:"), msg)
+	i.p.Fdiagf(i.err, ui.LevelInfo, "%s", msg)
 }
 
 // warnf is warn + fmt.Sprintf for the common "%v / %q" formatting.
@@ -927,18 +924,25 @@ func (i *importIO) warnf(format string, args ...any) {
 	i.warn(fmt.Sprintf(format, args...))
 }
 
-// note prints a yellow "agentsync:" prefix (matching apply.go) for diagnostics
-// that aren't warnings about user data but about how agentsync is proceeding.
-func (i *importIO) notef(format string, args ...any) {
-	fmt.Fprintf(i.err, "%s ", i.p.Yellow("agentsync:"))
-	fmt.Fprintf(i.err, format, args...)
-	if !strings.HasSuffix(format, "\n") {
-		fmt.Fprintln(i.err)
-	}
+// detailf emits a continuation line under the diagnostic above it, aligned to
+// the message column — the enumerated items under a note, say.
+func (i *importIO) detailf(format string, args ...any) {
+	i.p.Fdetailf(i.err, format, args...)
 }
 
-// info prints a faint informational line on stdout — for "nothing to do"
-// outcomes the user still wants confirmed, like "no importable items found".
+// notef emits an INFO diagnostic about how agentsync is proceeding, as opposed
+// to warn's "something about your data needs attention".
+//
+// Both tiers exist deliberately: an import that silently changes course (seeding
+// state, retiring a stale hook) is worth saying out loud, but saying it at WARN
+// would train the user to ignore the label that actually means "look at this".
+func (i *importIO) notef(format string, args ...any) {
+	i.p.Fdiagf(i.err, ui.LevelInfo, format, args...)
+}
+
+// infof prints an informational RESULT line on stdout — a "nothing to do"
+// outcome the user still wants confirmed, like "no importable items found".
+// Unlabeled by design: it is the command's answer, not a diagnostic about it.
 func (i *importIO) infof(format string, args ...any) {
 	fmt.Fprintf(i.out, "%s ", i.p.Faint(ui.GlyphInfo))
 	fmt.Fprintf(i.out, format, args...)
@@ -1086,13 +1090,15 @@ func importAllComponents(io *importIO, home string, a adapter.Adapter, agentName
 		noun = "item"
 	}
 	verb := importVerb(io.dryRun)
-	glyph := io.p.Green(ui.GlyphOK)
-	if io.dryRun {
-		glyph = io.p.Cyan(ui.GlyphArrow)
-	}
 	fmt.Fprintln(io.out, "")
-	fmt.Fprintf(io.out, "%s %s\n", glyph,
-		io.p.Bold(fmt.Sprintf("%s %d %s from %s", verb, total, noun, agentName)))
+	if io.dryRun {
+		// A dry run imported nothing — the emoji vocabulary is for outcomes
+		// that actually happened, so a preview keeps the neutral arrow.
+		fmt.Fprintf(io.out, "%s %s\n", io.p.Cyan(ui.GlyphArrow),
+			io.p.Bold(fmt.Sprintf("%s %d %s from %s", verb, total, noun, agentName)))
+	} else {
+		io.p.Fsuccessf(io.out, ui.EmojiImported, "%s %d %s from %s", verb, total, noun, agentName)
+	}
 	var parts []string
 	for _, comp := range importComponentOrder {
 		if counts[comp] > 0 {

--- a/internal/cli/import_warn_routing_test.go
+++ b/internal/cli/import_warn_routing_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,7 +15,7 @@ import (
 // warning-styling plumbing: a real adapter's Ingest warning — physically
 // emitted into the adapter's configured Stderr from inside
 // internal/adapter/<name>/ingest.go — must come out of the captured CLI
-// buffer with the bold-yellow "⚠️ warning:" prefix the user sees on every
+// buffer with the "⚠ WARN" label the user sees on every
 // other warning, NOT as plain "warning: …", and NOT only as a styled
 // "warning:" that the CLI itself could have emitted.
 //
@@ -32,7 +33,7 @@ import (
 // in each adapter package.
 //
 // **Which assertion is load-bearing?** The same-line regex below
-// (styled "⚠️ warning:" prefix appearing on the same line as a
+// (the "⚠ WARN" label appearing on the same line as a
 // lenient-YAML-specific token). Reasoning:
 //
 //   - A plain `"warning: …"` substring is not a sufficient negative: if
@@ -49,10 +50,10 @@ import (
 //     was both received AND styled — neither a CLI-only styled warning
 //     nor a routing-bypassed adapter warning matches the regex.
 func TestImport_StyledAdapterWarnings(t *testing.T) {
-	// Built once: the same-line regex requires the bold-yellow "⚠️ warning:"
-	// prefix (verbatim — the user-visible bytes) followed by anything up to
-	// the lenient-YAML phrase the adapter emits. ANSI byte order is not
-	// pinned, just the presence and the same-line locality.
+	// Built once: the same-line regex requires the shared "⚠ WARN" label
+	// (verbatim — the user-visible bytes) followed by anything up to the
+	// lenient-YAML phrase the adapter emits. ANSI byte order is not pinned,
+	// just the presence and the same-line locality.
 	//
 	// `[^\n\r]*` rather than `[^\n]*`: rejects both newline AND carriage-
 	// return between the prefix and the phrase. SGR bytes don't contain
@@ -61,8 +62,12 @@ func TestImport_StyledAdapterWarnings(t *testing.T) {
 	// negated class, a `\r` between the prefix and the phrase would let
 	// the regex match across what the terminal would render as separate
 	// lines.
+	// The runCLI harness captures into buffers, so color resolves off; build
+	// the expected label through the same code path the CLI uses rather than
+	// hardcoding bytes that rot when the vocabulary changes.
+	plainLabel := ui.LevelWarn.Label(ui.New(io.Discard, io.Discard, ui.ColorNever))
 	styledAdapterWarn := regexp.MustCompile(
-		regexp.QuoteMeta(ui.GlyphWarnEmoji+" warning:") +
+		regexp.QuoteMeta(plainLabel) +
 			`[^\n\r]*frontmatter is not strict YAML`,
 	)
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
 	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 const initialAgentsyncTOML = `# agentsync source-of-truth config
@@ -173,7 +174,7 @@ func scaffoldHome(cmd *cobra.Command, home string) error {
 	// "home exists, no record" as an unambiguous upgrade.
 	seedUpgradeNoticeRecord(home)
 	w := cmd.OutOrStdout()
-	fmt.Fprintln(w, "agentsync home initialized at", home)
+	success(cmd, ui.EmojiInit, "agentsync home initialized at %s", home)
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Next steps:")
 	fmt.Fprintln(w, "  1. agentsync agent add claude        # register an agent")
@@ -236,12 +237,12 @@ func scaffoldProjectHome(cmd *cobra.Command, root string) error {
 		return fmt.Errorf("write agentsync.toml: %w", err)
 	}
 	w := cmd.OutOrStdout()
-	fmt.Fprintln(w, "agentsync project source initialized at", home)
+	success(cmd, ui.EmojiInit, "agentsync project source initialized at %s", home)
 	// A stray retired single-file marker would be silently ignored now; nudge
 	// the user to fold its settings into the new tree and delete it.
 	if fi, err := os.Stat(filepath.Join(root, project.LegacyMarkerFile)); err == nil && !fi.IsDir() {
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"agentsync: a legacy %s is present at %s; it is no longer read — move its settings into %s/ and delete it.\n",
+		diag(cmd, ui.LevelWarn,
+			"a legacy %s is present at %s; it is no longer read — move its settings into %s/ and delete it.",
 			project.LegacyMarkerFile, root, project.DirName)
 	}
 	fmt.Fprintln(w, "")
@@ -264,8 +265,7 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 	if err := validateCloneURL(rawURL); err != nil {
 		return err
 	}
-	w := cmd.OutOrStdout()
-	fmt.Fprintf(w, "cloning %s into %s ...\n", rawURL, home)
+	diag(cmd, ui.LevelInfo, "cloning %s into %s ...", rawURL, home)
 	if _, err := git.PlainClone(home, false, &git.CloneOptions{URL: rawURL, Depth: 1}); err != nil {
 		return fmt.Errorf("clone %s: %w", rawURL, err)
 	}
@@ -280,7 +280,7 @@ func cloneSourceRepo(cmd *cobra.Command, home, rawURL string) error {
 	// about changes that predate it — and so the notice path can read
 	// "home exists, no record" as an unambiguous upgrade.
 	seedUpgradeNoticeRecord(home)
-	fmt.Fprintln(w, "cloned. Run `agentsync apply --dry-run` to preview against this machine.")
+	success(cmd, ui.EmojiInit, "cloned. Run `agentsync apply --dry-run` to preview against this machine.")
 	return nil
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -3,6 +3,8 @@ package cli_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 func TestIntegration_M0Lifecycle(t *testing.T) {
@@ -19,7 +21,7 @@ func TestIntegration_M0Lifecycle(t *testing.T) {
 		{args: []string{"agent", "add", "claude"}, wantSubs: []string{"added agent: claude"}},
 		{args: []string{"agent", "add", "opencode"}, wantSubs: []string{"added agent: opencode"}},
 		{args: []string{"agent", "list"}, wantSubs: []string{"claude", "opencode"}},
-		{args: []string{"check"}, wantSubs: []string{"ok"}},
+		{args: []string{"check"}, wantSubs: []string{ui.EmojiSuccess, "schema valid"}},
 		{args: []string{"apply", "--dry-run"}, wantSubs: []string{"Plan", "claude", "opencode"}},
 		{args: []string{"agent", "remove", "claude"}, wantSubs: []string{"removed agent: claude"}},
 	}

--- a/internal/cli/iss155_test.go
+++ b/internal/cli/iss155_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
-// exitCodeOf mirrors main()'s error→exit-code mapping: 0 for nil, the ExitCoder
-// code for the quiet --exit-code sentinel, else 1 for a generic error.
+// exitCodeOf mirrors the error→exit-code mapping that cli.Execute applies (via
+// reportErrorTo): 0 for nil, the ExitCoder code for the quiet --exit-code
+// sentinel, else 1 for a generic error. main() no longer maps anything itself.
 func exitCodeOf(err error) int {
 	if err == nil {
 		return 0

--- a/internal/cli/iss155_test.go
+++ b/internal/cli/iss155_test.go
@@ -318,11 +318,11 @@ func TestCLIStreams_JSONStdoutMessagesStderr(t *testing.T) {
 	if jerr := json.Unmarshal([]byte(stdout), &model); jerr != nil {
 		t.Fatalf("stdout is not clean JSON: %v\nstdout:\n%s", jerr, stdout)
 	}
-	if strings.Contains(stdout, "warning") {
+	if strings.Contains(stdout, "WARN") {
 		t.Fatalf("a warning leaked into the --json stdout payload:\n%s", stdout)
 	}
-	if !strings.Contains(stderr, "warning") {
-		t.Fatalf("expected the orphaned-agent warning on stderr; got:\n%s", stderr)
+	if !strings.Contains(stderr, "WARN") {
+		t.Fatalf("expected the orphaned-agent WARN diagnostic on stderr; got:\n%s", stderr)
 	}
 }
 

--- a/internal/cli/iss155_test.go
+++ b/internal/cli/iss155_test.go
@@ -3,12 +3,15 @@ package cli_test
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/cli"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // exitCodeOf mirrors main()'s error→exit-code mapping: 0 for nil, the ExitCoder
@@ -321,7 +324,13 @@ func TestCLIStreams_JSONStdoutMessagesStderr(t *testing.T) {
 	if strings.Contains(stdout, "WARN") {
 		t.Fatalf("a warning leaked into the --json stdout payload:\n%s", stdout)
 	}
-	if !strings.Contains(stderr, "WARN") {
+	// Same-line: pin the WARN label to the orphaned-agent message specifically,
+	// so an unrelated warning elsewhere on stderr cannot satisfy this.
+	orphanWarn := regexp.MustCompile(
+		regexp.QuoteMeta(ui.LevelWarn.Label(ui.New(io.Discard, io.Discard, ui.ColorNever))) +
+			`[^\n\r]*is not enabled but still owns tracked files`,
+	)
+	if !orphanWarn.MatchString(stderr) {
 		t.Fatalf("expected the orphaned-agent WARN diagnostic on stderr; got:\n%s", stderr)
 	}
 }

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -88,7 +88,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "added marketplace %s (sha=%s)\n",
+	success(cmd, ui.EmojiSuccess, "added marketplace %s (sha=%s)",
 		ui.Sanitize(mpName), truncate(headSHA, 12))
 	return nil
 }
@@ -223,7 +223,7 @@ func marketplaceRemoveRun(cmd *cobra.Command, args []string) error {
 		_ = state.Save(statePath, st)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "removed marketplace %s\n", name)
+	success(cmd, ui.EmojiRemoved, "removed marketplace %s", name)
 	return nil
 }
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -135,7 +135,7 @@ func mcpAddRun(cmd *cobra.Command, home, id, serverType, command, argsCSV, url, 
 	if err := source.WriteMCP(home, id, source.MCPServer{Server: spec}); err != nil {
 		return fmt.Errorf("write %s: %w", dest, err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "added mcp server: %s -> %s\n", id, dest)
+	success(cmd, ui.EmojiSuccess, "added mcp server: %s -> %s", id, dest)
 	return nil
 }
 
@@ -162,7 +162,7 @@ func newMCPRemoveCmd() *cobra.Command {
 					}
 					return fmt.Errorf("remove %s: %w", p, err)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "removed mcp server: %s\n", id)
+				success(cmd, ui.EmojiRemoved, "removed mcp server: %s", id)
 				return nil
 			})
 		},
@@ -380,7 +380,7 @@ func newMCPToggleCmd(enable bool) *cobra.Command {
 				if werr := source.WriteMCP(home, id, m); werr != nil {
 					return werr
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s mcp server: %s\n", past, id)
+				success(cmd, ui.EmojiSuccess, "%s mcp server: %s", past, id)
 				return nil
 			})
 		},

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -120,19 +120,15 @@ func runSubagentMigration(p *ui.Printer, userAgentsyncHome string, sc adapter.Sc
 	legacyDir := filepath.Join(srcHome, source.LegacySubagentsDir)
 	newDir := filepath.Join(srcHome, source.SubagentsDir)
 	if len(moved) == 0 {
-		fmt.Fprintf(p.Out, "%s %s\n", p.Green(ui.GlyphOK),
-			fmt.Sprintf("nothing to migrate — %s holds no subagent files", legacyDir))
+		p.Successf(ui.EmojiSuccess, "nothing to migrate — %s holds no subagent files", legacyDir)
 		return nil
 	}
-	fmt.Fprintf(p.Out, "%s %s\n", p.Green(ui.GlyphOK),
-		fmt.Sprintf("moved %d subagent file(s) from %s to %s", len(moved), legacyDir, newDir))
+	p.Successf(ui.EmojiSuccess, "moved %d subagent file(s) from %s to %s", len(moved), legacyDir, newDir)
 	for _, name := range moved {
 		fmt.Fprintf(p.Out, "  %s %s\n", p.Faint(ui.GlyphArrow), ui.Sanitize(name))
 	}
 	if sc != adapter.ScopeProject {
-		fmt.Fprintf(p.Out, "\n%s\n", p.Faint(
-			"note: ~/.agentsync is often a committed dotfiles repo — commit the rename so other machines pick it up.",
-		))
+		p.Infof("~/.agentsync is often a committed dotfiles repo — commit the rename so other machines pick it up.")
 	}
 	return nil
 }
@@ -362,9 +358,9 @@ func promptSubagentMigration(cmd *cobra.Command, p *ui.Printer, pending *source.
 	// The prompt goes to STDERR: it can fire before a `status --json` /
 	// `diff --json` payload, and stdout is that payload's channel.
 	w := cmd.ErrOrStderr()
-	fmt.Fprintf(w, "%s agentsync now reads subagents from %s, not %s.\n",
-		ui.GlyphInfo, filepath.Join(pending.Home, source.SubagentsDir), filepath.Join(pending.Home, source.LegacySubagentsDir))
-	fmt.Fprintf(w, "  %d file(s) are still in the old directory: %s\n", len(pending.Files), ui.Sanitize(strings.Join(pending.Files, ", ")))
+	p.Fdiagf(w, ui.LevelInfo, "agentsync now reads subagents from %s, not %s.",
+		filepath.Join(pending.Home, source.SubagentsDir), filepath.Join(pending.Home, source.LegacySubagentsDir))
+	p.Fdetailf(w, "%d file(s) are still in the old directory: %s", len(pending.Files), ui.Sanitize(strings.Join(pending.Files, ", ")))
 	return promptConfirmYes(w, cmd.InOrStdin(), "  Move them now (and update recorded state)? [y/N]: ")
 }
 

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -14,89 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spxrogers/agentsync/internal/cli"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
-
-// ---------------------------------------------------------------------------
-// The terminal error line (#211)
-// ---------------------------------------------------------------------------
-
-// The exact failure from the issue: `agentsync status` exits 1 and the last
-// thing printed is the error. It used to be a flat, unlabeled, uncolored
-// `agentsync: render codex: …` sitting directly below a WARN — nothing marked
-// it as the failure. It must now carry the ERROR label.
-func TestReportError_CarriesTheErrorLabel(t *testing.T) {
-	var buf bytes.Buffer
-	code := cli.ReportErrorTo(&buf, ui.ColorNever, errors.New(
-		`render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name`,
-	))
-
-	if code != 1 {
-		t.Fatalf("ReportErrorTo exit code = %d, want 1", code)
-	}
-	got := buf.String()
-	if !strings.HasPrefix(got, "✗ ERROR  ") {
-		t.Fatalf("terminal error must lead with the ERROR label; got: %q", got)
-	}
-	if strings.Contains(got, "agentsync:") {
-		t.Fatalf("the redundant program prefix should be gone; got: %q", got)
-	}
-	if !strings.Contains(got, "resolve to the same agent name") {
-		t.Fatalf("the error message body was lost; got: %q", got)
-	}
-}
-
-// With color on, the label is red — the second signal (after the glyph and the
-// word) that separates a failure from the warning above it.
-func TestReportError_ColorsTheLabel(t *testing.T) {
-	var buf bytes.Buffer
-	cli.ReportErrorTo(&buf, ui.ColorAlways, errors.New("boom"))
-	if !strings.Contains(buf.String(), "\x1b[31m") {
-		t.Fatalf("colored terminal error is missing red: %q", buf.String())
-	}
-}
-
-// The quiet exit-code sentinel (`status --exit-code`, `diff --exit-code`)
-// carries its own code and an empty message: it must map to that code and print
-// NOTHING, so a CI gate gets a stable non-zero exit with no spurious line.
-func TestReportError_QuietSentinelPrintsNothing(t *testing.T) {
-	var buf bytes.Buffer
-	code := cli.ReportErrorTo(&buf, ui.ColorNever, quietExit(3))
-	if code != 3 {
-		t.Fatalf("exit code = %d, want the sentinel's 3", code)
-	}
-	if buf.Len() != 0 {
-		t.Fatalf("quiet sentinel must print nothing; got: %q", buf.String())
-	}
-}
-
-func TestReportError_NilIsZeroAndSilent(t *testing.T) {
-	var buf bytes.Buffer
-	if code := cli.ReportErrorTo(&buf, ui.ColorNever, nil); code != 0 || buf.Len() != 0 {
-		t.Fatalf("nil error: code=%d out=%q, want 0 and empty", code, buf.String())
-	}
-}
-
-// quietExitErr mirrors the shape of the status/diff sentinel: an error whose
-// message is empty and which reports its own process exit code.
-type quietExitErr int
-
-func (q quietExitErr) Error() string { return "" }
-func (q quietExitErr) ExitCode() int { return int(q) }
-
-func quietExit(code int) error { return quietExitErr(code) }
-
-// The sentinel must be found through a wrapper too — commands wrap errors on
-// the way up, and a `%w`-wrapped sentinel that stopped being recognized would
-// turn a clean CI gate into a spurious ERROR line.
-func TestReportError_QuietSentinelThroughWrapper(t *testing.T) {
-	var buf bytes.Buffer
-	code := cli.ReportErrorTo(&buf, ui.ColorNever, fmt.Errorf("status: %w", quietExit(2)))
-	if code != 2 || buf.Len() != 0 {
-		t.Fatalf("wrapped sentinel: code=%d out=%q, want 2 and empty", code, buf.String())
-	}
-}
 
 // ---------------------------------------------------------------------------
 // The guard: no new ad-hoc diagnostic prefixes
@@ -294,6 +212,14 @@ func TestSweptDirsCoverTheEmitters(t *testing.T) {
 	for dir, covered := range must {
 		if !covered {
 			t.Errorf("%s dropped out of sweptDirs — that reopens the hole this guard exists to close", dir)
+		}
+	}
+	// A floor of 0 would make the per-directory check vacuous, so an entry could be
+	// neutered (rather than removed) without tripping the membership pin above.
+	for _, sd := range sweptDirs {
+		if sd.minFiles < 1 {
+			t.Errorf("sweptDirs entry %q has minFiles=%d; a floor below 1 cannot detect a "+
+				"moved or renamed directory", sd.dir, sd.minFiles)
 		}
 	}
 }

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -120,7 +120,7 @@ var bannedPrefixes = []bannedPrefix{
 var exemptLiterals = map[string]string{
 	// A panic value, not a printed diagnostic: it names the program because it
 	// surfaces through Go's own panic output, which carries no agentsync framing.
-	// It can never reach ReportError (a panic does not return an error), so it
+	// It can never reach reportErrorTo (a panic does not return an error), so it
 	// cannot produce a doubled "✗ ERROR  agentsync: …" line.
 	"agentsync: adapter registry wiring bug: %w": "internal panic value, never a printed diagnostic",
 }

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -101,38 +102,83 @@ func TestReportError_QuietSentinelThroughWrapper(t *testing.T) {
 // The guard: no new ad-hoc diagnostic prefixes
 // ---------------------------------------------------------------------------
 
-// packageSourceDir returns the directory holding this package's sources.
+// sweptDirs are the source directories the ad-hoc-prefix sweep covers, relative
+// to the repo root.
 //
-// It CANNOT be derived from the working directory: this package's TestMain
-// chdirs into a scratch dir so filesystem-touching tests never run against the
-// repo, so a `filepath.Glob("*.go")` here matches nothing and any sweep built on
-// it passes vacuously — which is exactly how this guard was first written, and
-// exactly the failure a source sweep must never have. runtime.Caller pins the
-// path at compile time instead.
-func packageSourceDir(t *testing.T) string {
+// `cmd/agentsync` is in the list because that is where the #211 regression
+// ACTUALLY lived: the offending line was `fmt.Fprintln(os.Stderr, "agentsync:",
+// err)` in main(), not in internal/cli. A sweep scoped to this package alone
+// passed green with that exact line restored — verified by reintroducing it.
+var sweptDirs = []string{"internal/cli", "cmd/agentsync"}
+
+// repoRoot locates the repository root from this test file's compiled-in path.
+//
+// It CANNOT be derived from the working directory: this package's TestMain chdirs
+// into a scratch dir so filesystem-touching tests never run against the repo, so
+// `filepath.Glob("*.go")` here matches nothing and any sweep built on it passes
+// vacuously — which is exactly how this guard was first written. runtime.Caller
+// pins the path at compile time instead.
+func repoRoot(t *testing.T) string {
 	t.Helper()
 	_, self, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller could not locate this test file")
 	}
-	return filepath.Dir(self)
+	// <root>/internal/cli/output_vocabulary_test.go
+	return filepath.Dir(filepath.Dir(filepath.Dir(self)))
 }
 
-// bannedPrefixes are the diagnostic prefixes this package used to hand-roll,
+// bannedPrefixes are the diagnostic prefixes this codebase used to hand-roll,
 // each of which produced a notice that looked different from every other one.
 // They are now all expressed through the ui vocabulary.
 //
-// Deliberately narrow — only prefixes whose ONLY plausible use is labeling a
-// diagnostic. A broader list (e.g. "scope:", "ok:") would also flag legitimate
-// field labels inside a report body, where no level belongs: `explain` prints
-// `  scope: user` as a data row, not as a notice about the run.
-var bannedPrefixes = []struct {
-	literal string
-	instead string
-}{
-	{`"agentsync:"`, "p.Warnf / p.Errorf — the level label replaces the program prefix"},
-	{`"warning:"`, "p.Warnf (or the bare \"warning: \" sentinel into a ui.WarnWriter)"},
-	{`"note:"`, "p.Infof"},
+// Two matching modes, because the three prefixes are not alike:
+//
+//   - `labelOnly: false` (agentsync:, note:) — these are never legitimate in
+//     output, in ANY form. Matched as a PREFIX of the unquoted literal, because
+//     the original #211 emitter and its likely reintroductions are
+//     `"agentsync:"`, `"agentsync: %v\n"`, and `"agentsync: "` — an equality
+//     check catches only the first, which is how the first version of this guard
+//     passed with the regression restored.
+//   - `labelOnly: true` (warning:) — the bare `warning: ` sentinel HEADING A
+//     FULL MESSAGE is a deliberate contract: the adapter and capture packages
+//     must not import ui, so they emit that plain prefix into an io.Writer and
+//     ui.WarnWriter rewrites it into the WARN label. Those must stay legal. What
+//     must not is `warning:` used as a standalone styled label token, e.g. the
+//     old `p.Yellow("warning:")`. So ban only the bare-token forms.
+//
+// Deliberately narrow in WHICH prefixes are listed: a broader set (e.g. "scope:",
+// "ok:") would also flag legitimate field labels inside a report body, where no
+// level belongs — `explain` prints `  scope: user` as a data row, not a notice.
+type bannedPrefix struct {
+	prefix    string
+	labelOnly bool
+	instead   string
+}
+
+// banned reports whether the unquoted literal val trips this rule.
+func (b bannedPrefix) banned(val string) bool {
+	if b.labelOnly {
+		return val == b.prefix || val == b.prefix+" "
+	}
+	return strings.HasPrefix(val, b.prefix)
+}
+
+var bannedPrefixes = []bannedPrefix{
+	{prefix: "agentsync:", instead: "p.Warnf / p.Errorf — the level label replaces the program prefix"},
+	{prefix: "note:", instead: "p.Infof"},
+	{prefix: "warning:", labelOnly: true, instead: "p.Warnf, or the \"warning: <message>\" sentinel into a ui.WarnWriter"},
+}
+
+// exemptLiterals are specific literals that match a banned prefix but are not
+// terminal diagnostics. Keyed by the unquoted literal so adding one is an
+// explicit, reviewable decision rather than a loosened pattern.
+var exemptLiterals = map[string]string{
+	// A panic value, not a printed diagnostic: it names the program because it
+	// surfaces through Go's own panic output, which carries no agentsync framing.
+	// It can never reach ReportError (a panic does not return an error), so it
+	// cannot produce a doubled "✗ ERROR  agentsync: …" line.
+	"agentsync: adapter registry wiring bug: %w": "internal panic value, never a printed diagnostic",
 }
 
 // TestNoAdHocDiagnosticPrefixes is the regression fence for #211's follow-up:
@@ -141,45 +187,62 @@ var bannedPrefixes = []struct {
 // hand-rolled prefix compiles, passes review as "just a Fprintf", and breaks
 // nothing — exactly the failure class that needs a mechanical guard.
 //
-// Scoped to string LITERALS in this package's non-test sources, so a comment
-// discussing the old format (several do, for history) never trips it.
+// Scoped to string LITERALS in non-test sources, so a comment discussing the old
+// format (several do, for history) never trips it.
 func TestNoAdHocDiagnosticPrefixes(t *testing.T) {
+	root := repoRoot(t)
 	fset := token.NewFileSet()
-	files, err := filepath.Glob(filepath.Join(packageSourceDir(t), "*.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(files) == 0 {
-		t.Fatal("no sources found — the sweep would pass vacuously")
-	}
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		src, err := os.ReadFile(path)
+	swept := 0
+	for _, dir := range sweptDirs {
+		files, err := filepath.Glob(filepath.Join(root, dir, "*.go"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		f, err := parser.ParseFile(fset, path, src, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
+		if len(files) == 0 {
+			t.Fatalf("no sources found under %s — the sweep would pass vacuously", dir)
 		}
-		ast.Inspect(f, func(n ast.Node) bool {
-			lit, ok := n.(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				return true
+		for _, path := range files {
+			if strings.HasSuffix(path, "_test.go") {
+				continue
 			}
-			for _, b := range bannedPrefixes {
-				// Exact-literal match: `"warning: %s"` inside a WarnWriter-bound
-				// Fprintf is the documented emitter contract and must stay legal,
-				// while a bare `p.Yellow("warning:")` prefix must not.
-				if lit.Value == b.literal {
-					t.Errorf("%s: ad-hoc diagnostic prefix %s — use %s instead",
-						fset.Position(lit.Pos()), b.literal, b.instead)
+			swept++
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := parser.ParseFile(fset, path, src, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
 				}
-			}
-			return true
-		})
+				// Unquote so both interpreted ("…") and raw (`…`) literals are
+				// compared as the text the terminal would actually receive.
+				val, uerr := strconv.Unquote(lit.Value)
+				if uerr != nil {
+					return true
+				}
+				if why, ok := exemptLiterals[val]; ok {
+					_ = why // documented exemption; see exemptLiterals
+					return true
+				}
+				for _, b := range bannedPrefixes {
+					if b.banned(val) {
+						t.Errorf("%s: ad-hoc diagnostic prefix %q — use %s instead",
+							fset.Position(lit.Pos()), val, b.instead)
+					}
+				}
+				return true
+			})
+		}
+	}
+	// A sweep that silently stops finding files is the failure mode this whole
+	// test exists to avoid, twice over now. Pin a floor.
+	if swept < 25 {
+		t.Fatalf("swept only %d source files; the sweep has lost its targets", swept)
 	}
 }
 

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -28,7 +28,8 @@ import (
 func TestReportError_CarriesTheErrorLabel(t *testing.T) {
 	var buf bytes.Buffer
 	code := cli.ReportErrorTo(&buf, ui.ColorNever, errors.New(
-		`render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name`))
+		`render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name`,
+	))
 
 	if code != 1 {
 		t.Fatalf("ReportErrorTo exit code = %d, want 1", code)

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -103,13 +103,39 @@ func TestReportError_QuietSentinelThroughWrapper(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // sweptDirs are the source directories the ad-hoc-prefix sweep covers, relative
-// to the repo root.
+// to the repo root, each with the minimum number of non-test files it must
+// contain.
 //
-// `cmd/agentsync` is in the list because that is where the #211 regression
-// ACTUALLY lived: the offending line was `fmt.Fprintln(os.Stderr, "agentsync:",
-// err)` in main(), not in internal/cli. A sweep scoped to this package alone
-// passed green with that exact line restored — verified by reintroducing it.
-var sweptDirs = []string{"internal/cli", "cmd/agentsync"}
+// `cmd/agentsync` is here because that is where the #211 regression ACTUALLY
+// lived: the offending line was `fmt.Fprintln(os.Stderr, "agentsync:", err)` in
+// main(), not in internal/cli. A sweep scoped to this package alone passed green
+// with that exact line restored — verified by reintroducing it.
+//
+// The floors are PER DIRECTORY, and TestSweptDirsCoverTheEmitters pins the set
+// itself, because a single aggregate floor does not protect this list. With 31
+// files in internal/cli and 1 in cmd/agentsync, deleting the cmd/agentsync entry
+// left 31 — comfortably over any aggregate floor — so the round-1 hole could be
+// reopened without failing anything. A one-file directory cannot be defended by
+// counting everything.
+//
+// DELIBERATELY OUT OF SCOPE, so a future reader does not read these as misses:
+//
+//   - `internal/testenv` prints three `agentsync: …` lines to os.Stderr
+//     (container.go), but it is a TestMain host-refusal guard that never runs in
+//     the shipped binary and exits before any CLI output exists. Naming the
+//     program there is right, exactly as it is for a panic value.
+//   - `internal/source` defines `agentsync:fragment` and `agentsync:managed` as
+//     RESERVED marker tokens written into memory files. They are file content, not
+//     terminal output, and a prefix match would flag them — which is the argument
+//     for scoping this sweep to the packages that actually emit diagnostics rather
+//     than widening it repo-wide.
+var sweptDirs = []struct {
+	dir      string
+	minFiles int
+}{
+	{dir: "internal/cli", minFiles: 25},
+	{dir: "cmd/agentsync", minFiles: 1},
+}
 
 // repoRoot locates the repository root from this test file's compiled-in path.
 //
@@ -192,20 +218,25 @@ var exemptLiterals = map[string]string{
 func TestNoAdHocDiagnosticPrefixes(t *testing.T) {
 	root := repoRoot(t)
 	fset := token.NewFileSet()
-	swept := 0
-	for _, dir := range sweptDirs {
-		files, err := filepath.Glob(filepath.Join(root, dir, "*.go"))
+	for _, sd := range sweptDirs {
+		files, err := filepath.Glob(filepath.Join(root, sd.dir, "*.go"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(files) == 0 {
-			t.Fatalf("no sources found under %s — the sweep would pass vacuously", dir)
+		var nonTest int
+		for _, p := range files {
+			if !strings.HasSuffix(p, "_test.go") {
+				nonTest++
+			}
+		}
+		if nonTest < sd.minFiles {
+			t.Fatalf("swept only %d non-test file(s) under %s, want >= %d — the sweep has lost its targets there",
+				nonTest, sd.dir, sd.minFiles)
 		}
 		for _, path := range files {
 			if strings.HasSuffix(path, "_test.go") {
 				continue
 			}
-			swept++
 			src, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
@@ -239,10 +270,31 @@ func TestNoAdHocDiagnosticPrefixes(t *testing.T) {
 			})
 		}
 	}
-	// A sweep that silently stops finding files is the failure mode this whole
-	// test exists to avoid, twice over now. Pin a floor.
-	if swept < 25 {
-		t.Fatalf("swept only %d source files; the sweep has lost its targets", swept)
+}
+
+// TestSweptDirsCoverTheEmitters pins the sweep's SCOPE, separately from its
+// matcher.
+//
+// The per-directory floors catch a directory going empty; they cannot catch an
+// entry being deleted outright, which is precisely how the round-1 hole existed in
+// the first place (`cmd/agentsync` absent). Pin the set so removing a directory is
+// a test failure and not a silent narrowing.
+func TestSweptDirsCoverTheEmitters(t *testing.T) {
+	must := map[string]bool{
+		// Where the CLI's diagnostics are emitted from. `cmd/agentsync` is
+		// non-negotiable: it held the original #211 line.
+		"internal/cli":  false,
+		"cmd/agentsync": false,
+	}
+	for _, sd := range sweptDirs {
+		if _, ok := must[sd.dir]; ok {
+			must[sd.dir] = true
+		}
+	}
+	for dir, covered := range must {
+		if !covered {
+			t.Errorf("%s dropped out of sweptDirs — that reopens the hole this guard exists to close", dir)
+		}
 	}
 }
 

--- a/internal/cli/output_vocabulary_test.go
+++ b/internal/cli/output_vocabulary_test.go
@@ -1,0 +1,200 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/cli"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// ---------------------------------------------------------------------------
+// The terminal error line (#211)
+// ---------------------------------------------------------------------------
+
+// The exact failure from the issue: `agentsync status` exits 1 and the last
+// thing printed is the error. It used to be a flat, unlabeled, uncolored
+// `agentsync: render codex: …` sitting directly below a WARN — nothing marked
+// it as the failure. It must now carry the ERROR label.
+func TestReportError_CarriesTheErrorLabel(t *testing.T) {
+	var buf bytes.Buffer
+	code := cli.ReportErrorTo(&buf, ui.ColorNever, errors.New(
+		`render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name`))
+
+	if code != 1 {
+		t.Fatalf("ReportErrorTo exit code = %d, want 1", code)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "✗ ERROR  ") {
+		t.Fatalf("terminal error must lead with the ERROR label; got: %q", got)
+	}
+	if strings.Contains(got, "agentsync:") {
+		t.Fatalf("the redundant program prefix should be gone; got: %q", got)
+	}
+	if !strings.Contains(got, "resolve to the same agent name") {
+		t.Fatalf("the error message body was lost; got: %q", got)
+	}
+}
+
+// With color on, the label is red — the second signal (after the glyph and the
+// word) that separates a failure from the warning above it.
+func TestReportError_ColorsTheLabel(t *testing.T) {
+	var buf bytes.Buffer
+	cli.ReportErrorTo(&buf, ui.ColorAlways, errors.New("boom"))
+	if !strings.Contains(buf.String(), "\x1b[31m") {
+		t.Fatalf("colored terminal error is missing red: %q", buf.String())
+	}
+}
+
+// The quiet exit-code sentinel (`status --exit-code`, `diff --exit-code`)
+// carries its own code and an empty message: it must map to that code and print
+// NOTHING, so a CI gate gets a stable non-zero exit with no spurious line.
+func TestReportError_QuietSentinelPrintsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	code := cli.ReportErrorTo(&buf, ui.ColorNever, quietExit(3))
+	if code != 3 {
+		t.Fatalf("exit code = %d, want the sentinel's 3", code)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("quiet sentinel must print nothing; got: %q", buf.String())
+	}
+}
+
+func TestReportError_NilIsZeroAndSilent(t *testing.T) {
+	var buf bytes.Buffer
+	if code := cli.ReportErrorTo(&buf, ui.ColorNever, nil); code != 0 || buf.Len() != 0 {
+		t.Fatalf("nil error: code=%d out=%q, want 0 and empty", code, buf.String())
+	}
+}
+
+// quietExitErr mirrors the shape of the status/diff sentinel: an error whose
+// message is empty and which reports its own process exit code.
+type quietExitErr int
+
+func (q quietExitErr) Error() string { return "" }
+func (q quietExitErr) ExitCode() int { return int(q) }
+
+func quietExit(code int) error { return quietExitErr(code) }
+
+// The sentinel must be found through a wrapper too — commands wrap errors on
+// the way up, and a `%w`-wrapped sentinel that stopped being recognized would
+// turn a clean CI gate into a spurious ERROR line.
+func TestReportError_QuietSentinelThroughWrapper(t *testing.T) {
+	var buf bytes.Buffer
+	code := cli.ReportErrorTo(&buf, ui.ColorNever, fmt.Errorf("status: %w", quietExit(2)))
+	if code != 2 || buf.Len() != 0 {
+		t.Fatalf("wrapped sentinel: code=%d out=%q, want 2 and empty", code, buf.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The guard: no new ad-hoc diagnostic prefixes
+// ---------------------------------------------------------------------------
+
+// packageSourceDir returns the directory holding this package's sources.
+//
+// It CANNOT be derived from the working directory: this package's TestMain
+// chdirs into a scratch dir so filesystem-touching tests never run against the
+// repo, so a `filepath.Glob("*.go")` here matches nothing and any sweep built on
+// it passes vacuously — which is exactly how this guard was first written, and
+// exactly the failure a source sweep must never have. runtime.Caller pins the
+// path at compile time instead.
+func packageSourceDir(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not locate this test file")
+	}
+	return filepath.Dir(self)
+}
+
+// bannedPrefixes are the diagnostic prefixes this package used to hand-roll,
+// each of which produced a notice that looked different from every other one.
+// They are now all expressed through the ui vocabulary.
+//
+// Deliberately narrow — only prefixes whose ONLY plausible use is labeling a
+// diagnostic. A broader list (e.g. "scope:", "ok:") would also flag legitimate
+// field labels inside a report body, where no level belongs: `explain` prints
+// `  scope: user` as a data row, not as a notice about the run.
+var bannedPrefixes = []struct {
+	literal string
+	instead string
+}{
+	{`"agentsync:"`, "p.Warnf / p.Errorf — the level label replaces the program prefix"},
+	{`"warning:"`, "p.Warnf (or the bare \"warning: \" sentinel into a ui.WarnWriter)"},
+	{`"note:"`, "p.Infof"},
+}
+
+// TestNoAdHocDiagnosticPrefixes is the regression fence for #211's follow-up:
+// the whole value of the vocabulary is that EVERY diagnostic looks the same, and
+// that property dies the moment one new command hand-rolls its own prefix. A
+// hand-rolled prefix compiles, passes review as "just a Fprintf", and breaks
+// nothing — exactly the failure class that needs a mechanical guard.
+//
+// Scoped to string LITERALS in this package's non-test sources, so a comment
+// discussing the old format (several do, for history) never trips it.
+func TestNoAdHocDiagnosticPrefixes(t *testing.T) {
+	fset := token.NewFileSet()
+	files, err := filepath.Glob(filepath.Join(packageSourceDir(t), "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no sources found — the sweep would pass vacuously")
+	}
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			for _, b := range bannedPrefixes {
+				// Exact-literal match: `"warning: %s"` inside a WarnWriter-bound
+				// Fprintf is the documented emitter contract and must stay legal,
+				// while a bare `p.Yellow("warning:")` prefix must not.
+				if lit.Value == b.literal {
+					t.Errorf("%s: ad-hoc diagnostic prefix %s — use %s instead",
+						fset.Position(lit.Pos()), b.literal, b.instead)
+				}
+			}
+			return true
+		})
+	}
+}
+
+// The emitter-side sentinel is a contract between the adapter/capture packages
+// (which must not import ui) and ui.WarnWriter. If it is ever renamed on one
+// side only, warnings silently stop being labeled — nothing fails to compile.
+// Pin both halves here.
+func TestWarnSentinelStaysWiredToTheWarnLabel(t *testing.T) {
+	var dest bytes.Buffer
+	p := ui.New(&dest, &dest, ui.ColorNever)
+	w := ui.NewWarnWriter(&dest, p)
+
+	fmt.Fprintf(w, "warning: %s\n", "something happened")
+
+	want := ui.LevelWarn.Label(p) + "  something happened\n"
+	if got := dest.String(); got != want {
+		t.Fatalf("the \"warning: \" sentinel no longer renders as the WARN label:\ngot:  %q\nwant: %q", got, want)
+	}
+}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -117,7 +117,7 @@ func pluginAddRun(cmd *cobra.Command, args []string) error {
 	// %s sanitizes it by construction — a control sequence in the version string
 	// cannot smuggle terminal escapes into the status line. (id is the user's own
 	// argument and sha is hex, so neither needs it.)
-	fmt.Fprintf(cmd.OutOrStdout(), "installed plugin %s (version=%s sha=%s)",
+	msg := fmt.Sprintf("installed plugin %s (version=%s sha=%s)",
 		id, spec.Version, truncate(spec.ManifestSHA, 12))
 	// When a re-install PRESERVED user-authored lifecycle fields that differ from
 	// the first-install defaults, surface it instead of reporting an unqualified
@@ -126,9 +126,9 @@ func pluginAddRun(cmd *cobra.Command, args []string) error {
 	// config; route them through ui.Sanitize so a hand-edited control byte cannot
 	// smuggle terminal escapes into the status line, mirroring the Version guard.
 	if kept := keptLifecycleSummary(spec); kept != "" {
-		fmt.Fprintf(cmd.OutOrStdout(), " (kept %s)", kept)
+		msg += fmt.Sprintf(" (kept %s)", kept)
 	}
-	fmt.Fprintln(cmd.OutOrStdout())
+	success(cmd, ui.EmojiSuccess, "%s", msg)
 	return nil
 }
 
@@ -401,8 +401,8 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 		case lerr != nil:
 			return fmt.Errorf("--lossless: cannot evaluate %s (%w); refusing the upgrade to be safe", id, lerr)
 		case isLossy:
-			fmt.Fprintf(cmd.OutOrStdout(),
-				"lossless: skipping lossy upgrade %s (candidate version drops translation for an agent)\n", id)
+			diag(cmd, ui.LevelInfo,
+				"lossless: skipping lossy upgrade %s (candidate version drops translation for an agent)", id)
 			return nil
 		}
 	}
@@ -444,7 +444,7 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 		return err
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "upgraded plugin %s (sha=%s)\n",
+	success(cmd, ui.EmojiSuccess, "upgraded plugin %s (sha=%s)",
 		id, truncate(manifestSHA, 12))
 
 	// Re-apply so the upgraded plugin's components reach the agents now. Same
@@ -500,7 +500,7 @@ func pluginEnableRun(cmd *cobra.Command, args []string) error {
 	if err := iox.AtomicWrite(pluginPath, data, 0o644); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "enabled plugin %s\n", id)
+	success(cmd, ui.EmojiSuccess, "enabled plugin %s", id)
 	return nil
 }
 
@@ -546,7 +546,7 @@ func pluginDisableRun(cmd *cobra.Command, args []string) error {
 	if err := iox.AtomicWrite(pluginPath, data, 0o644); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "disabled plugin %s\n", id)
+	success(cmd, ui.EmojiSuccess, "disabled plugin %s", id)
 	return nil
 }
 
@@ -599,7 +599,7 @@ func pluginRemoveRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("remove cache %s: %w", cacheDir, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "removed plugin %s\n", id)
+	success(cmd, ui.EmojiRemoved, "removed plugin %s", id)
 	return nil
 }
 

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -53,7 +53,15 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// wrote the raw sentinel to STDOUT, which both skipped the styling and put a
 	// diagnostic in the middle of the command's own output.
 	warnW := ui.NewWarnWriter(p.Err, p)
-	defer warnW.Flush()
+	// Flush drains any partial line the line-buffering writer still holds. It runs
+	// on the error return path too, and a partial line carries no trailing
+	// newline — so main's terminal ✗ ERROR line would otherwise be appended to it
+	// on the same row. Terminate it here; Flush itself is a no-op when the buffer
+	// is empty, which is the normal case (every emitter ends with \n).
+	defer func() {
+		warnW.Flush()
+		warnW.EndLine()
+	}()
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // pollOpts configures the shared marketplace-poll engine behind `plugin
@@ -46,6 +47,13 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	if err != nil {
 		return err
 	}
+	// The two helpers below take a plain io.Writer for their warnings and emit
+	// the bare "warning: " sentinel. Route it through a WarnWriter on STDERR so
+	// they pick up the same ⚠ WARN label as everything else — they previously
+	// wrote the raw sentinel to STDOUT, which both skipped the styling and put a
+	// diagnostic in the middle of the command's own output.
+	warnW := ui.NewWarnWriter(p.Err, p)
+	defer warnW.Flush()
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")
@@ -74,7 +82,7 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 
 		src, perr := parseMarketplaceSource(mp.Marketplace.URL)
 		if perr != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: marketplace %s has unparseable URL %q: %v\n", mpName, mp.Marketplace.URL, perr)
+			p.Warnf("marketplace %s has unparseable URL %q: %v", mpName, mp.Marketplace.URL, perr)
 			continue
 		}
 		if mp.Marketplace.Ref != "" {
@@ -86,7 +94,7 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 		result, err := fetcher.Fetch(src, cacheDir)
 		stopSpin()
 		if err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: re-fetch marketplace %s failed: %v\n", mpName, err)
+			p.Warnf("re-fetch marketplace %s failed: %v", mpName, err)
 			continue
 		}
 
@@ -110,20 +118,19 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 			}
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "fetched marketplace %s (sha=%s)\n",
+		p.Successf(ui.EmojiSuccess, "fetched marketplace %s (sha=%s)",
 			mpName, truncate(result.HeadSHA, 12))
 	}
 
 	// Compute fresh manifest SHAs for installed plugins (for SHA drift detection).
 	stopSpin := p.Spin("checking plugin manifests")
-	freshSHAs := computeFreshPluginSHAs(home, c.Plugins, fetched, cmd.OutOrStdout())
+	freshSHAs := computeFreshPluginSHAs(home, c.Plugins, fetched, warnW)
 	stopSpin()
 
 	// Detect re-uploaded (same version, different SHA) plugins.
 	shaWarnings := marketplace.DetectSHADrift(c.Plugins, freshSHAs)
 	for _, w := range shaWarnings {
-		fmt.Fprintf(cmd.OutOrStdout(),
-			"warning: manifest-sha-mismatch plugin=%s version=%s recorded=%s fetched=%s (re-uploaded?)\n",
+		p.Warnf("manifest-sha-mismatch plugin=%s version=%s recorded=%s fetched=%s (re-uploaded?)",
 			w.ID, w.Version, truncate(w.RecordedSHA, 12), truncate(w.FetchedSHA, 12))
 	}
 
@@ -138,17 +145,16 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// the delta is exactly the bump's effect. An excluded bump is REPORTED, never
 	// silently dropped. Evaluation failures are treated as lossy (conservative).
 	if o.lossless {
-		safe, lossy := filterSafeBumps(home, bumps, fetched, c.Config, userHome, cmd.OutOrStdout())
+		safe, lossy := filterSafeBumps(home, bumps, fetched, c.Config, userHome, warnW)
 		for _, b := range lossy {
-			fmt.Fprintf(cmd.OutOrStdout(),
-				"lossless: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)\n",
+			p.Infof("lossless: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)",
 				b.ID, b.From, b.To)
 		}
 		bumps = safe
 	}
 
 	if len(bumps) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "all plugins are up to date")
+		p.Successf(ui.EmojiSuccess, "all plugins are up to date")
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "\npending bumps (%d):\n", len(bumps))
 		for _, b := range bumps {
@@ -172,10 +178,9 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// Upgrade each plugin with a pending bump.
 	for _, b := range bumps {
 		if err := applyPluginBump(home, b, fetched); err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "warning: upgrade %s failed: %v\n", b.ID, err)
+			p.Warnf("upgrade %s failed: %v", b.ID, err)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s %s → %s\n",
-				b.ID, b.From, b.To)
+			p.Successf(ui.EmojiSuccess, "upgraded %s %s → %s", b.ID, b.From, b.To)
 		}
 	}
 
@@ -241,9 +246,10 @@ func reapplyAfterPluginChange(cmd *cobra.Command, home, userHome, statePath stri
 	}
 	if len(collisions) > 0 {
 		ew := cmd.ErrOrStderr()
-		fmt.Fprintf(ew, "agentsync: plugin upgrade backed up %d pre-existing target(s):\n", len(collisions))
+		ep := printerOn(cmd, ew)
+		ep.Warnf("plugin upgrade backed up %d pre-existing target(s):", len(collisions))
 		for _, r := range collisions {
-			fmt.Fprintf(ew, "  %s\n", r.String())
+			ep.Fdetailf(ew, "%s", r.String())
 		}
 	}
 	for name, res := range plan.PerAgent {
@@ -257,7 +263,7 @@ func reapplyAfterPluginChange(cmd *cobra.Command, home, userHome, statePath stri
 	if err := state.Save(statePath, st); err != nil {
 		return err
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "applied:", plan.Total(), "ops")
+	printerOn(cmd, cmd.OutOrStdout()).Successf(ui.EmojiApplied, "applied: %d ops", plan.Total())
 	return nil
 }
 

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -53,15 +53,11 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// wrote the raw sentinel to STDOUT, which both skipped the styling and put a
 	// diagnostic in the middle of the command's own output.
 	warnW := ui.NewWarnWriter(p.Err, p)
-	// Flush drains any partial line the line-buffering writer still holds. It runs
-	// on the error return path too, and a partial line carries no trailing
-	// newline — so main's terminal ✗ ERROR line would otherwise be appended to it
-	// on the same row. Terminate it here; Flush itself is a no-op when the buffer
-	// is empty, which is the normal case (every emitter ends with \n).
-	defer func() {
-		warnW.Flush()
-		warnW.EndLine()
-	}()
+	// Flush drains (and terminates) any partial line the writer still holds. It
+	// runs on the error return path too, where an unterminated fragment would put
+	// main's terminal ✗ ERROR line on the same row. A no-op in the normal case,
+	// since every emitter ends with \n.
+	defer warnW.Flush()
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	statePath := filepath.Join(home, ".state", "targets.json")

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -260,14 +260,14 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 					fmt.Fprintf(w, "%c\n", ch)
 					bk, berr := render.BackupFile(home, it.op.Path)
 					if berr != nil {
-						fmt.Fprintf(w, "  backup failed, NOT removing: %s\n", ui.Sanitize(berr.Error()))
+						p.Fdiagf(w, ui.LevelError, "backup failed, NOT removing: %s", ui.Sanitize(berr.Error()))
 						break orphanPrompt
 					}
 					if bk != "" {
 						fmt.Fprintf(w, "  backup: %s\n", ui.Sanitize(bk))
 					}
 					if rmErr := os.Remove(it.op.Path); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:forbidigo // the one NATIVE-destination delete outside DestWriter: interactive orphan removal, safe only because render.BackupFile succeeded just above
-						fmt.Fprintf(w, "  remove failed: %s\n", ui.Sanitize(rmErr.Error()))
+						p.Fdiagf(w, ui.LevelError, "remove failed: %s", ui.Sanitize(rmErr.Error()))
 						break orphanPrompt
 					}
 					pruneStateFilesForPath(s, userHome, it.op.Path)
@@ -398,7 +398,7 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 		switch action {
 		case 'w':
 			// write-back: persist destination value into the canonical source.
-			if attemptWriteBack(cmd, w, home, it, canonicalHookEvents(c), writtenSources) {
+			if attemptWriteBack(cmd, p, w, home, it, canonicalHookEvents(c), writtenSources) {
 				writeBackFailed++
 			}
 		case 'o':
@@ -846,7 +846,7 @@ func readChar(r *bufio.Reader) (byte, error) {
 // file and this write changes it, revert to the first write and report a
 // conflict (counted as a failure → non-zero exit) for the user to resolve.
 // Returns true on failure/conflict.
-func attemptWriteBack(cmd *cobra.Command, w io.Writer, home string, it reconcileItem, hookEvents []string, writtenSources map[string][]byte) bool {
+func attemptWriteBack(cmd *cobra.Command, p *ui.Printer, w io.Writer, home string, it reconcileItem, hookEvents []string, writtenSources map[string][]byte) bool {
 	srcFile := itemSourceFile(home, it, hookEvents)
 	var prior []byte
 	priorWritten := false
@@ -859,10 +859,10 @@ func attemptWriteBack(cmd *cobra.Command, w io.Writer, home string, it reconcile
 		// chose [w]rite-back to persist that. A pure deletion carries no secret, so
 		// remove the canonical mcp/<id>.toml directly (the same os.Remove primitive
 		// `mcp remove` uses) rather than routing an empty spec through capture.
-		return removeDroppedSource(w, home, it, srcFile, prior, priorWritten, writtenSources)
+		return removeDroppedSource(p, w, home, it, srcFile, prior, priorWritten, writtenSources)
 	}
 	if werr != nil {
-		fmt.Fprintf(w, "  write-back error: %s\n", ui.Sanitize(werr.Error()))
+		p.Fdiagf(w, ui.LevelError, "write-back: %s", ui.Sanitize(werr.Error()))
 		return true
 	}
 	if srcFile != "" {
@@ -891,26 +891,26 @@ func attemptWriteBack(cmd *cobra.Command, w io.Writer, home string, it reconcile
 // (nil bytes) in writtenSources so a LATER content write-back to the same file
 // this run is likewise flagged rather than silently resurrecting it. Returns true
 // on failure/conflict.
-func removeDroppedSource(w io.Writer, home string, it reconcileItem, srcFile string, prior []byte, priorWritten bool, writtenSources map[string][]byte) bool {
+func removeDroppedSource(p *ui.Printer, w io.Writer, home string, it reconcileItem, srcFile string, prior []byte, priorWritten bool, writtenSources map[string][]byte) bool {
 	if srcFile == "" {
-		fmt.Fprintf(w, "  write-back error: %s — cannot locate the canonical source file to delete\n", itemLabelDisp(it))
+		p.Fdiagf(w, ui.LevelError, "write-back: %s — cannot locate the canonical source file to delete", itemLabelDisp(it))
 		return true
 	}
 	// Defense-in-depth: srcFile derives from a native-config-supplied server id;
 	// never let a traversal segment escape ~/.agentsync into an arbitrary unlink.
 	if !withinDir(home, srcFile) {
-		fmt.Fprintf(w, "  write-back error: %s — refusing to delete outside the source tree\n", itemLabelDisp(it))
+		p.Fdiagf(w, ui.LevelError, "write-back: %s — refusing to delete outside the source tree", itemLabelDisp(it))
 		return true
 	}
 	if priorWritten && len(prior) > 0 {
 		rel, _ := filepath.Rel(home, srcFile)
-		fmt.Fprintf(w, "  conflict: %s — another agent wrote this source (%s) this run, so it is still in use; "+
-			"not deleting it. Make the agents agree (remove it from every native config), then re-run.\n",
+		p.Fdiagf(w, ui.LevelError, "conflict: %s — another agent wrote this source (%s) this run, so it is still in use; "+
+			"not deleting it. Make the agents agree (remove it from every native config), then re-run.",
 			itemLabelDisp(it), ui.Sanitize(rel))
 		return true
 	}
 	if rmErr := os.Remove(srcFile); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:forbidigo // removes a canonical source file under ~/.agentsync (withinDir-guarded above), not a native destination
-		fmt.Fprintf(w, "  write-back error: remove %s: %s\n", itemLabelDisp(it), ui.Sanitize(rmErr.Error()))
+		p.Fdiagf(w, ui.LevelError, "write-back: remove %s: %s", itemLabelDisp(it), ui.Sanitize(rmErr.Error()))
 		return true
 	}
 	writtenSources[srcFile] = nil // deletion sentinel for a later same-file write

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -374,7 +374,7 @@ func TestReconcile_WriteBackUnsupportedReturnsError(t *testing.T) {
 	// Press w (write-back this item, single).
 	out, err := runCLIWithStdin(t, env, "w\n", "reconcile")
 	// Should NOT silently print success for the hook write-back.
-	if strings.Contains(out, "write-back: ") && !strings.Contains(out, "write-back error") {
+	if strings.Contains(out, "write-back: ") && !strings.Contains(out, "ERROR") {
 		t.Fatalf("hook write-back must surface an error, not silent success; got:\n%s", out)
 	}
 	// And it must exit non-zero — a failed write-back did not persist the edit.

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -1,10 +1,13 @@
 package cli_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
 // TestReconcile_OrphanFile is the regression/feature test for the maintainer
@@ -374,8 +377,12 @@ func TestReconcile_WriteBackUnsupportedReturnsError(t *testing.T) {
 	// Press w (write-back this item, single).
 	out, err := runCLIWithStdin(t, env, "w\n", "reconcile")
 	// Should NOT silently print success for the hook write-back.
-	if strings.Contains(out, "write-back: ") && !strings.Contains(out, "ERROR") {
-		t.Fatalf("hook write-back must surface an error, not silent success; got:\n%s", out)
+	// Tie the label to THIS message: a bare Contains(out, "ERROR") would be
+	// satisfied by any unrelated ERROR elsewhere in the transcript, so a genuine
+	// silent-success regression could hide behind one.
+	wantErr := ui.LevelError.Label(ui.New(io.Discard, io.Discard, ui.ColorNever)) + "  write-back:"
+	if strings.Contains(out, "write-back: ") && !strings.Contains(out, wantErr) {
+		t.Fatalf("hook write-back must surface a labeled write-back error, not silent success; got:\n%s", out)
 	}
 	// And it must exit non-zero — a failed write-back did not persist the edit.
 	if err == nil {

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// resolvedColorMode is written in the root PersistentPreRunE and read by
+// ReportError in main(), after cobra has returned. Nothing else observes it, so
+// deleting the assignment previously failed no test — verified by removing it and
+// running the whole suite green.
+//
+// These tests close that hole from both ends: the assignment must happen, and it
+// must reach ReportError's rendering. An internal test because the variable is
+// package-private on purpose.
+func TestPersistentPreRunRecordsColorMode(t *testing.T) {
+	tests := []struct {
+		flag string
+		want ui.ColorMode
+	}{
+		{"--color=never", ui.ColorNever},
+		{"--color=always", ui.ColorAlways},
+		{"--color=auto", ui.ColorAuto},
+	}
+	for _, tc := range tests {
+		t.Run(tc.flag, func(t *testing.T) {
+			// Poison it first, so a test that passes only because the zero value
+			// happens to equal `want` cannot pass for the wrong reason.
+			resolvedColorMode = ui.ColorMode(-1)
+			t.Cleanup(func() { resolvedColorMode = ui.ColorAuto })
+
+			var buf bytes.Buffer
+			root := NewRoot()
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetArgs([]string{"version", tc.flag})
+			if err := root.Execute(); err != nil {
+				t.Fatalf("version %s: %v", tc.flag, err)
+			}
+			if resolvedColorMode != tc.want {
+				t.Fatalf("resolvedColorMode = %v after %s, want %v", resolvedColorMode, tc.flag, tc.want)
+			}
+		})
+	}
+}
+
+// An invalid --color must NOT skip the slog installation or lose the recorded
+// mode: gating that on `err == nil` meant a bad flag value left the process with
+// no handler, so library warnings fell back to the stdlib timestamped line —
+// reproducing the exact #211 shape in the one case where the user has already
+// made a mistake and most needs a legible diagnostic.
+func TestPersistentPreRunSurvivesInvalidColor(t *testing.T) {
+	resolvedColorMode = ui.ColorMode(-1)
+	t.Cleanup(func() { resolvedColorMode = ui.ColorAuto })
+
+	var buf bytes.Buffer
+	root := NewRoot()
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"version", "--color=banana"})
+	// `version` does not build a Printer, so it does not surface the bad value;
+	// what matters here is that the pre-run still ran to completion.
+	_ = root.Execute()
+
+	if resolvedColorMode != ui.ColorAuto {
+		t.Fatalf("an invalid --color must degrade to auto, got %v", resolvedColorMode)
+	}
+}
+
+// ReportError must honor the mode the pre-run recorded — the end of the chain
+// that makes `--color=never` actually reach the terminal error line.
+func TestReportErrorHonorsRecordedColorMode(t *testing.T) {
+	orig := resolvedColorMode
+	t.Cleanup(func() { resolvedColorMode = orig })
+
+	var colored, plain bytes.Buffer
+	resolvedColorMode = ui.ColorAlways
+	if code := reportErrorToStream(&colored, errors.New("boom")); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	resolvedColorMode = ui.ColorNever
+	if code := reportErrorToStream(&plain, errors.New("boom")); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+
+	if !strings.Contains(colored.String(), "\x1b[") {
+		t.Fatalf("ColorAlways produced no ANSI: %q", colored.String())
+	}
+	if strings.Contains(plain.String(), "\x1b[") {
+		t.Fatalf("ColorNever leaked ANSI: %q", plain.String())
+	}
+	if !strings.Contains(plain.String(), "✗ ERROR") {
+		t.Fatalf("plain terminal error lost its label: %q", plain.String())
+	}
+}
+
+// The terminal error is the last thing a failing run prints, and an error chain
+// routinely carries third-party agent-config text. A bare \r in it rewinds the
+// cursor over the "✗ ERROR" label, letting crafted config forge a success line;
+// a \x1b introduces an arbitrary escape sequence.
+func TestReportErrorSanitizesTheErrorChain(t *testing.T) {
+	var buf bytes.Buffer
+	ReportErrorTo(&buf, ui.ColorNever, errors.New("render codex: subagent \"a\rb\x1b]0;pwned\x07\" is bad"))
+
+	got := buf.String()
+	for _, bad := range []string{"\r", "\x1b]", "\x07"} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("control byte %q survived into the terminal error: %q", bad, got)
+		}
+	}
+	if !strings.HasPrefix(got, "✗ ERROR") {
+		t.Fatalf("label lost: %q", got)
+	}
+	if !strings.Contains(got, "render codex:") {
+		t.Fatalf("message body was blanked rather than sanitized: %q", got)
+	}
+}
+
+// A multi-line error keeps its line structure — sanitizing wholesale would
+// concatenate the lines (ui.Sanitize STRIPS newlines) and defeat the
+// message-column indentation.
+func TestReportErrorKeepsMultiLineStructure(t *testing.T) {
+	var buf bytes.Buffer
+	ReportErrorTo(&buf, ui.ColorNever, errors.New("first line\nsecond line"))
+	got := buf.String()
+	if !strings.Contains(got, "first line\n") || !strings.Contains(got, "second line") {
+		t.Fatalf("multi-line error was collapsed: %q", got)
+	}
+	if strings.Contains(got, "first linesecond line") {
+		t.Fatalf("lines were concatenated with no separator: %q", got)
+	}
+}
+
+// reportErrorToStream is ReportError with an injectable writer, exercising the
+// same resolvedColorMode read that main() relies on.
+func reportErrorToStream(w *bytes.Buffer, err error) int {
+	return ReportErrorTo(w, resolvedColorMode, err)
+}

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -207,9 +207,8 @@ type quietExitErr int
 func (q quietExitErr) Error() string { return "" }
 func (q quietExitErr) ExitCode() int { return int(q) }
 
-// executeWith drives the PRODUCTION seam (executeRoot), not a copy of it. An
-// earlier version of this helper duplicated Execute's body, which is why mutating
-// the real Execute went undetected.
+// executeWith drives the PRODUCTION seam (executeRoot). It must not duplicate
+// Execute's body: a copy leaves a mutation of the real Execute undetected.
 func executeWith(w io.Writer, args ...string) int {
 	root := NewRoot()
 	root.SetOut(io.Discard)

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -205,3 +206,101 @@ type quietExitErr int
 
 func (q quietExitErr) Error() string { return "" }
 func (q quietExitErr) ExitCode() int { return int(q) }
+
+// executeWith drives the PRODUCTION seam (executeRoot), not a copy of it. An
+// earlier version of this helper duplicated Execute's body, which is why mutating
+// the real Execute went undetected.
+func executeWith(w io.Writer, args ...string) int {
+	root := NewRoot()
+	root.SetOut(io.Discard)
+	root.SetErr(w)
+	root.SetArgs(args)
+	return executeRoot(root, w)
+}
+
+// The parsed --color value must reach the terminal ERROR line. Nothing connected
+// those two ends: replacing colorModeOf(root) with a constant passed every test.
+func TestExecuteWiresTheColorFlagToTheErrorLine(t *testing.T) {
+	for _, tc := range []struct {
+		flag     string
+		wantANSI bool
+	}{
+		{"--color=always", true},
+		{"--color=never", false},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			detachAfter(t)
+			var buf bytes.Buffer
+			// `mcp remove nope` fails predictably with a plain error.
+			code := executeWith(&buf, "mcp", "remove", "nope", tc.flag)
+			if code != 1 {
+				t.Fatalf("exit code = %d, want 1; output=%q", code, buf.String())
+			}
+			if !strings.Contains(buf.String(), "✗ ERROR") {
+				t.Fatalf("no labeled error line: %q", buf.String())
+			}
+			if gotANSI := strings.Contains(buf.String(), "\x1b["); gotANSI != tc.wantANSI {
+				t.Fatalf("%s: ANSI present = %v, want %v (output=%q)", tc.flag, gotANSI, tc.wantANSI, buf.String())
+			}
+		})
+	}
+}
+
+// The slog handler must be installed with a printer bound to STDERR, so a library
+// warning takes the stderr colour decision. Installing an Out-bound printer would
+// put ANSI into a redirected stderr — the same leak class as the label, the
+// pre-styled body, and the handler's own styling.
+func TestInstalledHandlerIsBoundToStderr(t *testing.T) {
+	detachAfter(t)
+	var out, errb bytes.Buffer
+	root := NewRoot()
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	// --color=always makes the decision observable in a buffer (no TTY in tests).
+	root.SetArgs([]string{"version", "--color=always"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	before := errb.Len()
+	slogWarnForTest("stream-check")
+	emitted := errb.String()[before:]
+	if !strings.Contains(emitted, "stream-check") {
+		t.Fatalf("the installed handler did not write to the command's stderr: %q", emitted)
+	}
+	if strings.Contains(out.String(), "stream-check") {
+		t.Fatalf("a library warning reached stdout: %q", out.String())
+	}
+}
+
+// --verbose must lower the slog threshold to Debug. log.New's level mapping was
+// pinned; the CLI WIRING that passes `verbose` into it was not, so passing a
+// hardcoded false broke nothing.
+func TestVerboseLowersTheSlogThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantDebug bool
+	}{
+		{"without --verbose", []string{"version"}, false},
+		{"with --verbose", []string{"version", "--verbose"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			detachAfter(t)
+			var buf bytes.Buffer
+			root := NewRoot()
+			root.SetOut(io.Discard)
+			root.SetErr(&buf)
+			root.SetArgs(tc.args)
+			if err := root.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			before := buf.Len()
+			slog.Debug("debug-probe")
+			got := strings.Contains(buf.String()[before:], "debug-probe")
+			if got != tc.wantDebug {
+				t.Fatalf("%v: DEBUG emitted = %v, want %v (output=%q)",
+					tc.args, got, tc.wantDebug, buf.String()[before:])
+			}
+		})
+	}
+}

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -3,21 +3,33 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
+	aslog "github.com/spxrogers/agentsync/internal/log"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
-// resolvedColorMode is written in the root PersistentPreRunE and read by
-// ReportError in main(), after cobra has returned. Nothing else observes it, so
-// deleting the assignment previously failed no test — verified by removing it and
-// running the whole suite green.
+// detachAfter unbinds the process-wide slog default once this test is done.
 //
-// These tests close that hole from both ends: the assignment must happen, and it
-// must reach ReportError's rendering. An internal test because the variable is
-// package-private on purpose.
-func TestPersistentPreRunRecordsColorMode(t *testing.T) {
+// The cli_test package gets this from runCLI's helper; an INTERNAL test calling
+// NewRoot().Execute() directly cannot see that helper, and every such call leaves
+// slog.Default() bound to a buffer this test is about to drop.
+func detachAfter(t *testing.T) {
+	t.Helper()
+	t.Cleanup(aslog.Detach)
+}
+
+// Execute() reads the resolved --color decision off the root command AFTER cobra
+// has parsed and run it, which is what let a package-level `resolvedColorMode`
+// var (written in PersistentPreRunE, read from main) be deleted entirely.
+//
+// This pins that mechanism. It calls colorModeOf on the executed root exactly as
+// Execute does; Execute itself is then a four-line shim over this plus the
+// already-tested ReportErrorTo, and writes to the real os.Stderr, which is why it
+// is not driven directly here.
+func TestColorModeIsReadableFromAnExecutedRoot(t *testing.T) {
 	tests := []struct {
 		flag string
 		want ui.ColorMode
@@ -25,68 +37,64 @@ func TestPersistentPreRunRecordsColorMode(t *testing.T) {
 		{"--color=never", ui.ColorNever},
 		{"--color=always", ui.ColorAlways},
 		{"--color=auto", ui.ColorAuto},
+		// An unparseable value must degrade to auto, NOT error out of the report
+		// path: ParseColorMode returns ColorAuto alongside its error, which is what
+		// makes Execute's `mode, _ := colorModeOf(root)` safe.
+		{"--color=banana", ui.ColorAuto},
 	}
 	for _, tc := range tests {
 		t.Run(tc.flag, func(t *testing.T) {
-			// Poison it first, so a test that passes only because the zero value
-			// happens to equal `want` cannot pass for the wrong reason.
-			resolvedColorMode = ui.ColorMode(-1)
-			t.Cleanup(func() { resolvedColorMode = ui.ColorAuto })
-
+			detachAfter(t)
 			var buf bytes.Buffer
 			root := NewRoot()
 			root.SetOut(&buf)
 			root.SetErr(&buf)
 			root.SetArgs([]string{"version", tc.flag})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("version %s: %v", tc.flag, err)
-			}
-			if resolvedColorMode != tc.want {
-				t.Fatalf("resolvedColorMode = %v after %s, want %v", resolvedColorMode, tc.flag, tc.want)
+			_ = root.Execute()
+
+			got, _ := colorModeOf(root)
+			if got != tc.want {
+				t.Fatalf("colorModeOf(root) = %v after %s, want %v", got, tc.flag, tc.want)
 			}
 		})
 	}
 }
 
-// An invalid --color must NOT skip the slog installation or lose the recorded
-// mode: gating that on `err == nil` meant a bad flag value left the process with
-// no handler, so library warnings fell back to the stdlib timestamped line —
-// reproducing the exact #211 shape in the one case where the user has already
-// made a mistake and most needs a legible diagnostic.
-func TestPersistentPreRunSurvivesInvalidColor(t *testing.T) {
-	resolvedColorMode = ui.ColorMode(-1)
-	t.Cleanup(func() { resolvedColorMode = ui.ColorAuto })
-
+// An invalid --color must not prevent the slog handler from being installed.
+// Gating installation on newPrinter's error meant a bad value left NO handler, so
+// library warnings fell back to the stdlib timestamped line — reproducing the
+// exact #211 shape in the one case where the user has already made a mistake and
+// most needs a legible diagnostic.
+func TestPersistentPreRunInstallsDespiteInvalidColor(t *testing.T) {
+	detachAfter(t)
 	var buf bytes.Buffer
 	root := NewRoot()
 	root.SetOut(&buf)
 	root.SetErr(&buf)
 	root.SetArgs([]string{"version", "--color=banana"})
-	// `version` does not build a Printer, so it does not surface the bad value;
-	// what matters here is that the pre-run still ran to completion.
 	_ = root.Execute()
 
-	if resolvedColorMode != ui.ColorAuto {
-		t.Fatalf("an invalid --color must degrade to auto, got %v", resolvedColorMode)
+	// The installed handler writes to the root's stderr. Emitting through the
+	// process default must therefore land in our buffer — if the pre-run skipped
+	// installation, this goes to the real os.Stderr instead and the buffer is bare.
+	before := buf.Len()
+	slogWarnForTest("installed-check")
+	if !strings.Contains(buf.String()[before:], "installed-check") {
+		t.Fatalf("no slog handler installed after an invalid --color; got: %q", buf.String()[before:])
+	}
+	if !strings.Contains(buf.String()[before:], "WARN") {
+		t.Fatalf("the installed handler is not labeling: %q", buf.String()[before:])
 	}
 }
 
-// ReportError must honor the mode the pre-run recorded — the end of the chain
-// that makes `--color=never` actually reach the terminal error line.
-func TestReportErrorHonorsRecordedColorMode(t *testing.T) {
-	orig := resolvedColorMode
-	t.Cleanup(func() { resolvedColorMode = orig })
-
+func TestReportErrorToHonorsColorMode(t *testing.T) {
 	var colored, plain bytes.Buffer
-	resolvedColorMode = ui.ColorAlways
-	if code := reportErrorToStream(&colored, errors.New("boom")); code != 1 {
+	if code := ReportErrorTo(&colored, ui.ColorAlways, errors.New("boom")); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	resolvedColorMode = ui.ColorNever
-	if code := reportErrorToStream(&plain, errors.New("boom")); code != 1 {
+	if code := ReportErrorTo(&plain, ui.ColorNever, errors.New("boom")); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-
 	if !strings.Contains(colored.String(), "\x1b[") {
 		t.Fatalf("ColorAlways produced no ANSI: %q", colored.String())
 	}
@@ -101,7 +109,7 @@ func TestReportErrorHonorsRecordedColorMode(t *testing.T) {
 // The terminal error is the last thing a failing run prints, and an error chain
 // routinely carries third-party agent-config text. A bare \r in it rewinds the
 // cursor over the "✗ ERROR" label, letting crafted config forge a success line;
-// a \x1b introduces an arbitrary escape sequence.
+// \x1b introduces an arbitrary escape sequence.
 func TestReportErrorSanitizesTheErrorChain(t *testing.T) {
 	var buf bytes.Buffer
 	ReportErrorTo(&buf, ui.ColorNever, errors.New("render codex: subagent \"a\rb\x1b]0;pwned\x07\" is bad"))
@@ -135,8 +143,7 @@ func TestReportErrorKeepsMultiLineStructure(t *testing.T) {
 	}
 }
 
-// reportErrorToStream is ReportError with an injectable writer, exercising the
-// same resolvedColorMode read that main() relies on.
-func reportErrorToStream(w *bytes.Buffer, err error) int {
-	return ReportErrorTo(w, resolvedColorMode, err)
-}
+// slogWarnForTest emits through the PROCESS DEFAULT logger, which is what the
+// pre-run installs. Deliberately not a *slog.Logger built here: the point is to
+// observe whatever handler the root command left installed.
+func slogWarnForTest(msg string) { slog.Warn(msg) }

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -27,8 +27,8 @@ func detachAfter(t *testing.T) {
 // var (written in PersistentPreRunE, read from main) be deleted entirely.
 //
 // This pins that mechanism. It calls colorModeOf on the executed root exactly as
-// Execute does; Execute itself is then a four-line shim over this plus the
-// already-tested ReportErrorTo, and writes to the real os.Stderr, which is why it
+// Execute does; Execute itself is then a thin shim over this plus the
+// already-tested reportErrorTo, and writes to the real os.Stderr, which is why it
 // is not driven directly here.
 func TestColorModeIsReadableFromAnExecutedRoot(t *testing.T) {
 	tests := []struct {

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -89,10 +90,10 @@ func TestPersistentPreRunInstallsDespiteInvalidColor(t *testing.T) {
 
 func TestReportErrorToHonorsColorMode(t *testing.T) {
 	var colored, plain bytes.Buffer
-	if code := ReportErrorTo(&colored, ui.ColorAlways, errors.New("boom")); code != 1 {
+	if code := reportErrorTo(&colored, ui.ColorAlways, errors.New("boom")); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	if code := ReportErrorTo(&plain, ui.ColorNever, errors.New("boom")); code != 1 {
+	if code := reportErrorTo(&plain, ui.ColorNever, errors.New("boom")); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
 	if !strings.Contains(colored.String(), "\x1b[") {
@@ -112,7 +113,7 @@ func TestReportErrorToHonorsColorMode(t *testing.T) {
 // \x1b introduces an arbitrary escape sequence.
 func TestReportErrorSanitizesTheErrorChain(t *testing.T) {
 	var buf bytes.Buffer
-	ReportErrorTo(&buf, ui.ColorNever, errors.New("render codex: subagent \"a\rb\x1b]0;pwned\x07\" is bad"))
+	reportErrorTo(&buf, ui.ColorNever, errors.New("render codex: subagent \"a\rb\x1b]0;pwned\x07\" is bad"))
 
 	got := buf.String()
 	for _, bad := range []string{"\r", "\x1b]", "\x07"} {
@@ -133,7 +134,7 @@ func TestReportErrorSanitizesTheErrorChain(t *testing.T) {
 // message-column indentation.
 func TestReportErrorKeepsMultiLineStructure(t *testing.T) {
 	var buf bytes.Buffer
-	ReportErrorTo(&buf, ui.ColorNever, errors.New("first line\nsecond line"))
+	reportErrorTo(&buf, ui.ColorNever, errors.New("first line\nsecond line"))
 	got := buf.String()
 	if !strings.Contains(got, "first line\n") || !strings.Contains(got, "second line") {
 		t.Fatalf("multi-line error was collapsed: %q", got)
@@ -147,3 +148,60 @@ func TestReportErrorKeepsMultiLineStructure(t *testing.T) {
 // pre-run installs. Deliberately not a *slog.Logger built here: the point is to
 // observe whatever handler the root command left installed.
 func slogWarnForTest(msg string) { slog.Warn(msg) }
+
+// The exact failure from #211: `agentsync status` exits 1 and the last thing
+// printed is the error. It used to be a flat, unlabeled, uncolored
+// `agentsync: render codex: …` sitting directly below a WARN, with nothing marking
+// it as the failure.
+func TestReportErrorCarriesTheErrorLabel(t *testing.T) {
+	var buf bytes.Buffer
+	code := reportErrorTo(&buf, ui.ColorNever, errors.New(
+		`render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name`,
+	))
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "✗ ERROR  ") {
+		t.Fatalf("terminal error must lead with the ERROR label; got: %q", got)
+	}
+	if strings.Contains(got, "agentsync:") {
+		t.Fatalf("the redundant program prefix should be gone; got: %q", got)
+	}
+	if !strings.Contains(got, "resolve to the same agent name") {
+		t.Fatalf("the error message body was lost; got: %q", got)
+	}
+}
+
+// The quiet exit-code sentinel (`status --exit-code`, `diff --exit-code`) carries
+// its own code and an empty message: it must map to that code and print NOTHING,
+// so a CI gate gets a stable non-zero exit with no spurious diagnostic line. It
+// must be found through a `%w` wrapper too, since commands wrap on the way up.
+func TestReportErrorQuietSentinel(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"direct", quietExitErr(3), 3},
+		{"wrapped", fmt.Errorf("status: %w", quietExitErr(2)), 2},
+		{"nil", nil, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if code := reportErrorTo(&buf, ui.ColorNever, tc.err); code != tc.want {
+				t.Fatalf("exit code = %d, want %d", code, tc.want)
+			}
+			if buf.Len() != 0 {
+				t.Fatalf("must print nothing; got: %q", buf.String())
+			}
+		})
+	}
+}
+
+// quietExitErr mirrors the status/diff sentinel: an empty message plus its own
+// process exit code.
+type quietExitErr int
+
+func (q quietExitErr) Error() string { return "" }
+func (q quietExitErr) ExitCode() int { return int(q) }

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -228,8 +228,7 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 		}
 		if st == agit.StateAgentsyncOwned {
 			// Folded into a parent agentsync repo — managed, but reverted via the parent.
-			fmt.Fprintf(p.Err, "%s %s is versioned as part of a parent directory; revert that to roll it back.\n",
-				p.Faint(ui.GlyphInfo), root)
+			p.Infof("%s is versioned as part of a parent directory; revert that to roll it back.", root)
 			return true, nil
 		}
 		if strict {
@@ -260,8 +259,8 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 			return true, fmt.Errorf("%s contains a nested git repository; refusing to revert "+
 				"as a precaution — remove or reconcile the inner repo first", root)
 		}
-		fmt.Fprintf(p.Err, "%s a nested git repository now lives below %s; skipping revert "+
-			"as a precaution — remove or reconcile the inner repo first.\n", p.Yellow(ui.GlyphWarn+" note:"), root)
+		p.Warnf("a nested git repository now lives below %s; skipping revert "+
+			"as a precaution — remove or reconcile the inner repo first.", root)
 		return true, nil
 	}
 
@@ -272,7 +271,7 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 			return true, herr
 		}
 		if !multi {
-			fmt.Fprintf(p.Err, "%s %s: only one checkpoint — skipping\n", p.Faint(ui.GlyphInfo), root)
+			p.Infof("%s: only one checkpoint — skipping", root)
 			return true, nil
 		}
 		target = "HEAD~1"
@@ -308,9 +307,9 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 		// mid-restore failure's restoreFailureHint also names the snapshot,
 		// which is redundancy in the safe direction, not a contradiction.
 		if snap != "" {
-			fmt.Fprintf(p.Err, "%s the revert did not complete, but it had already preserved uncommitted changes in %s as snapshot %s; "+
-				"that snapshot is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.\n",
-				p.Faint(ui.GlyphInfo), root, agit.Short(snap))
+			p.Infof("the revert did not complete, but it had already preserved uncommitted changes in %s as snapshot %s; "+
+				"that snapshot is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.",
+				root, agit.Short(snap))
 		}
 		return true, err
 	}
@@ -320,17 +319,16 @@ func revertRoot(p *ui.Printer, root, toRef string, dryRun bool, id agit.Identity
 		// The snapshot commits the dest files verbatim; like everything in this
 		// local-only history they may hold secrets resolved to cleartext. Caution the
 		// user rather than silently persist a freshly-typed secret (issue #126).
-		fmt.Fprintf(p.Err, "%s that snapshot is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.\n",
-			p.Faint(ui.GlyphInfo))
+		p.Infof("that snapshot is kept in the local-only history and, like the files it versions, may contain secrets in cleartext.")
 	}
 	if h == "" {
 		fmt.Fprintf(p.Out, "%s %s already matches %s; nothing to revert.\n", p.Faint(ui.GlyphInfo), root, agit.Short(targetHash))
 		return true, nil
 	}
-	fmt.Fprintf(p.Out, "%s reverted %s to checkpoint %s\n", p.Green(ui.GlyphOK), root, agit.Short(targetHash))
+	p.Successf(ui.EmojiReverted, "reverted %s to checkpoint %s", root, agit.Short(targetHash))
 	if len(sharedWith) > 0 {
-		fmt.Fprintf(p.Err, "%s %s is shared with %s — this also rolled back their files in it.\n",
-			p.Yellow(ui.GlyphWarn+" note:"), root, strings.Join(sharedWith, ", "))
+		p.Warnf("%s is shared with %s — this also rolled back their files in it.",
+			root, strings.Join(sharedWith, ", "))
 	}
 	printOutOfSyncNotice(p, root)
 	return true, nil
@@ -376,7 +374,7 @@ func previewRevert(p *ui.Printer, repo *agit.Repo, root, target string) error {
 	// drop the note — the preview would otherwise imply "no untracked files here".
 	untracked, uerr := repo.UntrackedPaths()
 	if uerr != nil {
-		fmt.Fprintf(p.Err, "%s could not enumerate untracked files in %s: %v\n", p.Yellow("agentsync:"), root, uerr)
+		p.Warnf("could not enumerate untracked files in %s: %v", root, uerr)
 	}
 	if len(untracked) > 0 {
 		fmt.Fprintf(p.Out, "  (%d untracked file(s) in this dir are left untouched)\n", len(untracked))
@@ -420,8 +418,7 @@ func cleanAll(dirs []string) []string {
 
 // printOutOfSyncNotice warns that the destination now diverges from canonical.
 func printOutOfSyncNotice(p *ui.Printer, dir string) {
-	fmt.Fprintf(p.Err, "%s the destination directory %s is now out of sync with the agentsync configuration.\n",
-		p.Yellow(ui.GlyphWarn+" note:"), dir)
-	fmt.Fprintf(p.Err, "  Reconcile as needed (`agentsync reconcile` / `agentsync import`) before your next "+
-		"`agentsync apply` to avoid re-losing these changes.\n")
+	p.Warnf("the destination directory %s is now out of sync with the agentsync configuration.", dir)
+	p.Detailf("Reconcile as needed (`agentsync reconcile` / `agentsync import`) before your next " +
+		"`agentsync apply` to avoid re-losing these changes.")
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,9 +4,13 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
+
+	aslog "github.com/spxrogers/agentsync/internal/log"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
@@ -55,6 +59,20 @@ func NewRoot() *cobra.Command {
 	// TestNoSubcommandOverridesPersistentPreRun guards the same hazard one level
 	// down.
 	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
+		// Install the process-wide slog default FIRST, before anything can log.
+		// Library packages (internal/render, internal/marketplace) emit their
+		// diagnostics through slog; with no handler installed those fell through
+		// to the stdlib default and printed timestamped, unstyled lines that
+		// looked nothing like the rest of the CLI (#211). Routing them here is
+		// what makes a library warning and a command's own p.Warnf identical.
+		//
+		// This also records the resolved color decision for ReportError, which
+		// runs in main() after cobra has returned and has no *cobra.Command to
+		// read the flag off.
+		if p, err := newPrinter(c); err == nil {
+			resolvedColorMode = p.ColorMode()
+			aslog.Install(c.ErrOrStderr(), p, verbose)
+		}
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a
 		// Homebrew cask's caveats print at install time only, and Scoop has
@@ -95,11 +113,65 @@ func NewRoot() *cobra.Command {
 // Execute is the main.go entry point.
 func Execute() error { return NewRoot().Execute() }
 
+// resolvedColorMode carries the --color decision from the root PersistentPreRunE
+// out to ReportError, which runs in main() after cobra has returned and so has
+// no *cobra.Command to read the flag from. It stays ColorAuto when the pre-run
+// never got that far (an unparseable flag, an unknown subcommand), which is the
+// right fallback: auto re-resolves against stderr's TTY-ness at print time.
+//
+// Package-scoped process state, which the rest of this package deliberately
+// avoids. It is safe here because it is written exactly once per process, on
+// the single-threaded path before any subcommand runs, and read exactly once
+// after every subcommand has returned. A test that needs isolation should
+// assert through ReportErrorTo, which takes its mode explicitly.
+var resolvedColorMode = ui.ColorAuto
+
+// ReportError prints err as the CLI's terminal diagnostic and returns the
+// process exit code. main() is the only caller.
+//
+// The error a command returns is the LAST thing a user reads, and #211 showed
+// what it cost to leave it unlabeled: a fatal `agentsync: render codex: …` sat
+// flush against the left margin directly below a WARN line, with nothing —
+// no glyph, no level, no color — marking it as the failure. Printing it through
+// the same vocabulary as every other diagnostic is the fix. The `agentsync:`
+// program prefix goes away with it: the ERROR label already says which stream
+// this is, and the prefix only made the line longer.
+func ReportError(err error) int { return ReportErrorTo(os.Stderr, resolvedColorMode, err) }
+
+// ReportErrorTo is ReportError against an explicit writer and color mode, so a
+// test can exercise the formatting without touching process state.
+func ReportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
+	if err == nil {
+		return 0
+	}
+	// A quiet exit-code sentinel (status/diff --exit-code) carries its own
+	// process exit code and an empty message: map it to that code and print
+	// nothing, so a CI gate gets a stable non-zero exit with no spurious
+	// diagnostic line.
+	var ec ExitCoder
+	if errors.As(err, &ec) {
+		return ec.ExitCode()
+	}
+	// Bind the printer's Out to w as well: resolveColor reads TTY-ness off Out,
+	// and this diagnostic's stream is w.
+	ui.New(w, w, mode).Errorf("%s", err)
+	return 1
+}
+
 // newPrinter builds the presentation Printer for a command invocation, reading
 // the inherited --color flag and binding to the command's stdout/stderr. The
 // color decision (TTY + NO_COLOR + flag) is made once, here, so every command
 // styles output identically. An invalid --color value is reported as an error.
 func newPrinter(cmd *cobra.Command) (*ui.Printer, error) {
+	mode, err := colorModeOf(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return ui.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), mode), nil
+}
+
+// colorModeOf reads the inherited --color flag off cmd.
+func colorModeOf(cmd *cobra.Command) (ui.ColorMode, error) {
 	modeStr, err := cmd.Flags().GetString("color")
 	if err != nil {
 		// Persistent flag not merged into this command's set; read it off the
@@ -108,11 +180,41 @@ func newPrinter(cmd *cobra.Command) (*ui.Printer, error) {
 			modeStr = f.Value.String()
 		}
 	}
-	mode, perr := ui.ParseColorMode(modeStr)
-	if perr != nil {
-		return nil, perr
+	return ui.ParseColorMode(modeStr)
+}
+
+// printerOn builds a Printer whose BOTH streams are w, honoring --color. Use it
+// for output that must land on one specific stream regardless of the command's
+// stdout — the scope prompt, which goes to stderr so it can't corrupt a
+// `--json` payload on stdout. Binding Out to w matters: ui resolves `auto`
+// against Out's TTY-ness, so a printer bound to stdout would make the color
+// decision for the wrong stream.
+//
+// An unparseable --color degrades to auto rather than erroring. The commands
+// that call this are mid-flow and have no good way to surface a flag error; the
+// value is validated (and reported) by newPrinter on the command's own path.
+func printerOn(cmd *cobra.Command, w io.Writer) *ui.Printer {
+	mode, err := colorModeOf(cmd)
+	if err != nil {
+		mode = ui.ColorAuto
 	}
-	return ui.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), mode), nil
+	return ui.New(w, w, mode)
+}
+
+// success writes a command's outcome line to its stdout through the shared
+// emoji vocabulary. A convenience for the many small mutating commands
+// (`agent add`, `mcp remove`, `secret set`, …) that have no *ui.Printer of
+// their own; a command that already holds one should call p.Successf directly.
+func success(cmd *cobra.Command, emoji, format string, args ...any) {
+	printerOn(cmd, cmd.OutOrStdout()).Successf(emoji, format, args...)
+}
+
+// diag writes a labeled diagnostic to the command's stderr. Same convenience
+// rationale as success — and same rule: diagnostics go to stderr, results go to
+// stdout, regardless of which one the caller finds more convenient.
+func diag(cmd *cobra.Command, level ui.Level, format string, args ...any) {
+	w := cmd.ErrOrStderr()
+	printerOn(cmd, w).Fdiagf(w, level, format, args...)
 }
 
 // emitJSON writes v as indented JSON to w. Used by the --json output modes,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,10 +67,6 @@ func NewRoot() *cobra.Command {
 		// looked nothing like the rest of the CLI (#211). Routing them here is
 		// what makes a library warning and a command's own p.Warnf identical.
 		//
-		// This also records the resolved color decision for ReportError, which
-		// runs in main() after cobra has returned and has no *cobra.Command to
-		// read the flag off.
-		//
 		// printerOn, NOT newPrinter: an invalid --color must not skip the
 		// installation. Gating this on `err == nil` meant a bad --color value left
 		// NO handler installed, so library warnings fell back to the stdlib
@@ -82,15 +78,13 @@ func NewRoot() *cobra.Command {
 		//
 		// Bound to Err: this printer styles diagnostics, and ui resolves `auto`
 		// per stream.
+		// Install's restore closure is deliberately dropped: a real process
+		// installs once and exits. A TEST binary runs many NewRoot().Execute()
+		// cycles, each leaving slog.Default() bound to a finished test's buffer —
+		// aslog.Detach is the seam for that, called via t.Cleanup from the CLI
+		// test harness (see detachSlog in testhelper_test.go).
 		ew := c.ErrOrStderr()
-		p := printerOn(c, ew)
-		resolvedColorMode = p.ColorMode()
-		// The restore closure is deliberately discarded HERE and reinstated by
-		// tests: a real process installs once and exits, but a test binary runs
-		// many NewRoot().Execute() cycles, each leaving slog.Default() bound to a
-		// finished test's buffer. ResetSlogForTest is the seam for that; see its
-		// doc.
-		aslog.Install(ew, p, verbose)
+		aslog.Install(ew, printerOn(c, ew), verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a
 		// Homebrew cask's caveats print at install time only, and Scoop has
@@ -128,36 +122,38 @@ func NewRoot() *cobra.Command {
 	return cmd
 }
 
-// Execute is the main.go entry point.
-func Execute() error { return NewRoot().Execute() }
-
-// resolvedColorMode carries the --color decision from the root PersistentPreRunE
-// out to ReportError, which runs in main() after cobra has returned and so has
-// no *cobra.Command to read the flag from. It stays ColorAuto when the pre-run
-// never got that far (an unparseable flag, an unknown subcommand), which is the
-// right fallback: auto re-resolves against stderr's TTY-ness at print time.
+// Execute builds and runs the command tree and returns the PROCESS EXIT CODE.
+// main.go is the only caller: `os.Exit(cli.Execute())`.
 //
-// Package-scoped process state, which the rest of this package deliberately
-// avoids. It is safe here because it is written exactly once per process, on
-// the single-threaded path before any subcommand runs, and read exactly once
-// after every subcommand has returned. A test that needs isolation should
-// assert through ReportErrorTo, which takes its mode explicitly.
-var resolvedColorMode = ui.ColorAuto
+// Owning the whole invocation — build, run, report, exit code — is what lets the
+// terminal error line be styled correctly with no package-level state. An earlier
+// shape had Execute return an error, main call a `ReportError` wrapper, and a
+// package var carry the resolved `--color` decision across that boundary, because
+// main had no `*cobra.Command` to read the flag from. It does not need one: `root`
+// is still in scope here after Execute returns, so colorModeOf reads the parsed
+// persistent flag directly.
+//
+// That collapsed three symbols — the package var, `Printer.ColorMode`, and the
+// `ReportError` wrapper — into this function with NO behavior change, including
+// the fallback: ParseColorMode already yields ColorAuto for an unparseable value,
+// exactly as the zero-valued package var did.
+func Execute() int {
+	root := NewRoot()
+	err := root.Execute()
+	mode, _ := colorModeOf(root)
+	return ReportErrorTo(os.Stderr, mode, err)
+}
 
-// ReportError prints err as the CLI's terminal diagnostic and returns the
-// process exit code. main() is the only caller.
+// ReportErrorTo renders err as the CLI's terminal diagnostic on w and returns the
+// process exit code. Exported, with its writer and color mode explicit, so a test
+// can exercise the formatting directly.
 //
 // The error a command returns is the LAST thing a user reads, and #211 showed
 // what it cost to leave it unlabeled: a fatal `agentsync: render codex: …` sat
-// flush against the left margin directly below a WARN line, with nothing —
-// no glyph, no level, no color — marking it as the failure. Printing it through
-// the same vocabulary as every other diagnostic is the fix. The `agentsync:`
-// program prefix goes away with it: the ERROR label already says which stream
-// this is, and the prefix only made the line longer.
-func ReportError(err error) int { return ReportErrorTo(os.Stderr, resolvedColorMode, err) }
-
-// ReportErrorTo is ReportError against an explicit writer and color mode, so a
-// test can exercise the formatting without touching process state.
+// flush against the left margin directly below a WARN line, with nothing — no
+// glyph, no level, no color — marking it as the failure. Printing it through the
+// same vocabulary as every other diagnostic is the fix. The `agentsync:` program
+// prefix goes away with it: the ERROR label already says which stream this is.
 func ReportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if err == nil {
 		return 0

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,8 +84,7 @@ func NewRoot() *cobra.Command {
 		// leaving slog.Default() bound to a finished test's buffer — aslog.Detach is
 		// the seam for that, called via t.Cleanup from the CLI test harness (see
 		// detachSlog in testhelper_test.go).
-		ew := c.ErrOrStderr()
-		aslog.Install(ew, printerOn(c, ew), verbose)
+		installDiagnosticLogger(c, verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a
 		// Homebrew cask's caveats print at install time only, and Scoop has
@@ -145,11 +144,19 @@ func NewRoot() *cobra.Command {
 // `ColorAuto`; that is precisely what the old package var did too, since its
 // writer (the pre-run) never ran in those cases. `mode, _` discards
 // ParseColorMode's error for the same reason: it returns ColorAuto alongside it.
-func Execute() int {
-	root := NewRoot()
+func Execute() int { return executeRoot(NewRoot(), os.Stderr) }
+
+// executeRoot is Execute with the root command and the diagnostic stream injected.
+//
+// It exists so a test can drive the REAL wiring. When Execute inlined this, the
+// only way to test it was to duplicate its four lines in the test file — and a
+// duplicate proves nothing: replacing colorModeOf(root) with a hardcoded mode in
+// production left every test green, because the tests were exercising their own
+// copy. Verified by mutation.
+func executeRoot(root *cobra.Command, errStream io.Writer) int {
 	err := root.Execute()
 	mode, _ := colorModeOf(root)
-	return reportErrorTo(os.Stderr, mode, err)
+	return reportErrorTo(errStream, mode, err)
 }
 
 // reportErrorTo renders err as the CLI's terminal diagnostic on w and returns the
@@ -214,6 +221,21 @@ func newPrinter(cmd *cobra.Command) (*ui.Printer, error) {
 		return nil, err
 	}
 	return ui.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), mode), nil
+}
+
+// installDiagnosticLogger makes the slog default write to cmd's stderr, styled for
+// that same stream.
+//
+// One function, one writer, deliberately: the call site previously passed the
+// writer AND a printer built from a writer, so the two could disagree — and an
+// Out-bound printer means a library warning takes stdout's TTY-ness while writing
+// to stderr, the leak class this PR has now fixed at four separate sites. Deriving
+// both from one expression makes the mismatch unrepresentable rather than merely
+// untested (it resisted testing: two in-memory buffers cannot diverge under
+// `auto`).
+func installDiagnosticLogger(cmd *cobra.Command, verbose bool) {
+	ew := cmd.ErrOrStderr()
+	aslog.Install(ew, printerOn(cmd, ew), verbose)
 }
 
 // colorModeOf reads the inherited --color flag off cmd.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,24 +60,15 @@ func NewRoot() *cobra.Command {
 	// TestNoSubcommandOverridesPersistentPreRun guards the same hazard one level
 	// down.
 	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
-		// Install the process-wide slog default FIRST, before anything can log.
-		// Library packages (internal/render, internal/marketplace) emit their
-		// diagnostics through slog; with no handler installed those fell through
-		// to the stdlib default and printed timestamped, unstyled lines that
-		// looked nothing like the rest of the CLI (#211). Routing them here is
-		// what makes a library warning and a command's own p.Warnf identical.
+		// Install the process-wide slog default FIRST, before anything can log:
+		// this is what makes a library warning (internal/render,
+		// internal/marketplace) and a command's own p.Warnf identical (#211).
 		//
-		// printerOn, NOT newPrinter: an invalid --color must not skip the
-		// installation. Gating this on `err == nil` meant a bad --color value left
-		// NO handler installed, so library warnings fell back to the stdlib
-		// timestamped line — reproducing the exact #211 shape this function exists
-		// to prevent, in the one case where the user already made a mistake and
-		// most needs a legible diagnostic. printerOn degrades a bad value to
-		// `auto`; the value is still validated and reported by the command's own
-		// newPrinter call.
-		//
-		// Bound to Err: this printer styles diagnostics, and ui resolves `auto`
-		// per stream.
+		// printerOn, NOT newPrinter — an invalid --color must not SKIP the install.
+		// Gating on `err == nil` left a bad value with no handler at all, so
+		// library warnings reverted to the stdlib shape exactly when the user had
+		// already made a mistake. printerOn degrades to `auto`; the value is still
+		// validated by the command's own newPrinter call.
 		//
 		// Nothing here undoes the install, by design: a real process installs once
 		// and exits. A TEST binary runs many NewRoot().Execute() cycles, each
@@ -126,33 +117,19 @@ func NewRoot() *cobra.Command {
 // main.go is the only caller: `os.Exit(cli.Execute())`.
 //
 // Owning the whole invocation — build, run, report, exit code — is what lets the
-// terminal error line be styled correctly with no package-level state. An earlier
-// shape had Execute return an error, main call a `ReportError` wrapper, and a
-// package var carry the resolved `--color` decision across that boundary, because
-// main had no `*cobra.Command` to read the flag from. It does not need one: `root`
-// is still in scope here after Execute returns, so colorModeOf reads the parsed
-// persistent flag directly.
+// terminal error be styled with no package-level state: `root` is still in scope
+// after it returns, so colorModeOf reads the parsed `--color` flag directly rather
+// than a package var carrying it across the main boundary.
 //
-// That collapsed three symbols — the package var, `Printer.ColorMode`, and the
-// `ReportError` wrapper — into this function with NO behavior change.
-//
-// Two details make that equivalence exact. Cobra shares one `*pflag.Flag` between
-// root and subcommands, so `colorModeOf(root)` sees a value parsed on a
-// SUBCOMMAND's line (`agentsync version --color=never` reads the same as
-// `agentsync --color=never version`). And when cobra fails BEFORE parsing flags —
-// an unknown subcommand, a malformed flag — the value is unset and this yields
-// `ColorAuto`; that is precisely what the old package var did too, since its
-// writer (the pre-run) never ran in those cases. `mode, _` discards
-// ParseColorMode's error for the same reason: it returns ColorAuto alongside it.
+// Two cobra details make that safe. One `*pflag.Flag` is shared between root and
+// subcommands, so `colorModeOf(root)` sees a value parsed on a SUBCOMMAND's line.
+// And when cobra fails before parsing flags (unknown subcommand, malformed flag)
+// the value is unset and this yields ColorAuto — which is also why `mode, _`
+// discards ParseColorMode's error: it returns ColorAuto alongside it.
 func Execute() int { return executeRoot(NewRoot(), os.Stderr) }
 
-// executeRoot is Execute with the root command and the diagnostic stream injected.
-//
-// It exists so a test can drive the REAL wiring. When Execute inlined this, the
-// only way to test it was to duplicate its four lines in the test file — and a
-// duplicate proves nothing: replacing colorModeOf(root) with a hardcoded mode in
-// production left every test green, because the tests were exercising their own
-// copy. Verified by mutation.
+// executeRoot is Execute with the root command and diagnostic stream injected, so
+// a test can drive the real wiring rather than a copy of it.
 func executeRoot(root *cobra.Command, errStream io.Writer) int {
 	err := root.Execute()
 	mode, _ := colorModeOf(root)
@@ -160,16 +137,13 @@ func executeRoot(root *cobra.Command, errStream io.Writer) int {
 }
 
 // reportErrorTo renders err as the CLI's terminal diagnostic on w and returns the
-// process exit code. Its writer and color mode are explicit so a test can exercise
-// the formatting directly; unexported because Execute is the only production
-// caller and the tests that drive it live in this package.
+// process exit code. Writer and color mode are explicit so a test can exercise the
+// formatting directly.
 //
-// The error a command returns is the LAST thing a user reads, and #211 showed
-// what it cost to leave it unlabeled: a fatal `agentsync: render codex: …` sat
-// flush against the left margin directly below a WARN line, with nothing — no
-// glyph, no level, no color — marking it as the failure. Printing it through the
-// same vocabulary as every other diagnostic is the fix. The `agentsync:` program
-// prefix goes away with it: the ERROR label already says which stream this is.
+// The error a command returns is the LAST thing a user reads, and #211 was
+// reported because it printed unlabeled — flush left, directly below a WARN, with
+// no glyph, level, or color marking it as the failure. The `agentsync:` program
+// prefix is gone with the fix: the ERROR label already says which stream this is.
 func reportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if err == nil {
 		return 0
@@ -226,13 +200,11 @@ func newPrinter(cmd *cobra.Command) (*ui.Printer, error) {
 // installDiagnosticLogger makes the slog default write to cmd's stderr, styled for
 // that same stream.
 //
-// One function, one writer, deliberately: the call site previously passed the
-// writer AND a printer built from a writer, so the two could disagree — and an
-// Out-bound printer means a library warning takes stdout's TTY-ness while writing
-// to stderr, the leak class this PR has now fixed at four separate sites. Deriving
-// both from one expression makes the mismatch unrepresentable rather than merely
-// untested (it resisted testing: two in-memory buffers cannot diverge under
-// `auto`).
+// One writer, one expression, deliberately: passing the writer AND a separately
+// built printer lets the two disagree, and an Out-bound printer means a library
+// warning takes stdout's TTY-ness while writing to stderr. Deriving both from `ew`
+// makes that unrepresentable — which matters because it also resists testing (two
+// in-memory buffers cannot diverge under `auto`).
 func installDiagnosticLogger(cmd *cobra.Command, verbose bool) {
 	ew := cmd.ErrOrStderr()
 	aslog.Install(ew, printerOn(cmd, ew), verbose)
@@ -258,18 +230,14 @@ func colorModeOf(cmd *cobra.Command) (ui.ColorMode, error) {
 // against Out's TTY-ness, so a printer bound to stdout would make the color
 // decision for the wrong stream.
 //
-// An unparseable --color degrades to auto rather than erroring. The commands
-// that call this are mid-flow and have no good way to surface a flag error; the
-// value is validated (and reported) by newPrinter on the command's own path.
-// ParseColorMode already returns ColorAuto alongside its error, so the error is
-// discarded rather than branched on.
+// An unparseable --color degrades to auto rather than erroring: callers are
+// mid-flow with no good way to surface a flag error, and the value is validated by
+// newPrinter on the command's own path. (ParseColorMode returns ColorAuto with its
+// error, so nothing branches on it.)
 //
-// This builds a Printer per call, which reads against Printer's "construct one
-// per command invocation" guidance. That guidance is about not re-deciding color
-// INCONSISTENTLY within one command, and this cannot: the mode comes from the
-// same flag and is re-resolved against the same writer every time, so every call
-// yields the same decision. The cost is one TTY probe per line, on output paths
-// that already syscall.
+// This builds a Printer per call. Printer's "one per invocation" guidance is about
+// not re-deciding color inconsistently within a command, which this cannot: same
+// flag, same writer, same answer every time.
 func printerOn(cmd *cobra.Command, w io.Writer) *ui.Printer {
 	mode, _ := colorModeOf(cmd)
 	return ui.New(w, w, mode)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -71,7 +71,8 @@ func NewRoot() *cobra.Command {
 		// validated by the command's own newPrinter call.
 		//
 		// Nothing here undoes the install, by design; aslog.Detach is the seam for
-		// test binaries, which need it for the reason its doc gives.
+		// test binaries, which need it for the reason its doc gives. This package
+		// calls it via t.Cleanup — see detachSlog in testhelper_test.go.
 		installDiagnosticLogger(c, verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -69,10 +70,27 @@ func NewRoot() *cobra.Command {
 		// This also records the resolved color decision for ReportError, which
 		// runs in main() after cobra has returned and has no *cobra.Command to
 		// read the flag off.
-		if p, err := newPrinter(c); err == nil {
-			resolvedColorMode = p.ColorMode()
-			aslog.Install(c.ErrOrStderr(), p, verbose)
-		}
+		//
+		// printerOn, NOT newPrinter: an invalid --color must not skip the
+		// installation. Gating this on `err == nil` meant a bad --color value left
+		// NO handler installed, so library warnings fell back to the stdlib
+		// timestamped line — reproducing the exact #211 shape this function exists
+		// to prevent, in the one case where the user already made a mistake and
+		// most needs a legible diagnostic. printerOn degrades a bad value to
+		// `auto`; the value is still validated and reported by the command's own
+		// newPrinter call.
+		//
+		// Bound to Err: this printer styles diagnostics, and ui resolves `auto`
+		// per stream.
+		ew := c.ErrOrStderr()
+		p := printerOn(c, ew)
+		resolvedColorMode = p.ColorMode()
+		// The restore closure is deliberately discarded HERE and reinstated by
+		// tests: a real process installs once and exits, but a test binary runs
+		// many NewRoot().Execute() cycles, each leaving slog.Default() bound to a
+		// finished test's buffer. ResetSlogForTest is the seam for that; see its
+		// doc.
+		aslog.Install(ew, p, verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a
 		// Homebrew cask's caveats print at install time only, and Scoop has
@@ -152,10 +170,33 @@ func ReportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if errors.As(err, &ec) {
 		return ec.ExitCode()
 	}
-	// Bind the printer's Out to w as well: resolveColor reads TTY-ness off Out,
-	// and this diagnostic's stream is w.
-	ui.New(w, w, mode).Errorf("%s", err)
+	// Bind BOTH streams to w: this diagnostic's destination is w, and ui resolves
+	// `auto` per stream.
+	//
+	// sanitizeLines, not raw err.Error(): an error chain routinely carries
+	// third-party agent-config text (a plugin id, a native subagent name, a
+	// filesystem path), and no single call site can pre-sanitize a wrapped chain
+	// assembled on the way up. Left raw, a bare \r in that text rewinds the
+	// cursor over the "✗ ERROR" label and lets crafted config forge a "✅" line —
+	// the terminal-spoofing class #93/#171 exist for. Sanitizing per line keeps a
+	// legitimately multi-line error readable while stripping the control bytes.
+	ui.New(w, w, mode).Errorf("%s", sanitizeLines(err.Error()))
 	return 1
+}
+
+// sanitizeLines applies ui.Sanitize to each line and rejoins with "\n".
+//
+// ui.Sanitize STRIPS newlines (it does not escape them), so sanitizing a
+// multi-line string wholesale would concatenate the lines with no separator and
+// defeat the message-column indentation Fdiagf applies. Splitting first keeps
+// the structure the author intended while still removing every control byte an
+// attacker could smuggle in.
+func sanitizeLines(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		lines[i] = ui.Sanitize(ln)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // newPrinter builds the presentation Printer for a command invocation, reading
@@ -193,11 +234,17 @@ func colorModeOf(cmd *cobra.Command) (ui.ColorMode, error) {
 // An unparseable --color degrades to auto rather than erroring. The commands
 // that call this are mid-flow and have no good way to surface a flag error; the
 // value is validated (and reported) by newPrinter on the command's own path.
+// ParseColorMode already returns ColorAuto alongside its error, so the error is
+// discarded rather than branched on.
+//
+// This builds a Printer per call, which reads against Printer's "construct one
+// per command invocation" guidance. That guidance is about not re-deciding color
+// INCONSISTENTLY within one command, and this cannot: the mode comes from the
+// same flag and is re-resolved against the same writer every time, so every call
+// yields the same decision. The cost is one TTY probe per line, on output paths
+// that already syscall.
 func printerOn(cmd *cobra.Command, w io.Writer) *ui.Printer {
-	mode, err := colorModeOf(cmd)
-	if err != nil {
-		mode = ui.ColorAuto
-	}
+	mode, _ := colorModeOf(cmd)
 	return ui.New(w, w, mode)
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,11 +78,12 @@ func NewRoot() *cobra.Command {
 		//
 		// Bound to Err: this printer styles diagnostics, and ui resolves `auto`
 		// per stream.
-		// Install's restore closure is deliberately dropped: a real process
-		// installs once and exits. A TEST binary runs many NewRoot().Execute()
-		// cycles, each leaving slog.Default() bound to a finished test's buffer —
-		// aslog.Detach is the seam for that, called via t.Cleanup from the CLI
-		// test harness (see detachSlog in testhelper_test.go).
+		//
+		// Nothing here undoes the install, by design: a real process installs once
+		// and exits. A TEST binary runs many NewRoot().Execute() cycles, each
+		// leaving slog.Default() bound to a finished test's buffer — aslog.Detach is
+		// the seam for that, called via t.Cleanup from the CLI test harness (see
+		// detachSlog in testhelper_test.go).
 		ew := c.ErrOrStderr()
 		aslog.Install(ew, printerOn(c, ew), verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
@@ -134,19 +135,27 @@ func NewRoot() *cobra.Command {
 // persistent flag directly.
 //
 // That collapsed three symbols — the package var, `Printer.ColorMode`, and the
-// `ReportError` wrapper — into this function with NO behavior change, including
-// the fallback: ParseColorMode already yields ColorAuto for an unparseable value,
-// exactly as the zero-valued package var did.
+// `ReportError` wrapper — into this function with NO behavior change.
+//
+// Two details make that equivalence exact. Cobra shares one `*pflag.Flag` between
+// root and subcommands, so `colorModeOf(root)` sees a value parsed on a
+// SUBCOMMAND's line (`agentsync version --color=never` reads the same as
+// `agentsync --color=never version`). And when cobra fails BEFORE parsing flags —
+// an unknown subcommand, a malformed flag — the value is unset and this yields
+// `ColorAuto`; that is precisely what the old package var did too, since its
+// writer (the pre-run) never ran in those cases. `mode, _` discards
+// ParseColorMode's error for the same reason: it returns ColorAuto alongside it.
 func Execute() int {
 	root := NewRoot()
 	err := root.Execute()
 	mode, _ := colorModeOf(root)
-	return ReportErrorTo(os.Stderr, mode, err)
+	return reportErrorTo(os.Stderr, mode, err)
 }
 
-// ReportErrorTo renders err as the CLI's terminal diagnostic on w and returns the
-// process exit code. Exported, with its writer and color mode explicit, so a test
-// can exercise the formatting directly.
+// reportErrorTo renders err as the CLI's terminal diagnostic on w and returns the
+// process exit code. Its writer and color mode are explicit so a test can exercise
+// the formatting directly; unexported because Execute is the only production
+// caller and the tests that drive it live in this package.
 //
 // The error a command returns is the LAST thing a user reads, and #211 showed
 // what it cost to leave it unlabeled: a fatal `agentsync: render codex: …` sat
@@ -154,7 +163,7 @@ func Execute() int {
 // glyph, no level, no color — marking it as the failure. Printing it through the
 // same vocabulary as every other diagnostic is the fix. The `agentsync:` program
 // prefix goes away with it: the ERROR label already says which stream this is.
-func ReportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
+func reportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if err == nil {
 		return 0
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -70,11 +70,8 @@ func NewRoot() *cobra.Command {
 		// already made a mistake. printerOn degrades to `auto`; the value is still
 		// validated by the command's own newPrinter call.
 		//
-		// Nothing here undoes the install, by design: a real process installs once
-		// and exits. A TEST binary runs many NewRoot().Execute() cycles, each
-		// leaving slog.Default() bound to a finished test's buffer — aslog.Detach is
-		// the seam for that, called via t.Cleanup from the CLI test harness (see
-		// detachSlog in testhelper_test.go).
+		// Nothing here undoes the install, by design; aslog.Detach is the seam for
+		// test binaries, which need it for the reason its doc gives.
 		installDiagnosticLogger(c, verbose)
 		// The first-run-after-upgrade notice is the ONLY hook that reaches every
 		// installation channel — `go install` has no post-install step, a
@@ -140,10 +137,9 @@ func executeRoot(root *cobra.Command, errStream io.Writer) int {
 // process exit code. Writer and color mode are explicit so a test can exercise the
 // formatting directly.
 //
-// The error a command returns is the LAST thing a user reads, and #211 was
-// reported because it printed unlabeled — flush left, directly below a WARN, with
-// no glyph, level, or color marking it as the failure. The `agentsync:` program
-// prefix is gone with the fix: the ERROR label already says which stream this is.
+// This is the line #211 was reported against (see ui/diag.go): the last thing a
+// user reads, printed unlabeled below a WARN. The `agentsync:` program prefix is
+// gone with the fix — the ERROR label already says which stream this is.
 func reportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if err == nil {
 		return 0
@@ -235,9 +231,9 @@ func colorModeOf(cmd *cobra.Command) (ui.ColorMode, error) {
 // newPrinter on the command's own path. (ParseColorMode returns ColorAuto with its
 // error, so nothing branches on it.)
 //
-// This builds a Printer per call. Printer's "one per invocation" guidance is about
-// not re-deciding color inconsistently within a command, which this cannot: same
-// flag, same writer, same answer every time.
+// Building a Printer per call is fine: Printer's "one per invocation" guidance is
+// against re-deciding color inconsistently, and this cannot — same flag, same
+// writer, same answer.
 func printerOn(cmd *cobra.Command, w io.Writer) *ui.Printer {
 	mode, _ := colorModeOf(cmd)
 	return ui.New(w, w, mode)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -94,6 +94,9 @@ func TestRoot_VersionInjection(t *testing.T) {
 // whitespace/newline divergence between the two version render paths.
 func renderRaw(t *testing.T, args ...string) []byte {
 	t.Helper()
+	// Bypassing runCLI also bypasses its slog detach, and the root installs a
+	// handler bound to the buffer below — which this function is about to drop.
+	detachSlog(t)
 	var buf bytes.Buffer
 	root := cli.NewRoot()
 	root.SetOut(&buf)

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -359,7 +359,7 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("re-encrypt: %w", err)
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), "secrets saved")
+	success(cmd, ui.EmojiSuccess, "secrets saved")
 	return nil
 }
 
@@ -392,8 +392,8 @@ func secretsGet(cmd *cobra.Command, args []string) error {
 	// stderr. Piped and redirected uses stay silent.
 	fmt.Fprintln(cmd.OutOrStdout(), s)
 	if stdoutIsTerminal(cmd) {
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"agentsync: that value is now in your terminal scrollback; pipe it (`agentsync secret get %s | …`) to keep it out.\n",
+		diag(cmd, ui.LevelWarn,
+			"that value is now in your terminal scrollback; pipe it (`agentsync secret get %s | …`) to keep it out.",
 			ui.Sanitize(args[0]))
 	}
 	return nil
@@ -448,7 +448,7 @@ func secretsSet(cmd *cobra.Command, arg string, useStdin, allowEmpty bool) error
 	if err := encryptMap(m, cfg, home); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "secret %q set\n", key)
+	success(cmd, ui.EmojiSuccess, "secret %q set", key)
 	return nil
 }
 
@@ -486,10 +486,10 @@ func resolveSecretKeyValue(cmd *cobra.Command, arg string, useStdin bool) (strin
 			return "", "", fmt.Errorf("set argument has empty key (expected <key>=<value>)")
 		}
 		value := arg[idx+1:]
-		fmt.Fprintln(cmd.ErrOrStderr(),
-			"agentsync: warning: passing the value on argv exposes it to ps(1), shell history, and process auditing.")
-		fmt.Fprintln(cmd.ErrOrStderr(),
-			"  Use `agentsync secret set <key> --stdin` or omit the value to be prompted.")
+		ew := cmd.ErrOrStderr()
+		ep := printerOn(cmd, ew)
+		ep.Fdiagf(ew, ui.LevelWarn, "passing the value on argv exposes it to ps(1), shell history, and process auditing.")
+		ep.Fdetailf(ew, "Use `agentsync secret set <key> --stdin` or omit the value to be prompted.")
 		return key, value, nil
 	}
 
@@ -610,7 +610,7 @@ func secretsRemove(cmd *cobra.Command, key string) error {
 	if err := encryptMap(m, cfg, home); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "secret %q removed\n", key)
+	success(cmd, ui.EmojiRemoved, "secret %q removed", key)
 	return nil
 }
 

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -244,7 +244,7 @@ func TestSecretsSet_LegacyArgWarns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("legacy set: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "warning") || !strings.Contains(out, "--stdin") {
+	if !strings.Contains(out, "WARN") || !strings.Contains(out, "--stdin") {
 		t.Fatalf("legacy form did not warn about argv exposure; got:\n%s", out)
 	}
 }

--- a/internal/cli/slog_routing_test.go
+++ b/internal/cli/slog_routing_test.go
@@ -181,3 +181,60 @@ func mustJSON(t *testing.T, v any) string {
 	}
 	return string(b)
 }
+
+// TestSuccessAndDiagUseTheRightStreams pins the PR's HEADLINE rule at the helper
+// that carries it for ~25 call sites across agent/check/init/mcp/plugin/secrets:
+// `success` writes a RESULT to stdout, `diag` writes a DIAGNOSTIC to stderr.
+//
+// It was previously unpinned in the worst possible way — swapping BOTH helpers'
+// streams simultaneously left `go test ./internal/cli/...` completely green.
+// `runCLI` merges stdout and stderr into one buffer, so no test built on it can
+// see a stream swap; only `runCLISplit` can, and none asserted on these helpers.
+//
+// The fixture is a real command pair rather than a synthetic one: `agent add
+// claude` succeeds (a ✅ result), and `agent add codex` additionally warns that the
+// codex binary is not on PATH (a WARN diagnostic) — so one invocation exercises
+// both helpers and both streams.
+func TestSuccessAndDiagUseTheRightStreams(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := runCLISplit(t, env, "agent", "add", "claude")
+	if err != nil {
+		t.Fatalf("agent add claude: %v\nstderr:\n%s", err, stderr)
+	}
+	// The success RESULT belongs on stdout, with its emoji and no level label.
+	if !strings.Contains(stdout, ui.EmojiSuccess+" added agent: claude") {
+		t.Errorf("success line missing from stdout: %q", stdout)
+	}
+	if strings.Contains(stderr, "added agent") {
+		t.Errorf("success line leaked onto stderr: %q", stderr)
+	}
+	for _, word := range []string{"INFO", "WARN", "ERROR", "DEBUG"} {
+		if strings.Contains(stdout, word) {
+			t.Errorf("a %s level label appeared on stdout: %q", word, stdout)
+		}
+	}
+
+	// codex is genuinely absent from PATH in the test container, so `agent add`
+	// emits a WARN through `diag` — which belongs on stderr.
+	stdout2, stderr2, err := runCLISplit(t, env, "agent", "add", "codex")
+	if err != nil {
+		t.Fatalf("agent add codex: %v\nstderr:\n%s", err, stderr2)
+	}
+	warnLabel := ui.LevelWarn.Label(ui.New(io.Discard, io.Discard, ui.ColorNever))
+	if !strings.Contains(stderr2, warnLabel) {
+		t.Fatalf("the diag WARN is not on stderr (is `diag` writing to stdout?): stderr=%q stdout=%q", stderr2, stdout2)
+	}
+	if strings.Contains(stdout2, warnLabel) || strings.Contains(stdout2, "not found on PATH") {
+		t.Errorf("a diagnostic leaked onto stdout: %q", stdout2)
+	}
+	// And the success half of the same invocation still went to stdout.
+	if !strings.Contains(stdout2, ui.EmojiSuccess+" added agent: codex") {
+		t.Errorf("success line missing from stdout: %q", stdout2)
+	}
+}

--- a/internal/cli/slog_routing_test.go
+++ b/internal/cli/slog_routing_test.go
@@ -1,0 +1,180 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// TestSlogWarningRoutesThroughTheDiagnosticVocabulary is the end-to-end regression
+// for the HALF of #211 that no other test covered.
+//
+// The library packages (internal/render, internal/marketplace) report through
+// `slog`, and before this change NO handler was ever installed — so those records
+// fell through to slog's default and printed via the standard log package:
+//
+//	2026/07/28 15:03:45 WARN plugin component frontmatter is not strict YAML …
+//
+// a timestamped, uncolored, unlabeled shape that made the fatal error one line
+// below it indistinguishable. The fix is one line in the root command's
+// PersistentPreRunE (`aslog.Install`). Deleting that line used to break NOTHING:
+// the full unit + e2e suite stayed green, because every existing assertion covers
+// either the ui package in isolation or the ADAPTER warning path
+// (`import_warn_routing_test.go`, which goes through Fprintf → ui.WarnWriter and
+// never touches slog).
+//
+// So this drives a real CLI invocation that trips a genuine slog.Warn deep in
+// marketplace projection, and asserts the record comes out of the process as an
+// agentsync diagnostic. It fails if the installation is removed, if the handler
+// stops labeling, or if the timestamp comes back.
+func TestSlogWarningRoutesThroughTheDiagnosticVocabulary(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
+
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A local marketplace whose plugin ships an agent with NON-STRICT frontmatter:
+	// the unquoted "description:" value contains ": ", which is what makes
+	// marketplace projection fall back to lenient parsing and emit the slog.Warn.
+	mp := filepath.Join(tmp, "fixture-mp")
+	writeFile(t, filepath.Join(mp, ".claude-plugin", "marketplace.json"), mustJSON(t, map[string]any{
+		"name":  "fixture-mp",
+		"owner": map[string]any{"name": "test"},
+		"plugins": []map[string]any{
+			{"name": "demo-plugin", "source": "./plugins/demo-plugin"},
+		},
+	}))
+	writeFile(t, filepath.Join(mp, "plugins", "demo-plugin", ".claude-plugin", "plugin.json"),
+		mustJSON(t, map[string]any{"name": "demo-plugin", "version": "1.0.0"}))
+	writeFile(t, filepath.Join(mp, "plugins", "demo-plugin", "agents", "hunter.md"),
+		"---\nname: hunter\ndescription: Finds silent failures: swallowed errors\n---\nbody\n")
+
+	if out, err := runCLI(t, env, "marketplace", "add", mp); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "demo-plugin@fixture-mp"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+
+	stdout, stderr, err := runCLISplit(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\nstderr:\n%s", err, stderr)
+	}
+
+	// The fixture must actually trip the warning, or this test proves nothing.
+	// Assert the phrase FIRST so a fixture that stopped provoking slog fails
+	// loudly here rather than silently making the label assertions vacuous.
+	const phrase = "frontmatter is not strict YAML"
+	if !strings.Contains(stderr, phrase) {
+		// Two causes, and the captured buffer cannot tell them apart — say both.
+		// With no handler installed, slog's default writes to the process's REAL
+		// os.Stderr, which runCLISplit does not capture, so the record vanishes
+		// from this buffer exactly as if the fixture had never provoked it.
+		t.Fatalf("no slog warning reached the captured stderr. Either the handler is not "+
+			"installed (aslog.Install in root.go's PersistentPreRunE — the stdlib default "+
+			"writes to the real os.Stderr, not this buffer), or the fixture stopped "+
+			"provoking the marketplace lenient-YAML warning.\nstderr:\n%s", stderr)
+	}
+
+	// It must carry the WARN label, on the SAME line as the message (a label
+	// anywhere in the buffer could have come from an unrelated warning).
+	plainLabel := ui.LevelWarn.Label(ui.New(io.Discard, io.Discard, ui.ColorNever))
+	sameLine := regexp.MustCompile(regexp.QuoteMeta(plainLabel) + `[^\n\r]*` + regexp.QuoteMeta(phrase))
+	if !sameLine.MatchString(stderr) {
+		t.Fatalf("the slog warning is not labeled — the handler is not installed, or stopped labeling.\nstderr:\n%s", stderr)
+	}
+
+	// And it must NOT carry the stdlib log package's wall-clock prefix, which is
+	// the single most visible thing that was wrong with the old output.
+	stdlibTimestamp := regexp.MustCompile(`(?m)^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `)
+	if stdlibTimestamp.MatchString(stderr) {
+		t.Fatalf("stdlib timestamped log line reappeared (handler not installed?):\n%s", stderr)
+	}
+
+	// A slog-sourced diagnostic is still a diagnostic: it belongs on stderr.
+	if strings.Contains(stdout, phrase) {
+		t.Fatalf("a slog warning leaked onto stdout:\n%s", stdout)
+	}
+}
+
+// TestSlogWarningNeverEntersAJSONPayload pins the stdout/stderr split at the
+// point where it actually matters: `status --json` promises a cleanly parseable
+// payload, and a library warning printing into it would corrupt what a caller is
+// piping. docs/architecture.md §11 states this; this is the assertion behind it.
+func TestSlogWarningNeverEntersAJSONPayload(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	mp := filepath.Join(tmp, "fixture-mp")
+	writeFile(t, filepath.Join(mp, ".claude-plugin", "marketplace.json"), mustJSON(t, map[string]any{
+		"name":  "fixture-mp",
+		"owner": map[string]any{"name": "test"},
+		"plugins": []map[string]any{
+			{"name": "demo-plugin", "source": "./plugins/demo-plugin"},
+		},
+	}))
+	writeFile(t, filepath.Join(mp, "plugins", "demo-plugin", ".claude-plugin", "plugin.json"),
+		mustJSON(t, map[string]any{"name": "demo-plugin", "version": "1.0.0"}))
+	writeFile(t, filepath.Join(mp, "plugins", "demo-plugin", "agents", "hunter.md"),
+		"---\nname: hunter\ndescription: Finds silent failures: swallowed errors\n---\nbody\n")
+	if _, err := runCLI(t, env, "marketplace", "add", mp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "plugin", "add", "demo-plugin@fixture-mp"); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := runCLISplit(t, env, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "frontmatter is not strict YAML") {
+		t.Fatalf("no slog warning reached the captured stderr — handler not installed, or the "+
+			"fixture stopped provoking it; either way this test proves nothing.\nstderr:\n%s", stderr)
+	}
+	var payload map[string]any
+	if jerr := json.Unmarshal([]byte(stdout), &payload); jerr != nil {
+		t.Fatalf("stdout is not clean JSON with a library warning in flight: %v\nstdout:\n%s", jerr, stdout)
+	}
+	// No level label of any severity may appear in the payload stream.
+	for _, l := range []ui.Level{ui.LevelDebug, ui.LevelInfo, ui.LevelWarn, ui.LevelError} {
+		if word := l.String(); strings.Contains(stdout, word) {
+			t.Errorf("the %s level word leaked into the --json payload:\n%s", word, stdout)
+		}
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/cli/slog_routing_test.go
+++ b/internal/cli/slog_routing_test.go
@@ -238,3 +238,48 @@ func TestSuccessAndDiagUseTheRightStreams(t *testing.T) {
 		t.Errorf("success line missing from stdout: %q", stdout2)
 	}
 }
+
+// The two idempotent no-op paths are exact mirrors — `agent add` on an
+// already-registered agent and `agent remove` on an unregistered one — and both are
+// RESULTS: the desired state already holds and the command succeeded. They must
+// therefore land on the same stream.
+//
+// They did not. One was a `success` on stdout and the other a `diag` INFO on
+// stderr, in the same file, so a script reading one outcome had to read its mirror
+// from the other stream. Nothing caught it because runCLI merges the two.
+func TestIdempotentNoOpsAreResultsOnStdout(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"add an already-registered agent", []string{"agent", "add", "claude"}, "already registered"},
+		{"remove an unregistered agent", []string{"agent", "remove", "opencode"}, "not registered"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runCLISplit(t, env, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v\nstderr:\n%s", tc.args, err, stderr)
+			}
+			if !strings.Contains(stdout, tc.want) {
+				t.Errorf("the no-op outcome belongs on stdout; stdout=%q stderr=%q", stdout, stderr)
+			}
+			if strings.Contains(stderr, tc.want) {
+				t.Errorf("the no-op outcome leaked onto stderr: %q", stderr)
+			}
+			if !strings.Contains(stdout, ui.EmojiSuccess) {
+				t.Errorf("an idempotent no-op is a success outcome; got: %q", stdout)
+			}
+		})
+	}
+}

--- a/internal/cli/slog_routing_test.go
+++ b/internal/cli/slog_routing_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spxrogers/agentsync/internal/testenv"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
@@ -34,6 +35,7 @@ import (
 // agentsync diagnostic. It fails if the installation is removed, if the handler
 // stops labeling, or if the timestamp comes back.
 func TestSlogWarningRoutesThroughTheDiagnosticVocabulary(t *testing.T) {
+	testenv.RequireContainer(t)
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
 
@@ -113,6 +115,7 @@ func TestSlogWarningRoutesThroughTheDiagnosticVocabulary(t *testing.T) {
 // payload, and a library warning printing into it would corrupt what a caller is
 // piping. docs/architecture.md §11 states this; this is the assertion behind it.
 func TestSlogWarningNeverEntersAJSONPayload(t *testing.T) {
+	testenv.RequireContainer(t)
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "HOME": tmp, "NO_COLOR": "1"}
 	if _, err := runCLI(t, env, "init"); err != nil {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -662,9 +662,8 @@ func renderStatusLegend(p *ui.Printer, summary map[string]int) {
 // the report shows.
 func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, enabled, selected []string) {
 	for _, a := range orphanedStateAgents(s, enabled) {
-		fmt.Fprintf(p.Err, "%s agent %q is not enabled but still owns tracked files/keys in state; its "+
-			"native config is orphaned. Run `agentsync agent disable %q --purge` to remove what agentsync wrote.\n",
-			p.Yellow("warning:"), a, a)
+		p.Warnf("agent %q is not enabled but still owns tracked files/keys in state; its "+
+			"native config is orphaned. Run `agentsync agent disable %q --purge` to remove what agentsync wrote.", a, a)
 	}
 	// Nudge: plugins installed natively in an enabled agent but not yet declared
 	// in source. agentsync treats them as foreign-managed (never drift), so this
@@ -679,9 +678,9 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 		// can influence them); they are untrusted.Text and sanitize on display by
 		// construction (untrusted.Join renders each via its String()), so no manual
 		// ui.Sanitize is needed here. The agent `name` is a trusted registry id.
-		fmt.Fprintf(p.Err, "%s %d plugin(s) installed in %s are not in your source (%s); "+
-			"run `agentsync import %s:plugin` to manage them.\n",
-			p.Cyan("note:"), len(missing), name, untrusted.Join(missing, ", "), name)
+		p.Infof("%d plugin(s) installed in %s are not in your source (%s); "+
+			"run `agentsync import %s:plugin` to manage them.",
+			len(missing), name, untrusted.Join(missing, ", "), name)
 	}
 }
 

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -7,7 +7,23 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/cli"
+	aslog "github.com/spxrogers/agentsync/internal/log"
 )
+
+// detachSlog unbinds the process-wide slog default from THIS invocation's
+// buffers once the test using them is done.
+//
+// The root command installs a slog handler bound to its stderr, and a real
+// process exits with it installed. A test binary does not: without this, every
+// runCLI leaves slog.Default() writing into a *bytes.Buffer owned by a test that
+// has already returned, so a later library slog.Warn writes into a dead buffer —
+// invisible today, and a data race the moment any test here adopts t.Parallel.
+// t.Cleanup rather than a defer so the detach happens after the CALLER's
+// assertions, not when the helper returns.
+func detachSlog(t *testing.T) {
+	t.Helper()
+	t.Cleanup(aslog.Detach)
+}
 
 // runCLI runs the CLI with given args, returns stdout+stderr combined and
 // the resulting error. Sets AGENTSYNC_TARGET_ROOT to the supplied tmp via env.
@@ -22,6 +38,7 @@ func runCLI(t *testing.T, env map[string]string, args ...string) (string, error)
 // test must know WHICH stream a message landed on.
 func runCLIWithStdin(t *testing.T, env map[string]string, stdinContent string, args ...string) (string, error) {
 	t.Helper()
+	detachSlog(t)
 	var buf bytes.Buffer
 	root := cli.NewRoot()
 	root.SetOut(&buf)
@@ -63,6 +80,7 @@ func runCLISplit(t *testing.T, env map[string]string, args ...string) (string, s
 // runCLIWithStdinSplit is runCLISplit with stdin supplied.
 func runCLIWithStdinSplit(t *testing.T, env map[string]string, stdinContent string, args ...string) (string, string, error) {
 	t.Helper()
+	detachSlog(t)
 	var outBuf, errBuf bytes.Buffer
 	root := cli.NewRoot()
 	root.SetOut(&outBuf)

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -282,18 +282,18 @@ func hasUserConfig(home string) bool {
 func printUpgradeNotices(p *ui.Printer, notices []upgradeNotice) {
 	w := p.Err
 	fmt.Fprintln(w, "")
-	fmt.Fprintf(w, "%s %s\n",
-		p.Yellow(ui.GlyphWarn+" agentsync "+Version+":"),
-		p.Bold("you upgraded across a change that needs your attention"))
+	// The banner leads with the shared WARN label — it IS a warning about this
+	// run — and hangs its body off the label's message column via Detailf, so
+	// it reads as one block rather than as a second, competing layout language.
+	p.Warnf("agentsync %s: %s", Version, p.Bold("you upgraded across a change that needs your attention"))
 	for _, n := range notices {
-		fmt.Fprintf(w, "  %s %s %s\n",
-			p.Yellow(ui.GlyphArrow), p.Bold("since "+n.Since+" —"), n.Headline)
+		p.Detailf("%s %s %s", p.Yellow(ui.GlyphArrow), p.Bold("since "+n.Since+" —"), n.Headline)
 		for _, a := range n.Actions {
-			fmt.Fprintf(w, "      %s %s\n", p.Faint(ui.GlyphInfo), a)
+			p.Detailf("    %s %s", p.Faint(ui.GlyphInfo), a)
 		}
-		fmt.Fprintf(w, "      %s %s\n", p.Faint("read more:"), p.Cyan(docsBaseURL+n.Path))
+		p.Detailf("    %s %s", p.Faint("read more:"), p.Cyan(docsBaseURL+n.Path))
 	}
-	fmt.Fprintf(w, "  %s\n", p.Faint("(shown once; silence it with "+NoUpgradeNoticeEnv+"=1)"))
+	p.Detailf("%s", p.Faint("(shown once; silence it with "+NoUpgradeNoticeEnv+"=1)"))
 	fmt.Fprintln(w, "")
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,18 +1,44 @@
-// Package log centralizes slog setup. CLI commands receive *slog.Logger from
-// the root cobra command's PersistentPreRun.
+// Package log centralizes slog setup. The root cobra command installs the
+// process-wide default logger in its PersistentPreRunE (see internal/cli/root.go),
+// which is what makes a slog.Warn from deep inside internal/render or
+// internal/marketplace render as an agentsync diagnostic rather than as a
+// stdlib log line.
+//
+// That wiring is the point of this package. It previously returned a JSON
+// handler that nothing ever installed, so every library-side slog call fell
+// through to slog's default handler and printed via the standard log package —
+// timestamped, uncolored, and shaped like nothing else the CLI emitted. #211
+// showed what that cost: a `2026/07/28 15:03:45 WARN …` line sitting directly
+// above an unlabeled fatal error, with nothing to tell the two apart.
 package log
 
 import (
 	"io"
 	"log/slog"
+
+	"github.com/spxrogers/agentsync/internal/ui"
 )
 
-// New returns a JSON slog.Logger writing to w. If verbose is true, level is
-// Debug; otherwise Info.
-func New(w io.Writer, verbose bool) *slog.Logger {
+// New returns a slog.Logger that renders through p's diagnostic vocabulary,
+// writing to w. If verbose is true the level is Debug; otherwise Info.
+//
+// Level here gates only slog-sourced diagnostics. It is not a global quiet
+// switch: a command's own result output and its direct p.Warnf calls are not
+// slog records and are unaffected.
+func New(w io.Writer, p *ui.Printer, verbose bool) *slog.Logger {
 	level := slog.LevelInfo
 	if verbose {
 		level = slog.LevelDebug
 	}
-	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
+	return slog.New(ui.NewSlogHandler(w, p, level))
+}
+
+// Install makes New's logger the process-wide slog default and returns a
+// function that restores the previous default. The restore exists for tests,
+// which must not leak a handler bound to a finished test's buffer into the next
+// test; the CLI itself installs once per process and never restores.
+func Install(w io.Writer, p *ui.Printer, verbose bool) func() {
+	prev := slog.Default()
+	slog.SetDefault(New(w, p, verbose))
+	return func() { slog.SetDefault(prev) }
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,15 +1,10 @@
 // Package log centralizes slog setup. The root cobra command installs the
-// process-wide default logger in its PersistentPreRunE (see internal/cli/root.go),
-// which is what makes a slog.Warn from deep inside internal/render or
-// internal/marketplace render as an agentsync diagnostic rather than as a
-// stdlib log line.
+// process-wide default logger in its PersistentPreRunE (internal/cli/root.go),
+// which is what makes a slog.Warn from internal/render or internal/marketplace
+// render as an agentsync diagnostic instead of a timestamped stdlib log line.
 //
-// That wiring is the point of this package. It previously returned a JSON
-// handler that nothing ever installed, so every library-side slog call fell
-// through to slog's default handler and printed via the standard log package —
-// timestamped, uncolored, and shaped like nothing else the CLI emitted. #211
-// showed what that cost: a `2026/07/28 15:03:45 WARN …` line sitting directly
-// above an unlabeled fatal error, with nothing to tell the two apart.
+// That wiring IS this package. Without it, library-side slog falls through to
+// slog's default handler — the shape #211 was reported against.
 package log
 
 import (
@@ -20,11 +15,11 @@ import (
 )
 
 // New returns a slog.Logger that renders through p's diagnostic vocabulary,
-// writing to w. If verbose is true the level is Debug; otherwise Info.
+// writing to w. Debug level when verbose, otherwise Info.
 //
-// Level here gates only slog-sourced diagnostics. It is not a global quiet
-// switch: a command's own result output and its direct p.Warnf calls are not
-// slog records and are unaffected.
+// This level gates only slog-sourced diagnostics. It is not a global quiet
+// switch: a command's own output and its direct p.Warnf calls are not slog
+// records and are unaffected.
 func New(w io.Writer, p *ui.Printer, verbose bool) *slog.Logger {
 	level := slog.LevelInfo
 	if verbose {
@@ -33,31 +28,22 @@ func New(w io.Writer, p *ui.Printer, verbose bool) *slog.Logger {
 	return slog.New(ui.NewSlogHandler(w, p, level))
 }
 
-// Install makes New's logger the process-wide slog default.
-//
-// It returns nothing. It briefly returned a restore closure "for tests", but
-// restoring the PREVIOUS default is the wrong undo: that default is the stdlib
-// handler, which prints timestamped lines to stderr — exactly the output shape
-// this package exists to replace — so restoring it would spray those lines across
-// `go test` output. Detach is the correct undo, and the closure went unused.
+// Install makes New's logger the process-wide slog default. Detach is the undo.
 func Install(w io.Writer, p *ui.Printer, verbose bool) {
 	slog.SetDefault(New(w, p, verbose))
 }
 
-// Detach restores the process default to a handler that discards everything.
+// Detach points the process default at a discarding handler.
 //
-// This exists for TEST BINARIES. A real `agentsync` process installs once in the
-// root command's PersistentPreRunE and exits, so the handler's writer outlives
-// it. A test binary runs many Execute() cycles, and each one leaves
-// slog.Default() bound to that invocation's stderr buffer — typically a
-// *bytes.Buffer owned by a test that has already finished. A library slog.Warn
-// reached later then writes into a dead buffer: silent today, and a data race
-// the moment a test in that package adopts t.Parallel.
+// For TEST BINARIES. A real process installs once and exits, so the handler's
+// writer outlives it. A test binary runs many Execute() cycles, each leaving
+// slog.Default() bound to that invocation's stderr — usually a *bytes.Buffer
+// owned by a test that has already finished. A later library slog.Warn then
+// writes into a dead buffer: silent today, a data race under t.Parallel.
 //
-// Discarding rather than restoring the ORIGINAL default is deliberate: the
-// stdlib default prints timestamped lines to stderr, so restoring it would spray
-// exactly the output shape this package exists to replace across `go test`
-// output. A test that wants to observe records installs its own handler.
+// Discarding, not restoring the original: the original is the stdlib handler,
+// whose timestamped stderr lines are the shape this package replaces. A test
+// that wants to observe records installs its own handler.
 func Detach() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -34,11 +34,29 @@ func New(w io.Writer, p *ui.Printer, verbose bool) *slog.Logger {
 }
 
 // Install makes New's logger the process-wide slog default and returns a
-// function that restores the previous default. The restore exists for tests,
-// which must not leak a handler bound to a finished test's buffer into the next
-// test; the CLI itself installs once per process and never restores.
+// function that restores the previous default. The CLI itself installs once per
+// process and never restores; the restore exists for callers that must not leak
+// a handler past the lifetime of the writer it holds.
 func Install(w io.Writer, p *ui.Printer, verbose bool) func() {
 	prev := slog.Default()
 	slog.SetDefault(New(w, p, verbose))
 	return func() { slog.SetDefault(prev) }
+}
+
+// Detach restores the process default to a handler that discards everything.
+//
+// This exists for TEST BINARIES. A real `agentsync` process installs once in the
+// root command's PersistentPreRunE and exits, so the handler's writer outlives
+// it. A test binary runs many Execute() cycles, and each one leaves
+// slog.Default() bound to that invocation's stderr buffer — typically a
+// *bytes.Buffer owned by a test that has already finished. A library slog.Warn
+// reached later then writes into a dead buffer: silent today, and a data race
+// the moment a test in that package adopts t.Parallel.
+//
+// Discarding rather than restoring the ORIGINAL default is deliberate: the
+// stdlib default prints timestamped lines to stderr, so restoring it would spray
+// exactly the output shape this package exists to replace across `go test`
+// output. A test that wants to observe records installs its own handler.
+func Detach() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -33,14 +33,15 @@ func New(w io.Writer, p *ui.Printer, verbose bool) *slog.Logger {
 	return slog.New(ui.NewSlogHandler(w, p, level))
 }
 
-// Install makes New's logger the process-wide slog default and returns a
-// function that restores the previous default. The CLI itself installs once per
-// process and never restores; the restore exists for callers that must not leak
-// a handler past the lifetime of the writer it holds.
-func Install(w io.Writer, p *ui.Printer, verbose bool) func() {
-	prev := slog.Default()
+// Install makes New's logger the process-wide slog default.
+//
+// It returns nothing. It briefly returned a restore closure "for tests", but
+// restoring the PREVIOUS default is the wrong undo: that default is the stdlib
+// handler, which prints timestamped lines to stderr — exactly the output shape
+// this package exists to replace — so restoring it would spray those lines across
+// `go test` output. Detach is the correct undo, and the closure went unused.
+func Install(w io.Writer, p *ui.Printer, verbose bool) {
 	slog.SetDefault(New(w, p, verbose))
-	return func() { slog.SetDefault(prev) }
 }
 
 // Detach restores the process default to a handler that discards everything.

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -7,17 +7,25 @@ import (
 	"testing"
 
 	aslog "github.com/spxrogers/agentsync/internal/log"
+	"github.com/spxrogers/agentsync/internal/ui"
 )
+
+func plainPrinter(buf *bytes.Buffer) *ui.Printer {
+	return ui.New(buf, buf, ui.ColorNever)
+}
 
 func TestNew_DefaultLevel(t *testing.T) {
 	var buf bytes.Buffer
-	lg := aslog.New(&buf, false)
+	lg := aslog.New(&buf, plainPrinter(&buf), false)
 	lg.Info("hello", slog.String("k", "v"))
 	lg.Debug("invisible at default level")
 
 	out := buf.String()
-	if !strings.Contains(out, `"msg":"hello"`) {
-		t.Fatalf("expected info-level msg, got: %s", out)
+	if !strings.Contains(out, "ℹ INFO   hello") {
+		t.Fatalf("expected labeled info line, got: %s", out)
+	}
+	if !strings.Contains(out, "k=v") {
+		t.Fatalf("expected attribute on the continuation line, got: %s", out)
 	}
 	if strings.Contains(out, "invisible") {
 		t.Fatalf("debug message leaked into default-level output: %s", out)
@@ -26,10 +34,34 @@ func TestNew_DefaultLevel(t *testing.T) {
 
 func TestNew_VerboseLevel(t *testing.T) {
 	var buf bytes.Buffer
-	lg := aslog.New(&buf, true)
+	lg := aslog.New(&buf, plainPrinter(&buf), true)
 	lg.Debug("now visible")
 
-	if !strings.Contains(buf.String(), "now visible") {
+	if !strings.Contains(buf.String(), "• DEBUG  now visible") {
 		t.Fatalf("debug message missing in verbose output: %s", buf.String())
+	}
+}
+
+// Install must make the logger the process default — that is the whole reason
+// the package exists — and its restore must put the previous default back so a
+// test never leaks a handler bound to its own finished buffer.
+func TestInstall_SetsAndRestoresDefault(t *testing.T) {
+	var buf bytes.Buffer
+	before := slog.Default()
+
+	restore := aslog.Install(&buf, plainPrinter(&buf), false)
+	slog.Warn("library-side warning", "path", "/tmp/x")
+	if got := buf.String(); !strings.Contains(got, "⚠ WARN   library-side warning") {
+		t.Fatalf("slog.Warn did not route through the installed handler, got: %q", got)
+	}
+	// The stdlib default prefixes every line with a wall-clock date; the whole
+	// point of installing is that the line now STARTS with the level label.
+	if !strings.HasPrefix(buf.String(), "⚠ WARN") {
+		t.Fatalf("expected the line to start with the level label, got: %q", buf.String())
+	}
+
+	restore()
+	if slog.Default() != before {
+		t.Fatal("restore did not put the previous default logger back")
 	}
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -43,13 +43,13 @@ func TestNew_VerboseLevel(t *testing.T) {
 }
 
 // Install must make the logger the process default — that is the whole reason
-// the package exists — and its restore must put the previous default back so a
-// test never leaks a handler bound to its own finished buffer.
-func TestInstall_SetsAndRestoresDefault(t *testing.T) {
+// the package exists — and Detach must unbind it, so a test never leaks a handler
+// pointed at its own finished buffer.
+func TestInstallThenDetach(t *testing.T) {
 	var buf bytes.Buffer
 	before := slog.Default()
 
-	restore := aslog.Install(&buf, plainPrinter(&buf), false)
+	aslog.Install(&buf, plainPrinter(&buf), false)
 	slog.Warn("library-side warning", "path", "/tmp/x")
 	if got := buf.String(); !strings.Contains(got, "⚠ WARN   library-side warning") {
 		t.Fatalf("slog.Warn did not route through the installed handler, got: %q", got)
@@ -60,8 +60,23 @@ func TestInstall_SetsAndRestoresDefault(t *testing.T) {
 		t.Fatalf("expected the line to start with the level label, got: %q", buf.String())
 	}
 
-	restore()
-	if slog.Default() != before {
-		t.Fatal("restore did not put the previous default logger back")
+	// Detach is the undo, and it must make the default INERT rather than restore
+	// the previous one: the previous default is the stdlib handler, which prints
+	// timestamped lines to stderr — exactly the shape this package replaces — so
+	// restoring it would spray those across `go test` output.
+	aslog.Detach()
+	if slog.Default() == before {
+		t.Fatal("Detach restored the previous default; it should install a discarding one")
+	}
+	buf.Reset()
+	slog.Warn("after detach")
+	if buf.Len() != 0 {
+		t.Fatalf("Detach left the old handler wired to the buffer: %q", buf.String())
+	}
+	// And nothing reaches the process stderr either — a discarding handler, not a
+	// re-pointed one. Observable only as "the buffer stayed empty", above; this
+	// asserts the handler is at least installed and callable.
+	if slog.Default() == nil {
+		t.Fatal("Detach left a nil default logger")
 	}
 }

--- a/internal/ui/diag.go
+++ b/internal/ui/diag.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Diagnostic severity levels. These are the ONLY severities agentsync renders;
+// they map 1:1 onto slog's levels so a slog.Warn from deep in the render
+// pipeline and a hand-written p.Warnf in a command produce byte-identical
+// lines (see slog.go).
+//
+// Every diagnostic — anything that is a *notice about* the run rather than the
+// run's own output — carries one. That is the whole point of the vocabulary:
+// #211 shipped a fatal error as an unlabeled flat line directly under a WARN,
+// and the eye had no way to tell which was which. A level word plus a glyph
+// gives it two.
+type Level int
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+// Rendered label geometry. Each label is `<glyph> <WORD padded to 5>`, giving a
+// constant 7-column label followed by a 2-column gutter — so message text always
+// starts at column 9 and wrapped/continuation lines can be indented to match.
+//
+// The level words are DEBUG/ERROR (5) and INFO/WARN (4), so 5 is the exact
+// natural width; the padding costs nothing and makes the column explicit.
+const (
+	levelWordWidth = 5
+	// DiagIndent is the blank prefix that aligns a continuation line under the
+	// message column of a labeled diagnostic. Callers emitting a follow-up
+	// detail line should use Detailf rather than hand-indenting with this, but
+	// it is exported for layout code that composes its own lines.
+	DiagIndent = "         " // 7 (label) + 2 (gutter)
+)
+
+// GlyphNote is the informational label glyph. Distinct from GlyphInfo ("•"),
+// which stays the neutral list bullet used inside `doctor`/`status` bodies —
+// the two must not be conflated: one prefixes a diagnostic, the other is a
+// layout mark inside report output.
+const GlyphNote = "ℹ"
+
+// glyph returns the label glyph for a level.
+func (l Level) glyph() string {
+	switch l {
+	case LevelError:
+		return GlyphErr
+	case LevelWarn:
+		return GlyphWarn
+	case LevelInfo:
+		return GlyphNote
+	default:
+		return GlyphInfo
+	}
+}
+
+// word returns the uppercase level word for a level.
+func (l Level) word() string {
+	switch l {
+	case LevelError:
+		return "ERROR"
+	case LevelWarn:
+		return "WARN"
+	case LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}
+
+// String implements fmt.Stringer with the rendered level word, so a Level can be
+// dropped into a message or a test failure without a switch.
+func (l Level) String() string { return l.word() }
+
+// colorize applies the level's semantic color via p. Color is bold so the label
+// separates from the message even on a busy screen; with color off the glyph and
+// the word carry the whole signal, which is why the glyph is unconditional.
+//
+// The bold+color codes are emitted as ONE sequence rather than nested
+// p.Bold(p.Red(…)) calls, which would emit two SGR opens and two resets around
+// every label.
+func (l Level) colorize(p *Printer, s string) string {
+	switch l {
+	case LevelError:
+		return p.wrap(codeBold+codeRed, s)
+	case LevelWarn:
+		return p.wrap(codeBold+codeYellow, s)
+	case LevelInfo:
+		return p.wrap(codeBold+codeCyan, s)
+	default:
+		return p.wrap(codeFaint, s)
+	}
+}
+
+// Label renders the styled, fixed-width label for a level — glyph, space, then
+// the level word padded to levelWordWidth. Padding is computed on the plain word
+// and color applied to the result, so ANSI bytes never enter the width
+// calculation (the same discipline Pad's doc describes).
+//
+// Exported so a test can construct the exact prefix it expects rather than
+// hardcoding a literal that silently rots when the vocabulary changes.
+func (l Level) Label(p *Printer) string {
+	return l.colorize(p, l.glyph()+" "+Pad(l.word(), levelWordWidth))
+}
+
+// Success emoji vocabulary. Success lines deliberately carry NO level word: an
+// "INFO" on "added agent: claude" is noise, and the emoji already says both
+// "this worked" and "this is the outcome line, not a diagnostic". Each is a
+// default-emoji-presentation rune (no variation selector), so terminals render
+// them consistently without a VS16 width surprise.
+//
+// Pick by what happened, not by which command ran — `mcp remove` and
+// `agent purge` are both EmojiRemoved.
+const (
+	EmojiSuccess  = "✅" // generic: added / set / saved / validated / passed
+	EmojiApplied  = "🎉" // an apply wrote changes
+	EmojiRemoved  = "🧹" // removed / purged / pruned
+	EmojiImported = "📥" // captured destination → canonical source
+	EmojiReverted = "🔙" // rolled back to a checkpoint
+	EmojiInit     = "✨" // a new home or project tree was created
+)
+
+// Errorf writes a labeled ERROR diagnostic to Err.
+func (p *Printer) Errorf(format string, args ...any) { p.Diagf(LevelError, format, args...) }
+
+// Warnf writes a labeled WARN diagnostic to Err.
+func (p *Printer) Warnf(format string, args ...any) { p.Diagf(LevelWarn, format, args...) }
+
+// Infof writes a labeled INFO diagnostic to Err.
+//
+// Diagnostics go to stderr — including INFO — so that a command's actual output
+// (a status table, a `--json` payload, a list) stays cleanly redirectable. An
+// informational line that is part of the *result* is not a diagnostic and should
+// be printed to Out directly or via Successf.
+func (p *Printer) Infof(format string, args ...any) { p.Diagf(LevelInfo, format, args...) }
+
+// Diagf writes a labeled diagnostic at l to Err.
+func (p *Printer) Diagf(l Level, format string, args ...any) {
+	p.Fdiagf(p.Err, l, format, args...)
+}
+
+// Fdiagf writes a labeled diagnostic at l to an explicit writer. Use it only
+// when a diagnostic must land on a stream other than Err — routing a warning
+// into a command's own report body, say. Prefer Diagf.
+//
+// Embedded newlines in the formatted message are indented to the message column
+// so a multi-line diagnostic reads as one block rather than one labeled line
+// followed by orphaned text at column 0.
+func (p *Printer) Fdiagf(w io.Writer, l Level, format string, args ...any) {
+	fmt.Fprintf(w, "%s  %s\n", l.Label(p), indentContinuation(fmt.Sprintf(format, args...)))
+}
+
+// Detailf writes an unlabeled continuation line to Err, indented to the message
+// column of the diagnostic above it. Use for the supporting detail of a
+// diagnostic — an enumerated list, a remedy, a path — so the block hangs
+// together under its label.
+func (p *Printer) Detailf(format string, args ...any) {
+	p.Fdetailf(p.Err, format, args...)
+}
+
+// Fdetailf is Detailf against an explicit writer.
+func (p *Printer) Fdetailf(w io.Writer, format string, args ...any) {
+	fmt.Fprintf(w, "%s%s\n", DiagIndent, indentContinuation(fmt.Sprintf(format, args...)))
+}
+
+// Successf writes a success line to Out: the emoji, then the message, green
+// when color is on. No level word — see the emoji vocabulary above.
+func (p *Printer) Successf(emoji, format string, args ...any) {
+	p.Fsuccessf(p.Out, emoji, format, args...)
+}
+
+// Fsuccessf is Successf against an explicit writer, for commands that stream
+// their result into a caller-supplied buffer.
+func (p *Printer) Fsuccessf(w io.Writer, emoji, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(w, "%s %s\n", emoji, p.Green(msg))
+}
+
+// indentContinuation aligns every line after the first to the message column.
+// Blank lines are left blank rather than padded to trailing whitespace.
+func indentContinuation(s string) string {
+	if !strings.Contains(s, "\n") {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == "" {
+			continue
+		}
+		lines[i] = DiagIndent + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/diag.go
+++ b/internal/ui/diag.go
@@ -168,7 +168,8 @@ func (p *Printer) Diagf(l Level, format string, args ...any) {
 // so a multi-line diagnostic reads as one block rather than one labeled line
 // followed by orphaned text at column 0.
 func (p *Printer) Fdiagf(w io.Writer, l Level, format string, args ...any) {
-	fmt.Fprintf(w, "%s  %s\n", l.Label(p.styleForDiag(w)), indentContinuation(fmt.Sprintf(format, args...)))
+	style := p.styleForDiag(w)
+	fmt.Fprintf(w, "%s  %s\n", l.Label(style), p.bodyFor(style, fmt.Sprintf(format, args...)))
 }
 
 // Detailf writes an unlabeled continuation line to Err, indented to the message
@@ -181,7 +182,7 @@ func (p *Printer) Detailf(format string, args ...any) {
 
 // Fdetailf is Detailf against an explicit writer.
 func (p *Printer) Fdetailf(w io.Writer, format string, args ...any) {
-	fmt.Fprintf(w, "%s%s\n", diagIndent, indentContinuation(fmt.Sprintf(format, args...)))
+	fmt.Fprintf(w, "%s%s\n", diagIndent, p.bodyFor(p.styleForDiag(w), fmt.Sprintf(format, args...)))
 }
 
 // Successf writes a success line to Out: the emoji, then the message, green
@@ -196,8 +197,12 @@ func (p *Printer) Fsuccessf(w io.Writer, emoji, format string, args ...any) {
 	// No indentContinuation here, deliberately: a success line is a single
 	// outcome, and there is no label column for a continuation to hang under.
 	// A multi-line success message is a call-site bug, not something to lay out.
+	style := p.styleForResult(w)
 	msg := fmt.Sprintf(format, args...)
-	fmt.Fprintf(w, "%s %s\n", emoji, p.styleForResult(w).Green(msg))
+	if !style.color {
+		msg = stripSGR(msg)
+	}
+	fmt.Fprintf(w, "%s %s\n", emoji, style.Green(msg))
 }
 
 // indentContinuation aligns every line after the first to the message column.

--- a/internal/ui/diag.go
+++ b/internal/ui/diag.go
@@ -18,12 +18,19 @@ import (
 // gives it two.
 type Level int
 
+// LevelDebug is deliberately the ZERO VALUE: a `var l Level` or a `Diagf(0, …)`
+// then renders as the least-severe level rather than silently claiming ERROR.
 const (
 	LevelDebug Level = iota
 	LevelInfo
 	LevelWarn
 	LevelError
 )
+
+// valid reports whether l is one of the four defined levels. Out-of-range values
+// are rendered as DEBUG (see glyph/word), so this exists to let String() stay
+// honest about a value it cannot name.
+func (l Level) valid() bool { return l >= LevelDebug && l <= LevelError }
 
 // Rendered label geometry. Each label is `<glyph> <WORD padded to 5>`, giving a
 // constant 7-column label followed by a 2-column gutter — so message text always
@@ -33,20 +40,17 @@ const (
 // natural width; the padding costs nothing and makes the column explicit.
 const (
 	levelWordWidth = 5
-	// DiagIndent is the blank prefix that aligns a continuation line under the
-	// message column of a labeled diagnostic. Callers emitting a follow-up
-	// detail line should use Detailf rather than hand-indenting with this, but
-	// it is exported for layout code that composes its own lines.
-	DiagIndent = "         " // 7 (label) + 2 (gutter)
+	// diagIndent is the blank prefix that aligns a continuation line under the
+	// message column of a labeled diagnostic. Unexported on purpose: Detailf /
+	// Fdetailf are the seam for a continuation line, and an exported string of
+	// literal spaces invites callers to hand-indent and drift out of alignment
+	// when the label geometry changes.
+	diagIndent = "         " // 7 (label) + 2 (gutter)
 )
 
-// GlyphNote is the informational label glyph. Distinct from GlyphInfo ("•"),
-// which stays the neutral list bullet used inside `doctor`/`status` bodies —
-// the two must not be conflated: one prefixes a diagnostic, the other is a
-// layout mark inside report output.
-const GlyphNote = "ℹ"
-
-// glyph returns the label glyph for a level.
+// glyph returns the label glyph for a level. The glyphs themselves are declared
+// with the rest of the curated vocabulary in ui.go; see GlyphBullet's doc there
+// for why DEBUG's mark is named separately from the report-body bullet.
 func (l Level) glyph() string {
 	switch l {
 	case LevelError:
@@ -56,7 +60,7 @@ func (l Level) glyph() string {
 	case LevelInfo:
 		return GlyphNote
 	default:
-		return GlyphInfo
+		return GlyphBullet
 	}
 }
 
@@ -76,15 +80,26 @@ func (l Level) word() string {
 
 // String implements fmt.Stringer with the rendered level word, so a Level can be
 // dropped into a message or a test failure without a switch.
-func (l Level) String() string { return l.word() }
+//
+// An out-of-range value reports itself as such rather than as "DEBUG". word()
+// has to pick SOME label to render, and picks the least-severe one; String is
+// where a test failure or a log line gets to say "this value has no name",
+// which is the difference between a confusing diagnostic and a silent lie.
+func (l Level) String() string {
+	if !l.valid() {
+		return fmt.Sprintf("Level(%d)", int(l))
+	}
+	return l.word()
+}
 
 // colorize applies the level's semantic color via p. Color is bold so the label
 // separates from the message even on a busy screen; with color off the glyph and
 // the word carry the whole signal, which is why the glyph is unconditional.
 //
-// The bold+color codes are emitted as ONE sequence rather than nested
-// p.Bold(p.Red(…)) calls, which would emit two SGR opens and two resets around
-// every label.
+// The bold+color codes are emitted through ONE wrap call rather than nested
+// p.Bold(p.Red(…)) calls. That still opens two SGR sequences (\x1b[1m\x1b[31m)
+// — SGR has no single bold-and-red parameter — but it emits ONE reset instead of
+// two, which is what nesting was actually costing.
 func (l Level) colorize(p *Printer, s string) string {
 	switch l {
 	case LevelError:
@@ -153,7 +168,7 @@ func (p *Printer) Diagf(l Level, format string, args ...any) {
 // so a multi-line diagnostic reads as one block rather than one labeled line
 // followed by orphaned text at column 0.
 func (p *Printer) Fdiagf(w io.Writer, l Level, format string, args ...any) {
-	fmt.Fprintf(w, "%s  %s\n", l.Label(p), indentContinuation(fmt.Sprintf(format, args...)))
+	fmt.Fprintf(w, "%s  %s\n", l.Label(p.styleFor(w)), indentContinuation(fmt.Sprintf(format, args...)))
 }
 
 // Detailf writes an unlabeled continuation line to Err, indented to the message
@@ -166,7 +181,7 @@ func (p *Printer) Detailf(format string, args ...any) {
 
 // Fdetailf is Detailf against an explicit writer.
 func (p *Printer) Fdetailf(w io.Writer, format string, args ...any) {
-	fmt.Fprintf(w, "%s%s\n", DiagIndent, indentContinuation(fmt.Sprintf(format, args...)))
+	fmt.Fprintf(w, "%s%s\n", diagIndent, indentContinuation(fmt.Sprintf(format, args...)))
 }
 
 // Successf writes a success line to Out: the emoji, then the message, green
@@ -178,8 +193,11 @@ func (p *Printer) Successf(emoji, format string, args ...any) {
 // Fsuccessf is Successf against an explicit writer, for commands that stream
 // their result into a caller-supplied buffer.
 func (p *Printer) Fsuccessf(w io.Writer, emoji, format string, args ...any) {
+	// No indentContinuation here, deliberately: a success line is a single
+	// outcome, and there is no label column for a continuation to hang under.
+	// A multi-line success message is a call-site bug, not something to lay out.
 	msg := fmt.Sprintf(format, args...)
-	fmt.Fprintf(w, "%s %s\n", emoji, p.Green(msg))
+	fmt.Fprintf(w, "%s %s\n", emoji, p.styleFor(w).Green(msg))
 }
 
 // indentContinuation aligns every line after the first to the message column.
@@ -193,7 +211,7 @@ func indentContinuation(s string) string {
 		if lines[i] == "" {
 			continue
 		}
-		lines[i] = DiagIndent + lines[i]
+		lines[i] = diagIndent + lines[i]
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/ui/diag.go
+++ b/internal/ui/diag.go
@@ -79,12 +79,9 @@ func (l Level) word() string {
 }
 
 // String implements fmt.Stringer with the rendered level word, so a Level can be
-// dropped into a message or a test failure without a switch.
-//
-// An out-of-range value reports itself as such rather than as "DEBUG". word()
-// has to pick SOME label to render, and picks the least-severe one; String is
-// where a test failure or a log line gets to say "this value has no name",
-// which is the difference between a confusing diagnostic and a silent lie.
+// dropped into a message or a test failure without a switch. An out-of-range value
+// names itself rather than borrowing word()'s least-severe fallback: a failure
+// reading Level(9) beats one reading DEBUG.
 func (l Level) String() string {
 	if !l.valid() {
 		return fmt.Sprintf("Level(%d)", int(l))

--- a/internal/ui/diag.go
+++ b/internal/ui/diag.go
@@ -168,7 +168,7 @@ func (p *Printer) Diagf(l Level, format string, args ...any) {
 // so a multi-line diagnostic reads as one block rather than one labeled line
 // followed by orphaned text at column 0.
 func (p *Printer) Fdiagf(w io.Writer, l Level, format string, args ...any) {
-	fmt.Fprintf(w, "%s  %s\n", l.Label(p.styleFor(w)), indentContinuation(fmt.Sprintf(format, args...)))
+	fmt.Fprintf(w, "%s  %s\n", l.Label(p.styleForDiag(w)), indentContinuation(fmt.Sprintf(format, args...)))
 }
 
 // Detailf writes an unlabeled continuation line to Err, indented to the message
@@ -197,7 +197,7 @@ func (p *Printer) Fsuccessf(w io.Writer, emoji, format string, args ...any) {
 	// outcome, and there is no label column for a continuation to hang under.
 	// A multi-line success message is a call-site bug, not something to lay out.
 	msg := fmt.Sprintf(format, args...)
-	fmt.Fprintf(w, "%s %s\n", emoji, p.styleFor(w).Green(msg))
+	fmt.Fprintf(w, "%s %s\n", emoji, p.styleForResult(w).Green(msg))
 }
 
 // indentContinuation aligns every line after the first to the message column.

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -390,12 +390,10 @@ func withTerminalCheck(t *testing.T, fn func(io.Writer) bool) {
 // New must resolve the color decision once PER STREAM, and assign each result to
 // the RIGHT field.
 //
-// An earlier version of this test counted Fd() probes, which was not enough: it
-// caught "resolved once and reused", but a SWAP —
-// `color: resolveColor(err), colorErr: resolveColor(out)` — probes each stream
-// exactly once and passed. That swap reproduces the original bug exactly (ANSI
-// into a redirected stderr), so the test was blind to the very thing it existed to
-// prevent. Forcing the two streams to answer differently is what closes it.
+// Counting Fd() probes is NOT enough: it catches "resolved once and reused", but a
+// swap (`color: resolveColor(err), colorErr: resolveColor(out)`) probes each stream
+// exactly once — and that swap reproduces the original bug, ANSI into a redirected
+// stderr. Forcing the two streams to answer differently is what closes it.
 func TestNewResolvesColorPerStreamAndDoesNotSwapThem(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
 	if err := os.Unsetenv("NO_COLOR"); err != nil {

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -1,0 +1,171 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The label column is the whole point of the vocabulary: message text must
+// start at the same column for every level, so a WARN and an ERROR stacked in a
+// terminal line up and the eye can tell them apart at a glance (#211). Assert
+// the rendered bytes, not the constant, so a change to the glyph or the level
+// word that breaks alignment fails here.
+func TestDiagLabelsShareOneMessageColumn(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+
+	tests := []struct {
+		level Level
+		want  string
+	}{
+		{LevelDebug, "• DEBUG  msg"},
+		{LevelInfo, "ℹ INFO   msg"},
+		{LevelWarn, "⚠ WARN   msg"},
+		{LevelError, "✗ ERROR  msg"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			buf.Reset()
+			p.Diagf(tc.level, "msg")
+			if got := buf.String(); got != tc.want+"\n" {
+				t.Fatalf("Diagf(%v) = %q, want %q", tc.level, got, tc.want+"\n")
+			}
+			// The message must begin exactly where DiagIndent ends, so a
+			// Detailf continuation hangs under it. Count RUNES, not bytes:
+			// the glyphs are multi-byte and the terminal column is a rune
+			// count (each glyph in the vocabulary is one display cell).
+			line := strings.TrimSuffix(buf.String(), "\n")
+			col := len([]rune(line)) - len([]rune("msg"))
+			if col != len([]rune(DiagIndent)) {
+				t.Fatalf("%v message starts at column %d, want %d (DiagIndent width)",
+					tc.level, col, len([]rune(DiagIndent)))
+			}
+		})
+	}
+}
+
+// A continuation line written with Detailf must land in the message column, and
+// an embedded newline inside a single Diagf message must be indented the same
+// way — otherwise a multi-line diagnostic breaks apart visually into a labeled
+// line plus orphaned text at column 0.
+func TestDiagContinuationAlignment(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+
+	p.Warnf("first line\nsecond line")
+	p.Detailf("third line")
+
+	want := "⚠ WARN   first line\n" +
+		DiagIndent + "second line\n" +
+		DiagIndent + "third line\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("continuation alignment:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// A blank line inside a multi-line message stays blank rather than becoming a
+// run of trailing whitespace — trailing spaces are invisible noise that shows
+// up in diffs and `cat -A`.
+func TestDiagBlankContinuationLineNotPadded(t *testing.T) {
+	var buf bytes.Buffer
+	New(&buf, &buf, ColorNever).Infof("a\n\nb")
+	if got := buf.String(); got != "ℹ INFO   a\n\n"+DiagIndent+"b\n" {
+		t.Fatalf("blank continuation line was padded: %q", got)
+	}
+}
+
+// Diagnostics go to Err, success goes to Out. That split is what keeps a
+// `--json` payload on stdout parseable while warnings still reach the user.
+func TestDiagnosticsToErrSuccessToOut(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := New(&out, &errb, ColorNever)
+
+	p.Errorf("boom")
+	p.Warnf("careful")
+	p.Infof("fyi")
+	if out.Len() != 0 {
+		t.Fatalf("diagnostics leaked onto stdout: %q", out.String())
+	}
+	if n := strings.Count(errb.String(), "\n"); n != 3 {
+		t.Fatalf("want 3 diagnostic lines on stderr, got %d: %q", n, errb.String())
+	}
+
+	errb.Reset()
+	p.Successf(EmojiApplied, "applied: %d ops", 12)
+	if errb.Len() != 0 {
+		t.Fatalf("success line leaked onto stderr: %q", errb.String())
+	}
+	if got, want := out.String(), EmojiApplied+" applied: 12 ops\n"; got != want {
+		t.Fatalf("Successf = %q, want %q", got, want)
+	}
+}
+
+// Success lines carry NO level word — that is the explicit product decision
+// (an "INFO" on "added agent: claude" is noise). Guard it: a well-meaning
+// future edit that routes success through Diagf would silently undo it.
+func TestSuccessCarriesNoLevelWord(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+	for _, emoji := range []string{EmojiSuccess, EmojiApplied, EmojiRemoved, EmojiImported, EmojiReverted, EmojiInit} {
+		buf.Reset()
+		p.Successf(emoji, "did the thing")
+		got := buf.String()
+		for _, word := range []string{"INFO", "WARN", "ERROR", "DEBUG"} {
+			if strings.Contains(got, word) {
+				t.Fatalf("success line %q must not carry the %s label", got, word)
+			}
+		}
+		if !strings.HasPrefix(got, emoji+" ") {
+			t.Fatalf("success line %q must lead with its emoji", got)
+		}
+	}
+}
+
+// Every success emoji must be a single default-emoji-presentation rune. A
+// variation-selector form (e.g. "↩️") renders at an inconsistent width
+// across terminals, which is exactly why the vocabulary avoids them — and the
+// mistake is invisible in source review.
+func TestSuccessEmojiHaveNoVariationSelector(t *testing.T) {
+	for _, emoji := range []string{EmojiSuccess, EmojiApplied, EmojiRemoved, EmojiImported, EmojiReverted, EmojiInit} {
+		if strings.ContainsRune(emoji, '️') || strings.ContainsRune(emoji, '︎') {
+			t.Errorf("emoji %q carries a variation selector; pick a default-presentation rune instead", emoji)
+		}
+	}
+}
+
+// With color on, the label is wrapped in ANSI but the PLAIN text is unchanged —
+// padding is computed before styling, so escape bytes never enter the width
+// calculation and a colored terminal aligns exactly like a piped one.
+func TestDiagColorDoesNotDisturbAlignment(t *testing.T) {
+	var plain, colored bytes.Buffer
+	New(&plain, &plain, ColorNever).Warnf("msg")
+	New(&colored, &colored, ColorAlways).Warnf("msg")
+
+	if !strings.Contains(colored.String(), codeYellow) {
+		t.Fatalf("colored warning is missing its color: %q", colored.String())
+	}
+	if stripped := stripANSI(colored.String()); stripped != plain.String() {
+		t.Fatalf("colored line differs once ANSI is stripped:\ngot:  %q\nwant: %q", stripped, plain.String())
+	}
+}
+
+// stripANSI removes SGR sequences so a colored line can be compared against its
+// plain counterpart. Deliberately minimal — it only needs to handle the
+// "\x1b[<params>m" forms this package emits.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			i = j + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -482,3 +482,87 @@ func TestSameWriterSurvivesUncomparableWriters(t *testing.T) {
 		})
 	}
 }
+
+// Each level's COLOUR is part of the vocabulary, not an implementation detail: red
+// vs yellow is the fastest signal distinguishing a failure from a warning, which is
+// the entire complaint behind #211.
+//
+// Previously only WARN's yellow was asserted anywhere. A test that checked ERROR
+// was red got deleted as "subsumed" by one asserting merely that SOME ANSI was
+// emitted — so recolouring ERROR to green passed the whole suite. Pin all four.
+func TestEachLevelHasItsOwnColour(t *testing.T) {
+	tests := []struct {
+		level Level
+		code  string
+		name  string
+	}{
+		{LevelError, codeRed, "red"},
+		{LevelWarn, codeYellow, "yellow"},
+		{LevelInfo, codeCyan, "cyan"},
+		{LevelDebug, codeFaint, "faint"},
+	}
+	seen := map[string]Level{}
+	for _, tc := range tests {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			New(&buf, &buf, ColorAlways).Diagf(tc.level, "msg")
+			if got := buf.String(); !strings.Contains(got, tc.code) {
+				t.Fatalf("%v should be %s (%q); got %q", tc.level, tc.name, tc.code, got)
+			}
+		})
+		// No two levels may share a colour — that would defeat the point.
+		if prev, dup := seen[tc.code]; dup {
+			t.Errorf("%v and %v share colour %s", prev, tc.level, tc.name)
+		}
+		seen[tc.code] = tc.level
+	}
+}
+
+// WarnWriter's input comes from the adapter and capture packages, which cannot
+// call ui.Sanitize (they must not import ui — the reason the "warning: " sentinel
+// exists). So ui must sanitize here or nothing does.
+//
+// This replaced a *documented convention* that every emitter use %q, which was
+// already violated at the moment it was written down.
+func TestWarnWriterSanitizesAdapterText(t *testing.T) {
+	var dest bytes.Buffer
+	p := New(&dest, &dest, ColorNever)
+	w := NewWarnWriter(&dest, p)
+
+	// A hostile native-config id: an OSC title-set sequence and a CR that would
+	// rewind over the label.
+	fmt.Fprintf(w, "warning: MCP server %s is odd\n", "srv\x1b]0;pwned\x07\rFORGED")
+
+	got := dest.String()
+	for _, bad := range []string{"\x1b]", "\x07", "\r"} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("control byte %q reached the terminal: %q", bad, got)
+		}
+	}
+	if !strings.HasPrefix(got, "⚠ WARN") {
+		t.Fatalf("label lost: %q", got)
+	}
+	// Sanitized, not blanked: the readable part survives.
+	if !strings.Contains(got, "FORGED") || !strings.Contains(got, "srv") {
+		t.Fatalf("body was blanked rather than sanitized: %q", got)
+	}
+	// Exactly one line — a CR/LF in adapter text must not forge a second diagnostic.
+	if n := strings.Count(got, "\n"); n != 1 {
+		t.Fatalf("want exactly 1 line, got %d: %q", n, got)
+	}
+}
+
+// The passthrough branch must stay verbatim: it carries our OWN already-styled
+// lines (importIO's INFO notes), whose ANSI sanitizing would strip.
+func TestWarnWriterPassthroughKeepsOurOwnStyling(t *testing.T) {
+	var dest bytes.Buffer
+	p := New(&dest, &dest, ColorAlways)
+	w := NewWarnWriter(&dest, p)
+
+	styled := LevelInfo.Label(p) + "  a pre-styled note\n"
+	_, _ = w.Write([]byte(styled))
+
+	if got := dest.String(); got != styled {
+		t.Fatalf("a pre-styled passthrough line was altered:\ngot:  %q\nwant: %q", got, styled)
+	}
+}

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -566,3 +566,55 @@ func TestWarnWriterPassthroughKeepsOurOwnStyling(t *testing.T) {
 		t.Fatalf("a pre-styled passthrough line was altered:\ngot:  %q\nwant: %q", got, styled)
 	}
 }
+
+// A caller may pre-style the text it hands a diagnostic writer (the upgrade-notice
+// banner composes p.Bold/p.Yellow fragments). Those helpers resolve colour from the
+// OUT decision, because a style helper cannot know which stream its result will be
+// written to — so on a split-stream printer they embed ANSI into a body bound for a
+// plain stream. The per-stream fix originally covered only the LABEL, leaving
+// `apply 2>err.log` from a terminal still leaking escapes into the file.
+func TestPreStyledBodyIsStrippedOnAPlainStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := splitStreamPrinter(&out, &errb) // color=true (Out), colorErr=false (Err)
+
+	// The real gitbackup call shape: a bolded fragment inside an INFO on stderr.
+	p.Infof("started a %s git backup of %s.", p.Bold("local-only"), "/x/.claude")
+	if got := errb.String(); strings.Contains(got, "\x1b[") {
+		t.Fatalf("pre-styled body leaked ANSI onto the plain Err stream: %q", got)
+	}
+	if !strings.Contains(errb.String(), "local-only") {
+		t.Fatalf("stripping removed the text, not just the escapes: %q", errb.String())
+	}
+
+	// Detailf too — the upgrade banner's body lines go through it.
+	errb.Reset()
+	p.Detailf("%s %s", p.Yellow(GlyphArrow), p.Bold("since 0.11.0 —"))
+	if got := errb.String(); strings.Contains(got, "\x1b[") {
+		t.Fatalf("pre-styled detail line leaked ANSI: %q", got)
+	}
+
+	// And the mirror: a colour-capable stream KEEPS the caller's styling.
+	out.Reset()
+	p.Fdiagf(&out, LevelInfo, "kept %s", p.Bold("bold"))
+	if !strings.Contains(out.String(), "\x1b[1m") {
+		t.Fatalf("a colour-capable stream must keep pre-styled text: %q", out.String())
+	}
+}
+
+func TestStripSGRLeavesEverythingElseAlone(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"\x1b[1mbold\x1b[0m", "bold"},
+		{"a\nb", "a\nb"},                                 // newlines survive
+		{"\x1b[1ma\n\x1b[31mb\x1b[0m", "a\nb"},           // across lines
+		{"\x1b[38;5;200mfancy\x1b[0m", "fancy"},          // multi-param
+		{"\x1b[1m", ""},                                  // trailing sequence
+		{"tail\x1b[", "tail"},                            // unterminated: dropped
+		{"\x1b]0;title\x07keep", "\x1b]0;title\x07keep"}, // OSC is not CSI; Sanitize's job
+	}
+	for _, tc := range tests {
+		if got := stripSGR(tc.in); got != tc.want {
+			t.Errorf("stripSGR(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -2,8 +2,12 @@ package ui
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The label column is the whole point of the vocabulary: message text must
@@ -31,15 +35,15 @@ func TestDiagLabelsShareOneMessageColumn(t *testing.T) {
 			if got := buf.String(); got != tc.want+"\n" {
 				t.Fatalf("Diagf(%v) = %q, want %q", tc.level, got, tc.want+"\n")
 			}
-			// The message must begin exactly where DiagIndent ends, so a
+			// The message must begin exactly where diagIndent ends, so a
 			// Detailf continuation hangs under it. Count RUNES, not bytes:
 			// the glyphs are multi-byte and the terminal column is a rune
 			// count (each glyph in the vocabulary is one display cell).
 			line := strings.TrimSuffix(buf.String(), "\n")
 			col := len([]rune(line)) - len([]rune("msg"))
-			if col != len([]rune(DiagIndent)) {
-				t.Fatalf("%v message starts at column %d, want %d (DiagIndent width)",
-					tc.level, col, len([]rune(DiagIndent)))
+			if col != len([]rune(diagIndent)) {
+				t.Fatalf("%v message starts at column %d, want %d (diagIndent width)",
+					tc.level, col, len([]rune(diagIndent)))
 			}
 		})
 	}
@@ -57,8 +61,8 @@ func TestDiagContinuationAlignment(t *testing.T) {
 	p.Detailf("third line")
 
 	want := "⚠ WARN   first line\n" +
-		DiagIndent + "second line\n" +
-		DiagIndent + "third line\n"
+		diagIndent + "second line\n" +
+		diagIndent + "third line\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("continuation alignment:\ngot:  %q\nwant: %q", got, want)
 	}
@@ -70,7 +74,7 @@ func TestDiagContinuationAlignment(t *testing.T) {
 func TestDiagBlankContinuationLineNotPadded(t *testing.T) {
 	var buf bytes.Buffer
 	New(&buf, &buf, ColorNever).Infof("a\n\nb")
-	if got := buf.String(); got != "ℹ INFO   a\n\n"+DiagIndent+"b\n" {
+	if got := buf.String(); got != "ℹ INFO   a\n\n"+diagIndent+"b\n" {
 		t.Fatalf("blank continuation line was padded: %q", got)
 	}
 }
@@ -128,8 +132,14 @@ func TestSuccessCarriesNoLevelWord(t *testing.T) {
 // mistake is invisible in source review.
 func TestSuccessEmojiHaveNoVariationSelector(t *testing.T) {
 	for _, emoji := range []string{EmojiSuccess, EmojiApplied, EmojiRemoved, EmojiImported, EmojiReverted, EmojiInit} {
-		if strings.ContainsRune(emoji, '️') || strings.ContainsRune(emoji, '︎') {
+		if strings.ContainsRune(emoji, '\ufe0f') || strings.ContainsRune(emoji, '\ufe0e') {
 			t.Errorf("emoji %q carries a variation selector; pick a default-presentation rune instead", emoji)
+		}
+		// The doc says "a single default-emoji-presentation rune". Assert the
+		// single-rune half too: a ZWJ sequence or a keycap carries no variation
+		// selector yet still renders at an unpredictable width.
+		if n := len([]rune(emoji)); n != 1 {
+			t.Errorf("emoji %q is %d runes; the vocabulary is single-rune by contract", emoji, n)
 		}
 	}
 }
@@ -168,4 +178,42 @@ func stripANSI(s string) string {
 		i++
 	}
 	return b.String()
+}
+
+// The package doc and docs/architecture.md §11 both claim that a library-side
+// slog.Warn, an adapter's "warning: " sentinel through a WarnWriter, and a
+// command's own p.Warnf are indistinguishable. That is the whole premise of the
+// change — "one vocabulary" — and it was previously only IMPLIED by three
+// separate hardcoded expectations in three separate tests, any one of which
+// could drift without the others noticing.
+//
+// Assert the triple directly, for one message, byte-for-byte.
+func TestWarnPathsAreByteIdentical(t *testing.T) {
+	const msg = "plugin component frontmatter is not strict YAML"
+
+	// Path 1: a command's own p.Warnf.
+	var direct bytes.Buffer
+	New(&direct, &direct, ColorNever).Warnf("%s", msg)
+
+	// Path 2: the emitter-side sentinel through a WarnWriter (adapter / capture,
+	// which cannot import this package).
+	var sentinel bytes.Buffer
+	sp := New(&sentinel, &sentinel, ColorNever)
+	ww := NewWarnWriter(&sentinel, sp)
+	fmt.Fprintf(ww, "warning: %s\n", msg)
+
+	// Path 3: a library slog.Warn through the installed handler.
+	var viaSlog bytes.Buffer
+	lp := New(&viaSlog, &viaSlog, ColorNever)
+	_ = slog.New(NewSlogHandler(&viaSlog, lp, slog.LevelInfo)).Handler().
+		Handle(context.Background(), slog.NewRecord(time.Time{}, slog.LevelWarn, msg, 0))
+
+	if direct.String() != sentinel.String() {
+		t.Errorf("p.Warnf and the \"warning: \" sentinel diverge:\n  Warnf:    %q\n  sentinel: %q",
+			direct.String(), sentinel.String())
+	}
+	if direct.String() != viaSlog.String() {
+		t.Errorf("p.Warnf and slog.Warn diverge:\n  Warnf: %q\n  slog:  %q",
+			direct.String(), viaSlog.String())
+	}
 }

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -599,6 +599,41 @@ func TestPreStyledBodyIsStrippedOnAPlainStream(t *testing.T) {
 	}
 }
 
+// The RESULT half of the per-stream split, which the DIAGNOSTIC tests above do not
+// reach. Both of its pieces were unpinned: deleting styleForResult's `sameWriter(w,
+// p.Err)` branch, or Fsuccessf's `if !style.color { stripSGR }`, left the whole
+// suite green — nothing routes a result line to Err on a split-stream printer, so
+// the two survivors of this PR's ANSI-leak class had no test between them.
+//
+// A success line on Err is unusual but legitimate: a command whose stdout carries a
+// --json payload puts its outcome on stderr, and that is precisely the shape where
+// Out is a terminal and Err is redirected.
+func TestSuccessLineOnThePlainErrStreamIsStripped(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := splitStreamPrinter(&out, &errb) // color=true (Out), colorErr=false (Err)
+
+	// styleForResult must recognize Err and take ITS decision (plain), and the
+	// pre-styled fragment must then lose its escapes — the Fsuccessf analogue of
+	// TestPreStyledBodyIsStrippedOnAPlainStream.
+	p.Fsuccessf(&errb, EmojiApplied, "applied %s", p.Bold("3 ops"))
+	if got := errb.String(); strings.Contains(got, "\x1b[") {
+		t.Fatalf("a success line leaked ANSI onto the plain Err stream: %q", got)
+	}
+	if !strings.Contains(errb.String(), "3 ops") {
+		t.Fatalf("stripping removed the text, not just the escapes: %q", errb.String())
+	}
+	if !strings.Contains(errb.String(), EmojiApplied) {
+		t.Fatalf("the success emoji is content, not decoration; it must survive: %q", errb.String())
+	}
+
+	// The mirror, so neither assertion above can pass by blanket-stripping: the
+	// colour-capable Out stream keeps the caller's styling.
+	p.Fsuccessf(&out, EmojiApplied, "applied %s", p.Bold("3 ops"))
+	if !strings.Contains(out.String(), "\x1b[1m") {
+		t.Fatalf("a colour-capable stream must keep a pre-styled success body: %q", out.String())
+	}
+}
+
 func TestStripSGRLeavesEverythingElseAlone(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"plain", "plain"},

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -215,5 +217,233 @@ func TestWarnPathsAreByteIdentical(t *testing.T) {
 	if direct.String() != viaSlog.String() {
 		t.Errorf("p.Warnf and slog.Warn diverge:\n  Warnf: %q\n  slog:  %q",
 			direct.String(), viaSlog.String())
+	}
+}
+
+// splitStreamPrinter builds a Printer whose two streams have DIVERGENT color
+// decisions, which no other test in this package does — `New(&buf, &buf, …)`
+// makes both agree, so it cannot see a per-stream bug at all.
+//
+// Constructed as a struct literal because that divergence is exactly what New
+// cannot produce from two in-memory buffers: `auto` resolves both to false, and
+// always/never force both the same way. Only a real terminal-plus-redirect gets
+// here, which is the case that shipped the bug.
+func splitStreamPrinter(out, errw io.Writer) *Printer {
+	return &Printer{Out: out, Err: errw, color: true, colorErr: false, mode: ColorAuto}
+}
+
+// The bug this pins: color was resolved once from Out and reused for Err, so
+// `agentsync apply 2>err.log` from a terminal wrote ANSI into the file — the
+// package doc promises the exact opposite ("color never leaks into a redirect").
+// Deleting `colorErr` from New used to break nothing.
+func TestDiagnosticColorFollowsTheErrStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := splitStreamPrinter(&out, &errb)
+
+	// Err is the redirected stream (colorErr=false): a diagnostic must be plain
+	// even though Out is a color-capable terminal.
+	p.Warnf("careful")
+	if strings.Contains(errb.String(), "\x1b[") {
+		t.Fatalf("ANSI leaked into the redirected Err stream: %q", errb.String())
+	}
+	if !strings.Contains(errb.String(), "⚠ WARN") {
+		t.Fatalf("the label itself was lost: %q", errb.String())
+	}
+
+	// A RESULT line on the color-capable Out stream must still be colored.
+	p.Successf(EmojiApplied, "applied: 3 ops")
+	if !strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("Out is color-capable but the success line is plain: %q", out.String())
+	}
+}
+
+// Fdiagf takes an explicit writer, so it must style for THAT writer rather than
+// inheriting whichever decision the Printer was built around.
+func TestFdiagfStylesForItsTargetStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := splitStreamPrinter(&out, &errb)
+
+	p.Fdiagf(&out, LevelError, "to stdout")
+	if !strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("a diagnostic routed to the color-capable Out lost its color: %q", out.String())
+	}
+	p.Fdiagf(&errb, LevelError, "to stderr")
+	if strings.Contains(errb.String(), "\x1b[") {
+		t.Fatalf("a diagnostic on the redirected Err gained color: %q", errb.String())
+	}
+}
+
+// An UNRECOGNIZED writer takes the stream matching its output KIND: a diagnostic
+// falls back to the Err decision, a result to the Out decision. The two fallbacks
+// are deliberately opposite; assert both so a future refactor cannot quietly
+// collapse them into one.
+func TestUnknownWriterFallbacksAreOpposite(t *testing.T) {
+	var out, errb, other bytes.Buffer
+	p := splitStreamPrinter(&out, &errb)
+
+	p.Fdiagf(&other, LevelWarn, "diag to a third writer")
+	if strings.Contains(other.String(), "\x1b[") {
+		t.Fatalf("diagnostic fallback should take the Err (plain) decision: %q", other.String())
+	}
+
+	other.Reset()
+	p.Fsuccessf(&other, EmojiSuccess, "result to a third writer")
+	if !strings.Contains(other.String(), "\x1b[") {
+		t.Fatalf("result fallback should take the Out (colored) decision: %q", other.String())
+	}
+}
+
+// WarnWriter is constructed over p.Err by both its call sites, so it must take the
+// Err decision too. It previously styled from p directly — meaning `agentsync
+// import 2>err.log` still wrote ANSI into the file, and this path diverged from
+// p.Warnf, falsifying the "one vocabulary" claim in the very place the vocabulary
+// is supposed to converge.
+func TestWarnWriterStylesForItsOwnStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	p := splitStreamPrinter(&out, &errb)
+	w := NewWarnWriter(&errb, p)
+
+	fmt.Fprintf(w, "warning: %s\n", "from an adapter")
+
+	if strings.Contains(errb.String(), "\x1b[") {
+		t.Fatalf("WarnWriter leaked ANSI into the redirected Err stream: %q", errb.String())
+	}
+
+	// And it must still be byte-identical to p.Warnf on the SAME stream — the
+	// divergent-stream case the ColorNever triple test cannot reach.
+	var direct bytes.Buffer
+	dp := splitStreamPrinter(&out, &direct)
+	dp.Warnf("%s", "from an adapter")
+	if direct.String() != errb.String() {
+		t.Fatalf("WarnWriter and p.Warnf diverge on a split-stream printer:\n  Warnf:      %q\n  WarnWriter: %q",
+			direct.String(), errb.String())
+	}
+}
+
+// Flush must terminate the fragment it emits. An unterminated line leaves the
+// next writer to that stream — main's terminal ✗ ERROR line, typically — on the
+// same row. This was briefly a separate EndLine() the caller had to pair with
+// Flush, and one of the two call sites promptly forgot to.
+func TestWarnWriterFlushTerminatesItsLine(t *testing.T) {
+	var dest bytes.Buffer
+	p := New(&dest, &dest, ColorNever)
+	w := NewWarnWriter(&dest, p)
+
+	_, _ = w.Write([]byte("warning: partial with no newline"))
+	w.Flush()
+	if got := dest.String(); !strings.HasSuffix(got, "\n") {
+		t.Fatalf("Flush left an unterminated line: %q", got)
+	}
+
+	// Flush on an empty buffer adds nothing — no spurious blank line.
+	before := dest.Len()
+	w.Flush()
+	if dest.Len() != before {
+		t.Fatalf("Flush on an empty buffer emitted %q", dest.String()[before:])
+	}
+
+	// An already-terminated line is not double-terminated.
+	dest.Reset()
+	_, _ = w.Write([]byte("warning: complete\n"))
+	w.Flush()
+	if strings.HasSuffix(dest.String(), "\n\n") {
+		t.Fatalf("a terminated line was given a second newline: %q", dest.String())
+	}
+}
+
+// Level's out-of-range handling: word() must render SOMETHING (the least-severe
+// label), but String() must not claim that value is DEBUG.
+func TestLevelOutOfRangeIsNamedHonestly(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+
+	rogue := Level(99)
+	if got := rogue.String(); got != "Level(99)" {
+		t.Fatalf("Level(99).String() = %q, want %q", got, "Level(99)")
+	}
+	if got := Level(-1).String(); got != "Level(-1)" {
+		t.Fatalf("Level(-1).String() = %q", got)
+	}
+	// It still renders rather than panicking or emitting an empty label.
+	p.Diagf(rogue, "msg")
+	if !strings.Contains(buf.String(), "DEBUG") {
+		t.Fatalf("an out-of-range level should still render the least-severe label: %q", buf.String())
+	}
+	// And the four real levels keep naming themselves.
+	for _, l := range []Level{LevelDebug, LevelInfo, LevelWarn, LevelError} {
+		if strings.HasPrefix(l.String(), "Level(") {
+			t.Errorf("%d is a defined level but String() reports %q", int(l), l.String())
+		}
+	}
+}
+
+// fdProbe is a writer that reports an Fd (so isTerminal's type assertion
+// succeeds) and records that it was asked. The fd is deliberately invalid, so
+// term.IsTerminal says "not a terminal" — what is being observed is WHICH streams
+// New probes, not the answer.
+type fdProbe struct {
+	io.Writer
+	probed *int
+}
+
+func (f fdProbe) Fd() uintptr {
+	*f.probed++
+	// ^uintptr(0) → int(-1): never a valid descriptor, so IsTerminal is false
+	// without touching any real file.
+	return ^uintptr(0)
+}
+
+// New must resolve the color decision ONCE PER STREAM.
+//
+// This is the assertion that was missing: the split-stream tests above build a
+// Printer as a struct literal, because two in-memory buffers cannot produce
+// divergent `auto` decisions (isTerminal is false for both). So they verify that a
+// divergence is HONORED, but not that New ever computes one — and with only those,
+// changing `colorErr: resolveColor(err, mode)` to resolve from `out` again broke
+// nothing. Verified by making that exact edit.
+//
+// Observing the probe count is the way in: one probe per stream means each stream's
+// TTY-ness was asked about independently.
+func TestNewResolvesColorPerStream(t *testing.T) {
+	// NO_COLOR disables color for ANY value, including empty, and it short-circuits
+	// before the isTerminal probe this test observes — so it must be genuinely
+	// ABSENT, not empty. t.Setenv registers the restore; Unsetenv does the removal.
+	t.Setenv("NO_COLOR", "")
+	if err := os.Unsetenv("NO_COLOR"); err != nil {
+		t.Fatal(err)
+	}
+
+	var outProbes, errProbes int
+	out := fdProbe{Writer: &bytes.Buffer{}, probed: &outProbes}
+	errw := fdProbe{Writer: &bytes.Buffer{}, probed: &errProbes}
+
+	_ = New(out, errw, ColorAuto)
+
+	if outProbes != 1 {
+		t.Errorf("Out was probed %d times, want exactly 1", outProbes)
+	}
+	if errProbes != 1 {
+		t.Errorf("Err was probed %d times, want exactly 1 — a single decision reused "+
+			"across both streams is the bug this guards", errProbes)
+	}
+}
+
+// The forced modes must NOT probe either stream: --color=always/never is the
+// user's explicit override, and consulting the terminal would be wrong (and, for
+// a closed descriptor, potentially a syscall on a stale fd).
+func TestForcedColorModesDoNotProbeTheStreams(t *testing.T) {
+	for _, mode := range []ColorMode{ColorAlways, ColorNever} {
+		var outProbes, errProbes int
+		out := fdProbe{Writer: &bytes.Buffer{}, probed: &outProbes}
+		errw := fdProbe{Writer: &bytes.Buffer{}, probed: &errProbes}
+
+		p := New(out, errw, mode)
+		if outProbes != 0 || errProbes != 0 {
+			t.Errorf("mode %v probed the streams (out=%d err=%d); a forced mode must not", mode, outProbes, errProbes)
+		}
+		// And both streams agree, since the override applies to everything.
+		if p.color != p.colorErr {
+			t.Errorf("mode %v produced divergent decisions (out=%v err=%v)", mode, p.color, p.colorErr)
+		}
 	}
 }

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -229,7 +229,7 @@ func TestWarnPathsAreByteIdentical(t *testing.T) {
 // always/never force both the same way. Only a real terminal-plus-redirect gets
 // here, which is the case that shipped the bug.
 func splitStreamPrinter(out, errw io.Writer) *Printer {
-	return &Printer{Out: out, Err: errw, color: true, colorErr: false, mode: ColorAuto}
+	return &Printer{Out: out, Err: errw, color: true, colorErr: false}
 }
 
 // The bug this pins: color was resolved once from Out and reused for Err, so
@@ -377,73 +377,108 @@ func TestLevelOutOfRangeIsNamedHonestly(t *testing.T) {
 	}
 }
 
-// fdProbe is a writer that reports an Fd (so isTerminal's type assertion
-// succeeds) and records that it was asked. The fd is deliberately invalid, so
-// term.IsTerminal says "not a terminal" — what is being observed is WHICH streams
-// New probes, not the answer.
-type fdProbe struct {
-	io.Writer
-	probed *int
+// withTerminalCheck overrides the TTY probe for the duration of a test, so the two
+// streams can be made to answer DIFFERENTLY — the only way to observe a per-stream
+// color decision, since two in-memory buffers never diverge under `auto`.
+func withTerminalCheck(t *testing.T, fn func(io.Writer) bool) {
+	t.Helper()
+	prev := terminalCheck
+	terminalCheck = fn
+	t.Cleanup(func() { terminalCheck = prev })
 }
 
-func (f fdProbe) Fd() uintptr {
-	*f.probed++
-	// ^uintptr(0) → int(-1): never a valid descriptor, so IsTerminal is false
-	// without touching any real file.
-	return ^uintptr(0)
-}
-
-// New must resolve the color decision ONCE PER STREAM.
+// New must resolve the color decision once PER STREAM, and assign each result to
+// the RIGHT field.
 //
-// This is the assertion that was missing: the split-stream tests above build a
-// Printer as a struct literal, because two in-memory buffers cannot produce
-// divergent `auto` decisions (isTerminal is false for both). So they verify that a
-// divergence is HONORED, but not that New ever computes one — and with only those,
-// changing `colorErr: resolveColor(err, mode)` to resolve from `out` again broke
-// nothing. Verified by making that exact edit.
-//
-// Observing the probe count is the way in: one probe per stream means each stream's
-// TTY-ness was asked about independently.
-func TestNewResolvesColorPerStream(t *testing.T) {
-	// NO_COLOR disables color for ANY value, including empty, and it short-circuits
-	// before the isTerminal probe this test observes — so it must be genuinely
-	// ABSENT, not empty. t.Setenv registers the restore; Unsetenv does the removal.
+// An earlier version of this test counted Fd() probes, which was not enough: it
+// caught "resolved once and reused", but a SWAP —
+// `color: resolveColor(err), colorErr: resolveColor(out)` — probes each stream
+// exactly once and passed. That swap reproduces the original bug exactly (ANSI
+// into a redirected stderr), so the test was blind to the very thing it existed to
+// prevent. Forcing the two streams to answer differently is what closes it.
+func TestNewResolvesColorPerStreamAndDoesNotSwapThem(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
 	if err := os.Unsetenv("NO_COLOR"); err != nil {
 		t.Fatal(err)
 	}
+	var out, errb bytes.Buffer
+	// Only Out is a "terminal": the redirected-stderr case that shipped the bug.
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&out) })
 
-	var outProbes, errProbes int
-	out := fdProbe{Writer: &bytes.Buffer{}, probed: &outProbes}
-	errw := fdProbe{Writer: &bytes.Buffer{}, probed: &errProbes}
+	p := New(&out, &errb, ColorAuto)
 
-	_ = New(out, errw, ColorAuto)
-
-	if outProbes != 1 {
-		t.Errorf("Out was probed %d times, want exactly 1", outProbes)
+	if !p.color {
+		t.Error("Out is a terminal but p.color is false — the streams are swapped or Out was not probed")
 	}
-	if errProbes != 1 {
-		t.Errorf("Err was probed %d times, want exactly 1 — a single decision reused "+
-			"across both streams is the bug this guards", errProbes)
+	if p.colorErr {
+		t.Error("Err is redirected but p.colorErr is true — the streams are swapped, or one decision was reused for both")
+	}
+
+	// And the mirror case, so neither field can be hardcoded.
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&errb) })
+	q := New(&out, &errb, ColorAuto)
+	if q.color {
+		t.Error("Out is redirected but q.color is true")
+	}
+	if !q.colorErr {
+		t.Error("Err is a terminal but q.colorErr is false")
 	}
 }
 
 // The forced modes must NOT probe either stream: --color=always/never is the
-// user's explicit override, and consulting the terminal would be wrong (and, for
-// a closed descriptor, potentially a syscall on a stale fd).
+// user's explicit override, and consulting the terminal would be wrong (and, for a
+// closed descriptor, a syscall on a stale fd).
 func TestForcedColorModesDoNotProbeTheStreams(t *testing.T) {
 	for _, mode := range []ColorMode{ColorAlways, ColorNever} {
-		var outProbes, errProbes int
-		out := fdProbe{Writer: &bytes.Buffer{}, probed: &outProbes}
-		errw := fdProbe{Writer: &bytes.Buffer{}, probed: &errProbes}
+		probed := 0
+		withTerminalCheck(t, func(io.Writer) bool { probed++; return true })
 
-		p := New(out, errw, mode)
-		if outProbes != 0 || errProbes != 0 {
-			t.Errorf("mode %v probed the streams (out=%d err=%d); a forced mode must not", mode, outProbes, errProbes)
+		p := New(&bytes.Buffer{}, &bytes.Buffer{}, mode)
+		if probed != 0 {
+			t.Errorf("mode %v probed the streams %d time(s); a forced mode must not", mode, probed)
 		}
-		// And both streams agree, since the override applies to everything.
 		if p.color != p.colorErr {
 			t.Errorf("mode %v produced divergent decisions (out=%v err=%v)", mode, p.color, p.colorErr)
 		}
+	}
+}
+
+// uncomparableWriter holds a func, making it uncomparable at VALUE level.
+type uncomparableWriter struct{ fn func() }
+
+func (uncomparableWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+// embeddingWriter is statically comparable — reflect.Type.Comparable() reports
+// true, because an interface-typed field's comparability is only knowable from the
+// value it holds. That is precisely why the type-level guard did not work.
+type embeddingWriter struct{ io.Writer }
+
+// sameWriter must not panic on an uncomparable dynamic type. The first version of
+// this guard used reflect.Type.Comparable() and DID panic on the case below —
+// while the CLI was reporting an error, the worst possible moment.
+func TestSameWriterSurvivesUncomparableWriters(t *testing.T) {
+	cases := []struct {
+		name string
+		w    io.Writer
+	}{
+		{"directly uncomparable", uncomparableWriter{fn: func() {}}},
+		{"uncomparable behind a statically-comparable wrapper", embeddingWriter{Writer: uncomparableWriter{fn: func() {}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Passing the same value as both arguments is the worst case: the type
+			// check matches, so only the comparability check stands between this and
+			// a runtime panic.
+			if sameWriter(tc.w, tc.w) {
+				t.Error("an uncomparable writer must report 'not the same' rather than being compared")
+			}
+			// And through the real call path: a Printer whose streams are that
+			// writer, emitting a diagnostic.
+			p := New(tc.w, tc.w, ColorNever)
+			p.Fdiagf(tc.w, LevelError, "must not panic")
+			p.Fsuccessf(tc.w, EmojiSuccess, "must not panic")
+			w := NewWarnWriter(tc.w, p)
+			fmt.Fprintf(w, "warning: %s\n", "must not panic")
+		})
 	}
 }

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -618,3 +618,69 @@ func TestStripSGRLeavesEverythingElseAlone(t *testing.T) {
 		}
 	}
 }
+
+// Color() reports the OUT decision, and that is load-bearing rather than
+// incidental: diff.go hands a writer to a third-party colorizer and gates it on
+// this, so reporting the Err decision here would put ANSI into a redirected stdout.
+// Nothing pinned which stream it reports.
+func TestColorReportsTheOutStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&out) })
+	if p := New(&out, &errb, ColorAuto); !p.Color() {
+		t.Error("Out is a terminal, so Color() must be true")
+	}
+	// Mirror: a terminal Err with a redirected Out must NOT report colour.
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&errb) })
+	if p := New(&out, &errb, ColorAuto); p.Color() {
+		t.Error("Out is redirected, so Color() must be false even though Err is a terminal")
+	}
+}
+
+// The spinner writes to p.Err, so it must take the Err decision. This was fixed in
+// round 3 and had no test at all — the fix could be reverted silently.
+func TestSpinnerTakesTheErrStreamDecision(t *testing.T) {
+	var out, errb bytes.Buffer
+	// Err is the terminal here; Out is not. If the spinner took the Out decision it
+	// would render plain on a colour-capable stderr.
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&errb) })
+	p := New(&out, &errb, ColorAuto)
+	if s := p.Spinner("working"); !s.color {
+		t.Fatal("the spinner writes to Err; with a terminal Err it must use colour")
+	}
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&out) })
+	if s := New(&out, &errb, ColorAuto).Spinner("working"); s.color {
+		t.Fatal("with a redirected Err the spinner must be plain, regardless of Out")
+	}
+}
+
+// NO_COLOR (https://no-color.org) disables colour for ANY value, including empty,
+// and it must short-circuit before the terminal probe. A documented external
+// contract with zero coverage until now.
+func TestNoColorDisablesColourEvenOnATerminal(t *testing.T) {
+	var buf bytes.Buffer
+	withTerminalCheck(t, func(io.Writer) bool { return true }) // pretend both are TTYs
+	for _, val := range []string{"", "1", "anything"} {
+		t.Run("NO_COLOR="+val, func(t *testing.T) {
+			t.Setenv("NO_COLOR", val)
+			p := New(&buf, &buf, ColorAuto)
+			if p.Color() || p.colorErr {
+				t.Fatalf("NO_COLOR=%q must disable colour on both streams", val)
+			}
+		})
+	}
+	// And --color=always still overrides NO_COLOR: an explicit flag beats the env.
+	t.Setenv("NO_COLOR", "1")
+	if !New(&buf, &buf, ColorAlways).Color() {
+		t.Fatal("--color=always must override NO_COLOR")
+	}
+}
+
+func TestSameWriterHandlesNilWriters(t *testing.T) {
+	var buf bytes.Buffer
+	if !sameWriter(nil, nil) {
+		t.Error("two nil writers are the same writer")
+	}
+	if sameWriter(nil, &buf) || sameWriter(&buf, nil) {
+		t.Error("a nil writer is not the same as a real one")
+	}
+}

--- a/internal/ui/diag_test.go
+++ b/internal/ui/diag_test.go
@@ -520,8 +520,9 @@ func TestEachLevelHasItsOwnColour(t *testing.T) {
 // call ui.Sanitize (they must not import ui — the reason the "warning: " sentinel
 // exists). So ui must sanitize here or nothing does.
 //
-// This replaced a *documented convention* that every emitter use %q, which was
-// already violated at the moment it was written down.
+// This replaced a *documented convention* that every emitter use %q: a rule each
+// future emitter must remember is weaker than a chokepoint, and %q was never a
+// control for the %v-of-error sites at all.
 func TestWarnWriterSanitizesAdapterText(t *testing.T) {
 	var dest bytes.Buffer
 	p := New(&dest, &dest, ColorNever)

--- a/internal/ui/layering_test.go
+++ b/internal/ui/layering_test.go
@@ -1,0 +1,84 @@
+package ui_test
+
+import (
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestAdapterAndCaptureDoNotImportUI enforces the layering rule that the
+// `warning: ` sentinel exists to satisfy.
+//
+// `internal/adapter/*` and `internal/capture` must not depend on `internal/ui`.
+// That is why an adapter emits a plain `warning: <message>` line into an
+// `io.Writer` it was handed, and why `ui.WarnWriter` — not the adapter — attaches
+// the label and sanitizes the body. `docs/architecture.md` §11–§12 state the rule,
+// and §12's mermaid graph draws `ui` as its own node specifically so that an
+// `adapter → INFRA` edge cannot imply `adapter → ui`.
+//
+// Until this test existed, nothing checked it. A stated architectural rule with no
+// enforcement is a convention: the next person to want a styled warning inside an
+// adapter would add the import, every test would pass, and the sentinel would
+// quietly become dead weight. This is deliberately a source-level import check
+// rather than a lint rule so it lives next to the package it protects.
+func TestAdapterAndCaptureDoNotImportUI(t *testing.T) {
+	const forbidden = "github.com/spxrogers/agentsync/internal/ui"
+	root := repoRootForLayering(t)
+
+	dirs, err := filepath.Glob(filepath.Join(root, "internal", "adapter", "*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs = append(
+		dirs,
+		filepath.Join(root, "internal", "adapter"),
+		filepath.Join(root, "internal", "capture"),
+	)
+
+	fset := token.NewFileSet()
+	checked := 0
+	for _, dir := range dirs {
+		files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range files {
+			// Test files may import ui (a test asserting on styled output is fine);
+			// the constraint is on the packages themselves.
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			checked++
+			f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, imp := range f.Imports {
+				if strings.Trim(imp.Path.Value, `"`) == forbidden {
+					t.Errorf("%s imports internal/ui — adapters and capture must not; "+
+						"emit a plain \"warning: \" line into the io.Writer you were handed and let "+
+						"ui.WarnWriter label it (see docs/architecture.md §11)",
+						fset.Position(imp.Pos()))
+				}
+			}
+		}
+	}
+	// The adapter tree is large; a glob that silently stops matching would make
+	// this pass vacuously — the failure mode two other guards in this repo hit.
+	if checked < 40 {
+		t.Fatalf("only checked %d adapter/capture sources; the sweep has lost its targets", checked)
+	}
+}
+
+func repoRootForLayering(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not locate this test file")
+	}
+	// <root>/internal/ui/layering_test.go
+	return filepath.Dir(filepath.Dir(filepath.Dir(self)))
+}

--- a/internal/ui/routeto_test.go
+++ b/internal/ui/routeto_test.go
@@ -130,9 +130,9 @@ func TestWarnWriter_Flush(t *testing.T) {
 		w.Flush()
 		got := dest.String()
 		// Color is off (ColorNever), so the styled prefix is the bare
-		// glyph + "warning:" — emit's HasPrefix("warning: ") still
+		// glyph + level word — emit's HasPrefix("warning: ") still
 		// triggers the prefix rewrite even without a trailing newline.
-		const wantPrefix = GlyphWarnEmoji + " warning:"
+		wantPrefix := LevelWarn.Label(p)
 		if !strings.HasPrefix(got, wantPrefix) {
 			t.Fatalf("Flush should style the partial warning prefix; got: %q", got)
 		}

--- a/internal/ui/routeto_test.go
+++ b/internal/ui/routeto_test.go
@@ -141,13 +141,25 @@ func TestWarnWriter_Flush(t *testing.T) {
 		}
 	})
 
-	t.Run("partial non-warning line drains verbatim", func(t *testing.T) {
+	t.Run("partial non-warning line drains unlabeled, and terminated", func(t *testing.T) {
 		dest.Reset()
 		w2 := NewWarnWriter(&dest, p)
 		_, _ = w2.Write([]byte("note: agentsync did things"))
 		w2.Flush()
-		if got := dest.String(); got != "note: agentsync did things" {
-			t.Fatalf("non-warning partial line should drain verbatim; got: %q", got)
+		got := dest.String()
+		// The contract being pinned is that a line without the "warning: "
+		// sentinel is passed through UNLABELED — its content is untouched.
+		if got != "note: agentsync did things\n" {
+			t.Fatalf("non-warning partial line should drain with its content intact; got: %q", got)
+		}
+		// Flush DOES add the missing line terminator, and that is deliberate: a
+		// drained fragment has no trailing newline by definition, so whatever
+		// writes to this stream next — main's terminal ✗ ERROR line — would render
+		// on the same row. The hazard is identical for labeled and passthrough
+		// lines, so Flush terminates both rather than leaving the caller to
+		// remember which case needs it.
+		if !strings.HasSuffix(got, "\n") {
+			t.Fatalf("Flush must terminate the fragment it drains; got: %q", got)
 		}
 	})
 

--- a/internal/ui/slog.go
+++ b/internal/ui/slog.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 )
 
 // SlogHandler renders slog records through the diagnostic vocabulary in diag.go,
@@ -36,6 +37,18 @@ type SlogHandler struct {
 	p     *Printer
 	w     io.Writer
 	level slog.Leveler
+	// mu serializes writes to w. slog.Handler implementations are expected to be
+	// safe for concurrent use — the stdlib's own handlers lock their writer — and
+	// callers reasonably assume a *slog.Logger can be shared across goroutines.
+	// A record here renders as a label line plus an optional attribute line, so
+	// without the lock two concurrent records could interleave and split an
+	// attribute line away from the diagnostic it belongs to.
+	//
+	// SHARED by derivation: clone() copies the pointer, so every handler derived
+	// via WithAttrs/WithGroup locks the SAME mutex as its parent. That is required
+	// for correctness — they all write to the same w, and a per-clone mutex would
+	// serialize nothing.
+	mu *sync.Mutex
 	// attrs are the accumulated WithAttrs attributes, already prefixed with any
 	// enclosing group path. Held pre-rendered as key=value strings: the handler
 	// only ever formats them, never inspects them.
@@ -48,7 +61,7 @@ type SlogHandler struct {
 // above level. Pass p.Err as w for the normal case; the writer is explicit so a
 // caller can tee logs somewhere else without restyling them.
 func NewSlogHandler(w io.Writer, p *Printer, level slog.Leveler) *SlogHandler {
-	return &SlogHandler{p: p, w: w, level: level}
+	return &SlogHandler{p: p, w: w, level: level, mu: new(sync.Mutex)}
 }
 
 // Enabled implements slog.Handler.
@@ -85,6 +98,7 @@ func (h *SlogHandler) clone() *SlogHandler {
 		p:     h.p,
 		w:     h.w,
 		level: h.level,
+		mu:    h.mu, // deliberately shared — see the field doc
 		// Copy rather than share the backing array: two handlers derived from
 		// the same parent must not have one's append clobber the other's tail.
 		attrs:  append([]string(nil), h.attrs...),
@@ -108,12 +122,29 @@ func (h *SlogHandler) Handle(_ context.Context, r slog.Record) error {
 
 	// Sanitize: slog messages and attributes routinely carry filesystem paths
 	// and error strings harvested from third-party agent config, which is
-	// untrusted text headed for a terminal (#93/#171).
-	fmt.Fprintf(h.w, "%s  %s\n", levelOf(r.Level).Label(h.p), Sanitize(r.Message))
+	// untrusted text headed for a terminal (#93/#171). Note Sanitize STRIPS
+	// newlines rather than escaping them, so a multi-line slog message collapses
+	// to one line — acceptable here because a log record's Message is a single
+	// line by convention, and the alternative (indenting attacker-chosen line
+	// breaks into the message column) would let a crafted message forge what
+	// looks like a second, separate diagnostic.
+	style := h.p.styleFor(h.w)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s  %s\n", levelOf(r.Level).Label(style), Sanitize(r.Message))
 	if len(attrs) > 0 {
-		fmt.Fprintf(h.w, "%s%s\n", DiagIndent, h.p.Faint(Sanitize(strings.Join(attrs, " "))))
+		fmt.Fprintf(&b, "%s%s\n", diagIndent, style.Faint(Sanitize(strings.Join(attrs, " "))))
 	}
-	return nil
+
+	// ONE Write under the lock: the label line and its attribute line are a
+	// single logical diagnostic and must not be split by a concurrent record.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Return the write error rather than swallowing it. slog's own Logger
+	// discards what Handle returns, so this changes nothing for a live CLI — but
+	// a handler that reports "success" after a failed write is a lie that makes
+	// a tee'd or piped sink impossible to debug, and a test can assert on it.
+	_, err := io.WriteString(h.w, b.String())
+	return err
 }
 
 // levelOf maps a slog.Level onto the CLI's four-level vocabulary. slog levels

--- a/internal/ui/slog.go
+++ b/internal/ui/slog.go
@@ -12,17 +12,10 @@ import (
 // SlogHandler renders slog records through the diagnostic vocabulary in diag.go,
 // so a library-side slog.Warn is indistinguishable from a command's p.Warnf.
 //
-// Before this existed, agentsync had two unrelated warning renderings. Commands
-// emitted a styled line via WarnWriter, while the render and marketplace
-// pipelines called slog.Warn — which, with no handler ever installed, fell
-// through to slog's default and printed through the standard log package:
-//
-//	2026/07/28 15:03:45 WARN plugin component frontmatter is not strict YAML …
-//
-// A wall-clock timestamp no user asked for, no color, no glyph, and a shape
-// nothing else in the CLI used. #211 caught the real cost: that line sat
-// directly above an unlabeled fatal error, and the two were indistinguishable
-// at a glance. Routing slog here collapses them onto one vocabulary.
+// Without it, the render and marketplace pipelines' slog.Warn calls fall through
+// to slog's default and print through the standard log package —
+// `2026/07/28 15:03:45 WARN …`, a shape nothing else in the CLI uses. See diag.go
+// for why that mattered.
 //
 // Records render as the level label, the message, then any attributes on a
 // continuation line indented to the message column:

--- a/internal/ui/slog.go
+++ b/internal/ui/slog.go
@@ -128,7 +128,7 @@ func (h *SlogHandler) Handle(_ context.Context, r slog.Record) error {
 	// line by convention, and the alternative (indenting attacker-chosen line
 	// breaks into the message column) would let a crafted message forge what
 	// looks like a second, separate diagnostic.
-	style := h.p.styleFor(h.w)
+	style := h.p.styleForDiag(h.w)
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s  %s\n", levelOf(r.Level).Label(style), Sanitize(r.Message))
 	if len(attrs) > 0 {

--- a/internal/ui/slog.go
+++ b/internal/ui/slog.go
@@ -1,0 +1,169 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+// SlogHandler renders slog records through the diagnostic vocabulary in diag.go,
+// so a library-side slog.Warn is indistinguishable from a command's p.Warnf.
+//
+// Before this existed, agentsync had two unrelated warning renderings. Commands
+// emitted a styled line via WarnWriter, while the render and marketplace
+// pipelines called slog.Warn — which, with no handler ever installed, fell
+// through to slog's default and printed through the standard log package:
+//
+//	2026/07/28 15:03:45 WARN plugin component frontmatter is not strict YAML …
+//
+// A wall-clock timestamp no user asked for, no color, no glyph, and a shape
+// nothing else in the CLI used. #211 caught the real cost: that line sat
+// directly above an unlabeled fatal error, and the two were indistinguishable
+// at a glance. Routing slog here collapses them onto one vocabulary.
+//
+// Records render as the level label, the message, then any attributes on a
+// continuation line indented to the message column:
+//
+//	⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently
+//	         path=/Users/me/.agentsync/.state/cache/plugins/x/agents/y.md
+//
+// Attributes go on their own line because the ones agentsync logs are paths and
+// wrapped errors — long enough that appending them inline pushes the message
+// itself off the screen.
+type SlogHandler struct {
+	p     *Printer
+	w     io.Writer
+	level slog.Leveler
+	// attrs are the accumulated WithAttrs attributes, already prefixed with any
+	// enclosing group path. Held pre-rendered as key=value strings: the handler
+	// only ever formats them, never inspects them.
+	attrs []string
+	// groups is the open WithGroup path, joined with "." to qualify keys.
+	groups []string
+}
+
+// NewSlogHandler returns a handler that writes records to w styled by p at or
+// above level. Pass p.Err as w for the normal case; the writer is explicit so a
+// caller can tee logs somewhere else without restyling them.
+func NewSlogHandler(w io.Writer, p *Printer, level slog.Leveler) *SlogHandler {
+	return &SlogHandler{p: p, w: w, level: level}
+}
+
+// Enabled implements slog.Handler.
+func (h *SlogHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level.Level()
+}
+
+// WithAttrs implements slog.Handler, returning a handler that prepends attrs to
+// every record. The receiver is left untouched (slog requires handlers be safe
+// to derive from concurrently).
+func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	out := h.clone()
+	for _, a := range attrs {
+		out.attrs = append(out.attrs, renderAttr(h.groups, a)...)
+	}
+	return out
+}
+
+// WithGroup implements slog.Handler. An empty name is a no-op per the contract.
+func (h *SlogHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	out := h.clone()
+	out.groups = append(out.groups, name)
+	return out
+}
+
+func (h *SlogHandler) clone() *SlogHandler {
+	return &SlogHandler{
+		p:     h.p,
+		w:     h.w,
+		level: h.level,
+		// Copy rather than share the backing array: two handlers derived from
+		// the same parent must not have one's append clobber the other's tail.
+		attrs:  append([]string(nil), h.attrs...),
+		groups: append([]string(nil), h.groups...),
+	}
+}
+
+// Handle implements slog.Handler.
+//
+// The record's time is deliberately dropped. agentsync's slog output is
+// user-facing CLI diagnostics, not a log stream anyone greps by timestamp, and
+// a wall clock on every warning was the single loudest thing wrong with the
+// pre-existing output. Nothing here feeds a content hash or the drift
+// classifier, so dropping it costs nothing downstream.
+func (h *SlogHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := append([]string(nil), h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, renderAttr(h.groups, a)...)
+		return true
+	})
+
+	// Sanitize: slog messages and attributes routinely carry filesystem paths
+	// and error strings harvested from third-party agent config, which is
+	// untrusted text headed for a terminal (#93/#171).
+	fmt.Fprintf(h.w, "%s  %s\n", levelOf(r.Level).Label(h.p), Sanitize(r.Message))
+	if len(attrs) > 0 {
+		fmt.Fprintf(h.w, "%s%s\n", DiagIndent, h.p.Faint(Sanitize(strings.Join(attrs, " "))))
+	}
+	return nil
+}
+
+// levelOf maps a slog.Level onto the CLI's four-level vocabulary. slog levels
+// are an open integer scale, so anything at or above Error is an error and
+// anything below Info is debug — a custom intermediate level lands on the
+// nearest label below it rather than being dropped.
+func levelOf(l slog.Level) Level {
+	switch {
+	case l >= slog.LevelError:
+		return LevelError
+	case l >= slog.LevelWarn:
+		return LevelWarn
+	case l >= slog.LevelInfo:
+		return LevelInfo
+	default:
+		return LevelDebug
+	}
+}
+
+// renderAttr flattens one attribute into zero or more `key=value` strings,
+// qualifying keys with the enclosing group path. Group-valued attrs recurse, an
+// empty Attr is dropped per the slog.Handler contract, and a value containing a
+// space is quoted so the continuation line stays parseable by eye.
+func renderAttr(groups []string, a slog.Attr) []string {
+	a.Value = a.Value.Resolve() // run any LogValuer before inspecting the kind
+	if a.Equal(slog.Attr{}) {
+		return nil
+	}
+	if a.Value.Kind() == slog.KindGroup {
+		inner := a.Value.Group()
+		if len(inner) == 0 {
+			return nil // an empty group is elided, key and all
+		}
+		sub := groups
+		if a.Key != "" {
+			sub = append(append([]string(nil), groups...), a.Key)
+		}
+		var out []string
+		for _, g := range inner {
+			out = append(out, renderAttr(sub, g)...)
+		}
+		return out
+	}
+	key := a.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".") + "." + key
+	}
+	val := a.Value.String()
+	if strings.ContainsAny(val, " \t") {
+		val = fmt.Sprintf("%q", val)
+	}
+	return []string{key + "=" + val}
+}

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -261,3 +261,37 @@ func TestSlogHandlerReportsWriteErrors(t *testing.T) {
 type failingWriter struct{ err error }
 
 func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+// TestSlogHandlerMutexIsLoadBearing is the companion to the test above, and exists
+// because that one CANNOT detect a missing lock: its writeRecorder takes its own
+// mutex, so `-race` sees a properly synchronized writer no matter what the handler
+// does. Deleting h.mu.Lock()/Unlock() left it green.
+//
+// This one writes into a bare *bytes.Buffer shared across goroutines with NO
+// external synchronization, so the handler's own lock is the only thing making the
+// writes safe. Under `-race` (which CI runs), removing that lock is a reported data
+// race here.
+func TestSlogHandlerMutexIsLoadBearing(t *testing.T) {
+	var unsynchronized bytes.Buffer // deliberately NOT guarded by the test
+	p := New(io.Discard, io.Discard, ColorNever)
+	lg := slog.New(NewSlogHandler(&unsynchronized, p, slog.LevelInfo))
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			sub := lg.With("g", g)
+			for i := 0; i < 25; i++ {
+				sub.Warn("racy record", "i", i)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Every record still landed intact — the lock serializes whole records, so no
+	// write is torn even though the buffer itself is unguarded.
+	if n := strings.Count(unsynchronized.String(), "⚠ WARN"); n != 8*25 {
+		t.Fatalf("got %d labeled records, want %d", n, 8*25)
+	}
+}

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -1,0 +1,176 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func handlerBuf(t *testing.T, level slog.Leveler) (*bytes.Buffer, *slog.Logger) {
+	t.Helper()
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+	return &buf, slog.New(NewSlogHandler(&buf, p, level))
+}
+
+// The regression from #211: a library-side slog.Warn used to print through the
+// stdlib default handler as `2026/07/28 15:03:45 WARN <msg> path=<p>` — a
+// timestamp nothing else in the CLI carried, and a shape that made a fatal
+// error one line below it indistinguishable. It must now render exactly like a
+// p.Warnf, with attributes hanging in the message column.
+func TestSlogHandlerRendersAsDiagnostic(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.Warn("plugin component frontmatter is not strict YAML; parsed leniently",
+		"path", "/home/me/.agentsync/.state/cache/plugins/x/agents/y.md")
+
+	want := "⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently\n" +
+		DiagIndent + "path=/home/me/.agentsync/.state/cache/plugins/x/agents/y.md\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("slog warning render:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// No wall-clock timestamp, ever. This is the single most visible thing that was
+// wrong with the pre-existing output, and a handler rewrite could reintroduce
+// it without any other assertion noticing.
+func TestSlogHandlerDropsTimestamp(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.Info("hello")
+	if !strings.HasPrefix(buf.String(), "ℹ INFO") {
+		t.Fatalf("line must start with the level label, got: %q", buf.String())
+	}
+}
+
+func TestSlogHandlerLevelMapping(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+		want  string
+	}{
+		{"debug", slog.LevelDebug, "• DEBUG"},
+		{"info", slog.LevelInfo, "ℹ INFO"},
+		{"warn", slog.LevelWarn, "⚠ WARN"},
+		{"error", slog.LevelError, "✗ ERROR"},
+		// slog levels are an open integer scale: a custom level between two
+		// named ones must land on the nearest label BELOW it, never be dropped.
+		{"between info and warn", slog.LevelInfo + 2, "ℹ INFO"},
+		{"above error", slog.LevelError + 4, "✗ ERROR"},
+		{"below debug", slog.LevelDebug - 4, "• DEBUG"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, lg := handlerBuf(t, slog.LevelDebug-8)
+			lg.Log(context.Background(), tc.level, "msg")
+			if !strings.HasPrefix(buf.String(), tc.want) {
+				t.Fatalf("level %v rendered as %q, want prefix %q", tc.level, buf.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestSlogHandlerEnabledGatesByLevel(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelWarn)
+	lg.Info("suppressed")
+	lg.Warn("shown")
+	got := buf.String()
+	if strings.Contains(got, "suppressed") {
+		t.Fatalf("below-threshold record was emitted: %q", got)
+	}
+	if !strings.Contains(got, "shown") {
+		t.Fatalf("at-threshold record was dropped: %q", got)
+	}
+}
+
+// WithAttrs/WithGroup must compose without one derived handler clobbering
+// another — the classic append-shares-backing-array bug. Two loggers derived
+// from the same parent must not see each other's attributes.
+func TestSlogHandlerDerivedHandlersAreIndependent(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+	base := slog.New(NewSlogHandler(&buf, p, slog.LevelInfo)).With("shared", "1")
+
+	a := base.With("only", "a")
+	b := base.With("only", "b")
+
+	buf.Reset()
+	a.Info("x")
+	gotA := buf.String()
+	buf.Reset()
+	b.Info("x")
+	gotB := buf.String()
+
+	if !strings.Contains(gotA, "only=a") || strings.Contains(gotA, "only=b") {
+		t.Fatalf("handler a saw the wrong attrs: %q", gotA)
+	}
+	if !strings.Contains(gotB, "only=b") || strings.Contains(gotB, "only=a") {
+		t.Fatalf("handler b saw the wrong attrs: %q", gotB)
+	}
+	if !strings.Contains(gotA, "shared=1") || !strings.Contains(gotB, "shared=1") {
+		t.Fatalf("both handlers should keep the parent attr; a=%q b=%q", gotA, gotB)
+	}
+}
+
+func TestSlogHandlerGroupsQualifyKeys(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.WithGroup("plugin").With("id", "feature-dev").Info("msg", "sha", "abc")
+	got := buf.String()
+	if !strings.Contains(got, "plugin.id=feature-dev") {
+		t.Fatalf("WithGroup did not qualify the WithAttrs key: %q", got)
+	}
+	if !strings.Contains(got, "plugin.sha=abc") {
+		t.Fatalf("WithGroup did not qualify the record key: %q", got)
+	}
+}
+
+// slog.Handler contract corners: an empty Attr is dropped, an empty group is
+// elided key and all, and a nested group-valued Attr flattens with a dotted key.
+func TestSlogHandlerAttrEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		attr slog.Attr
+		want []string // substrings that must appear; empty means "no attr line"
+	}{
+		{"empty attr dropped", slog.Attr{}, nil},
+		{"empty group elided", slog.Group("g"), nil},
+		{"nested group flattened", slog.Group("outer", slog.String("k", "v")), []string{"outer.k=v"}},
+		{"value with space is quoted", slog.String("k", "a b"), []string{`k="a b"`}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, lg := handlerBuf(t, slog.LevelInfo)
+			lg.Info("msg", tc.attr)
+			lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+			if len(tc.want) == 0 {
+				if len(lines) != 1 {
+					t.Fatalf("expected no attribute line, got: %q", buf.String())
+				}
+				return
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(buf.String(), w) {
+					t.Fatalf("missing %q in: %q", w, buf.String())
+				}
+			}
+		})
+	}
+}
+
+// slog records carry filesystem paths and error strings harvested from
+// third-party agent config — untrusted text headed for a terminal. It must be
+// sanitized on the way out, in both the message and the attributes (#93/#171).
+func TestSlogHandlerSanitizesUntrustedText(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.Warn("skill \x1b[31mred\x1b[0m is odd", "path", "/tmp/\x1b]0;pwned\x07x")
+
+	got := buf.String()
+	if strings.Contains(got, "\x1b]") || strings.Contains(got, "\x07") {
+		t.Fatalf("escape sequences survived into terminal output: %q", got)
+	}
+	// The ESC introducer is stripped; the inert parameter bytes remain, which
+	// is Sanitize's documented behavior.
+	if !strings.Contains(got, "[31mred") {
+		t.Fatalf("message body was lost, not just neutralized: %q", got)
+	}
+}

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -3,9 +3,13 @@ package ui
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func handlerBuf(t *testing.T, level slog.Leveler) (*bytes.Buffer, *slog.Logger) {
@@ -174,3 +178,86 @@ func TestSlogHandlerSanitizesUntrustedText(t *testing.T) {
 		t.Fatalf("message body was lost, not just neutralized: %q", got)
 	}
 }
+
+// SlogHandler must be safe for concurrent use: slog.Handler implementations are
+// contractually expected to be, callers reasonably share a *slog.Logger across
+// goroutines, and the stdlib's own handlers lock their writer.
+//
+// Nothing exercised the mutex before this, so `-race` never saw the handler at
+// all. Two things are asserted: no race (under -race), and no INTERLEAVING — a
+// record renders as a label line plus an optional attribute line, and those two
+// must stay adjacent or an attribute gets orphaned under someone else's warning.
+func TestSlogHandlerIsConcurrencySafe(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+	// A writer that records each Write as one unit, so an interleaved pair of
+	// records would show up as a torn entry.
+	rec := writeRecorder{mu: &mu, lines: &lines}
+
+	p := New(io.Discard, io.Discard, ColorNever)
+	lg := slog.New(NewSlogHandler(rec, p, slog.LevelInfo))
+
+	const goroutines, each = 8, 25
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			// Derive per goroutine too, exercising the shared mutex through clone().
+			sub := lg.With("g", g)
+			for i := 0; i < each; i++ {
+				sub.Warn("concurrent record", "i", i)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if len(lines) != goroutines*each {
+		t.Fatalf("got %d writes, want %d", len(lines), goroutines*each)
+	}
+	// Every write must be a complete record: the label line, then exactly one
+	// indented attribute line, and nothing else.
+	for _, ln := range lines {
+		parts := strings.SplitAfter(ln, "\n")
+		if len(parts) != 3 || parts[2] != "" {
+			t.Fatalf("record was not written as one whole unit: %q", ln)
+		}
+		if !strings.HasPrefix(parts[0], "⚠ WARN") {
+			t.Fatalf("record does not start with its label: %q", ln)
+		}
+		if !strings.HasPrefix(parts[1], diagIndent) {
+			t.Fatalf("attribute line is not in the message column: %q", ln)
+		}
+	}
+}
+
+// writeRecorder captures each Write call as a discrete entry.
+type writeRecorder struct {
+	mu    *sync.Mutex
+	lines *[]string
+}
+
+func (w writeRecorder) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	*w.lines = append(*w.lines, string(b))
+	return len(b), nil
+}
+
+// Handle must report a write failure rather than swallowing it. slog's Logger
+// discards the return, so this changes nothing for a live CLI — but a handler
+// that claims success after a failed write makes a tee'd sink undebuggable.
+func TestSlogHandlerReportsWriteErrors(t *testing.T) {
+	want := errors.New("disk on fire")
+	p := New(io.Discard, io.Discard, ColorNever)
+	h := NewSlogHandler(failingWriter{err: want}, p, slog.LevelInfo)
+
+	err := h.Handle(context.Background(), slog.NewRecord(time.Time{}, slog.LevelWarn, "msg", 0))
+	if !errors.Is(err, want) {
+		t.Fatalf("Handle returned %v, want %v", err, want)
+	}
+}
+
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -373,7 +373,7 @@ func TestSlogHandlerElidesEmptyGroupReachingHandleDirectly(t *testing.T) {
 
 	// WithAttrs, not Record.AddAttrs: slog elides an empty group inside AddAttrs
 	// too, so a record built that way never reaches renderAttr and the assertion
-	// below is vacuous. Do not "simplify" this back.
+	// below would be vacuous. Do not "simplify" this back.
 	withEmpty := h.WithAttrs([]slog.Attr{{Key: "g", Value: slog.GroupValue()}})
 	r := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
 	if err := withEmpty.Handle(context.Background(), r); err != nil {

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -373,8 +373,7 @@ func TestSlogHandlerElidesEmptyGroupReachingHandleDirectly(t *testing.T) {
 
 	// WithAttrs, not Record.AddAttrs: slog elides an empty group inside AddAttrs
 	// too, so a record built that way never reaches renderAttr and the assertion
-	// below would be vacuous. This was the actual bug in the first version of this
-	// test — it passed while renderAttr emitted "g=[]".
+	// below is vacuous. Do not "simplify" this back.
 	withEmpty := h.WithAttrs([]slog.Attr{{Key: "g", Value: slog.GroupValue()}})
 	r := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
 	if err := withEmpty.Handle(context.Background(), r); err != nil {

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -295,3 +295,95 @@ func TestSlogHandlerMutexIsLoadBearing(t *testing.T) {
 		t.Fatalf("got %d labeled records, want %d", n, 8*25)
 	}
 }
+
+// The handler sanitizes the record MESSAGE as well as the attributes, and until now
+// only the attribute half was asserted — so deleting `Sanitize(r.Message)` broke
+// nothing. A log message is as attacker-influenced as an attribute: marketplace
+// projection interpolates config-derived names straight into it.
+func TestSlogHandlerSanitizesTheMessageNotJustAttrs(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.Warn("skill a\rb\x1b]0;pwned\x07 is odd") // NO attrs: only the message can carry this
+
+	got := buf.String()
+	for _, bad := range []string{"\r", "\x1b]", "\x07"} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("control byte %q survived in the MESSAGE: %q", bad, got)
+		}
+	}
+	if !strings.Contains(got, "is odd") {
+		t.Fatalf("message was blanked rather than sanitized: %q", got)
+	}
+}
+
+// The handler must style for the stream it writes to, not for the Printer's Out
+// decision. This is the same leak class as the label and the pre-styled body — the
+// third site — and it was the only one with no test.
+func TestSlogHandlerStylesForItsOwnStream(t *testing.T) {
+	var out, errb bytes.Buffer
+	withTerminalCheck(t, func(w io.Writer) bool { return w == io.Writer(&out) })
+	p := New(&out, &errb, ColorAuto) // Out is a "terminal", Err is redirected
+
+	slog.New(NewSlogHandler(&errb, p, slog.LevelInfo)).Warn("to a redirected stderr")
+	if got := errb.String(); strings.Contains(got, "\x1b[") {
+		t.Fatalf("the slog handler leaked ANSI into a plain stream: %q", got)
+	}
+}
+
+// clone must COPY the attr/group backing arrays. Sharing them lets one derived
+// handler's append overwrite a sibling's tail — silent corruption that no race
+// detector reports, because it is not a race, just aliasing.
+func TestSlogHandlerCloneDoesNotAliasSiblings(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+	// Give the parent spare capacity, which is what makes append() alias.
+	base := slog.New(NewSlogHandler(&buf, p, slog.LevelInfo)).
+		With("a", "1", "b", "2", "c", "3")
+
+	childA := base.With("only", "A")
+	_ = base.With("only", "B") // would clobber A's tail if the array were shared
+
+	buf.Reset()
+	childA.Info("x")
+	if got := buf.String(); !strings.Contains(got, "only=A") || strings.Contains(got, "only=B") {
+		t.Fatalf("sibling handlers alias their attr storage: %q", got)
+	}
+}
+
+// renderAttr must resolve a LogValuer before inspecting the kind, or a lazily
+// computed value renders as its wrapper type instead of its content.
+func TestSlogHandlerResolvesLogValuer(t *testing.T) {
+	buf, lg := handlerBuf(t, slog.LevelInfo)
+	lg.Info("msg", "lazy", lazyValue{})
+	if got := buf.String(); !strings.Contains(got, "lazy=resolved") {
+		t.Fatalf("LogValuer was not resolved: %q", got)
+	}
+}
+
+type lazyValue struct{}
+
+func (lazyValue) LogValue() slog.Value { return slog.StringValue("resolved") }
+
+// An empty group is elided key-and-all. The existing table row for this is VACUOUS:
+// slog itself drops an empty group inside Record.Add, so the handler never sees one
+// when the attr arrives through a *slog.Logger. Reach Handle directly.
+func TestSlogHandlerElidesEmptyGroupReachingHandleDirectly(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, &buf, ColorNever)
+	h := NewSlogHandler(&buf, p, slog.LevelInfo)
+
+	// WithAttrs, not Record.AddAttrs: slog elides an empty group inside AddAttrs
+	// too, so a record built that way never reaches renderAttr and the assertion
+	// below would be vacuous. This was the actual bug in the first version of this
+	// test — it passed while renderAttr emitted "g=[]".
+	withEmpty := h.WithAttrs([]slog.Attr{{Key: "g", Value: slog.GroupValue()}})
+	r := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
+	if err := withEmpty.Handle(context.Background(), r); err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(buf.String(), "\n"); n != 1 {
+		t.Fatalf("an empty group must produce no attribute line; got %q", buf.String())
+	}
+	if strings.Contains(buf.String(), "g=") {
+		t.Fatalf("empty group leaked a key: %q", buf.String())
+	}
+}

--- a/internal/ui/slog_test.go
+++ b/internal/ui/slog_test.go
@@ -26,7 +26,7 @@ func TestSlogHandlerRendersAsDiagnostic(t *testing.T) {
 		"path", "/home/me/.agentsync/.state/cache/plugins/x/agents/y.md")
 
 	want := "⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently\n" +
-		DiagIndent + "path=/home/me/.agentsync/.state/cache/plugins/x/agents/y.md\n"
+		diagIndent + "path=/home/me/.agentsync/.state/cache/plugins/x/agents/y.md\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("slog warning render:\ngot:  %q\nwant: %q", got, want)
 	}

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -44,7 +44,7 @@ func (p *Printer) Spinner(label string) *Spinner {
 		w:       p.Err,
 		label:   label,
 		animate: isTerminal(p.Err),
-		color:   p.color,
+		color:   p.colorErr, // the spinner writes to p.Err; use that stream's decision
 		stopCh:  make(chan struct{}),
 		doneCh:  make(chan struct{}),
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -168,24 +168,19 @@ func (p *Printer) withColor(color bool) *Printer {
 
 // sameWriter reports whether two io.Writer values are the same writer.
 //
-// It does NOT just use `a == b`. Comparing interface values panics at runtime
-// when the dynamic type is not comparable (a struct containing a slice, map, or
-// func) — and this runs on every diagnostic line, so a panic here would take down
-// the CLI while it was trying to report an error, which is the worst possible
-// place for one.
+// Not a bare `a == b`: comparing interface values panics when the dynamic type is
+// uncomparable (a struct holding a slice, map, or func), and this runs on every
+// diagnostic line — the worst place for a panic is while reporting an error.
 //
-// reflect.VALUE.Comparable(), not reflect.TYPE.Comparable(). The distinction is
-// the whole correctness of this function and it is easy to get backwards — the
-// first version of this guard used the type-level check and still panicked. A
-// struct with an `io.Writer` FIELD is statically comparable (Type.Comparable()
-// reports true), because comparability of an interface-typed field is only
-// decidable from the value it holds at runtime. So `struct{ io.Writer }` wrapping
-// a func-holding writer sails past the type check and panics on `==`.
-// Value.Comparable() inspects the actual dynamic contents and answers correctly.
+// reflect.VALUE.Comparable(), NOT reflect.TYPE.Comparable() — easy to get
+// backwards, and the whole correctness of this function. `struct{ io.Writer }` is
+// statically comparable (an interface field's comparability is only decidable from
+// what it holds), so a type-level check lets a func-holding writer through and
+// panics on `==`. The value-level check inspects the actual contents.
 //
-// Two values of different dynamic types can never be equal, so a type mismatch
-// short-circuits first. An uncomparable value reports "not the same writer",
-// degrading to the caller's documented fallback rather than crashing.
+// Different dynamic types can never be equal, so a type mismatch short-circuits.
+// An uncomparable value reports "not the same writer", degrading to the caller's
+// documented fallback rather than crashing.
 func sameWriter(a, b io.Writer) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
@@ -356,12 +351,10 @@ func (s *WarnWriter) Flush() {
 	if len(s.buf) == 0 {
 		return
 	}
-	// Terminate the line here rather than leaving it to the caller. A buffered
-	// partial line has no trailing newline by definition, so whatever writes to
-	// this stream next — main's terminal ✗ ERROR line, typically — would render on
-	// the same row. This was briefly a separate EndLine() method the caller had to
-	// pair with Flush; one of the two call sites promptly forgot to, which is the
-	// argument against a two-call protocol when the primitive can just be correct.
+	// Terminate here rather than leaving it to the caller. A buffered partial line
+	// has no trailing newline by definition, so whatever writes to this stream next
+	// — main's terminal ✗ ERROR line, typically — lands on the same row. Making the
+	// primitive correct beats a two-call protocol callers must remember.
 	if s.buf[len(s.buf)-1] != '\n' {
 		s.buf = append(s.buf, '\n')
 	}
@@ -511,24 +504,18 @@ func spaces(n int) string {
 // stripSGR removes ANSI CSI escape sequences from s, leaving everything else —
 // including newlines — untouched.
 //
-// It exists because a caller may legitimately pre-style the text it hands a
-// diagnostic writer: the upgrade-notice banner composes p.Bold/p.Yellow/p.Cyan
-// fragments, and gitbackup bolds "local-only". Those helpers resolve color from
-// p.color — the OUT decision — because a style helper cannot know which stream its
-// result will be written to. So `agentsync apply 2>err.log` from a terminal produced
-// a correctly-plain LABEL followed by a body still carrying \x1b[1m: the per-stream
-// fix covered the label and missed the body, leaving the package doc's "color never
-// leaks into a redirect" false for exactly the case it names.
+// Callers legitimately pre-style the text they hand a diagnostic writer (the
+// upgrade-notice banner composes p.Bold/p.Yellow fragments; gitbackup bolds
+// "local-only"). Those helpers resolve color from p.color — the OUT decision —
+// because a style helper cannot know which stream its result reaches. So
+// `apply 2>err.log` from a terminal gave a plain LABEL followed by a body still
+// carrying \x1b[1m.
 //
-// Rather than require six call sites — and every future one — to remember which
-// stream they target, the diagnostic writers strip SGR from the body when the
-// target stream renders without color. If color is off for that stream, ANY escape
-// in the body is unwanted by definition, so this cannot discard something a caller
-// wanted. Newlines survive because indentContinuation still needs them.
-//
-// Sanitize would also remove these sequences, but it strips newlines too, and the
-// diagnostic writers deliberately do not sanitize — see the "who sanitizes" note in
-// docs/components.md.
+// The diagnostic writers therefore strip SGR from the body when the target stream
+// renders plain, instead of asking every call site to know its own stream. If color
+// is off there, ANY escape in the body is unwanted, so nothing a caller wanted is
+// lost. Newlines survive because indentContinuation needs them — which is also why
+// this is not just Sanitize, whose stripping of newlines would defeat that.
 func stripSGR(s string) string {
 	if !strings.Contains(s, "\x1b") {
 		return s // overwhelmingly the common case; no allocation

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -40,6 +40,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strings"
 
 	"golang.org/x/term"
 
@@ -461,11 +462,35 @@ func (s *WarnWriter) emit(line []byte) {
 		return
 	}
 	rest := line[len(warnLinePrefix):]
+	// Sanitize the BODY. This writer's input comes from the adapter and capture
+	// packages, which cannot call ui.Sanitize themselves — they must not import ui,
+	// which is the whole reason the "warning: " sentinel exists — so if ui does not
+	// sanitize here, nothing in the pipeline does.
+	//
+	// This used to rely on every emitter interpolating untrusted values with %q.
+	// That convention was ALREADY violated when it was written down
+	// (internal/adapter/continuedev/ingest.go quoted a native-config id twice with
+	// %q and once with %s on the same line), which is the argument for a backstop
+	// over a documented requirement. %q at the emitters remains good practice —
+	// it keeps the value legible — but it is no longer load-bearing.
+	//
+	// Only the labeled branch is sanitized; the passthrough branch above must stay
+	// verbatim because it carries OUR OWN already-styled lines (importIO's INFO
+	// notes), whose ANSI this would otherwise strip.
+	//
+	// Sanitize drops newlines rather than escaping them, which is right here: a
+	// control byte in adapter text must not be able to forge what looks like a
+	// second, separate diagnostic line.
+	//
 	// styleForDiag, not s.p directly: this writer is constructed over p.Err, and
 	// taking the Out decision meant `agentsync import 2>err.log` from a terminal
 	// wrote ANSI into the file — the exact leak the per-stream split exists to
 	// close, and the one that made this path diverge from p.Warnf.
-	fmt.Fprintf(s.w, "%s  %s", LevelWarn.Label(s.p.styleForDiag(s.w)), rest)
+	body, nl := string(rest), ""
+	if strings.HasSuffix(body, "\n") {
+		body, nl = strings.TrimSuffix(body, "\n"), "\n"
+	}
+	fmt.Fprintf(s.w, "%s  %s%s", LevelWarn.Label(s.p.styleForDiag(s.w)), Sanitize(body), nl)
 }
 
 func spaces(n int) string {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -120,7 +120,6 @@ type Printer struct {
 	// the common path for ~170 emission sites and for SlogHandler.
 	color    bool
 	colorErr bool
-	mode     ColorMode
 }
 
 // New builds a Printer bound to out/err, resolving whether to emit color from
@@ -132,7 +131,6 @@ func New(out, err io.Writer, mode ColorMode) *Printer {
 		Err:      err,
 		color:    resolveColor(out, mode),
 		colorErr: resolveColor(err, mode),
-		mode:     mode,
 	}
 }
 
@@ -164,27 +162,35 @@ func (p *Printer) withColor(color bool) *Printer {
 	if p.color == color {
 		return p
 	}
-	return &Printer{Out: p.Out, Err: p.Err, color: color, colorErr: p.colorErr, mode: p.mode}
+	return &Printer{Out: p.Out, Err: p.Err, color: color, colorErr: p.colorErr}
 }
 
 // sameWriter reports whether two io.Writer values are the same writer.
 //
 // It does NOT just use `a == b`. Comparing interface values panics at runtime
 // when the dynamic type is not comparable (a struct containing a slice, map, or
-// func) — and this runs on every diagnostic line, so a panic here would take
-// down the CLI while it was trying to report an error, which is the worst
-// possible place for one. No writer in this repo is uncomparable today; the
-// guard costs one reflect.TypeOf and removes the hazard permanently.
+// func) — and this runs on every diagnostic line, so a panic here would take down
+// the CLI while it was trying to report an error, which is the worst possible
+// place for one.
+//
+// reflect.VALUE.Comparable(), not reflect.TYPE.Comparable(). The distinction is
+// the whole correctness of this function and it is easy to get backwards — the
+// first version of this guard used the type-level check and still panicked. A
+// struct with an `io.Writer` FIELD is statically comparable (Type.Comparable()
+// reports true), because comparability of an interface-typed field is only
+// decidable from the value it holds at runtime. So `struct{ io.Writer }` wrapping
+// a func-holding writer sails past the type check and panics on `==`.
+// Value.Comparable() inspects the actual dynamic contents and answers correctly.
 //
 // Two values of different dynamic types can never be equal, so a type mismatch
-// short-circuits. An uncomparable matching type reports "not the same writer",
-// which degrades to the caller's documented fallback rather than crashing.
+// short-circuits first. An uncomparable value reports "not the same writer",
+// degrading to the caller's documented fallback rather than crashing.
 func sameWriter(a, b io.Writer) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
-	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
-	if ta != tb || !ta.Comparable() {
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if va.Type() != vb.Type() || !va.Comparable() || !vb.Comparable() {
 		return false
 	}
 	return a == b
@@ -209,9 +215,21 @@ func resolveColor(out io.Writer, mode ColorMode) bool {
 		if _, ok := os.LookupEnv("NO_COLOR"); ok {
 			return false
 		}
-		return isTerminal(out)
+		return terminalCheck(out)
 	}
 }
+
+// terminalCheck is the TTY probe resolveColor uses, indirected through a variable
+// so a test can make the two streams answer DIFFERENTLY.
+//
+// That capability is not a convenience — it is the only way to test the invariant
+// this package got wrong once already. Two in-memory buffers can never diverge
+// under `auto` (isTerminal is false for both), and the forced modes force both the
+// same way. So a test that cannot override this cannot distinguish "resolved per
+// stream" from "resolved once and reused", nor from the two assignments being
+// SWAPPED — and the swap reproduces the original bug exactly (ANSI into a
+// redirected stderr) while probing each stream exactly once.
+var terminalCheck = isTerminal
 
 // isTerminal reports whether w is backed by a terminal. A *bytes.Buffer / pipe
 // (tests, redirects) has no Fd and is therefore plain — which is exactly what
@@ -330,9 +348,9 @@ func (s *WarnWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Flush emits any buffered partial line (no trailing \n) as-is. Call at end of
-// command if you've routed a writer that may not always end in \n; the import
-// path does always terminate, so this is defensive.
+// Flush drains any buffered partial line, TERMINATING it. Call at end of command
+// if you've routed a writer that may not always end in \n; every emitter today
+// does terminate its lines, so this is defensive.
 func (s *WarnWriter) Flush() {
 	if len(s.buf) == 0 {
 		return

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,10 +1,25 @@
 // Package ui centralizes agentsync's terminal presentation: semantic color, a
-// curated glyph vocabulary, and small layout primitives (sections, status
-// lines, aligned labels). It is the single place that decides whether to emit
-// ANSI, so every command renders through a *Printer and the color/glyph/spacing
-// language stays consistent across `status`, `diff`, `doctor`, and `apply`.
+// curated glyph vocabulary, a labeled diagnostic vocabulary, and small layout
+// primitives (sections, status lines, aligned labels). It is the single place
+// that decides whether to emit ANSI, so every command renders through a
+// *Printer and the color/glyph/spacing language stays consistent across
+// `status`, `diff`, `doctor`, and `apply`.
 //
-// Two independent axes:
+// Output splits into two kinds, and the distinction is the organizing rule of
+// this package:
+//
+//   - A DIAGNOSTIC is a notice *about* the run — an error, a warning, an
+//     informational aside. Every one carries a level label (`✗ ERROR`,
+//     `⚠ WARN`, `ℹ INFO`) and goes to stderr. See diag.go for the vocabulary
+//     and slog.go for the handler that gives library-side slog calls the same
+//     shape.
+//   - RESULT output is what the command was asked to produce — a status table,
+//     a diff, a `--json` payload, a list, or the one-line outcome of a mutating
+//     command. It carries no level label. Its success line instead leads with a
+//     curated emoji (`✅ added agent: claude`), because labeling an outcome
+//     "INFO" is noise that dilutes the labels that matter.
+//
+// Two independent axes govern how any of it is styled:
 //
 //   - Color is TTY-gated. `--color=always|never` forces it; `auto` (the
 //     default) enables color only when the output is a terminal and NO_COLOR
@@ -86,13 +101,22 @@ type Printer struct {
 	Out   io.Writer
 	Err   io.Writer
 	color bool
+	mode  ColorMode
 }
 
 // New builds a Printer bound to out/err, resolving whether to emit color from
 // mode, the NO_COLOR environment variable, and whether out is a terminal.
 func New(out, err io.Writer, mode ColorMode) *Printer {
-	return &Printer{Out: out, Err: err, color: resolveColor(out, mode)}
+	return &Printer{Out: out, Err: err, color: resolveColor(out, mode), mode: mode}
 }
+
+// ColorMode returns the requested mode this Printer was built with — NOT the
+// resolved boolean (that is Color). The distinction matters for a caller that
+// must rebuild a Printer against different writers and honor the same user
+// intent: `auto` has to be re-resolved against the NEW writer's TTY-ness, so
+// carrying the resolved bool across would be wrong. ReportError does exactly
+// this, rebuilding against os.Stderr after cobra has returned.
+func (p *Printer) ColorMode() ColorMode { return p.mode }
 
 // Color reports whether this Printer emits ANSI. Commands that hand a writer to
 // a third-party renderer (e.g. the diff library's own colorizer) consult this
@@ -181,15 +205,21 @@ func Pad(s string, width int) string {
 // calculation, so a stripped rune never throws off column alignment.
 func Sanitize(s string) string { return untrusted.Sanitize(s) }
 
-// WarnWriter wraps a destination writer and styles "warning: " line prefixes
-// as a bold-yellow "⚠️ warning:" so every warning — whether emitted by the
-// CLI itself, by an adapter's Ingest, or by capture's re-reference path —
-// reads consistently. Lines that do not start with the literal "warning: "
-// prefix (e.g. pre-styled ANSI lines, indented continuation lines, or
-// "agentsync:" notes) pass through verbatim. The writer is line-buffered so a
+// WarnWriter wraps a destination writer and rewrites "warning: " line prefixes
+// into the shared WARN diagnostic label (see diag.go) so every warning —
+// whether emitted by the CLI itself, by an adapter's Ingest, or by capture's
+// re-reference path — is byte-identical to a p.Warnf and to a slog.Warn from
+// the render pipeline. Lines that do not start with the literal "warning: "
+// prefix (e.g. pre-styled ANSI lines, indented continuation lines, or already-
+// labeled diagnostics) pass through verbatim. The writer is line-buffered so a
 // callers' partial Write is held until a newline arrives — fmt.Fprintf in
 // practice always finishes a line per call, but buffering keeps a chunked
 // writer correct.
+//
+// The "warning: " sentinel stays the emitter-side contract because the adapter
+// packages must not depend on ui: an adapter writes a plain prefixed line into
+// an io.Writer it was handed, and the styling happens here, at the one place
+// that knows whether this terminal gets color.
 //
 // Not safe for concurrent use: the line-assembly buffer is unsynchronized.
 // One *WarnWriter per command invocation is the intended pattern.
@@ -200,9 +230,9 @@ type WarnWriter struct {
 }
 
 // NewWarnWriter returns a *WarnWriter that flushes styled lines to w using p.
-// p's color decision is honored: with color off, the prefix becomes a plain
-// "⚠️ warning:" (the glyph is content, not decoration — same rule as the
-// curated glyph vocabulary above).
+// p's color decision is honored: with color off, the prefix degrades to a plain
+// "⚠ WARN" (the glyph and the level word are content, not decoration — same
+// rule as the curated glyph vocabulary above).
 func NewWarnWriter(w io.Writer, p *Printer) *WarnWriter {
 	return &WarnWriter{w: w, p: p}
 }
@@ -234,11 +264,6 @@ func (s *WarnWriter) Flush() {
 		s.buf = nil
 	}
 }
-
-// GlyphWarnEmoji is the colourful warning sign (with VS16) used as the warning
-// label prefix. Wider than one column in some terminals, which is fine — the
-// warning lines are not part of any padded layout.
-const GlyphWarnEmoji = "⚠️"
 
 // stderrSetter is the structural shape of adapter.WarnEmitter. Duplicated
 // here so ui doesn't depend on the adapter package; each concrete adapter's
@@ -333,8 +358,7 @@ func (s *WarnWriter) emit(line []byte) {
 		return
 	}
 	rest := line[len(warnLinePrefix):]
-	label := s.p.Yellow(s.p.Bold(GlyphWarnEmoji + " warning:"))
-	fmt.Fprintf(s.w, "%s %s", label, rest)
+	fmt.Fprintf(s.w, "%s  %s", LevelWarn.Label(s.p), rest)
 }
 
 func spaces(n int) string {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -507,3 +507,58 @@ func spaces(n int) string {
 	}
 	return string(out)
 }
+
+// stripSGR removes ANSI CSI escape sequences from s, leaving everything else —
+// including newlines — untouched.
+//
+// It exists because a caller may legitimately pre-style the text it hands a
+// diagnostic writer: the upgrade-notice banner composes p.Bold/p.Yellow/p.Cyan
+// fragments, and gitbackup bolds "local-only". Those helpers resolve color from
+// p.color — the OUT decision — because a style helper cannot know which stream its
+// result will be written to. So `agentsync apply 2>err.log` from a terminal produced
+// a correctly-plain LABEL followed by a body still carrying \x1b[1m: the per-stream
+// fix covered the label and missed the body, leaving the package doc's "color never
+// leaks into a redirect" false for exactly the case it names.
+//
+// Rather than require six call sites — and every future one — to remember which
+// stream they target, the diagnostic writers strip SGR from the body when the
+// target stream renders without color. If color is off for that stream, ANY escape
+// in the body is unwanted by definition, so this cannot discard something a caller
+// wanted. Newlines survive because indentContinuation still needs them.
+//
+// Sanitize would also remove these sequences, but it strips newlines too, and the
+// diagnostic writers deliberately do not sanitize — see the "who sanitizes" note in
+// docs/components.md.
+func stripSGR(s string) string {
+	if !strings.Contains(s, "\x1b") {
+		return s // overwhelmingly the common case; no allocation
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		// CSI: ESC '[' <params> <final byte in @..~>
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && (s[j] < '@' || s[j] > '~') {
+				j++
+			}
+			if j < len(s) {
+				i = j + 1 // skip the final byte too
+				continue
+			}
+			break // unterminated: drop the remainder rather than emit a bare ESC
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// bodyFor prepares a caller-supplied message for the stream w: SGR is stripped when
+// that stream renders without color, then continuation lines are aligned.
+func (p *Printer) bodyFor(style *Printer, msg string) string {
+	if !style.color {
+		msg = stripSGR(msg)
+	}
+	return indentContinuation(msg)
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -136,42 +136,67 @@ func New(out, err io.Writer, mode ColorMode) *Printer {
 	}
 }
 
-// styleFor returns a view of p whose color decision matches the stream w. Used
-// by the diagnostic writers, which take an explicit io.Writer and must not
-// inherit the wrong stream's TTY-ness.
-//
-// Interface comparison is exact (dynamic type + value), so this recognizes
-// p.Out/p.Err and nothing else. An UNRECOGNIZED writer falls back to the Err
-// decision: every caller passing a third writer today is emitting a diagnostic,
-// and Err is the conservative choice for one (a diagnostic reaching an unknown
-// sink is more likely redirected than interactive).
-func (p *Printer) styleFor(w io.Writer) *Printer {
-	// Out is the only stream whose decision differs from the diagnostic default,
-	// so it is the only case worth naming. Everything else — Err and any
-	// unrecognized writer — takes the Err decision.
-	if w == p.Out || p.color == p.colorErr {
-		return p // already the right decision, or the two streams agree
+// styleForDiag returns a view of p whose color decision matches the stream w, for
+// DIAGNOSTIC output. An unrecognized writer takes the Err decision: a diagnostic
+// reaching an unknown sink is more likely redirected than interactive.
+func (p *Printer) styleForDiag(w io.Writer) *Printer {
+	if sameWriter(w, p.Out) {
+		return p.withColor(p.color)
 	}
-	return &Printer{Out: p.Out, Err: p.Err, color: p.colorErr, colorErr: p.colorErr, mode: p.mode}
+	return p.withColor(p.colorErr)
 }
 
-// ColorMode returns the requested mode this Printer was built with — NOT the
-// resolved boolean (that is Color). The distinction matters for a caller that
-// must rebuild a Printer against different writers and honor the same user
-// intent: `auto` has to be re-resolved against the NEW writer's TTY-ness, so
-// carrying the resolved bool across would be wrong. ReportError does exactly
-// this, rebuilding against os.Stderr after cobra has returned.
-func (p *Printer) ColorMode() ColorMode { return p.mode }
+// styleForResult returns a view of p whose color decision matches the stream w,
+// for RESULT output (a success line). The fallback is the mirror image of
+// styleForDiag's: an unrecognized writer takes the OUT decision, because a
+// result line's natural home is stdout — Fsuccessf's doc invites a
+// caller-supplied buffer, and giving that stderr's TTY-ness would be backwards.
+func (p *Printer) styleForResult(w io.Writer) *Printer {
+	if sameWriter(w, p.Err) {
+		return p.withColor(p.colorErr)
+	}
+	return p.withColor(p.color)
+}
 
-// Color reports whether this Printer emits ANSI on Out. Commands that hand a
-// writer to a third-party renderer (e.g. the diff library's own colorizer)
-// consult this to gate that output through the same decision — and every such
-// caller today renders to Out, which is why this reports the Out decision.
+// withColor returns p when the requested decision already matches (the common
+// case, and it avoids an allocation per output line), otherwise a shallow copy.
+func (p *Printer) withColor(color bool) *Printer {
+	if p.color == color {
+		return p
+	}
+	return &Printer{Out: p.Out, Err: p.Err, color: color, colorErr: p.colorErr, mode: p.mode}
+}
+
+// sameWriter reports whether two io.Writer values are the same writer.
+//
+// It does NOT just use `a == b`. Comparing interface values panics at runtime
+// when the dynamic type is not comparable (a struct containing a slice, map, or
+// func) — and this runs on every diagnostic line, so a panic here would take
+// down the CLI while it was trying to report an error, which is the worst
+// possible place for one. No writer in this repo is uncomparable today; the
+// guard costs one reflect.TypeOf and removes the hazard permanently.
+//
+// Two values of different dynamic types can never be equal, so a type mismatch
+// short-circuits. An uncomparable matching type reports "not the same writer",
+// which degrades to the caller's documented fallback rather than crashing.
+func sameWriter(a, b io.Writer) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
+	if ta != tb || !ta.Comparable() {
+		return false
+	}
+	return a == b
+}
+
+// Color reports whether this Printer emits ANSI ON OUT. Every diagnostic goes to
+// Err, whose decision is resolved separately (see the struct doc) and reached
+// internally via styleForDiag — so this is deliberately NOT "does this Printer
+// use color". Commands that hand a writer to a third-party renderer (e.g. the
+// diff library's own colorizer) consult this to gate that output through the same
+// decision, and every such caller renders to Out.
 func (p *Printer) Color() bool { return p.color }
-
-// ColorErr reports whether this Printer emits ANSI on Err — the stream every
-// diagnostic uses. Distinct from Color; see the Printer struct doc.
-func (p *Printer) ColorErr() bool { return p.colorErr }
 
 func resolveColor(out io.Writer, mode ColorMode) bool {
 	switch mode {
@@ -277,9 +302,6 @@ type WarnWriter struct {
 	w   io.Writer
 	p   *Printer
 	buf []byte
-	// partial records that the last emit wrote a line with no trailing newline
-	// (only Flush can do that), so EndLine knows whether to terminate it.
-	partial bool
 }
 
 // NewWarnWriter returns a *WarnWriter that flushes styled lines to w using p.
@@ -312,11 +334,20 @@ func (s *WarnWriter) Write(p []byte) (int, error) {
 // command if you've routed a writer that may not always end in \n; the import
 // path does always terminate, so this is defensive.
 func (s *WarnWriter) Flush() {
-	if len(s.buf) > 0 {
-		s.emit(s.buf)
-		s.buf = nil
-		s.partial = true
+	if len(s.buf) == 0 {
+		return
 	}
+	// Terminate the line here rather than leaving it to the caller. A buffered
+	// partial line has no trailing newline by definition, so whatever writes to
+	// this stream next — main's terminal ✗ ERROR line, typically — would render on
+	// the same row. This was briefly a separate EndLine() method the caller had to
+	// pair with Flush; one of the two call sites promptly forgot to, which is the
+	// argument against a two-call protocol when the primitive can just be correct.
+	if s.buf[len(s.buf)-1] != '\n' {
+		s.buf = append(s.buf, '\n')
+	}
+	s.emit(s.buf)
+	s.buf = nil
 }
 
 // stderrSetter is the structural shape of adapter.WarnEmitter. Duplicated
@@ -412,7 +443,11 @@ func (s *WarnWriter) emit(line []byte) {
 		return
 	}
 	rest := line[len(warnLinePrefix):]
-	fmt.Fprintf(s.w, "%s  %s", LevelWarn.Label(s.p), rest)
+	// styleForDiag, not s.p directly: this writer is constructed over p.Err, and
+	// taking the Out decision meant `agentsync import 2>err.log` from a terminal
+	// wrote ANSI into the file — the exact leak the per-stream split exists to
+	// close, and the one that made this path diverge from p.Warnf.
+	fmt.Fprintf(s.w, "%s  %s", LevelWarn.Label(s.p.styleForDiag(s.w)), rest)
 }
 
 func spaces(n int) string {
@@ -428,19 +463,4 @@ func spaces(n int) string {
 		out[i] = ' '
 	}
 	return string(out)
-}
-
-// EndLine terminates a partial line if one was just flushed, so a subsequent
-// writer to the same stream starts at column 0.
-//
-// Flush drains whatever incomplete line the buffer held, by definition without a
-// trailing newline — and the next thing written to that stream may come from a
-// different layer entirely (main's terminal ✗ ERROR line, say), which would then
-// render on the same row as the fragment. Pairing Flush with EndLine keeps the
-// two visually separate. A no-op unless the last emitted byte was a partial line.
-func (s *WarnWriter) EndLine() {
-	if s.partial {
-		fmt.Fprintln(s.w)
-		s.partial = false
-	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -216,15 +216,10 @@ func resolveColor(out io.Writer, mode ColorMode) bool {
 }
 
 // terminalCheck is the TTY probe resolveColor uses, indirected through a variable
-// so a test can make the two streams answer DIFFERENTLY.
-//
-// That capability is not a convenience — it is the only way to test the invariant
-// this package got wrong once already. Two in-memory buffers can never diverge
-// under `auto` (isTerminal is false for both), and the forced modes force both the
-// same way. So a test that cannot override this cannot distinguish "resolved per
-// stream" from "resolved once and reused", nor from the two assignments being
-// SWAPPED — and the swap reproduces the original bug exactly (ANSI into a
-// redirected stderr) while probing each stream exactly once.
+// so a test can make the two streams answer DIFFERENTLY. Nothing else can: two
+// in-memory buffers never diverge under `auto`, and the forced modes force both the
+// same way. See TestNewResolvesColorPerStreamAndDoesNotSwapThem for what that
+// buys, including why counting probes is not enough.
 var terminalCheck = isTerminal
 
 // isTerminal reports whether w is backed by a terminal. A *bytes.Buffer / pipe
@@ -468,14 +463,12 @@ func (s *WarnWriter) emit(line []byte) {
 	// verbatim because it carries OUR OWN already-styled lines (importIO's INFO
 	// notes), whose ANSI this would otherwise strip.
 	//
-	// That asymmetry bounds what this backstop covers, and the bound is easy to
-	// overstate — so, precisely: Write splits on '\n' BEFORE calling emit, so the
-	// body here never holds an interior newline, and Sanitize's newline-stripping
-	// cannot fire. An emitter that interpolates a raw newline lands lines 2..n in
-	// the passthrough branch instead — unlabeled and unsanitized. %q at the
-	// emitters is what keeps a newline out (it escapes one), so for THAT case it is
-	// still load-bearing. Pre-existing and tracked separately; do not read this
-	// Sanitize as covering it.
+	// That asymmetry bounds the backstop, and the bound is easy to overstate: Write
+	// splits on '\n' BEFORE emit, so this body never holds an interior newline and
+	// Sanitize's newline-stripping cannot fire. An emitter interpolating a raw
+	// newline lands lines 2..n in the passthrough branch — unlabeled, unsanitized —
+	// which is why %q at the emitters is still load-bearing for THAT case.
+	// Pre-existing; do not read this Sanitize as covering it.
 	//
 	// styleForDiag, not s.p directly: this writer is constructed over p.Err, so
 	// taking the Out decision wrote ANSI into `agentsync import 2>err.log`.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -67,8 +67,19 @@ const (
 	GlyphPartial = "◐" // partial coverage (mirrors the capability matrix)
 	GlyphErr     = "✗" // failure / drift / missing
 	GlyphWarn    = "⚠" // warning / needs attention
-	GlyphInfo    = "•" // neutral bullet
+	GlyphInfo    = "•" // neutral bullet, inside a report body
 	GlyphArrow   = "→" // transition / "see"
+
+	// The two glyphs below belong to the DIAGNOSTIC label vocabulary in diag.go
+	// rather than to report layout, but they live here so the whole curated set
+	// is visible in one place.
+	//
+	// GlyphBullet is the same rune as GlyphInfo and that is deliberate: a faint
+	// bullet is the right mark for a DEBUG label and for a list item alike. They
+	// are named separately so a future change to one cannot silently move the
+	// other — the failure mode a shared constant invites.
+	GlyphNote   = "ℹ" // INFO label
+	GlyphBullet = "•" // DEBUG label
 )
 
 // ColorMode is the resolved value of the global --color flag.
@@ -96,18 +107,52 @@ func ParseColorMode(s string) (ColorMode, error) {
 }
 
 // Printer renders styled output to a pair of writers. Construct one per command
-// invocation via New; the color decision is frozen at construction.
+// invocation via New; the color decisions are frozen at construction.
 type Printer struct {
-	Out   io.Writer
-	Err   io.Writer
-	color bool
-	mode  ColorMode
+	Out io.Writer
+	Err io.Writer
+	// color and colorErr are resolved SEPARATELY, one per stream. `auto` asks
+	// whether the destination is a terminal, and Out and Err are different
+	// destinations: `agentsync apply 2>err.log` run from a terminal has a TTY
+	// stdout and a file stderr. Deciding once off Out and reusing it for Err
+	// wrote ANSI into that file — precisely what the package doc promises never
+	// happens. Every diagnostic goes to Err, so this is not a corner case; it is
+	// the common path for ~170 emission sites and for SlogHandler.
+	color    bool
+	colorErr bool
+	mode     ColorMode
 }
 
 // New builds a Printer bound to out/err, resolving whether to emit color from
-// mode, the NO_COLOR environment variable, and whether out is a terminal.
+// mode, the NO_COLOR environment variable, and whether each writer is a
+// terminal. The two streams are resolved independently — see the struct doc.
 func New(out, err io.Writer, mode ColorMode) *Printer {
-	return &Printer{Out: out, Err: err, color: resolveColor(out, mode), mode: mode}
+	return &Printer{
+		Out:      out,
+		Err:      err,
+		color:    resolveColor(out, mode),
+		colorErr: resolveColor(err, mode),
+		mode:     mode,
+	}
+}
+
+// styleFor returns a view of p whose color decision matches the stream w. Used
+// by the diagnostic writers, which take an explicit io.Writer and must not
+// inherit the wrong stream's TTY-ness.
+//
+// Interface comparison is exact (dynamic type + value), so this recognizes
+// p.Out/p.Err and nothing else. An UNRECOGNIZED writer falls back to the Err
+// decision: every caller passing a third writer today is emitting a diagnostic,
+// and Err is the conservative choice for one (a diagnostic reaching an unknown
+// sink is more likely redirected than interactive).
+func (p *Printer) styleFor(w io.Writer) *Printer {
+	// Out is the only stream whose decision differs from the diagnostic default,
+	// so it is the only case worth naming. Everything else — Err and any
+	// unrecognized writer — takes the Err decision.
+	if w == p.Out || p.color == p.colorErr {
+		return p // already the right decision, or the two streams agree
+	}
+	return &Printer{Out: p.Out, Err: p.Err, color: p.colorErr, colorErr: p.colorErr, mode: p.mode}
 }
 
 // ColorMode returns the requested mode this Printer was built with — NOT the
@@ -118,10 +163,15 @@ func New(out, err io.Writer, mode ColorMode) *Printer {
 // this, rebuilding against os.Stderr after cobra has returned.
 func (p *Printer) ColorMode() ColorMode { return p.mode }
 
-// Color reports whether this Printer emits ANSI. Commands that hand a writer to
-// a third-party renderer (e.g. the diff library's own colorizer) consult this
-// to gate that output through the same decision.
+// Color reports whether this Printer emits ANSI on Out. Commands that hand a
+// writer to a third-party renderer (e.g. the diff library's own colorizer)
+// consult this to gate that output through the same decision — and every such
+// caller today renders to Out, which is why this reports the Out decision.
 func (p *Printer) Color() bool { return p.color }
+
+// ColorErr reports whether this Printer emits ANSI on Err — the stream every
+// diagnostic uses. Distinct from Color; see the Printer struct doc.
+func (p *Printer) ColorErr() bool { return p.colorErr }
 
 func resolveColor(out io.Writer, mode ColorMode) bool {
 	switch mode {
@@ -227,6 +277,9 @@ type WarnWriter struct {
 	w   io.Writer
 	p   *Printer
 	buf []byte
+	// partial records that the last emit wrote a line with no trailing newline
+	// (only Flush can do that), so EndLine knows whether to terminate it.
+	partial bool
 }
 
 // NewWarnWriter returns a *WarnWriter that flushes styled lines to w using p.
@@ -262,6 +315,7 @@ func (s *WarnWriter) Flush() {
 	if len(s.buf) > 0 {
 		s.emit(s.buf)
 		s.buf = nil
+		s.partial = true
 	}
 }
 
@@ -374,4 +428,19 @@ func spaces(n int) string {
 		out[i] = ' '
 	}
 	return string(out)
+}
+
+// EndLine terminates a partial line if one was just flushed, so a subsequent
+// writer to the same stream starts at column 0.
+//
+// Flush drains whatever incomplete line the buffer held, by definition without a
+// trailing newline — and the next thing written to that stream may come from a
+// different layer entirely (main's terminal ✗ ERROR line, say), which would then
+// render on the same row as the fragment. Pairing Flush with EndLine keeps the
+// two visually separate. A no-op unless the last emitted byte was a partial line.
+func (s *WarnWriter) EndLine() {
+	if s.partial {
+		fmt.Fprintln(s.w)
+		s.partial = false
+	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -460,25 +460,25 @@ func (s *WarnWriter) emit(line []byte) {
 	// which is the whole reason the "warning: " sentinel exists — so if ui does not
 	// sanitize here, nothing in the pipeline does.
 	//
-	// This used to rely on every emitter interpolating untrusted values with %q.
-	// That convention was ALREADY violated when it was written down
-	// (internal/adapter/continuedev/ingest.go quoted a native-config id twice with
-	// %q and once with %s on the same line), which is the argument for a backstop
-	// over a documented requirement. %q at the emitters remains good practice —
-	// it keeps the value legible — but it is no longer load-bearing.
+	// It is a backstop, not a replacement for %q at the emitters: that convention
+	// was already violated when it was written down, so it cannot be the only
+	// control. See "Who sanitizes" in docs/components.md.
 	//
-	// Only the labeled branch is sanitized; the passthrough branch above must stay
+	// Only the labeled branch is sanitized. The passthrough branch above stays
 	// verbatim because it carries OUR OWN already-styled lines (importIO's INFO
 	// notes), whose ANSI this would otherwise strip.
 	//
-	// Sanitize drops newlines rather than escaping them, which is right here: a
-	// control byte in adapter text must not be able to forge what looks like a
-	// second, separate diagnostic line.
+	// That asymmetry bounds what this backstop covers, and the bound is easy to
+	// overstate — so, precisely: Write splits on '\n' BEFORE calling emit, so the
+	// body here never holds an interior newline, and Sanitize's newline-stripping
+	// cannot fire. An emitter that interpolates a raw newline lands lines 2..n in
+	// the passthrough branch instead — unlabeled and unsanitized. %q at the
+	// emitters is what keeps a newline out (it escapes one), so for THAT case it is
+	// still load-bearing. Pre-existing and tracked separately; do not read this
+	// Sanitize as covering it.
 	//
-	// styleForDiag, not s.p directly: this writer is constructed over p.Err, and
-	// taking the Out decision meant `agentsync import 2>err.log` from a terminal
-	// wrote ANSI into the file — the exact leak the per-stream split exists to
-	// close, and the one that made this path diverge from p.Warnf.
+	// styleForDiag, not s.p directly: this writer is constructed over p.Err, so
+	// taking the Out decision wrote ANSI into `agentsync import 2>err.log`.
 	body, nl := string(rest), ""
 	if strings.HasSuffix(body, "\n") {
 		body, nl = strings.TrimSuffix(body, "\n"), "\n"
@@ -515,7 +515,9 @@ func spaces(n int) string {
 // renders plain, instead of asking every call site to know its own stream. If color
 // is off there, ANY escape in the body is unwanted, so nothing a caller wanted is
 // lost. Newlines survive because indentContinuation needs them — which is also why
-// this is not just Sanitize, whose stripping of newlines would defeat that.
+// this is not just Sanitize, whose stripping of newlines would defeat that. The
+// diagnostic writers deliberately do not sanitize at all: see the "Who sanitizes"
+// note in docs/components.md for which sites do and why.
 func stripSGR(s string) string {
 	if !strings.Contains(s, "\x1b") {
 		return s // overwhelmingly the common case; no allocation

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -455,9 +455,9 @@ func (s *WarnWriter) emit(line []byte) {
 	// which is the whole reason the "warning: " sentinel exists — so if ui does not
 	// sanitize here, nothing in the pipeline does.
 	//
-	// It is a backstop, not a replacement for %q at the emitters: that convention
-	// was already violated when it was written down, so it cannot be the only
-	// control. See "Who sanitizes" in docs/components.md.
+	// It is a backstop, not a replacement for %q at the emitters. A convention every
+	// future emitter has to remember is weaker than a chokepoint, and %q does not
+	// cover the %v-of-error sites at all. See "Who sanitizes" in docs/components.md.
 	//
 	// Only the labeled branch is sanitized. The passthrough branch above stays
 	// verbatim because it carries OUR OWN already-styled lines (importIO's INFO

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -457,7 +457,11 @@ func (s *WarnWriter) emit(line []byte) {
 	//
 	// It is a backstop, not a replacement for %q at the emitters. A convention every
 	// future emitter has to remember is weaker than a chokepoint, and %q does not
-	// cover the %v-of-error sites at all. See "Who sanitizes" in docs/components.md.
+	// cover the %v-of-error sites at all — claude/ingest.go:88 quotes e.Name() with
+	// %q and then prints %v of an error whose *fs.PathError re-embeds that same
+	// ReadDir name RAW (the hazard untrusted.go:37 names, handled by hand in
+	// secrets/age.go, cli/doctor.go and cli/check.go). This line is what catches it
+	// here. See "Who sanitizes" in docs/components.md.
 	//
 	// Only the labeled branch is sanitized. The passthrough branch above stays
 	// verbatim because it carries OUR OWN already-styled lines (importIO's INFO

--- a/justfile
+++ b/justfile
@@ -55,6 +55,7 @@ test-fast:
     go test -race -count=1 \
         -skip 'TestReadFileOptional|TestReadDirOptional' \
         ./internal/log/... \
+        ./internal/ui/... \
         ./internal/jsonkeys/... \
         ./internal/drift/... \
         ./internal/paths/... \

--- a/test/bdd/features/01_bootstrap.feature
+++ b/test/bdd/features/01_bootstrap.feature
@@ -26,7 +26,7 @@ Feature: Bootstrap and inspect commands
     And I have run "agentsync init"
     When I run "agentsync check"
     Then the command succeeds
-    And the output contains "ok"
+    And the output contains "schema valid"
 
   Scenario: doctor inspects the environment
     Given a clean agentsync home

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -462,8 +462,11 @@ label and go to **stderr**:
 ⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently
          path=~/.agentsync/.state/cache/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
 ℹ INFO   scope: project (~/dev/app)
-• DEBUG  (only with --verbose)
 ```
+
+A fourth level, `• DEBUG`, exists in the vocabulary and is what `--verbose` unlocks,
+but nothing in agentsync currently logs at that level — so you will not see one
+today. It is the level a future library-side diagnostic would use.
 
 The label is a glyph plus the level word, padded so message text always starts
 at the same column; wrapped detail lines hang under it. When color is on the
@@ -480,10 +483,10 @@ all results, which is why a warning never lands in the middle of one. A success
 outcome leads with an emoji chosen by what happened:
 
 ```
-🎉 applied: 12 ops across 3 agents
+🎉 applied: 12 ops
 ✅ added agent: claude
 🧹 removed mcp server: github
-📥 imported 4 skills, 2 commands from claude
+📥 imported 6 items from claude
 🔙 reverted ~/.claude to checkpoint a1b2c3d
 ✨ agentsync home initialized at ~/.agentsync
 ```

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -458,8 +458,8 @@ visible at a glance.
 label and go to **stderr**:
 
 ```
-✗ ERROR  render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name
-⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently
+✗ ERROR  render codex: codex subagents feature-dev/code-reviewer and pr-review-toolkit/code-reviewer both resolve to the agent name "code-reviewer"; rename one or set distinct frontmatter names
+⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')
          path=~/.agentsync/.state/cache/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
 ℹ INFO   scope: project (~/dev/app)
 ```
@@ -470,7 +470,7 @@ today. It is the level a future library-side diagnostic would use.
 
 The label is a glyph plus the level word, padded so message text always starts
 at the same column; wrapped detail lines hang under it. When color is on the
-label is bold red / yellow / cyan / faint. With color off — piped, redirected,
+label is bold red, bold yellow, or bold cyan; `DEBUG` is faint rather than bold. With color off — piped, redirected,
 `NO_COLOR`, or `--color never` — the glyph and the word carry the whole signal,
 so the level survives into a log file or a CI transcript.
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -446,3 +446,47 @@ For per-plugin translation coverage, see [`plugin explain`](#plugin-explain-plug
 | `--color auto\|always\|never` | all | Control ANSI color + bold. Default `auto` (on for a TTY, off when piped/redirected; honors `NO_COLOR`). |
 | `-v`, `--verbose` | all | Verbose logging. In `status`, also expands each collapsed skill directory back to one row per bundled file. |
 | `--version` | root | Print version information and exit. The `agentsync version` subcommand is an alias. |
+
+---
+
+## How output is formatted
+
+Every command splits what it prints into two kinds, and the difference is
+visible at a glance.
+
+**Diagnostics** — anything that is a notice *about* the run — carry a level
+label and go to **stderr**:
+
+```
+✗ ERROR  render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name
+⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently
+         path=~/.agentsync/.state/cache/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
+ℹ INFO   scope: project (~/dev/app)
+• DEBUG  (only with --verbose)
+```
+
+The label is a glyph plus the level word, padded so message text always starts
+at the same column; wrapped detail lines hang under it. When color is on the
+label is bold red / yellow / cyan / faint. With color off — piped, redirected,
+`NO_COLOR`, or `--color never` — the glyph and the word carry the whole signal,
+so the level survives into a log file or a CI transcript.
+
+This applies to the *last* line a failing run prints too: the terminal error is
+an `✗ ERROR` diagnostic like any other, not a bare `agentsync: …` line.
+
+**Results** — what the command was asked to produce — go to **stdout** and carry
+no level label. A `--json` payload, a `status` table, a `diff`, and a `list` are
+all results, which is why a warning never lands in the middle of one. A success
+outcome leads with an emoji chosen by what happened:
+
+```
+🎉 applied: 12 ops across 3 agents
+✅ added agent: claude
+🧹 removed mcp server: github
+📥 imported 4 skills, 2 commands from claude
+🔙 reverted ~/.claude to checkpoint a1b2c3d
+✨ agentsync home initialized at ~/.agentsync
+```
+
+Success lines deliberately carry no `INFO`: labeling an outcome would dilute the
+labels that mean something.


### PR DESCRIPTION
## Summary

Follow-up to [#211 (comment)](https://github.com/spxrogers/agentsync/issues/211#issuecomment-5108532310). The formatting of agentsync's output was the reason a correct, deliberate fatal error read as a broken tool: it printed as a flat, uncolored, unlabeled line sitting directly beneath a `WARN` from a different subsystem, with nothing marking which was the failure.

```
2026/07/28 15:03:45 WARN plugin component frontmatter is not strict YAML; parsed leniently (…)
agentsync: render codex: codex subagents "code-reviewer" and "code-reviewer" resolve to the same agent name
```

The cause wasn't one bad message — it was **three unrelated renderings coexisting**, none aware of the others:

1. Commands hand-rolled their own prefixes (`p.Yellow("agentsync:")`, `p.Cyan("note:")`, `p.Yellow("warning:")`, a bare `•`).
2. Library packages called `slog.Warn` and **no handler had ever been installed** — `internal/log` was dead code — so those fell through to the stdlib default and printed a wall-clock timestamp in a shape nothing else in the CLI used.
3. `main` printed the terminal error itself, bypassing `ui` entirely.

All three now converge on one vocabulary in `internal/ui`.

### Diagnostics carry a level; results don't

| | What it is | Stream | Rendering |
| --- | --- | --- | --- |
| **Diagnostic** | a notice *about* the run | stderr | `✗ ERROR` / `⚠ WARN` / `ℹ INFO` / `• DEBUG`, message after a fixed 9-column prefix |
| **Result** | what the command was asked to produce | stdout | no level label; a success outcome leads with a curated emoji |

```
⚠ WARN   plugin component frontmatter is not strict YAML; parsed leniently (consider quoting values containing ': ')
         path=~/.agentsync/.state/cache/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
ℹ INFO   scope: user
✗ ERROR  unresolved secret references: ${secret:github.token}
```

- **The terminal error line is one of them.** `cli.Execute() int` owns the whole invocation and prints it through `reportErrorTo`; the redundant `agentsync:` prefix goes away since the label already says which stream this is. The quiet `--exit-code` sentinel still prints nothing and keeps its own exit code.
- **`ui.SlogHandler`** renders slog records through the same labels, and `internal/log` installs it as the process default from the root `PersistentPreRunE`. Record timestamps are dropped — these are user-facing CLI diagnostics, not a log stream anyone greps by time.
- **Color is a second signal, never the only one.** The glyph and the level word are content, so severity survives `NO_COLOR`, a pipe, and a CI transcript. Bold red / bold yellow / bold cyan when color is on; `DEBUG` is faint.
- **Color is resolved per stream.** `auto` asks whether the *destination* is a terminal, and stdout and stderr are different destinations: `apply 2>err.log` from a terminal has a TTY stdout and a file stderr. One decision reused across both wrote ANSI into that file.
- **Success carries no level word** — an `INFO` on `added agent: claude` is noise that dilutes the labels that matter — and leads with an emoji chosen by *what happened*, not which command ran: `🎉 applied: 12 ops`, `✅ added agent: claude`, `🧹 removed mcp server: github`, `📥 imported 6 items from claude`, `🔙 reverted…`, `✨ …initialized`. A zero-op apply gets `✅`, not `🎉`.

### Behavior changes worth calling out

- Several `plugin outdated` / `plugin upgrade --all` warnings (marketplace re-fetch, SHA-drift, lossless-bump) had been printing to **stdout**, interleaved with the command's own output. They move to stderr and route through `ui.WarnWriter`.
- Scripts grepping human-readable output for `warning:`, `note:`, `agentsync:`, or `ok:` need updating. `--json` payloads are unaffected — that separation is exactly what the stdout/stderr split protects, and is now asserted end-to-end.

## Review history

This went through five rounds of the `review-loop` skill (four independent lenses per round, 20 lens-runs). Commits `6b2f0e5`, `04b2de0`, `69bec6b`, `b84bc75`, `6956731`, `7dbc4be` are review fixes. Reviewers found one dominant defect shape — **a behavior whose deletion breaks no test** — in every round, so the final round replaced two lenses with a **mechanical mutation sweep** (91 mutations; 77 caught, 13 unpinned) and a **doc-claim audit**. Both found things four rounds of reading had not.

Substantive things those rounds changed, beyond tests:

- **The guard written to prevent #211 did not prevent #211.** Reintroducing the verbatim emitter — `fmt.Fprintln(os.Stderr, "agentsync:", err)` in `cmd/agentsync/main.go` — left the sweep green, because it was scoped to `internal/cli` and matched literals by equality. It now sweeps `cmd/agentsync` too, unquotes each literal, matches by prefix, and has per-directory file-count floors plus a test pinning the swept set.
- **The core fix had no test at all.** Deleting `aslog.Install(...)` broke nothing across unit + e2e. Now covered end-to-end by a real CLI run that trips a genuine marketplace `slog.Warn`.
- **Per-stream color needed fixing at four sites**, found one at a time: the label, `WarnWriter`, the slog handler, and pre-styled bodies (`p.Bold(…)` inside a diagnostic resolves color from the *Out* decision, so the writers now strip SGR when the target stream is plain).
- **`Execute() error` + a package var + `Printer.ColorMode()` + a `ReportError` wrapper collapsed into `Execute() int`** — the root command is still in scope after `Execute` returns, so no process state is needed to carry the `--color` decision to `main`.
- **`ReportError` sanitizes the error chain per line.** A bare `\r` in third-party agent-config text rewinds the cursor over the `✗ ERROR` label and can forge a `✅` line.
- **`WarnWriter` sanitizes adapter text.** This was briefly documented as a *requirement* that emitters use `%q` — a convention already violated when it was written down, so the check moved into `ui`, the only layer that can do it (adapters must not import `ui`).
- **A stated architectural rule gained enforcement.** §11–§12 say `internal/adapter` and `internal/capture` must not import `internal/ui` — the reason the `warning: ` sentinel exists — and only review was checking. `TestAdapterAndCaptureDoNotImportUI` now does.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

`internal/ui` — the vocabulary itself: label geometry and the shared message column (asserted on rendered bytes, counting runes); continuation alignment; each level's distinct colour, and that no two share one; success lines carrying no level word; every success emoji being a single default-presentation rune; per-stream colour honored and resolved once *per stream*; SGR stripped from pre-styled bodies on a plain stream; `sameWriter` across uncomparable dynamic types; `Flush` self-terminating; `Level` naming an out-of-range value honestly.

`internal/ui` — the slog handler: the exact #211 record rendering as a diagnostic; no timestamp; level mapping including custom levels between named ones; `Enabled` gating; derived-handler attr independence and backing-array copying; `LogValuer` resolution; empty-group elision; message *and* attribute sanitization; concurrency under `-race`, with a companion test whose writer is deliberately unsynchronized so the handler's own mutex is load-bearing; write-error propagation.

`internal/cli`: the terminal error's label, colour, sanitization, multi-line structure, and quiet-sentinel exit codes; the `--color` flag reaching that error line through the real `executeRoot`; the installed handler's stream; `--verbose` lowering the slog threshold; `success`/`diag` stream routing end-to-end; idempotent no-ops landing on stdout; the ad-hoc-prefix sweep; the `warning: ` sentinel contract; a library `slog.Warn` never entering a `--json` payload.

Every non-trivial fix was break-verified by inducing the regression and confirming a clean failure. Three tests written during review were themselves found flawed by re-running the sweep against them — one vacuous, one asserting a *copy* of the production function, one asserting the wrong property — and were fixed.

- [x] `just test-release` is green — **verified by CI** (`test-release (hermetic gate)` passes on `7dbc4be`). `just` isn't installed in my environment, so locally I ran the constituent suites: `go test ./...`, `-tags=e2e`, `-tags=bdd`, and `-race` on `internal/ui` + `internal/cli`.
- [x] `just lint` is clean — `golangci-lint@v2.12.2` reports **0 issues**; `gofmt -s`, `gofumpt` (v0.10.0, the pinned version), and `go mod tidy` leave no diff.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. — **No secret-handling path is touched.** No change to `walkSecretFields`, `capture.Capture`, the `Resolved`/`Canonical` split, or any `source.Write*` call. Two adjacent edits are presentational and strictly tightening: `secret set <k>=<v>`'s argv-exposure warning becomes a `WARN` diagnostic (same text, same stream), and `WarnWriter` now sanitizes the adapter text it relays.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/architecture.md` §11 (new) and §12, the `internal/ui` / `internal/log` / `internal/cli` entries in `docs/components.md` plus the layering statements (`log` is no longer a leaf), `docs/user-guide.md`, `CHANGELOG.md`, and a "How output is formatted" section in `website/src/content/docs/reference/cli.mdx`. The doc-claim audit in round 5 caught several assertions the code did not back — a fabricated error sample, an unproducible `imported …` line, a `• DEBUG` level nothing emits, and a mermaid edge (`render → drift`) that isn't a real import — all corrected.

Refs #211

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCbeUeLqAvGHrXAALqRiAH)_
