### PR TITLE
docs: fix mermaid diagram label syntax in updating guide

### DIFF
--- a/website/src/content/docs/guides/updating.mdx
+++ b/website/src/content/docs/guides/updating.mdx
@@ -39,8 +39,8 @@ fetch. It is simply the one the daily loop runs.
 
 ```mermaid
 flowchart LR
-    NET["marketplaces<br/>+ npm registry"] -->|plugin outdated (network)| CACHE[".state/cache/"]
-    CACHE -->|apply (offline)| AGENTS["agent configs"]
+    NET["marketplaces<br/>+ npm registry"] -->|"plugin outdated (network)"| CACHE[".state/cache/"]
+    CACHE -->|"apply (offline)"| AGENTS["agent configs"]
 ```
 
 Separating "fetch" from "render" means:


### PR DESCRIPTION
## Summary

Fix mermaid flowchart diagram syntax in the updating guide by properly quoting edge labels that contain parentheses. The labels `plugin outdated (network)` and `apply (offline)` were causing rendering issues; wrapping them in quotes resolves the syntax error.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [ ] Tests / CI / tooling

## Test plan

The mermaid diagram will now render correctly on the website without syntax errors.

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed. (N/A — docs only)
- [x] Docs updated if behavior, CLI surface, or capability coverage changed.

https://claude.ai/code/session_01N4AW4CrKkpZveCrtUWEMgi