### PR TITLE
fix(ci): fall back to docker when podman's build fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`test-release`'s hermetic gate no longer fails the release pipeline when a
+  hosted CI runner ships a broken rootless podman/crun pairing.** A GitHub
+  Actions Ubuntu runner-image update introduced a crun regression (`unknown
+  version specified`) that aborted `scripts/test-in-container.sh`'s image build
+  before a single test ran — on a commit whose only diff was to release
+  packaging docs, unrelated to the test image. `podman build` failing (as
+  opposed to podman being absent) now falls back to docker, which every
+  GitHub-hosted Ubuntu runner ships, instead of failing the gate on infra
+  neither our Containerfile nor our code caused.
 - **Two plugins shipping a same-named component no longer break `status` and
   `apply`.** `feature-dev` and `pr-review-toolkit` — both stock official Claude
   plugins — each ship `agents/code-reviewer.md`, which made both commands exit 1

--- a/scripts/test-in-container.sh
+++ b/scripts/test-in-container.sh
@@ -40,17 +40,36 @@ fi
 
 # rootless podman needs the host UID/GID baked in to keep mounted files
 # writable; docker we leave alone.
-BUILD_ARGS=()
-if [[ "$ENGINE" == "podman" ]]; then
-    BUILD_ARGS+=(--build-arg "UID=$(id -u)" --build-arg "GID=$(id -g)")
-fi
+build_image() {
+    local engine="$1"
+    local build_args=()
+    if [[ "$engine" == "podman" ]]; then
+        build_args+=(--build-arg "UID=$(id -u)" --build-arg "GID=$(id -g)")
+    fi
+    "$engine" build \
+        "${build_args[@]}" \
+        -f "$ROOT/test/container/Containerfile" \
+        -t "$IMAGE_NAME" \
+        "$ROOT"
+}
 
 echo "==> building test image with $ENGINE"
-"$ENGINE" build \
-    "${BUILD_ARGS[@]}" \
-    -f "$ROOT/test/container/Containerfile" \
-    -t "$IMAGE_NAME" \
-    "$ROOT"
+if ! build_image "$ENGINE"; then
+    # A podman *build* failure (as opposed to podman being absent) is usually
+    # the host's rootless podman/crun toolchain, not our Containerfile — seen
+    # on CI when a hosted-runner image update ships a broken podman/crun
+    # pairing (e.g. crun erroring "unknown version specified" on a plain
+    # groupadd/useradd RUN step). Docker ships on every GH-hosted Ubuntu
+    # runner, so fall back to it rather than failing release-gate CI on an
+    # infra regression neither engine choice nor our image caused.
+    if [[ "$ENGINE" == "podman" ]] && command -v docker >/dev/null 2>&1; then
+        echo "==> podman build failed; falling back to docker" >&2
+        ENGINE="docker"
+        build_image "$ENGINE"
+    else
+        exit 1
+    fi
+fi
 
 # ----- run -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The `release` workflow's hermetic gate (`test-release (hermetic gate)`, run via `ci.yml`'s `workflow_call`) went red on `main`: https://github.com/spxrogers/agentsync/actions/runs/30561079580/job/90933954800

The failure is **not** a code regression:

- The last green run of this exact job was the day before (run #19, commit `f4714d0`), on the identical Containerfile/script.
- The only commit that landed on `main` between that green run and the red one is `1c86f1d` (#219), which touched only `.goreleaser.yaml`, `CHANGELOG.md`, `README.md`, and docs — nothing in `test/container/Containerfile`, `scripts/test-in-container.sh`, or any Go source.
- The job fails within ~15 seconds, inside `podman build`, at the base image's plain `groupadd`/`useradd` `RUN` step, with `crun` erroring `unknown version specified` — an OCI-runtime-level failure, not an application error.

This is a GitHub Actions hosted-runner image regression: a broken rootless podman/crun pairing shipped in the Ubuntu 24.04 runner image between the two runs. Nothing merged into `main` caused it.

## Fix

`scripts/test-in-container.sh`'s header comment already claimed "picks podman first... and falls back to docker," but the fallback only triggered when podman was *absent* from `PATH` — not when a *present* podman failed to build. This PR makes that fallback real: if `podman build` fails, the script now retries with `docker` (which every GitHub-hosted Ubuntu runner ships) before giving up. A genuine test failure inside a successfully-built image is untouched — only a failure to build the image itself triggers the fallback.

## Type of change

- [x] Bug fix (CI resilience)
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [x] Tests / CI / tooling

## Test plan

- [x] Verified the new fallback logic with fake `podman`/`docker` binaries on `PATH`:
  - podman build fails → falls back to docker build+run, command executes successfully.
  - podman build fails, no docker available → exits non-zero as before (no silent success).
  - podman build succeeds → unchanged behavior, docker never invoked.
- No podman available in this sandbox to exercise the real Containerfile end-to-end; the logic change itself is isolated to engine selection and was validated directly.
- [ ] `just test-release` is green (the release bar) — could not run in this sandbox (no podman/docker daemon); logic validated via mocks above.
- [ ] `just lint` is clean — this change is bash-only (no Go changed); no linter run.

## Checklist

- [x] Conventional commit messages with a scope (`fix(ci): …`).
- [x] Tests added/updated for the behavior changed (mocked-engine verification, see Test plan).
- [ ] N/A — does not touch `internal/secrets`, `internal/capture`, or `source.Write*`.
- [x] Docs updated: `CHANGELOG.md` under `[Unreleased] / Fixed`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N3d8KjNvSji4YKh6uzwq2C)_