### PR TITLE
fix(plugin): don't project a plugin into an agent that installs it itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   every hook handler firing twice.
   - `plugins/<id>.toml` gains **`native_agents`** — the agents whose own plugin
     manager installs this plugin. Their components are not projected there.
-    `import` seeds it from what it discovers (`import claude:plugin` records
-    `native_agents = ["claude"]`) and reports it on the import line; every other
-    enabled agent still receives the full fan-out.
+    `import` **asks** per plugin for what it discovers — *"Let claude keep
+    serving this plugin?"* — and records `native_agents = ["claude"]` when you
+    accept; every other enabled agent still receives the full fan-out.
+    Declining warns, explicitly, that agentsync will duplicate the plugin's
+    content in that harness and that you should disable it there. Under
+    `--no-input` or a non-TTY stdin the deferral is recorded without asking:
+    unlike this package's other prompts, the unattended fallback is the SAFE
+    branch, because a silent scripted import producing two of every component
+    is the worse outcome.
   - To hand a plugin over to agentsync completely, uninstall it in the agent and
     drop that agent from `native_agents`; the next apply projects it there. The
     decision lives entirely in canonical source — `apply` never probes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`apply`'s translation report no longer over-counts.** `countMCPServers` /
+  `countLSPServers` honoured each server's own `agents` list but not the
+  providing plugin's, so a deferred plugin's servers were counted under another
+  plugin's row for the same agent — reporting "2 mcp" to an agent that got one.
+- **`doctor` no longer warns about agents agentsync does not render to.** It
+  passes every registered adapter to the duplicate check (where `status` passes
+  its enabled set), and the check itself did not verify the agent was enabled —
+  so a plugin natively installed in a disabled agent was reported as duplicated,
+  with a remedy that would have removed working functionality. The gate moved
+  into the check, where a caller cannot get it wrong.
 - **`agentsync plugin explain` no longer reports a deferred plugin as a
   failure.** It renders translation-report rows through its own path, which fell
   through to the generic mark and printed a red `✗ native  no components` for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
-- **`apply`'s translation report no longer over-counts.** `countMCPServers` /
-  `countLSPServers` honoured each server's own `agents` list but not the
-  providing plugin's, so a deferred plugin's servers were counted under another
-  plugin's row for the same agent — reporting "2 mcp" to an agent that got one.
+- **`apply`'s translation report no longer over-counts.** Every per-agent count
+  honours the providing plugin's gates now; previously none did, so a deferred
+  plugin's components were counted under another plugin's row for the same agent
+  — a row could report more commands than its own mcp count reflected.
+- **`status --scope project` reads the project's plugin pin.** `project.Merge`
+  does not overlay `Plugins`, so the duplicate warning was reading the USER
+  pin's `native_agents` while a project-scope render honours the PROJECT one —
+  warning about a duplicate the repo does not have, and staying silent about one
+  it does.
 - **`doctor` no longer warns about agents agentsync does not render to.** It
   passes every registered adapter to the duplicate check (where `status` passes
   its enabled set), and the check itself did not verify the agent was enabled —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`agentsync plugin explain` no longer reports a deferred plugin as a
+  failure.** It renders translation-report rows through its own path, which fell
+  through to the generic mark and printed a red `✗ native  no components` for a
+  plugin the user had deliberately deferred — indistinguishable from an adapter
+  that could translate nothing. The wording now lives on
+  `render.PluginRow.TargetingNote()`, and the `Coverage` vocabulary is exported,
+  so the two renderers cannot drift on a string literal.
 - **`native_agents = []` ("defer to nobody") now survives a rewrite.** The field
   was a plain slice with `omitempty`, so an explicitly empty list decoded
   correctly — the prompt stayed quiet — and was then erased by the next write,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ## [Unreleased]
 
+### Added
+
+- **A plugin an agent installs itself is no longer projected into that agent,
+  so `import <agent>` + `apply` stops manufacturing duplicates.** `apply` never
+  writes plugin enablement back into an agent's config (the `PluginIngester`
+  read-only invariant) — but it never removed it either, so a plugin enabled in
+  Claude Code kept being served from Claude's own install dir while agentsync
+  ALSO projected its components into Claude's standalone paths. Namespacing
+  (`<plugin>-<name>`) meant the two sets coexisted rather than collided: two of
+  every skill, subagent and command, one MCP id registered from two sources, and
+  every hook handler firing twice.
+  - `plugins/<id>.toml` gains **`native_agents`** — the agents whose own plugin
+    manager installs this plugin. Their components are not projected there.
+    `import` seeds it from what it discovers (`import claude:plugin` records
+    `native_agents = ["claude"]`) and reports it on the import line; every other
+    enabled agent still receives the full fan-out.
+  - To hand a plugin over to agentsync completely, uninstall it in the agent and
+    drop that agent from `native_agents`; the next apply projects it there. The
+    decision lives entirely in canonical source — `apply` never probes the
+    destination, so the same `~/.agentsync/` renders identically on every
+    machine.
+  - `status` and `doctor` now warn when a plugin is installed natively in an
+    agent **and** projected there by agentsync — the case `apply` cannot see,
+    since its plan is a pure function of canonical state.
+
+### Fixed
+
+- **`agents` in `plugins/<id>.toml` now actually narrows a plugin's fan-out.**
+  The key has been documented since v1.0 ("Control fan-out per plugin with
+  `agents = [...]`") and was written, preserved across re-installs, and never
+  read: `projectOnePlugin` honoured only `disabled`, and nothing in the render
+  path consulted `PluginSpec.Agents`. A narrowed allowlist silently fanned the
+  plugin out to every enabled agent anyway. Both it and the new `native_agents`
+  are enforced in ONE place — the render waist (`source.FilterForAgent` via
+  `secrets.Resolved.ForAgent` in `render.Plan`) — so no adapter can forget one.
+  `import`'s capture-refusal filter uses the same function, so it no longer
+  refuses to capture a hand-authored component from an agent a plugin does not
+  project to.
+
 ### Changed
 
 - **Every diagnostic across the CLI now carries a severity label, and success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`native_agents = []` ("defer to nobody") now survives a rewrite.** The field
+  was a plain slice with `omitempty`, so an explicitly empty list decoded
+  correctly — the prompt stayed quiet — and was then erased by the next write,
+  after which the following import re-seeded the deferral, silently, and under
+  `--no-input` without asking. It is a pointer now, so all three on-disk states
+  (absent / empty / populated) round-trip.
 - **`agents` in `plugins/<id>.toml` now actually narrows a plugin's fan-out.**
   The key has been documented since v1.0 ("Control fan-out per plugin with
   `agents = [...]`") and was written, preserved across re-installs, and never
@@ -50,9 +56,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   plugin out to every enabled agent anyway. Both it and the new `native_agents`
   are enforced in ONE place — the render waist (`source.FilterForAgent` via
   `secrets.Resolved.ForAgent` in `render.Plan`) — so no adapter can forget one.
-  `import`'s capture-refusal filter uses the same function, so it no longer
-  refuses to capture a hand-authored component from an agent a plugin does not
-  project to.
+  `import`'s capture-refusal filter deliberately does NOT narrow the same way:
+  between recording a deferral and the apply that reclaims the files, the
+  destination still holds agentsync's own rendered output, and a narrowed filter
+  would capture that back into the canonical source as hand-authored. It refuses
+  anything any installed plugin provides — over-refusal fails loudly and names
+  the plugin, under-refusal fails silently and permanently.
 
 ### Changed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -275,6 +275,49 @@ marketplace source and re-fetches it through the same code path as
 `plugins/<id>.toml` + `marketplaces/<name>.toml` pair with a pinned manifest
 SHA. From then on, the projection layer drives every apply.
 
+#### The other half of "no double-install": `native_agents`
+
+The bullet above explains why apply must not write `enabledPlugins` back. It
+does not, by itself, prevent the duplicate — because apply does not *remove* the
+native enablement either. A plugin the agent installed itself stays installed,
+and agentsync projecting the same plugin's components into that agent's
+standalone paths lands two of every skill, subagent and command, and fires every
+hook twice. Namespacing (`<plugin>-<name>`) keeps the two sets from colliding on
+one path, which is precisely why they coexist rather than overwrite.
+
+So the deferral is recorded in canonical source, per plugin:
+
+| key | meaning | who writes it |
+|---|---|---|
+| `agents` | the user's fan-out allowlist (`["*"]` / omitted = every enabled agent) | the user |
+| `native_agents` | agents whose OWN plugin manager installs this plugin, so apply must not project it there | `import` seeds it; the user edits it |
+
+A plugin component renders for an agent only if `agents` targets it **and**
+`native_agents` does not claim it (`source.PluginTargetsAgent`).
+
+Two properties are load-bearing:
+
+- **Declared, never inferred.** apply does NOT probe the destination to decide
+  what to render. If it did, the render would become a function of destination
+  state: the same `~/.agentsync/` would render differently on two machines,
+  `diff` would stop being reproducible, and — worse — the 3-way drift classifier
+  compares source / last-applied / destination on the assumption that the first
+  is independent of the third. `import` reads native state ONCE and writes the
+  conclusion into canonical source; every later apply reads only that.
+- **One enforcement point.** The filter runs at the render waist —
+  `source.FilterForAgent`, reached via `secrets.Resolved.ForAgent` in
+  `render.Plan` — never inside an adapter. Ten adapters × six component kinds is
+  sixty places to forget, and each omission silently re-creates the duplicate
+  for one kind on one agent. `import`'s capture-refusal filter (`pluginProvided`)
+  calls the SAME function so its refusal set is exactly the render set per agent;
+  otherwise it would refuse to capture a hand-authored component from an agent
+  the plugin never projects to.
+
+The residual — a plugin installed natively AFTER it was declared in agentsync —
+is invisible to apply by construction. `status` and `doctor` do read native
+state, and report a plugin that is both installed in an agent and projected to
+it (`duplicatedNativePlugins`), naming both remedies.
+
 #### Per-adapter
 
 The **Codex** adapter implements `IngestPlugins`; **Cursor** has a native plugin

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,10 +308,15 @@ Two properties are load-bearing:
   `source.FilterForAgent`, reached via `secrets.Resolved.ForAgent` in
   `render.Plan` — never inside an adapter. Ten adapters × six component kinds is
   sixty places to forget, and each omission silently re-creates the duplicate
-  for one kind on one agent. `import`'s capture-refusal filter (`pluginProvided`)
-  calls the SAME function so its refusal set is exactly the render set per agent;
-  otherwise it would refuse to capture a hand-authored component from an agent
-  the plugin never projects to.
+  for one kind on one agent.
+- **The import-side refusal set is deliberately WIDER than the render set.**
+  `import` refuses to capture any component ANY installed plugin provides, not
+  just the ones this agent receives. Narrowing it to the render set would be
+  symmetric and wrong: between recording a deferral and the apply that reclaims
+  the files, the destination still holds agentsync's own rendered output, and a
+  narrowed filter would capture that into the canonical source as hand-authored.
+  Over-refusal fails loudly, naming the plugin; under-refusal silently mints a
+  canonical copy that diverges from the plugin's on its next update.
 
 The residual — a plugin installed natively AFTER it was declared in agentsync —
 is invisible to apply by construction. `status` and `doctor` do read native

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -290,7 +290,7 @@ So the deferral is recorded in canonical source, per plugin:
 | key | meaning | who writes it |
 |---|---|---|
 | `agents` | the user's fan-out allowlist (`["*"]` / omitted = every enabled agent) | the user |
-| `native_agents` | agents whose OWN plugin manager installs this plugin, so apply must not project it there | `import` seeds it; the user edits it |
+| `native_agents` | agents whose OWN plugin manager installs this plugin, so apply must not project it there | `import` prompts per plugin (declining warns about the duplicate); the user edits it |
 
 A plugin component renders for an agent only if `agents` targets it **and**
 `native_agents` does not claim it (`source.PluginTargetsAgent`).

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -557,9 +557,14 @@ You control fan-out explicitly:
 
 - `agents = ["claude", "opencode"]` on an MCP server or plugin entry → fan out
   only to those agents.
+- `native_agents = ["claude"]` on a plugin entry → those agents install the
+  plugin through their OWN plugin manager, so agentsync does not project its
+  components there. Without it you get two of every skill, subagent and command
+  and every hook fires twice, because `apply` never disables a plugin inside
+  another tool's plugin manager. `import` offers to record this for you.
 
 (A per-component `[plugin.overrides.<agent>]` skip was specced but is **not
-wired in v1** — the projector does not consult it. Use the `agents` allowlist.)
+wired in v1** — the projector does not consult it. Use the keys above.)
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -74,9 +74,12 @@ memory-fragment expansion.
   `StripManagedBanner` (inject / strip the managed-file banner — see
   `docs/architecture.md`); `NamespacedComponentName` / `PluginTargetsAgent` /
   `AgentTargeted` (plugin provenance + the `agents`/`native_agents` gates);
-  `FilterForAgent` (the ONE narrowing of a canonical to what one agent renders —
-  used by `render.Plan` via `secrets.Resolved.ForAgent` and by import's
-  capture-refusal filter, so the two can never disagree).
+  `FilterForAgent` (the ONE narrowing of a canonical to what one agent renders,
+  used by `render.Plan` via `secrets.Resolved.ForAgent` — its only caller.
+  import's capture-refusal filter deliberately does NOT narrow the same way; its
+  refusal set is WIDER than the render set, because the destination can still
+  hold un-reclaimed output from before a deferral was recorded. Do not restore
+  symmetry between them — see `docs/architecture.md`).
 - **Depends on:** iox, jsonkeys.
 - **Files:** `schema.go`, `loader.go`, `writer.go`, `memory.go`,
   `provenance.go`, `targeting.go`.

--- a/docs/components.md
+++ b/docs/components.md
@@ -72,9 +72,14 @@ memory-fragment expansion.
   `WriteSubagent`, `WriteCommand`, `WriteHooks`, `WriteMemory`); `ReadMCP`/`ReadLSP`
   (carry source-only fields); `ExpandMemoryImports`; `RenderManagedMemory` /
   `StripManagedBanner` (inject / strip the managed-file banner — see
-  `docs/architecture.md`).
+  `docs/architecture.md`); `NamespacedComponentName` / `PluginTargetsAgent` /
+  `AgentTargeted` (plugin provenance + the `agents`/`native_agents` gates);
+  `FilterForAgent` (the ONE narrowing of a canonical to what one agent renders —
+  used by `render.Plan` via `secrets.Resolved.ForAgent` and by import's
+  capture-refusal filter, so the two can never disagree).
 - **Depends on:** iox, jsonkeys.
-- **Files:** `schema.go`, `loader.go`, `writer.go`, `memory.go`.
+- **Files:** `schema.go`, `loader.go`, `writer.go`, `memory.go`,
+  `provenance.go`, `targeting.go`.
 
 ### `internal/secrets`
 Resolves `${secret:dotted.key}` and `${env:NAME}` at apply time; re-references
@@ -84,7 +89,9 @@ The `Resolved` wrapper type is the load-bearing leak guard.
   `SubstituteCanonical` (→ `Resolved`); `ReReferenceCanonical`; `CollectResolved`;
   `UnresolvedSecretRefs`; `SecretRefsByComponent` (per-component REFERENCES, for
   `explain`); `MaskResolved`; `AgeBackend`/`EnvBackend`/`NopResolver`;
-  `SelectBackend`; and the single field list `walkSecretFields` (in `walk.go`).
+  `SelectBackend`; `Resolved.ForAgent` (per-agent narrowing at the render waist,
+  delegating to `source.FilterForAgent`); and the single field list
+  `walkSecretFields` (in `walk.go`).
 - **Depends on:** source, iox.
 - **Files:** `secrets.go`, `age.go`, `resolved.go`, `substitute.go`,
   `rereference.go`, `mask.go`, `refs.go`, `walk.go`, `secretpaths.go`, `leakscan.go`
@@ -415,8 +422,10 @@ manifests into canonical components.
   `GitFetcher`/`NPMFetcher`/`RelativeFetcher`; `LoadProjected`/
   `LoadProjectedLenient`/`LoadProjectedExcluding`; `namespaceProjected` (renames
   each plugin-provided subagent/skill/command to `<plugin>-<name>` and stamps its
-  provenance, so two plugins shipping one name cannot collide at a destination
-  path — see architecture.md § Plugin component namespacing).
+  provenance — including the providing plugin's `agents`/`native_agents`
+  targeting, which travels with the component because the flattened canonical
+  drops the association — so two plugins shipping one name cannot collide at a
+  destination path — see architecture.md § Plugin component namespacing).
 - **Depends on:** source, log.
 - **Files:** `manifest.go`, `treehash.go` (the `tree:v1:` content hash),
   `projection.go`, `loadprojected.go`, `fetcher.go`, `fetch_git.go`,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -187,6 +187,20 @@ for discovery, `apply` never re-emits it. See
 [architecture.md § PluginIngester (read-only)](architecture.md#pluginingester-read-only)
 for the full rationale.
 
+**An agent that installs a plugin itself is not projected to.** Because apply
+never writes plugin enablement back, a plugin the agent's own manager installs
+stays installed there — so projecting that plugin's components into the same
+agent's standalone paths would DUPLICATE every one of them (and double-fire its
+hooks). `plugins/<id>.toml` therefore carries two targeting keys: `agents`, your
+fan-out allowlist, and `native_agents`, the agents that serve the plugin
+themselves. A component renders for an agent only if `agents` targets it and
+`native_agents` does not claim it. `import` seeds `native_agents` with the agents
+it discovered the plugin installed in, so the import→apply round trip does not
+manufacture a duplicate; uninstalling the native copy and dropping the entry
+hands the plugin to agentsync. Both gates are enforced in ONE place — the render
+waist (`source.FilterForAgent`, via `secrets.Resolved.ForAgent`) — never in an
+adapter. See the [user guide](user-guide.md).
+
 **Plugin components are namespaced by their plugin.** Because apply flattens
 every enabled plugin's components into one destination directory, two plugins
 shipping a same-named component would render two files at one path — so a

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -221,6 +221,13 @@ does not project plugins or print a coverage report):
 - **◐ projected** — lossy but defensible translation, explicitly reported.
 - **✗ skipped** — no honest translation exists; logged so it's never silent.
 
+A row can also report that a plugin contributed nothing to an agent by
+*configuration* rather than by failed translation — `disabled` for a plugin
+turned off in this scope, `not-targeted` when its `agents` allowlist excludes the
+agent, and `native` when its `native_agents` list defers to that agent's own
+plugin manager. These are deliberate outcomes, so they are never rendered in the
+✗ failure vocabulary.
+
 ### Polling (the networked verb of the daily loop)
 `agentsync plugin outdated` is the command that touches the network in the daily
 loop: it polls marketplaces, refreshes the cache, and recomputes version pins.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -194,10 +194,11 @@ agent's standalone paths would DUPLICATE every one of them (and double-fire its
 hooks). `plugins/<id>.toml` therefore carries two targeting keys: `agents`, your
 fan-out allowlist, and `native_agents`, the agents that serve the plugin
 themselves. A component renders for an agent only if `agents` targets it and
-`native_agents` does not claim it. `import` seeds `native_agents` with the agents
-it discovered the plugin installed in, so the import→apply round trip does not
-manufacture a duplicate; uninstalling the native copy and dropping the entry
-hands the plugin to agentsync. Both gates are enforced in ONE place — the render
+`native_agents` does not claim it. `import` offers `native_agents` per plugin for the
+agents it discovered the plugin installed in, so the import→apply round trip
+does not manufacture a duplicate by default; declining warns that it will, and
+uninstalling the native copy and dropping the entry hands the plugin to
+agentsync. Both gates are enforced in ONE place — the render
 waist (`source.FilterForAgent`, via `secrets.Resolved.ForAgent`) — never in an
 adapter. See the [user guide](user-guide.md).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -201,11 +201,13 @@ Claude's built-in `claude-plugins-official` (which doesn't appear in
 `extraKnownMarketplaces`) before you have registered it — is reported and
 skipped; register it with `agentsync marketplace add <source>` and re-import.
 
-An imported plugin is **not projected back into the agent it came from**. That
-agent has it installed, and apply never disables a plugin inside another tool's
-plugin manager — so projecting the same components there would duplicate every
-one of them. `import` records `native_agents = ["claude"]` and says so; every
-other enabled agent gets the full fan-out. See
+An imported plugin is **not projected back into the agent it came from** unless
+you ask for it. That agent has the plugin installed, and apply never disables a
+plugin inside another tool's plugin manager — so projecting the same components
+there would duplicate every one of them. `import` offers to record
+`native_agents = ["claude"]`; accepting is the default, and declining warns that
+you must disable the plugin inside Claude yourself. Either way every other
+enabled agent gets the full fan-out. See
 [Which agents a plugin fans out to](#which-agents-a-plugin-fans-out-to).
 
 **Importing a project's native config.** `import <agent> --scope project`
@@ -595,11 +597,41 @@ another tool's plugin manager (see [architecture.md § PluginIngester
 (read-only)](architecture.md#pluginingester-read-only)), so the only way to
 avoid the duplicate is not to project there.
 
-**`import` fills `native_agents` in for you.** Importing a plugin out of an
-agent means, by definition, that the agent has it installed — so
-`agentsync import claude:plugin` records `native_agents = ["claude"]` and says
-so on the import line. Claude keeps serving the plugin itself; every OTHER
-enabled agent gets the fan-out. That is the whole point of importing it.
+**`import` asks, per plugin.** Importing a plugin out of an agent means, by
+definition, that the agent has it installed, so `agentsync import claude:plugin`
+stops and offers the deferral:
+
+```
+ℹ INFO   claude already installs the plugin "feature-dev".
+         agentsync can leave those components to claude, or project its own copy alongside them.
+  Let claude keep serving this plugin? [Y]es / [n]o, project it there too:
+```
+
+Accepting records `native_agents = ["claude"]`. Claude keeps serving the plugin
+itself; every OTHER enabled agent still gets the fan-out — that is the whole
+point of importing it.
+
+Declining is a real choice, and agentsync says what it costs:
+
+```
+⚠ WARN   this will DUPLICATE the plugin "feature-dev"'s content in your claude
+         harness — every skill, subagent and command it ships will appear twice,
+         and its hooks will fire twice. Disable or uninstall "feature-dev" in
+         claude now that agentsync is managing it.
+```
+
+That is a working setup **only** if you then turn the plugin off inside Claude
+Code. Declining writes no key, so a later import asks again — and asks only if
+the duplicate still exists. Once you disable the plugin natively, the question
+stops being asked. To silence it while keeping the plugin enabled in both, write
+`native_agents = []` by hand: an explicitly empty list means "defer to nobody"
+and is preserved.
+
+You are only asked when the answer can take effect — never for a plugin whose
+`native_agents` you have already set, since a re-import preserves it. With
+`--no-input`, or when stdin is not a terminal, the deferral is recorded without
+asking and an INFO line says so: a scripted import must not silently produce two
+of everything.
 
 To hand a plugin over to agentsync completely, uninstall it in the agent
 (`/plugin uninstall` in Claude Code) and drop that agent from `native_agents`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -201,6 +201,13 @@ Claude's built-in `claude-plugins-official` (which doesn't appear in
 `extraKnownMarketplaces`) before you have registered it — is reported and
 skipped; register it with `agentsync marketplace add <source>` and re-import.
 
+An imported plugin is **not projected back into the agent it came from**. That
+agent has it installed, and apply never disables a plugin inside another tool's
+plugin manager — so projecting the same components there would duplicate every
+one of them. `import` records `native_agents = ["claude"]` and says so; every
+other enabled agent gets the full fan-out. See
+[Which agents a plugin fans out to](#which-agents-a-plugin-fans-out-to).
+
 **Importing a project's native config.** `import <agent> --scope project`
 (optionally `--project <path>`) reads the agent's *native project-scope* config
 (e.g. `<root>/.claude/`) and captures it into the project source tree
@@ -355,7 +362,8 @@ first-class. Layout:
 ├── marketplaces/<name>.toml  # one marketplace per file (its `head_sha`/`name`
 │                             #   keys are CLI fetch-cache metadata, regenerated on
 │                             #   fetch — not modeled in the canonical schema)
-├── plugins/<id>.toml         # one plugin enablement per file
+├── plugins/<id>.toml         # one plugin enablement per file (`agents` /
+│                             #   `native_agents` decide which agents it renders to)
 ├── memory/AGENTS.md          # canonical memory (+ fragments/*.md)
 ├── skills/<name>/            # a skill is a DIRECTORY: SKILL.md + bundled
 │   ├── SKILL.md              #   scripts/, references/, assets/, nested files —
@@ -561,9 +569,54 @@ and names both sides rather than picking a winner. MCP and LSP servers keep thei
 server id is refused rather than renamed apart, because repointing a trusted
 server's endpoint is a hijack, not a naming clash.
 
-Control fan-out per plugin with `agents = [...]` in the plugin's TOML file. (A
-per-component `[plugin.overrides.<agent>]` table was specced but is **not wired
-in v1** — the projector does not consult it; use the `agents` allowlist.)
+### Which agents a plugin fans out to
+
+Two keys in `plugins/<id>.toml` decide where a plugin's components render. They
+are enforced once, at the render waist, so every agent and every component kind
+obeys them identically:
+
+```toml
+[plugin]
+id            = "feature-dev@claude-plugins-official"
+agents        = ["*"]        # your fan-out choice: which agents may receive it
+native_agents = ["claude"]   # agents that install it THEMSELVES — do not project there
+```
+
+`agents` is the allowlist you control: `["*"]` (the default, and the same
+meaning as omitting the key) sends the plugin to every enabled agent, or name
+agents explicitly to narrow it.
+
+`native_agents` is a statement about the world rather than a preference. When an
+agent's own plugin manager already installs a plugin — you ran `/plugin install`
+in Claude Code — agentsync must not ALSO project that plugin's components into
+that agent's standalone paths, or you get two of every skill, subagent, and
+command, and every hook fires twice. agentsync never disables a plugin inside
+another tool's plugin manager (see [architecture.md § PluginIngester
+(read-only)](architecture.md#pluginingester-read-only)), so the only way to
+avoid the duplicate is not to project there.
+
+**`import` fills `native_agents` in for you.** Importing a plugin out of an
+agent means, by definition, that the agent has it installed — so
+`agentsync import claude:plugin` records `native_agents = ["claude"]` and says
+so on the import line. Claude keeps serving the plugin itself; every OTHER
+enabled agent gets the fan-out. That is the whole point of importing it.
+
+To hand a plugin over to agentsync completely, uninstall it in the agent
+(`/plugin uninstall` in Claude Code) and drop that agent from `native_agents`.
+The next apply projects the components there. Nothing about the agent's own
+config is touched either way — the deferral lives entirely in your canonical
+source, which is what keeps `apply` reproducible from a dotfiles repo alone
+rather than dependent on whatever the machine happens to have installed.
+
+Both keys survive re-installs and re-imports untouched (issue #140), so a
+narrowed allowlist or an adopted plugin is never silently reset.
+
+Because apply's plan never reads the destination, agentsync cannot notice a
+plugin you install natively AFTER declaring it. `status` and `doctor` do read
+it, and warn when a plugin is installed in an agent *and* projected there.
+
+(A per-component `[plugin.overrides.<agent>]` table was specced but is **not
+wired in v1** — the projector does not consult it; use the keys above.)
 
 ### Secrets
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -315,7 +315,8 @@ func checkPlugins(p *ui.Printer, home string) {
 			warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf(
 				"%d also projected by agentsync: %s — components land twice; uninstall them in %s "+
 					"or add %q to `native_agents`",
-				len(dupes), untrusted.Join(dupes, ", "), name, name))
+				len(dupes), untrusted.Join(dupes, ", "), name, name,
+			))
 		}
 		missing := undeclared[name]
 		if len(missing) == 0 {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -302,11 +302,21 @@ func checkPlugins(p *ui.Printer, home string) {
 	}
 	reg := registryFactory()
 	undeclared := undeclaredNativePlugins(c, reg, reg.Names())
-	if len(undeclared) == 0 {
-		okCheck(p, "", "ok (no undeclared native plugins)")
+	// A plugin the agent installs itself that agentsync ALSO projects there
+	// duplicates every component it ships. apply cannot see this (its plan never
+	// reads the destination), so doctor is one of the two places it surfaces.
+	duplicated := duplicatedNativePlugins(c, reg, reg.Names())
+	if len(undeclared) == 0 && len(duplicated) == 0 {
+		okCheck(p, "", "ok (no undeclared or duplicated native plugins)")
 		return
 	}
 	for _, name := range reg.Names() {
+		if dupes := duplicated[name]; len(dupes) > 0 {
+			warnCheck(p, fmt.Sprintf("%-10s ", name), fmt.Sprintf(
+				"%d also projected by agentsync: %s — components land twice; uninstall them in %s "+
+					"or add %q to `native_agents`",
+				len(dupes), untrusted.Join(dupes, ", "), name, name))
+		}
 		missing := undeclared[name]
 		if len(missing) == 0 {
 			continue

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -232,7 +233,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// what lets already-labeled diagnostics (INFO notes, aligned continuation
 	// lines) reach the terminal untouched.
 	warnW := ui.NewWarnWriter(p.Err, p)
-	io := &importIO{p: p, out: p.Out, err: warnW, dryRun: dryRun}
+	io := &importIO{p: p, out: p.Out, err: warnW, dryRun: dryRun, cmd: cmd}
 
 	// agentsyncHome is the user-scope home: it owns the central state file and
 	// plugin cache, and the global lock, regardless of import scope. srcHome is
@@ -851,6 +852,13 @@ func importVerb(dryRun bool) string {
 // cyan → vocabulary `apply` and `status` use. The lazy `section` header keeps
 // component groups from showing a name with no rows under it.
 type importIO struct {
+	// cmd is the running command, carried for the one interactive decision
+	// import makes: whether to defer a plugin to an agent that installs it
+	// itself (see promptNativeAgentsDeferral). It supplies stdin, the inherited
+	// --no-input flag, and the TTY check — the same three inputs every other
+	// prompter in this package takes. Like pluginProvided below, this is per-RUN
+	// context living here because the struct is already threaded everywhere.
+	cmd    *cobra.Command
 	p      *ui.Printer
 	out    io.Writer
 	err    io.Writer
@@ -1802,7 +1810,28 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		if !mpOK {
 			continue
 		}
+		// Ask before deferring — but ONLY when the answer would be used. A
+		// re-install preserves an existing `native_agents` (issue #140), so
+		// prompting for a plugin that already has one would ask a question whose
+		// answer is discarded, and re-asking on every re-import would be nagging
+		// about a decision already recorded.
 		native := owners[plName]
+		if len(native) > 0 && !io.dryRun && pluginNativeAgentsUnset(home, plName) {
+			if chosen := nativeAgentsPrompter(io, plName, native); len(chosen) == 0 {
+				warnDuplicateOptOut(io, plName, native)
+				// Write no key at all, so a later import asks again — and asks
+				// only if the duplicate still exists. Acting on the warning
+				// (disabling the plugin inside the agent) removes the agent from
+				// nativePluginOwners, so the question simply stops being asked.
+				// Ignoring it leaves the duplicate in place, which is worth
+				// raising again. A hand-written `native_agents = []` is the way
+				// to say "defer to nobody, stop asking"; installPluginInto
+				// preserves it.
+				native = nil
+			} else {
+				native = chosen
+			}
+		}
 		if io.dryRun {
 			io.item(fmt.Sprintf("plugins/%s.toml", plName), nativeAgentsSuffix(native))
 			ids = append(ids, plName)
@@ -1822,6 +1851,81 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		ids = append(ids, plName)
 	}
 	return ids, nil
+}
+
+// nativeAgentsPrompter is the interactive deferral offer, injectable so tests
+// can drive the accept/decline branches without a terminal.
+var nativeAgentsPrompter = promptNativeAgentsDeferral
+
+// promptNativeAgentsDeferral asks whether to leave a plugin to the agents that
+// install it themselves, and returns the agents to record in `native_agents`.
+// Returning nil means "project everywhere anyway" — the duplicate, chosen
+// deliberately — and the caller warns about what that implies.
+//
+// It fails SAFE rather than closed. With no TTY or under --no-input it records
+// the deferral without asking, because the alternative is a headless run
+// silently producing two of every component the plugin ships. The other
+// prompters in this package fail closed because their unattended fallback is
+// inaction; here inaction is the damaging outcome, so the fallback is the one
+// that changes nothing about the agent's own setup: agentsync simply does not
+// project on top of what the agent already serves. The choice is recorded in
+// plugins/<id>.toml either way, so a scripted import stays inspectable and
+// editable after the fact.
+//
+// candidates is non-empty and holds registry-derived agent names (never native
+// config strings), so it needs no sanitizing. plugin has already passed
+// source.ValidateComponentID, which rejects control and deceptive runes.
+func promptNativeAgentsDeferral(io *importIO, plugin string, candidates []string) []string {
+	list := strings.Join(candidates, ", ")
+	if io.cmd == nil || noInputFlag(io.cmd) || !stdinIsTerminal(io.cmd) {
+		io.infof("%s already installs %q; recording it in `native_agents` so apply does not "+
+			"project a second copy there. Edit plugins/%s.toml to change that.", list, plugin, plugin)
+		return candidates
+	}
+	return askDeferralAnswer(io, plugin, candidates)
+}
+
+// askDeferralAnswer is promptNativeAgentsDeferral's question loop, split from
+// the TTY/--no-input gate above so it can be driven in tests without a terminal.
+// An unrecognized line re-asks; a bare Enter takes the safe default (defer), and
+// so does EOF — a closed stdin must never spin or fall through to the duplicate.
+func askDeferralAnswer(io *importIO, plugin string, candidates []string) []string {
+	list := strings.Join(candidates, ", ")
+	// STDERR, like every other prompt in this package: import writes its item
+	// lines to stdout, and a caller reading those should not have to filter a
+	// question out of them.
+	w := io.cmd.ErrOrStderr()
+	io.p.Fdiagf(w, ui.LevelInfo, "%s already installs the plugin %q.", list, plugin)
+	io.p.Fdetailf(w, "agentsync can leave those components to %s, or project its own copy alongside them.", list)
+	r := bufio.NewReader(io.cmd.InOrStdin())
+	for attempts := 0; attempts < 5; attempts++ {
+		fmt.Fprintf(w, "  Let %s keep serving this plugin? [Y]es / [n]o, project it there too: ", list)
+		line, err := r.ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "", "y", "yes":
+			return candidates
+		case "n", "no":
+			return nil
+		}
+		if err != nil {
+			return candidates // EOF / closed stdin: take the safe branch, never loop
+		}
+		fmt.Fprintf(w, "  please enter y or n.\n")
+	}
+	return candidates
+}
+
+// warnDuplicateOptOut is the explicit consequence of declining the deferral. The
+// user has chosen to have agentsync project a plugin into an agent that already
+// installs it, which is a real, working configuration only if they then turn the
+// plugin off inside that agent — so say exactly that, at WARN, naming the agents.
+func warnDuplicateOptOut(io *importIO, plugin string, agents []string) {
+	list := strings.Join(agents, ", ")
+	io.warnf("this will DUPLICATE the plugin %q's content in your %s harness — every skill, "+
+		"subagent and command it ships will appear twice, and its hooks will fire twice. "+
+		"Disable or uninstall %q in %s now that agentsync is managing it. "+
+		"(To defer to %s instead, set `native_agents = [%q]` in plugins/%s.toml.)",
+		plugin, list, plugin, list, list, list, plugin)
 }
 
 // nativeAgentsSuffix renders the item-line note naming the agents a plugin is

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -290,7 +290,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// set would silently disable the defence — and since the projection is fed by
 	// plugin data, an upstream roll or a tampered cache could trigger it on
 	// demand.
-	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, sc); ppErr != nil {
+	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, agentName, sc); ppErr != nil {
 		io.pluginProvidedErr = ppErr
 	} else {
 		io.pluginProvided = pp
@@ -1184,11 +1184,13 @@ func idsFromWritten(written []string) []string {
 //
 // It mirrors apply's projection so the skipped set is exactly the rendered set:
 // lenient (an unrelated strict plugin conflict must not abort an import), honours
-// the project tree's `disabled = true` plugin markers, and reads the home whose
-// components the render at this scope actually uses. A projection failure is
-// returned, and the caller records it so every component capture then refuses —
-// see skipPluginProvided.
-func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.Scope) (map[string]string, error) {
+// the project tree's `disabled = true` plugin markers, reads the home whose
+// components the render at this scope actually uses, and narrows to agentName's
+// own render set (source.FilterForAgent) so a plugin that projects nothing to
+// this agent blocks nothing here. A projection failure is returned, and the
+// caller records it so every component capture then refuses — see
+// skipPluginProvided.
+func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot, agentName string, sc adapter.Scope) (map[string]string, error) {
 	pluginCacheRoot := filepath.Join(agentsyncHome, ".state", "cache", "plugins")
 	var disabled []string
 	projHome := ""
@@ -1280,7 +1282,13 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.S
 	if err != nil {
 		return nil, fmt.Errorf("project plugins from %s: %w", home, err)
 	}
-	collect(c)
+	// Narrow to what THIS agent actually receives, through the same filter
+	// render.Plan applies. A plugin whose `agents` allowlist excludes this agent,
+	// or whose `native_agents` defers to the agent's own plugin manager, projects
+	// NOTHING here — so it provides nothing here either, and a same-named file in
+	// this agent's native config is the user's own to capture. Refusing it would
+	// lock the user out of importing their own component.
+	collect(source.FilterForAgent(c, agentName))
 	return out, nil
 }
 
@@ -1703,6 +1711,20 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		return nil, nil
 	}
 
+	// Which agents already serve each plugin from their OWN plugin manager. A
+	// plugin imported from an agent is, by definition, installed natively there
+	// — so without this every import would set up a duplicate on the very next
+	// apply: the agent keeps loading its own copy from its install dir while
+	// agentsync projects the same components into the agent's standalone paths.
+	// The seed records the deferral in plugins/<id>.toml (`native_agents`), so
+	// apply's decision stays a pure function of canonical state rather than of
+	// whatever the destination happens to look like at apply time.
+	//
+	// Probed ONCE for the whole import (each probe reads a native config) and
+	// across every PluginIngester, since a plugin can be installed natively in
+	// more than the agent being imported from.
+	owners := nativePluginOwners(registryFactory())
+
 	// Resolve (and, on a real run, fetch) each needed marketplace exactly once.
 	// The cached value is the agentsync marketplace name a plugin installs from;
 	// "" marks an unresolvable marketplace already warned about.
@@ -1780,19 +1802,40 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		if !mpOK {
 			continue
 		}
+		native := owners[plName]
 		if io.dryRun {
-			io.item(fmt.Sprintf("plugins/%s.toml", plName), "")
+			io.item(fmt.Sprintf("plugins/%s.toml", plName), nativeAgentsSuffix(native))
 			ids = append(ids, plName)
 			continue
 		}
-		if _, ierr := installPluginInto(home, plName, mpName); ierr != nil {
+		spec, ierr := installPluginInto(home, plName, mpName, native)
+		if ierr != nil {
 			io.warnf("skipping plugin %q from %q: %v", pl.Name, mpName, ierr)
 			continue
 		}
-		io.item(fmt.Sprintf("plugins/%s.toml", plName), "")
+		// Report the deferral on the item line rather than silently: it changes
+		// what the next apply writes, and the user needs to know which agents
+		// keep serving the plugin themselves. spec.NativeAgents (not `native`)
+		// is what was actually written — a re-import over an existing TOML
+		// preserves the user's own list instead of re-seeding it.
+		io.item(fmt.Sprintf("plugins/%s.toml", plName), nativeAgentsSuffix(spec.NativeAgents))
 		ids = append(ids, plName)
 	}
 	return ids, nil
+}
+
+// nativeAgentsSuffix renders the item-line note naming the agents a plugin is
+// NOT projected to because they install it themselves. Empty for the ordinary
+// case (nothing deferred), so the line stays quiet when there is nothing to say.
+// Agent names come from agentsync's own registry, not from native config, so
+// they need no sanitizing — but item() sanitizes the whole path anyway and the
+// suffix is appended after it, so keep this to registry-derived values only.
+func nativeAgentsSuffix(native []string) string {
+	if len(native) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (native_agents=[%s] — %s %s this plugin natively, so apply will not project it there)",
+		strings.Join(native, ","), strings.Join(native, " and "), plural(len(native), "serves", "serve"))
 }
 
 // claudeSourceToAgentsync maps a native marketplace source (Claude's

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1988,10 +1988,15 @@ func dryRunNativeAgentsNote(home, plName string, candidates []string) string {
 		return ""
 	}
 	if !pluginNativeAgentsUnset(home, plName) {
-		if existing, err := readPluginTOML(filepath.Join(home, "plugins", plName+".toml")); err == nil {
-			return nativeAgentsSuffix(existing.Plugin.NativeAgents)
+		existing, err := readPluginTOML(filepath.Join(home, "plugins", plName+".toml"))
+		if err != nil {
+			// Unreadable but present: installPluginInto refuses this outright
+			// rather than resetting lifecycle fields, so the preview must say the
+			// real run will fail — not print a clean line for an import that is
+			// about to be skipped.
+			return " (existing plugins/" + plName + ".toml is unreadable — the real import will skip this plugin)"
 		}
-		return ""
+		return nativeAgentsSuffix(existing.Plugin.NativeAgents)
 	}
 	list := sanitizedList(candidates)
 	return fmt.Sprintf(" (%s %s this plugin natively — the real import will ask whether to defer to %s)",

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -291,7 +291,7 @@ func importRun(cmd *cobra.Command, args []string, dryRun bool) error {
 	// set would silently disable the defence — and since the projection is fed by
 	// plugin data, an upstream roll or a tampered cache could trigger it on
 	// demand.
-	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, agentName, sc); ppErr != nil {
+	if pp, ppErr := pluginProvided(loaderFsForState(), agentsyncHome, projectRoot, sc); ppErr != nil {
 		io.pluginProvidedErr = ppErr
 	} else {
 		io.pluginProvided = pp
@@ -1190,15 +1190,13 @@ func idsFromWritten(written []string) []string {
 // plugin components are namespaced: a hand-authored component can only shadow a
 // plugin-provided one by being named `<plugin>-<name>` on purpose.
 //
-// It mirrors apply's projection so the skipped set is exactly the rendered set:
-// lenient (an unrelated strict plugin conflict must not abort an import), honours
-// the project tree's `disabled = true` plugin markers, reads the home whose
-// components the render at this scope actually uses, and narrows to agentName's
-// own render set (source.FilterForAgent) so a plugin that projects nothing to
-// this agent blocks nothing here. A projection failure is returned, and the
-// caller records it so every component capture then refuses — see
-// skipPluginProvided.
-func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot, agentName string, sc adapter.Scope) (map[string]string, error) {
+// It mirrors apply's projection: lenient (an unrelated strict plugin conflict
+// must not abort an import), honours the project tree's `disabled = true` plugin
+// markers, and reads the home whose components the render at this scope actually
+// uses. It is deliberately NOT narrowed per agent — see the note at the collect
+// call below. A projection failure is returned, and the caller records it so
+// every component capture then refuses — see skipPluginProvided.
+func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot string, sc adapter.Scope) (map[string]string, error) {
 	pluginCacheRoot := filepath.Join(agentsyncHome, ".state", "cache", "plugins")
 	var disabled []string
 	projHome := ""
@@ -1290,13 +1288,26 @@ func pluginProvided(fs afero.Fs, agentsyncHome, projectRoot, agentName string, s
 	if err != nil {
 		return nil, fmt.Errorf("project plugins from %s: %w", home, err)
 	}
-	// Narrow to what THIS agent actually receives, through the same filter
-	// render.Plan applies. A plugin whose `agents` allowlist excludes this agent,
-	// or whose `native_agents` defers to the agent's own plugin manager, projects
-	// NOTHING here — so it provides nothing here either, and a same-named file in
-	// this agent's native config is the user's own to capture. Refusing it would
-	// lock the user out of importing their own component.
-	collect(source.FilterForAgent(c, agentName))
+	// DELIBERATELY NOT narrowed to this agent's render set (source.FilterForAgent).
+	//
+	// The narrowing looks right — a plugin that projects nothing here provides
+	// nothing here, so a same-named file must be the user's own — and it is
+	// wrong, because the destination can still hold agentsync's OWN un-reclaimed
+	// output. Sequence: a plugin projects to claude; the user records
+	// `native_agents = ["claude"]`; before the reclaiming apply runs, a second
+	// `import claude:subagent` sees the still-present rendered files, decides the
+	// plugin no longer provides them here, and captures agentsync's own output
+	// into ~/.agentsync as hand-authored components — permanent copies that
+	// diverge from the plugin's on its next update. The same window opens when a
+	// newly-honoured `agents` allowlist narrows a plugin away from an agent.
+	//
+	// So the refusal set stays the UNION over every installed plugin. The cost is
+	// over-refusal in a contrived case (the user hand-authors a component whose
+	// name exactly matches a plugin's NAMESPACED name — `toolkit-audit` — on an
+	// agent that plugin does not project to), and that case fails LOUDLY with an
+	// error naming the plugin, which the user can act on. Under-refusal fails
+	// silently and permanently. Prefer the loud one.
+	collect(c)
 	return out, nil
 }
 
@@ -1810,30 +1821,9 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		if !mpOK {
 			continue
 		}
-		// Ask before deferring — but ONLY when the answer would be used. A
-		// re-install preserves an existing `native_agents` (issue #140), so
-		// prompting for a plugin that already has one would ask a question whose
-		// answer is discarded, and re-asking on every re-import would be nagging
-		// about a decision already recorded.
-		native := owners[plName]
-		if len(native) > 0 && !io.dryRun && pluginNativeAgentsUnset(home, plName) {
-			if chosen := nativeAgentsPrompter(io, plName, native); len(chosen) == 0 {
-				warnDuplicateOptOut(io, plName, native)
-				// Write no key at all, so a later import asks again — and asks
-				// only if the duplicate still exists. Acting on the warning
-				// (disabling the plugin inside the agent) removes the agent from
-				// nativePluginOwners, so the question simply stops being asked.
-				// Ignoring it leaves the duplicate in place, which is worth
-				// raising again. A hand-written `native_agents = []` is the way
-				// to say "defer to nobody, stop asking"; installPluginInto
-				// preserves it.
-				native = nil
-			} else {
-				native = chosen
-			}
-		}
+		native := resolveNativeAgents(io, home, plName, owners[plName])
 		if io.dryRun {
-			io.item(fmt.Sprintf("plugins/%s.toml", plName), nativeAgentsSuffix(native))
+			io.item(fmt.Sprintf("plugins/%s.toml", plName), dryRunNativeAgentsNote(home, plName, native))
 			ids = append(ids, plName)
 			continue
 		}
@@ -1851,6 +1841,34 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 		ids = append(ids, plName)
 	}
 	return ids, nil
+}
+
+// resolveNativeAgents decides what `native_agents` an import should seed for one
+// plugin: the agents that install it themselves, or nil to record nothing.
+//
+// It asks — but ONLY when the answer would be used. installPluginInto preserves
+// an existing `native_agents` (issue #140), so prompting for a plugin that
+// already has one would put a question whose reply is discarded, and re-asking
+// on every re-import would nag about a decision already recorded. A dry run
+// never asks either; it has its own preview line (dryRunNativeAgentsNote).
+//
+// Declining records NO key rather than an empty list, so a later import asks
+// again — and asks only if the duplicate still exists. Acting on the warning
+// (disabling the plugin inside the agent) removes that agent from
+// nativePluginOwners, so the question stops being asked on its own; ignoring it
+// leaves a duplicate worth raising again. A hand-written `native_agents = []`
+// is how a user says "defer to nobody, stop asking" — installPluginInto
+// preserves that, and it survives a rewrite because the field is a pointer.
+func resolveNativeAgents(io *importIO, home, plugin string, candidates []string) []string {
+	if len(candidates) == 0 || io.dryRun || !pluginNativeAgentsUnset(home, plugin) {
+		return candidates
+	}
+	chosen := nativeAgentsPrompter(io, plugin, candidates)
+	if len(chosen) == 0 {
+		warnDuplicateOptOut(io, plugin, candidates)
+		return nil
+	}
+	return chosen
 }
 
 // nativeAgentsPrompter is the interactive deferral offer, injectable so tests
@@ -1920,26 +1938,76 @@ func askDeferralAnswer(io *importIO, plugin string, candidates []string) []strin
 // installs it, which is a real, working configuration only if they then turn the
 // plugin off inside that agent — so say exactly that, at WARN, naming the agents.
 func warnDuplicateOptOut(io *importIO, plugin string, agents []string) {
-	list := strings.Join(agents, ", ")
+	sanitized := sanitizedList(agents)
+	list := strings.Join(sanitized, ", ")
+	// Render the remedy as VALID TOML. A naive `[%q]` over the comma-joined
+	// string produced `native_agents = ["claude, cursor"]` for two agents — a
+	// single bogus agent name that silently defers to nobody if pasted.
+	quoted := make([]string, len(sanitized))
+	for i, a := range sanitized {
+		quoted[i] = fmt.Sprintf("%q", a)
+	}
 	io.warnf("this will DUPLICATE the plugin %q's content in your %s harness — every skill, "+
 		"subagent and command it ships will appear twice, and its hooks will fire twice. "+
 		"Disable or uninstall %q in %s now that agentsync is managing it. "+
-		"(To defer to %s instead, set `native_agents = [%q]` in plugins/%s.toml.)",
-		plugin, list, plugin, list, list, list, plugin)
+		"(To defer to %s instead, set `native_agents = [%s]` in plugins/%s.toml.)",
+		plugin, list, plugin, list, list, strings.Join(quoted, ", "), plugin)
 }
 
 // nativeAgentsSuffix renders the item-line note naming the agents a plugin is
 // NOT projected to because they install it themselves. Empty for the ordinary
 // case (nothing deferred), so the line stays quiet when there is nothing to say.
-// Agent names come from agentsync's own registry, not from native config, so
-// they need no sanitizing — but item() sanitizes the whole path anyway and the
-// suffix is appended after it, so keep this to registry-derived values only.
-func nativeAgentsSuffix(native []string) string {
-	if len(native) == 0 {
+// A non-nil EMPTY list is also quiet: "defer to nobody" is the same outcome as
+// no deferral, and the item line reports outcomes.
+//
+// The values are SANITIZED even though the seed comes from agentsync's own
+// registry, because this renders what was actually WRITTEN — read back from
+// plugins/<id>.toml, which is a hand-editable file in a synced dotfiles repo.
+// item() sanitizes only the path it is given and appends this suffix verbatim,
+// so an ANSI/bidi sequence hand-pasted into that TOML would otherwise reach the
+// terminal. The sibling display site (keptLifecycleSummary) sanitizes the same
+// value for the same reason.
+func nativeAgentsSuffix(native *[]string) string {
+	if native == nil || len(*native) == 0 {
 		return ""
 	}
+	list := sanitizedList(*native)
 	return fmt.Sprintf(" (native_agents=[%s] — %s %s this plugin natively, so apply will not project it there)",
-		strings.Join(native, ","), strings.Join(native, " and "), plural(len(native), "serves", "serve"))
+		strings.Join(list, ","), strings.Join(list, " and "), plural(len(list), "serves", "serve"))
+}
+
+// dryRunNativeAgentsNote is the preview counterpart of nativeAgentsSuffix. It
+// must NOT assert a deferral, because a real run ASKS: printing
+// `native_agents=[claude]` would advertise an outcome the user may decline.
+//
+// It reports what the real run will actually do: preview the recorded value when
+// one already exists (the real run preserves it and does not ask), and otherwise
+// say that the question will be put.
+func dryRunNativeAgentsNote(home, plName string, candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	if !pluginNativeAgentsUnset(home, plName) {
+		if existing, err := readPluginTOML(filepath.Join(home, "plugins", plName+".toml")); err == nil {
+			return nativeAgentsSuffix(existing.Plugin.NativeAgents)
+		}
+		return ""
+	}
+	list := sanitizedList(candidates)
+	return fmt.Sprintf(" (%s %s this plugin natively — the real import will ask whether to defer to %s)",
+		strings.Join(list, " and "), plural(len(list), "installs", "install"),
+		plural(len(list), "it", "them"))
+}
+
+// sanitizedList strips terminal control/bidi sequences from every element of a
+// list destined for a diagnostic line. Agent names reaching a display site can
+// originate from a hand-edited plugins/<id>.toml, not only from the registry.
+func sanitizedList(in []string) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = ui.Sanitize(v)
+	}
+	return out
 }
 
 // claudeSourceToAgentsync maps a native marketplace source (Claude's

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -86,7 +86,9 @@ func TestAskDeferralAnswer_BoundedAgainstEndlessGarbage(t *testing.T) {
 		t.Fatalf("exhausting the attempt cap must land on the SAFE branch (defer); got %v", got)
 	}
 	// Five prompts, five re-asks — not one, and not forever.
-	if n := strings.Count(out.String(), "Let claude keep serving"); n != 5 {
+	// Count the ANSWER AFFORDANCE, not the question's wording — this test is
+	// about the loop being bounded, and rewording the prompt should not break it.
+	if n := strings.Count(out.String(), "[Y]es"); n != 5 {
 		t.Errorf("expected the documented 5-attempt cap, saw %d prompts", n)
 	}
 }

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,6 +48,46 @@ func TestPromptNativeAgentsDeferral_NonInteractiveDefersWithoutAsking(t *testing
 	}
 	if strings.Contains(out.String(), "[Y]es") {
 		t.Errorf("it must not print a prompt nobody can answer; got:\n%s", out.String())
+	}
+}
+
+// endlessReader answers every read with the same unrecognized line and NEVER
+// reaches EOF. It exists because every other fixture EOFs, and on EOF the loop
+// exits via `case ""` regardless — so deleting the attempt cap, or the EOF
+// guard, stayed green against all of them. Only a reader that never ends can
+// tell a bounded loop from an unbounded one.
+type endlessReader struct{ reads int }
+
+func (e *endlessReader) Read(p []byte) (int, error) {
+	e.reads++
+	if e.reads > 10_000 { // a runaway loop must fail the test, not hang the suite
+		return 0, io.ErrUnexpectedEOF
+	}
+	return copy(p, "what\n"), nil
+}
+
+// TestAskDeferralAnswer_BoundedAgainstEndlessGarbage pins the attempt cap and
+// the branch it lands on. An unbounded loop against a terminal that keeps
+// sending unparseable input would hang `import` with no way out, and landing on
+// the DECLINE branch would silently opt the user into the duplicate.
+func TestAskDeferralAnswer_BoundedAgainstEndlessGarbage(t *testing.T) {
+	testenv.RequireContainer(t)
+	var out bytes.Buffer
+	p := &ui.Printer{Out: &out, Err: &out}
+	cmd := &cobra.Command{}
+	r := &endlessReader{}
+	cmd.SetIn(r)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	io := &importIO{p: p, out: &out, err: &out, cmd: cmd}
+
+	got := askDeferralAnswer(io, "toolkit", []string{"claude"})
+	if len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("exhausting the attempt cap must land on the SAFE branch (defer); got %v", got)
+	}
+	// Five prompts, five re-asks — not one, and not forever.
+	if n := strings.Count(out.String(), "Let claude keep serving"); n != 5 {
+		t.Errorf("expected the documented 5-attempt cap, saw %d prompts", n)
 	}
 }
 

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -66,6 +66,16 @@ func TestPromptNativeAgentsDeferral_AnswerParsing(t *testing.T) {
 		{name: "explicit no opts into the duplicate", typed: "n\n", want: nil},
 		{name: "no spelled out", typed: "no\n", want: nil},
 		{name: "unrecognized then no", typed: "maybe\nn\n", want: nil},
+		// A line with no trailing newline reaches ReadString's err!=nil path with
+		// a non-empty line, which is the ONLY route to the EOF guard — the "\n"
+		// case above hits `case ""` first and never exercises it. Closed stdin
+		// must land on the safe branch (defer), never fall through to the
+		// duplicate.
+		{name: "unrecognized then EOF takes the safe default", typed: "maybe", want: []string{"claude"}},
+		{name: "bare EOF, no input at all", typed: "", want: []string{"claude"}},
+		// Exhausting the attempt cap must also land safe rather than loop or
+		// return the duplicate.
+		{name: "cap exhausted by repeated garbage", typed: strings.Repeat("what\n", 8), want: []string{"claude"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/testenv"
 	"github.com/spxrogers/agentsync/internal/ui"
@@ -155,6 +156,208 @@ func TestPluginNativeAgentsUnset(t *testing.T) {
 			}
 			if got := pluginNativeAgentsUnset(home, "toolkit"); got != tc.want {
 				t.Errorf("pluginNativeAgentsUnset = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// stubNativeAgentsPrompter replaces the deferral prompt for one test and returns
+// a restore closure, mirroring stubPrompter in gitbackup_test.go. It also
+// records whether the prompt was reached at all — several behaviors below are
+// about NOT asking, and "returned the right value" cannot distinguish "asked and
+// accepted" from "never asked".
+func stubNativeAgentsPrompter(t *testing.T, reply []string, asked *bool) {
+	t.Helper()
+	prev := nativeAgentsPrompter
+	nativeAgentsPrompter = func(*importIO, string, []string) []string {
+		*asked = true
+		return reply
+	}
+	t.Cleanup(func() { nativeAgentsPrompter = prev })
+}
+
+// writePluginTOMLFixture writes plugins/<id>.toml under home. Empty content
+// writes no file at all (the "first install" state).
+func writePluginTOMLFixture(t *testing.T, home, id, content string) {
+	t.Helper()
+	if content == "" {
+		return
+	}
+	dir := filepath.Join(home, "plugins")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+".toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveNativeAgents covers the whole decision `import` makes per plugin —
+// including the branches that must NOT ask. Each case asserts BOTH the returned
+// value and whether the prompt was reached; without the second, "did not ask"
+// and "asked and got the same answer back" are indistinguishable, which is
+// exactly the gap that let the prompt-gate behavior go unpinned.
+func TestResolveNativeAgents(t *testing.T) {
+	testenv.RequireContainer(t)
+	candidates := []string{"claude"}
+	cases := []struct {
+		name      string
+		existing  string // plugins/toolkit.toml content; "" = no file
+		dryRun    bool
+		reply     []string // what the stubbed prompt answers
+		wantAsked bool
+		want      []string
+	}{
+		{
+			name:  "first install, accepted — records the deferral",
+			reply: candidates, wantAsked: true, want: candidates,
+		},
+		{
+			name:  "first install, declined — records nothing, so a later import re-asks",
+			reply: nil, wantAsked: true, want: nil,
+		},
+		{
+			name:     "already recorded — the answer would be discarded, so do not ask",
+			existing: "[plugin]\nid = \"toolkit@mp\"\nnative_agents = [\"claude\"]\n",
+			reply:    nil, wantAsked: false, want: candidates,
+		},
+		{
+			name:     "explicitly empty — a decision already made; do not re-litigate it",
+			existing: "[plugin]\nid = \"toolkit@mp\"\nnative_agents = []\n",
+			reply:    nil, wantAsked: false, want: candidates,
+		},
+		{
+			name:     "upgraded from before the key existed — ask",
+			existing: "[plugin]\nid = \"toolkit@mp\"\nagents = [\"*\"]\n",
+			reply:    candidates, wantAsked: true, want: candidates,
+		},
+		{
+			name:   "dry run never asks — it has its own preview line",
+			dryRun: true, reply: nil, wantAsked: false, want: candidates,
+		},
+		{
+			name:  "no candidates — nothing to defer, nothing to ask",
+			reply: nil, wantAsked: false, want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writePluginTOMLFixture(t, home, "toolkit", tc.existing)
+			io, _ := newPromptIO(t, "")
+			io.dryRun = tc.dryRun
+			var asked bool
+			stubNativeAgentsPrompter(t, tc.reply, &asked)
+
+			in := candidates
+			if tc.name == "no candidates — nothing to defer, nothing to ask" {
+				in = nil
+			}
+			got := resolveNativeAgents(io, home, "toolkit", in)
+
+			if asked != tc.wantAsked {
+				t.Errorf("prompt asked = %v, want %v", asked, tc.wantAsked)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveNativeAgents_DeclineWarns pins that declining is never silent. The
+// decline branch returns nil, which on its own is indistinguishable from "there
+// was nothing to defer" — the warning is what tells the user they now own a
+// duplicate and must disable the plugin inside the agent themselves.
+func TestResolveNativeAgents_DeclineWarns(t *testing.T) {
+	testenv.RequireContainer(t)
+	io, out := newPromptIO(t, "")
+	var asked bool
+	stubNativeAgentsPrompter(t, nil, &asked)
+
+	if got := resolveNativeAgents(io, t.TempDir(), "toolkit", []string{"claude"}); got != nil {
+		t.Fatalf("declining must record no deferral; got %v", got)
+	}
+	if !strings.Contains(out.String(), "DUPLICATE") || !strings.Contains(out.String(), "Disable or uninstall") {
+		t.Errorf("declining must warn about the duplicate it creates; got:\n%s", out.String())
+	}
+}
+
+// TestWarnDuplicateOptOut_RemedyIsValidTOML pins the remedy line for the
+// MULTI-agent case. A naive `[%q]` over a comma-joined list rendered
+// `native_agents = ["claude, cursor"]` — valid TOML syntax naming one agent that
+// does not exist, so a user who pasted it would silently defer to nobody and
+// keep the duplicate the warning is about.
+func TestWarnDuplicateOptOut_RemedyIsValidTOML(t *testing.T) {
+	testenv.RequireContainer(t)
+	io, out := newPromptIO(t, "")
+	warnDuplicateOptOut(io, "toolkit", []string{"claude", "cursor"})
+	got := out.String()
+	if !strings.Contains(got, `native_agents = ["claude", "cursor"]`) {
+		t.Errorf("the remedy must be valid TOML naming both agents; got:\n%s", got)
+	}
+	if strings.Contains(got, `["claude, cursor"]`) {
+		t.Errorf("the remedy collapsed both agents into one bogus name; got:\n%s", got)
+	}
+}
+
+// TestPluginTOML_NativeAgentsRoundTrip is the durability pin for the three
+// on-disk states of `native_agents`. The field is a POINTER precisely because
+// `omitempty` drops an empty slice: before that fix, a user's explicit
+// `native_agents = []` ("defer to nobody, stop asking") survived being READ —
+// so the prompt correctly stayed quiet — and was then erased by the next write,
+// after which the following import re-seeded the deferral, silently and, under
+// --no-input, without asking.
+//
+// The oracle is a full write→read→write cycle, not a single decode: the bug was
+// invisible to a decode-only test.
+func TestPluginTOML_NativeAgentsRoundTrip(t *testing.T) {
+	testenv.RequireContainer(t)
+	empty := []string{}
+	populated := []string{"claude"}
+	cases := []struct {
+		name    string
+		in      *[]string
+		wantKey string // substring the re-marshalled TOML must contain
+		absent  bool   // or: the key must not appear at all
+	}{
+		{name: "absent stays absent", in: nil, absent: true},
+		{name: "explicitly empty survives", in: &empty, wantKey: "native_agents = []"},
+		{name: "populated survives", in: &populated, wantKey: "native_agents = ['claude']"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first, err := toml.Marshal(pluginTOML{Plugin: pluginTOMLSpec{ID: "toolkit@mp", NativeAgents: tc.in}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded pluginTOML
+			if err := toml.Unmarshal(first, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			// The read side must preserve the absent/empty distinction, since it
+			// is what pluginNativeAgentsUnset branches on.
+			if (decoded.Plugin.NativeAgents == nil) != (tc.in == nil) {
+				t.Fatalf("absent/present distinction lost on read: got nil=%v, want nil=%v",
+					decoded.Plugin.NativeAgents == nil, tc.in == nil)
+			}
+			second, err := toml.Marshal(decoded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.absent {
+				if strings.Contains(string(second), "native_agents") {
+					t.Fatalf("no key was set, but one was written:\n%s", second)
+				}
+				return
+			}
+			if !strings.Contains(string(second), tc.wantKey) {
+				t.Fatalf("rewrite lost the recorded decision; want %q, got:\n%s", tc.wantKey, second)
 			}
 		})
 	}

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -201,12 +201,13 @@ func TestResolveNativeAgents(t *testing.T) {
 	testenv.RequireContainer(t)
 	candidates := []string{"claude"}
 	cases := []struct {
-		name      string
-		existing  string // plugins/toolkit.toml content; "" = no file
-		dryRun    bool
-		reply     []string // what the stubbed prompt answers
-		wantAsked bool
-		want      []string
+		name         string
+		existing     string // plugins/toolkit.toml content; "" = no file
+		noCandidates bool   // pass an empty candidate list rather than the default
+		dryRun       bool
+		reply        []string // what the stubbed prompt answers
+		wantAsked    bool
+		want         []string
 	}{
 		{
 			name:  "first install, accepted — records the deferral",
@@ -236,8 +237,9 @@ func TestResolveNativeAgents(t *testing.T) {
 			dryRun: true, reply: nil, wantAsked: false, want: candidates,
 		},
 		{
-			name:  "no candidates — nothing to defer, nothing to ask",
-			reply: nil, wantAsked: false, want: nil,
+			name:         "no candidates — nothing to defer, nothing to ask",
+			noCandidates: true,
+			reply:        nil, wantAsked: false, want: nil,
 		},
 	}
 	for _, tc := range cases {
@@ -250,7 +252,7 @@ func TestResolveNativeAgents(t *testing.T) {
 			stubNativeAgentsPrompter(t, tc.reply, &asked)
 
 			in := candidates
-			if tc.name == "no candidates — nothing to defer, nothing to ask" {
+			if tc.noCandidates {
 				in = nil
 			}
 			got := resolveNativeAgents(io, home, "toolkit", in)
@@ -358,6 +360,114 @@ func TestPluginTOML_NativeAgentsRoundTrip(t *testing.T) {
 			}
 			if !strings.Contains(string(second), tc.wantKey) {
 				t.Fatalf("rewrite lost the recorded decision; want %q, got:\n%s", tc.wantKey, second)
+			}
+		})
+	}
+}
+
+// TestNativeAgentsSuffix_SanitizesAndStaysQuiet pins both halves of the item-line
+// suffix. The values are read back from plugins/<id>.toml — a hand-editable file
+// in a synced dotfiles repo — and item() sanitizes only the path it is given,
+// appending this suffix verbatim, so an ESC pasted into that TOML would reach the
+// terminal. The quiet branches matter too: a non-nil EMPTY list is the same
+// OUTCOME as no deferral, and the item line reports outcomes.
+func TestNativeAgentsSuffix_SanitizesAndStaysQuiet(t *testing.T) {
+	testenv.RequireContainer(t)
+	empty := []string{}
+	hostile := []string{"claude\x1b[31m", "co\x1b]0;pwn\adex"}
+	populated := []string{"claude"}
+
+	if got := nativeAgentsSuffix(nil); got != "" {
+		t.Errorf("no deferral must print nothing; got %q", got)
+	}
+	if got := nativeAgentsSuffix(&empty); got != "" {
+		t.Errorf("an empty deferral defers to nobody — same outcome, same silence; got %q", got)
+	}
+	if got := nativeAgentsSuffix(&populated); !strings.Contains(got, "native_agents=[claude]") {
+		t.Errorf("a real deferral must name the agents; got %q", got)
+	}
+	got := nativeAgentsSuffix(&hostile)
+	if strings.ContainsAny(got, "\x1b\a") {
+		t.Errorf("a control byte from a hand-edited TOML reached the suffix: %q", got)
+	}
+}
+
+// TestKeptLifecycleSummary_Sanitizes covers the sibling display site. Both read
+// the same user-editable file, and the pair is exactly where "one site
+// remembered, the other forgot" happens.
+func TestKeptLifecycleSummary_Sanitizes(t *testing.T) {
+	testenv.RequireContainer(t)
+	hostile := []string{"claude\x1b[31m"}
+	got := keptLifecycleSummary(pluginTOMLSpec{
+		Agents:       []string{"codex\x1b[32m"},
+		NativeAgents: &hostile,
+		Update:       "track",
+	})
+	if strings.ContainsAny(got, "\x1b\a") {
+		t.Errorf("a control byte from a hand-edited TOML reached the install summary: %q", got)
+	}
+	if !strings.Contains(got, "native_agents=[") || !strings.Contains(got, "agents=[") {
+		t.Errorf("both preserved lists should still be reported; got %q", got)
+	}
+}
+
+// TestDryRunNativeAgentsNote covers the preview's three states. A dry run must
+// never ASSERT a deferral, because the real run asks and the user may decline —
+// advertising an outcome the real run will not produce is worse than saying
+// nothing. Equally it must not stay silent when the real run will not ask at all.
+func TestDryRunNativeAgentsNote(t *testing.T) {
+	testenv.RequireContainer(t)
+	cases := []struct {
+		name       string
+		existing   string
+		candidates []string
+		wantSubstr string // "" means the note must be empty
+		wantAbsent string
+	}{
+		{
+			name: "nothing to defer", candidates: nil, wantSubstr: "",
+		},
+		{
+			name:       "no key yet — the real run will ask, so say that, do not assert it",
+			candidates: []string{"claude"},
+			wantSubstr: "will ask",
+			wantAbsent: "native_agents=[claude]",
+		},
+		{
+			name:       "already recorded — the real run preserves it, so preview the real value",
+			existing:   "[plugin]\nid = \"toolkit@mp\"\nnative_agents = [\"claude\"]\n",
+			candidates: []string{"claude"},
+			wantSubstr: "native_agents=[claude]",
+		},
+		{
+			name:       "recorded as empty — defers to nobody, so nothing to report",
+			existing:   "[plugin]\nid = \"toolkit@mp\"\nnative_agents = []\n",
+			candidates: []string{"claude"},
+			wantSubstr: "",
+		},
+		{
+			name:       "unreadable — the real run refuses, so the preview must not look clean",
+			existing:   "[plugin\nid = broken",
+			candidates: []string{"claude"},
+			wantSubstr: "will skip this plugin",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writePluginTOMLFixture(t, home, "toolkit", tc.existing)
+			got := dryRunNativeAgentsNote(home, "toolkit", tc.candidates)
+			if tc.wantSubstr == "" {
+				if got != "" {
+					t.Fatalf("expected no note, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("note = %q, want it to contain %q", got, tc.wantSubstr)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("the preview asserted an outcome the prompt may decline: %q", got)
 			}
 		})
 	}

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/testenv"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// newPromptIO builds an importIO whose stdin carries the given typed lines and
+// whose output is captured, so the prompter can be driven without a terminal.
+// cmd.InOrStdin() is a strings.Reader here, so stdinIsTerminal reports false —
+// tests that want the interactive branch call the prompter body directly, which
+// is what these do; the TTY gate itself is covered by
+// TestPromptNativeAgentsDeferral_NonInteractiveDefersWithoutAsking.
+func newPromptIO(t *testing.T, typed string) (*importIO, *bytes.Buffer) {
+	t.Helper()
+	var out bytes.Buffer
+	p := &ui.Printer{Out: &out, Err: &out}
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(typed))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	return &importIO{p: p, out: &out, err: &out, cmd: cmd}, &out
+}
+
+// TestPromptNativeAgentsDeferral_NonInteractiveDefersWithoutAsking pins the
+// fail-SAFE direction. Every other prompter in this package fails closed,
+// because their unattended fallback is inaction. Here inaction is the damaging
+// outcome — a scripted `agentsync import claude:plugin` that answered "no" by
+// default would leave every component duplicated in Claude — so the unattended
+// path takes the branch that changes nothing about the agent's own setup.
+func TestPromptNativeAgentsDeferral_NonInteractiveDefersWithoutAsking(t *testing.T) {
+	io, out := newPromptIO(t, "") // a strings.Reader is not a TTY
+	got := promptNativeAgentsDeferral(io, "toolkit", []string{"claude"})
+	if len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("a non-interactive import must record the deferral; got %v", got)
+	}
+	if !strings.Contains(out.String(), "native_agents") {
+		t.Errorf("it must say what it did and where to change it; got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "[Y]es") {
+		t.Errorf("it must not print a prompt nobody can answer; got:\n%s", out.String())
+	}
+}
+
+// TestPromptNativeAgentsDeferral_AnswerParsing drives the question loop
+// directly — askDeferralAnswer is split from the TTY gate precisely so both
+// branches are reachable without a terminal. A bare Enter and an EOF both take
+// the safe default; only an explicit "no" opts into the duplicate.
+func TestPromptNativeAgentsDeferral_AnswerParsing(t *testing.T) {
+	cases := []struct {
+		name  string
+		typed string
+		want  []string
+	}{
+		{name: "explicit yes", typed: "y\n", want: []string{"claude"}},
+		{name: "yes spelled out", typed: "yes\n", want: []string{"claude"}},
+		{name: "bare enter takes the safe default", typed: "\n", want: []string{"claude"}},
+		{name: "explicit no opts into the duplicate", typed: "n\n", want: nil},
+		{name: "no spelled out", typed: "no\n", want: nil},
+		{name: "unrecognized then no", typed: "maybe\nn\n", want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			io, _ := newPromptIO(t, tc.typed)
+			got := askDeferralAnswer(io, "toolkit", []string{"claude"})
+			if len(got) != len(tc.want) {
+				t.Fatalf("typed %q: got %v, want %v", tc.typed, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("typed %q: got %v, want %v", tc.typed, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestWarnDuplicateOptOut pins the wording of the opt-out warning. Declining the
+// deferral produces a working setup ONLY if the user then turns the plugin off
+// inside the agent, so the warning has to say that in as many words — naming the
+// agent, and naming the consequence if they do not.
+func TestWarnDuplicateOptOut(t *testing.T) {
+	io, out := newPromptIO(t, "")
+	warnDuplicateOptOut(io, "toolkit", []string{"claude"})
+	got := out.String()
+	for _, want := range []string{
+		"DUPLICATE", // the consequence, stated plainly
+		"twice",     // what that means concretely
+		"claude",    // which harness
+		"Disable or uninstall",
+		"native_agents", // and the way back
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the opt-out warning should mention %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// TestPluginNativeAgentsUnset gates whether import ASKS at all. Prompting for a
+// plugin whose plugins/<id>.toml already carries `native_agents` would ask a
+// question whose answer installPluginInto discards (it preserves the existing
+// list, per #140) — so the reply must only be solicited when it can take effect.
+//
+// The three states are distinct on purpose: an ABSENT file is a first install
+// (ask), a file with NO key is an upgrade from before the key existed (ask), and
+// a file WITH a key — including a deliberately empty one, which reads as "defer
+// to nobody" — is a decision already made (do not ask).
+func TestPluginNativeAgentsUnset(t *testing.T) {
+	testenv.RequireContainer(t)
+	cases := []struct {
+		name    string
+		content string // "" means write no file at all
+		want    bool
+	}{
+		{name: "no file — a first install", content: "", want: true},
+		{
+			name:    "file without the key — upgraded from before it existed",
+			content: "[plugin]\nid = \"toolkit@mp\"\nagents = [\"*\"]\n",
+			want:    true,
+		},
+		{
+			name:    "file with a deferral already recorded",
+			content: "[plugin]\nid = \"toolkit@mp\"\nnative_agents = [\"claude\"]\n",
+			want:    false,
+		},
+		{
+			name:    "explicitly empty list — a deliberate \"defer to nobody\"",
+			content: "[plugin]\nid = \"toolkit@mp\"\nnative_agents = []\n",
+			want:    false,
+		},
+		{
+			name:    "unparseable file — installPluginInto refuses it, nothing to ask",
+			content: "[plugin\nid = broken",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			if tc.content != "" {
+				dir := filepath.Join(home, "plugins")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "toolkit.toml"), []byte(tc.content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := pluginNativeAgentsUnset(home, "toolkit"); got != tc.want {
+				t.Errorf("pluginNativeAgentsUnset = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -155,21 +155,13 @@ func keptLifecycleSummary(spec pluginTOMLSpec) string {
 	var parts []string
 	defaultAgents := len(spec.Agents) == 1 && spec.Agents[0] == "*"
 	if !defaultAgents {
-		sanitized := make([]string, len(spec.Agents))
-		for i, a := range spec.Agents {
-			sanitized[i] = ui.Sanitize(a)
-		}
-		parts = append(parts, fmt.Sprintf("agents=[%s]", strings.Join(sanitized, ",")))
+		parts = append(parts, fmt.Sprintf("agents=[%s]", strings.Join(sanitizedList(spec.Agents), ",")))
 	}
 	if spec.NativeAgents != nil {
 		// A non-nil EMPTY list is reported too: "defer to nobody" is a deliberate
 		// decision the user recorded, and a re-install preserving it is exactly
 		// what this summary exists to surface.
-		sanitized := make([]string, len(*spec.NativeAgents))
-		for i, a := range *spec.NativeAgents {
-			sanitized[i] = ui.Sanitize(a)
-		}
-		parts = append(parts, fmt.Sprintf("native_agents=[%s]", strings.Join(sanitized, ",")))
+		parts = append(parts, fmt.Sprintf("native_agents=[%s]", strings.Join(sanitizedList(*spec.NativeAgents), ",")))
 	}
 	if spec.Update != "track" {
 		parts = append(parts, fmt.Sprintf("update=%s", ui.Sanitize(spec.Update)))

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -78,7 +78,12 @@ type pluginTOMLSpec struct {
 	ManifestSHA string         `toml:"manifest_sha,omitempty"`
 	Update      string         `toml:"update,omitempty"`
 	Agents      []string       `toml:"agents,omitempty"`
-	Disabled    bool           `toml:"disabled,omitempty"`
+	// NativeAgents mirrors source.PluginSpec.NativeAgents: agents whose own
+	// plugin manager already installs this plugin, so apply must not project
+	// its components there. Populated by `import` and preserved across
+	// re-installs like every other lifecycle field.
+	NativeAgents []string `toml:"native_agents,omitempty"`
+	Disabled     bool     `toml:"disabled,omitempty"`
 }
 
 // ---- install ----------------------------------------------------------------
@@ -109,7 +114,7 @@ func pluginAddRun(cmd *cobra.Command, args []string) error {
 	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 
-	spec, err := installPluginInto(home, id, mpName)
+	spec, err := installPluginInto(home, id, mpName, nil)
 	if err != nil {
 		return err
 	}
@@ -148,6 +153,13 @@ func keptLifecycleSummary(spec pluginTOMLSpec) string {
 		}
 		parts = append(parts, fmt.Sprintf("agents=[%s]", strings.Join(sanitized, ",")))
 	}
+	if len(spec.NativeAgents) > 0 {
+		sanitized := make([]string, len(spec.NativeAgents))
+		for i, a := range spec.NativeAgents {
+			sanitized[i] = ui.Sanitize(a)
+		}
+		parts = append(parts, fmt.Sprintf("native_agents=[%s]", strings.Join(sanitized, ",")))
+	}
 	if spec.Update != "track" {
 		parts = append(parts, fmt.Sprintf("update=%s", ui.Sanitize(spec.Update)))
 	}
@@ -162,7 +174,11 @@ func keptLifecycleSummary(spec pluginTOMLSpec) string {
 // may be empty (the marketplace is then searched for across all caches). It
 // does not print or acquire the global lock — callers do. Both `plugin install`
 // and `import` use it so the two produce byte-identical canonical artifacts.
-func installPluginInto(home, id, mpName string) (pluginTOMLSpec, error) {
+// defaultNativeAgents, when non-empty, seeds `native_agents` on a FIRST install
+// (it is ignored when plugins/<id>.toml already exists — an existing file's
+// lifecycle fields always win, per #140). `import` passes the agents whose
+// native config already enables this plugin; `plugin add` passes nil.
+func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (pluginTOMLSpec, error) {
 	// Resolve marketplace.json from the marketplace cache.
 	mpData, mpEntry, resolvedMP, err := resolveMarketplaceEntry(home, mpName, id)
 	if err != nil {
@@ -213,12 +229,23 @@ func installPluginInto(home, id, mpName string) (pluginTOMLSpec, error) {
 	// `import` still produce byte-identical canonical artifacts (see the doc
 	// comment above): Agents=["*"], Update="track", Disabled absent.
 	agents := []string{"*"}
+	nativeAgents := defaultNativeAgents
 	update := "track"
 	disabled := false
 	switch existing, rerr := readPluginTOML(pluginPath); {
 	case rerr == nil:
 		if len(existing.Plugin.Agents) > 0 {
 			agents = existing.Plugin.Agents
+		}
+		// An existing file's deferral list wins over the caller's default, for
+		// the same reason the allowlist does: a user who removed an agent from
+		// native_agents (having uninstalled the native copy) must not have it
+		// re-added by the next import, which would silently stop projecting to
+		// an agent they deliberately adopted. Re-seed only when the key is
+		// absent — a deliberately EMPTIED list is a decision, so it is
+		// preserved as-is (non-nil and empty reads as "defer to nobody").
+		if existing.Plugin.NativeAgents != nil {
+			nativeAgents = existing.Plugin.NativeAgents
 		}
 		if existing.Plugin.Update != "" {
 			update = existing.Plugin.Update
@@ -241,12 +268,13 @@ func installPluginInto(home, id, mpName string) (pluginTOMLSpec, error) {
 	spec := pluginTOMLSpec{
 		// id/marketplace are validated cache keys; wrap the composed id as Text to
 		// match the canonical model (the ManifestSHA below stays a plain string).
-		ID:          untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
-		Version:     mpEntry.Version,
-		ManifestSHA: manifestSHA,
-		Update:      update,
-		Agents:      agents,
-		Disabled:    disabled,
+		ID:           untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
+		Version:      mpEntry.Version,
+		ManifestSHA:  manifestSHA,
+		Update:       update,
+		Agents:       agents,
+		NativeAgents: nativeAgents,
+		Disabled:     disabled,
 	}
 	if result.Version != "" {
 		spec.Version = untrusted.Wrap(result.Version)

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -169,6 +169,24 @@ func keptLifecycleSummary(spec pluginTOMLSpec) string {
 	return strings.Join(parts, ", ")
 }
 
+// pluginNativeAgentsUnset reports whether a first install of id would actually
+// USE a caller-supplied `native_agents` default: true when plugins/<id>.toml is
+// absent, or present with no `native_agents` key. It lets `import` ask about the
+// deferral only when the answer can take effect — installPluginInto preserves an
+// existing list, so prompting for a plugin that already has one would discard
+// the reply and re-ask on every re-import.
+//
+// An unreadable file counts as SET (false): installPluginInto refuses that case
+// outright rather than resetting lifecycle fields, so there is nothing to ask
+// about.
+func pluginNativeAgentsUnset(home, id string) bool {
+	existing, err := readPluginTOML(filepath.Join(home, "plugins", id+".toml"))
+	if err != nil {
+		return errors.Is(err, os.ErrNotExist)
+	}
+	return existing.Plugin.NativeAgents == nil
+}
+
 // installPluginInto fetches plugin id from the named marketplace into the
 // plugin cache and writes plugins/<id>.toml, returning the written spec. mpName
 // may be empty (the marketplace is then searched for across all caches). It

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -195,7 +195,7 @@ func pluginNativeAgentsUnset(home, id string) bool {
 // may be empty (the marketplace is then searched for across all caches). It
 // does not print or acquire the global lock — callers do. Both `plugin install`
 // and `import` use it so the two produce byte-identical canonical artifacts.
-// defaultNativeAgents, when non-empty, seeds `native_agents` on a FIRST install
+// defaultNativeAgents, when non-nil, seeds `native_agents` on a FIRST install
 // (it is ignored when plugins/<id>.toml already exists — an existing file's
 // lifecycle fields always win, per #140). `import` passes the agents whose
 // native config already enables this plugin; `plugin add` passes nil.

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -78,12 +78,20 @@ type pluginTOMLSpec struct {
 	ManifestSHA string         `toml:"manifest_sha,omitempty"`
 	Update      string         `toml:"update,omitempty"`
 	Agents      []string       `toml:"agents,omitempty"`
-	// NativeAgents mirrors source.PluginSpec.NativeAgents: agents whose own
-	// plugin manager already installs this plugin, so apply must not project
-	// its components there. Populated by `import` and preserved across
-	// re-installs like every other lifecycle field.
-	NativeAgents []string `toml:"native_agents,omitempty"`
-	Disabled     bool     `toml:"disabled,omitempty"`
+	// NativeAgents mirrors source.PluginSpec.NativeAgents — agents whose own
+	// plugin manager already installs this plugin, so apply must not project its
+	// components there. Populated by `import` and preserved across re-installs
+	// like every other lifecycle field.
+	//
+	// It is a POINTER for the same reason the canonical field is: `omitempty`
+	// drops an EMPTY slice, so a user's explicit `native_agents = []` ("defer to
+	// nobody, stop asking") vanished on the next rewrite and the decision was
+	// silently reverted — after which the next import re-seeded it, under
+	// --no-input without even asking. A nil pointer omits the key; a pointer to
+	// an empty slice writes `native_agents = []`. Pinned by
+	// TestPluginTOML_NativeAgentsRoundTrip.
+	NativeAgents *[]string `toml:"native_agents,omitempty"`
+	Disabled     bool      `toml:"disabled,omitempty"`
 }
 
 // ---- install ----------------------------------------------------------------
@@ -153,9 +161,12 @@ func keptLifecycleSummary(spec pluginTOMLSpec) string {
 		}
 		parts = append(parts, fmt.Sprintf("agents=[%s]", strings.Join(sanitized, ",")))
 	}
-	if len(spec.NativeAgents) > 0 {
-		sanitized := make([]string, len(spec.NativeAgents))
-		for i, a := range spec.NativeAgents {
+	if spec.NativeAgents != nil {
+		// A non-nil EMPTY list is reported too: "defer to nobody" is a deliberate
+		// decision the user recorded, and a re-install preserving it is exactly
+		// what this summary exists to surface.
+		sanitized := make([]string, len(*spec.NativeAgents))
+		for i, a := range *spec.NativeAgents {
 			sanitized[i] = ui.Sanitize(a)
 		}
 		parts = append(parts, fmt.Sprintf("native_agents=[%s]", strings.Join(sanitized, ",")))
@@ -247,7 +258,11 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (p
 	// `import` still produce byte-identical canonical artifacts (see the doc
 	// comment above): Agents=["*"], Update="track", Disabled absent.
 	agents := []string{"*"}
-	nativeAgents := defaultNativeAgents
+	var nativeAgents *[]string
+	if defaultNativeAgents != nil {
+		seed := defaultNativeAgents
+		nativeAgents = &seed
+	}
 	update := "track"
 	disabled := false
 	switch existing, rerr := readPluginTOML(pluginPath); {

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -76,6 +76,27 @@ func mustNotExist(t *testing.T, label, path string) {
 	}
 }
 
+// mustNotMention asserts a shared destination file does not carry needle. A
+// MISSING file satisfies it — for a component rendered into a shared JSON file
+// (an MCP server in .claude.json, a hook in settings.json) "the file was never
+// created" and "the file exists without this key" are the same outcome — but the
+// check is explicit about that rather than skipping silently when the file is
+// absent, which would make the assertion vacuous exactly when the render path
+// changed.
+func mustNotMention(t *testing.T, label, path, needle string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // nothing was written here at all
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if strings.Contains(string(data), needle) {
+		t.Errorf("%s must not be projected to this agent; %s contains %q:\n%s", label, path, needle, data)
+	}
+}
+
 // mustReadFile is readFileString's fatal-on-error sibling: these tests always
 // treat a missing file as a test failure, never as a condition to branch on.
 func mustReadFile(t *testing.T, path string) string {
@@ -141,16 +162,13 @@ func TestImportApply_NativePluginIsNotDuplicated(t *testing.T) {
 	}
 	// The MCP server and the hook are the two that misbehave rather than merely
 	// clutter — a doubly-registered server id, and a handler that fires twice.
-	if data, err := os.ReadFile(filepath.Join(tmp, ".claude.json")); err == nil {
-		if strings.Contains(string(data), "toolkit-srv") {
-			t.Errorf("the plugin's MCP server must not be projected to claude:\n%s", data)
-		}
-	}
-	if data, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.json")); err == nil {
-		if strings.Contains(string(data), "toolkit-guard") {
-			t.Errorf("the plugin's hook must not be projected to claude (it would fire twice):\n%s", data)
-		}
-	}
+	// Both live inside shared JSON files, so "absent" means either the file does
+	// not exist or it does not mention the component; mustNotMention states that
+	// rather than leaving it to an `err == nil` conditional that silently skips
+	// the assertion when the file happens not to exist.
+	mustNotMention(t, "the plugin's MCP server", filepath.Join(tmp, ".claude.json"), "toolkit-srv")
+	mustNotMention(t, "the plugin's hook (it would fire twice)",
+		filepath.Join(tmp, ".claude", "settings.json"), "toolkit-guard")
 
 	// Codex does not have the plugin natively, so it gets the full fan-out —
 	// which is the entire point of importing the plugin in the first place.
@@ -351,5 +369,172 @@ func TestStatus_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
 	}
 	if strings.Contains(out, "projected there by agentsync") {
 		t.Errorf("recording the deferral should clear the warning; got:\n%s", out)
+	}
+}
+
+// TestImport_RefusesLeftoverProjectedFilesAfterDeferral is the regression for the
+// window between recording a deferral and the apply that reclaims the files.
+//
+// import's capture-refusal filter is deliberately NOT narrowed to the agent's
+// own render set. Narrowing it reads as correct — a plugin that projects nothing
+// here provides nothing here — and is wrong: for as long as the reclaiming apply
+// has not run, the destination still holds agentsync's OWN rendered output, and a
+// narrowed filter captures that back into ~/.agentsync as if the user had
+// written it. Those copies then diverge from the plugin's on its next update,
+// permanently, with no signal.
+//
+// The oracle is the canonical source: nothing plugin-provided may appear there.
+func TestImport_RefusesLeftoverProjectedFilesAfterDeferral(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	// Positive control: the files really are on disk, so the refusal below is
+	// about a real capture opportunity rather than an empty directory.
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustExist(t, label, path)
+	}
+
+	// Record the deferral (what `import claude:plugin` does) and do NOT apply —
+	// this is the window.
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
+	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, component := range []string{"subagent", "skill", "command"} {
+		out, err := runCLI(t, env, "import", "claude:"+component)
+		if err != nil {
+			t.Fatalf("import claude:%s: %v\n%s", component, err, out)
+		}
+		if !strings.Contains(out, "it is projected from the plugin") {
+			t.Errorf("import claude:%s must still refuse the plugin's own output; got:\n%s", component, out)
+		}
+	}
+	for _, rel := range []string{
+		filepath.Join("subagents", "toolkit-reviewer.md"),
+		filepath.Join("skills", "toolkit-audit", "SKILL.md"),
+		filepath.Join("commands", "toolkit-scan.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(tmp, ".agentsync", rel)); err == nil {
+			t.Errorf("import captured agentsync's own projected output as hand-authored: %s", rel)
+		}
+	}
+}
+
+// TestImport_DoesNotReAddADeferralAfterAdoption pins the adoption path end to
+// end. Adopting a plugin means uninstalling it inside the agent and dropping the
+// `native_agents` entry; the next import must not quietly put it back, which
+// would stop projecting to an agent the user deliberately took over — and under
+// a non-TTY stdin it would do so without even asking.
+func TestImport_DoesNotReAddADeferralAfterAdoption(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	if !strings.Contains(mustReadFile(t, tomlPath), "native_agents = ['claude']") {
+		t.Fatalf("setup: the first import should have recorded the deferral:\n%s", mustReadFile(t, tomlPath))
+	}
+
+	// Adopt: uninstall the plugin inside Claude, and drop the deferral.
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir))
+	adopted := strings.ReplaceAll(mustReadFile(t, tomlPath), "native_agents = ['claude']\n", "")
+	if err := os.WriteFile(tomlPath, []byte(adopted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A re-import must not resurrect it: Claude no longer installs the plugin,
+	// so there is nothing to defer to.
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("re-import: %v\n%s", err, out)
+	}
+	if got := mustReadFile(t, tomlPath); strings.Contains(got, "native_agents") {
+		t.Errorf("a re-import re-added a deferral the user adopted away:\n%s", got)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustExist(t, label, path)
+	}
+}
+
+// TestImport_PreservesAnExplicitlyEmptyDeferral pins the "defer to nobody, stop
+// asking" escape hatch across a full import cycle. `native_agents = []` is the
+// user saying they want the plugin projected everywhere INCLUDING agents that
+// install it themselves — a duplicate they chose. A re-import must preserve
+// that: before the field became a pointer, `omitempty` erased the empty list on
+// the rewrite and the next import silently re-seeded the deferral instead.
+func TestImport_PreservesAnExplicitlyEmptyDeferral(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	emptied := strings.ReplaceAll(mustReadFile(t, tomlPath),
+		"native_agents = ['claude']", "native_agents = []")
+	if err := os.WriteFile(tomlPath, []byte(emptied), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claude still installs the plugin, so a re-import has every reason to
+	// re-seed — and must not, because the empty list is a recorded decision.
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("re-import: %v\n%s", err, out)
+	}
+	got := mustReadFile(t, tomlPath)
+	if !strings.Contains(got, "native_agents = []") {
+		t.Fatalf("the explicit 'defer to nobody' decision did not survive a re-import:\n%s", got)
+	}
+	// And it means what it says: apply projects to claude despite the native copy.
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustExist(t, label, path)
+	}
+}
+
+// TestDoctor_WarnsWhenAgentAlsoInstallsThePluginItself mirrors the status test on
+// the other command that reads native state. Both surfaces matter: `doctor` is
+// where a user looks when something is wrong with the machine, and it was the
+// half whose warning no test covered.
+func TestDoctor_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	out, err := runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "also projected by agentsync") {
+		t.Errorf("doctor must not warn before the plugin is installed natively; got:\n%s", out)
+	}
+
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	out, err = runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "also projected by agentsync") || !strings.Contains(out, "native_agents") {
+		t.Errorf("doctor should report the duplicate and name the remedy; got:\n%s", out)
 	}
 }

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -603,3 +603,60 @@ func TestPluginExplain_ReportsDeferralRatherThanFailure(t *testing.T) {
 		t.Errorf("--json should expose notTargeted + the native coverage value; got:\n%s", jsonOut)
 	}
 }
+
+// TestProjectScope_NativeAgentsIsHonoured pins the deferral at PROJECT scope.
+// Project scope renders from the project-only overlay rather than the merged
+// canonical, so it reaches the filter by a different path than the user-scope
+// tests above — and a pin committed into a repo carries its `native_agents` with
+// it, which is the intended behavior: committing the pin commits the statement
+// that this agent serves the plugin natively.
+func TestProjectScope_NativeAgentsIsHonoured(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	for _, args := range [][]string{
+		{"init"},
+		{"agent", "add", "claude"},
+		{"init", "--scope", "project", "--project", proj},
+		{"agent", "add", "claude", "--scope", "project", "--project", proj},
+	} {
+		if out, err := runCLI(t, env, args...); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Acquire the plugin at user scope, then commit its pin into the project.
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	pin := mustReadFile(t, filepath.Join(tmpHome, ".agentsync", "plugins", "toolkit.toml"))
+	projPlugins := filepath.Join(proj, ".agentsync", "plugins")
+	if err := os.MkdirAll(projPlugins, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projPin := filepath.Join(projPlugins, "toolkit.toml")
+	if err := os.WriteFile(projPin, []byte(pin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Positive control: with no deferral the project apply projects to claude.
+	if out, err := runCLI(t, env, "apply", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project apply: %v\n%s", err, out)
+	}
+	projected := filepath.Join(proj, ".claude", "agents", "toolkit-reviewer.md")
+	mustExist(t, "project-scope plugin subagent", projected)
+
+	// Now record the deferral in the PROJECT pin and re-apply.
+	if err := os.WriteFile(projPin, []byte(pin+"\nnative_agents = ['claude']\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("project apply after deferring: %v\n%s", err, out)
+	}
+	mustNotExist(t, "project-scope plugin subagent", projected)
+}

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -83,6 +83,57 @@ func mustNotExist(t *testing.T, label, path string) {
 // check is explicit about that rather than skipping silently when the file is
 // absent, which would make the assertion vacuous exactly when the render path
 // changed.
+// pinPath is the canonical pin for a plugin under an agentsync home.
+func pinPath(tmp, plugin string) string {
+	return filepath.Join(tmp, ".agentsync", "plugins", plugin+".toml")
+}
+
+// deferInPin records `native_agents = [<agents>]` in a plugin's pin — what the
+// user does by hand, and what `import` does for them. It APPENDS rather than
+// rewriting an existing key, so callers must not use it on a pin that already
+// has one; adoptInPin is the inverse.
+//
+// Both exist because the read-edit-write block was copy-pasted across eight
+// call sites, every one hard-coding go-toml's single-quote rendering. A change
+// in quoting style would have silently turned each `ReplaceAll` into a no-op —
+// failing safe, but leaving tests that assert nothing.
+func deferInPin(t *testing.T, tmp, plugin string, agents ...string) {
+	t.Helper()
+	quoted := make([]string, len(agents))
+	for i, a := range agents {
+		quoted[i] = "'" + a + "'"
+	}
+	body := mustReadFile(t, pinPath(tmp, plugin)) +
+		"\nnative_agents = [" + strings.Join(quoted, ", ") + "]\n"
+	if err := os.WriteFile(pinPath(tmp, plugin), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// adoptInPin removes the `native_agents` key from a plugin's pin — what a user
+// does after uninstalling the plugin inside the agent. It asserts the key was
+// actually there, so a quoting or formatting change cannot turn this into a
+// silent no-op that leaves the test asserting nothing.
+func adoptInPin(t *testing.T, tmp, plugin string) {
+	t.Helper()
+	before := mustReadFile(t, pinPath(tmp, plugin))
+	var kept []string
+	removed := false
+	for _, line := range strings.Split(before, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "native_agents") {
+			removed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if !removed {
+		t.Fatalf("adoptInPin found no native_agents key to remove in:\n%s", before)
+	}
+	if err := os.WriteFile(pinPath(tmp, plugin), []byte(strings.Join(kept, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func mustNotMention(t *testing.T, label, path, needle string) {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -203,11 +254,7 @@ func TestApply_AdoptingANativePluginProjectsItAgain(t *testing.T) {
 
 	// The user uninstalls the plugin in Claude and adopts it into agentsync by
 	// dropping the deferral.
-	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
-	adopted := strings.ReplaceAll(mustReadFile(t, tomlPath), "native_agents = ['claude']\n", "")
-	if err := os.WriteFile(tomlPath, []byte(adopted), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	adoptInPin(t, tmp, "toolkit")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply after adopting: %v\n%s", err, out)
 	}
@@ -243,17 +290,20 @@ func TestApply_DeferralReclaimsPreviouslyProjectedFiles(t *testing.T) {
 	}
 
 	// Now the user installs the plugin in Claude natively and records it.
-	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
-	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
-	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	deferInPin(t, tmp, "toolkit", "claude")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply after deferring: %v\n%s", err, out)
 	}
 	for label, path := range claudeToolkitPaths(tmp) {
 		mustNotExist(t, label, path)
 	}
+	// The key-merge kinds are reclaimed by a DIFFERENT path (orphanCleanupOps,
+	// not orphanDeletes), and pipeline.go claims both are handled. The fixture
+	// ships an MCP server and a hook precisely because those are the two that
+	// misbehave when duplicated, so assert them here rather than trusting the
+	// claim — per "point to the test that backs it".
+	mustNotMention(t, "the plugin's MCP server", filepath.Join(tmp, ".claude.json"), "toolkit-srv")
+	mustNotMention(t, "the plugin's hook", filepath.Join(tmp, ".claude", "settings.json"), "toolkit-guard")
 }
 
 // TestApply_PluginAgentsAllowlistNarrowsFanOut covers the OTHER gate — the
@@ -358,11 +408,7 @@ func TestStatus_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
 
 	// Recording the deferral resolves it — and the warning goes away without any
 	// change to Claude's own config.
-	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
-	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
-	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	deferInPin(t, tmp, "toolkit", "claude")
 	out, err = runCLI(t, env, "status")
 	if err != nil {
 		t.Fatalf("status: %v\n%s", err, out)
@@ -404,11 +450,7 @@ func TestImport_RefusesLeftoverProjectedFilesAfterDeferral(t *testing.T) {
 
 	// Record the deferral (what `import claude:plugin` does) and do NOT apply —
 	// this is the window.
-	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
-	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
-	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	deferInPin(t, tmp, "toolkit", "claude")
 
 	for _, component := range []string{"subagent", "skill", "command"} {
 		out, err := runCLI(t, env, "import", "claude:"+component)
@@ -427,6 +469,31 @@ func TestImport_RefusesLeftoverProjectedFilesAfterDeferral(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(tmp, ".agentsync", rel)); err == nil {
 			t.Errorf("import captured agentsync's own projected output as hand-authored: %s", rel)
 		}
+	}
+}
+
+// TestImport_DryRunPreviewsTheQuestionRatherThanTheAnswer pins the call site of
+// the preview note. Round 2 tested the note builder in isolation; replacing the
+// call with "" stayed green, so the wiring itself was unpinned — and a preview
+// that silently says nothing is exactly as wrong as one that over-promises.
+func TestImport_DryRunPreviewsTheQuestionRatherThanTheAnswer(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	out, err := runCLI(t, env, "import", "claude:plugin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "will ask") {
+		t.Errorf("the preview must say the real run asks; got:\n%s", out)
+	}
+	if strings.Contains(out, "native_agents=[claude]") {
+		t.Errorf("the preview asserted an outcome the user may decline; got:\n%s", out)
+	}
+	// A dry run writes nothing at all.
+	if _, err := os.Stat(pinPath(tmp, "toolkit")); err == nil {
+		t.Error("--dry-run wrote a plugin pin")
 	}
 }
 
@@ -449,10 +516,7 @@ func TestImport_DoesNotReAddADeferralAfterAdoption(t *testing.T) {
 
 	// Adopt: uninstall the plugin inside Claude, and drop the deferral.
 	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir))
-	adopted := strings.ReplaceAll(mustReadFile(t, tomlPath), "native_agents = ['claude']\n", "")
-	if err := os.WriteFile(tomlPath, []byte(adopted), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	adoptInPin(t, tmp, "toolkit")
 
 	// A re-import must not resurrect it: Claude no longer installs the plugin,
 	// so there is nothing to defer to.
@@ -492,8 +556,16 @@ func TestImport_PreservesAnExplicitlyEmptyDeferral(t *testing.T) {
 
 	// Claude still installs the plugin, so a re-import has every reason to
 	// re-seed — and must not, because the empty list is a recorded decision.
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
 		t.Fatalf("re-import: %v\n%s", err, out)
+	}
+	// The item line reports what was WRITTEN, not what was a candidate. Reporting
+	// the candidates here would claim `native_agents=[claude]` for an import that
+	// deliberately wrote nothing of the sort — the same misreport class that made
+	// `plugin explain` call a deferred plugin a failure.
+	if strings.Contains(out, "native_agents=[claude]") {
+		t.Errorf("the item line claimed a deferral the import did not write; got:\n%s", out)
 	}
 	got := mustReadFile(t, tomlPath)
 	if !strings.Contains(got, "native_agents = []") {
@@ -540,11 +612,7 @@ func TestDoctor_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
 
 	// Recording the deferral resolves it. Without this phase the test would pass
 	// for a doctor that warned unconditionally once any plugin was declared.
-	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
-	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
-	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	deferInPin(t, tmp, "toolkit", "claude")
 	out, err = runCLI(t, env, "doctor")
 	if err != nil {
 		t.Fatalf("doctor: %v\n%s", err, out)

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -1,0 +1,355 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeFanOutMarketplace builds a local marketplace with ONE plugin that ships
+// every component kind whose duplication the `native_agents` deferral exists to
+// prevent: a subagent, a skill, a command, an MCP server, and a hook.
+//
+// Each kind has a distinct failure mode when it lands twice — two agents in the
+// picker, two entries in the skill list, one server id registered from two
+// sources, and (the one that actually misbehaves rather than just cluttering) a
+// hook handler that fires twice per event.
+func makeFanOutMarketplace(t *testing.T, dir string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "fanout-marketplace")
+
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(mpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(".claude-plugin/marketplace.json", `{
+		"name": "fanout-mp",
+		"owner": {"name": "tester"},
+		"plugins": [{"name": "toolkit", "source": "./plugins/toolkit"}]
+	}`)
+	write("plugins/toolkit/.claude-plugin/plugin.json", `{"name":"toolkit","version":"1.0.0"}`)
+	write("plugins/toolkit/agents/reviewer.md",
+		"---\nname: reviewer\ndescription: review code\n---\nReview the diff.\n")
+	write("plugins/toolkit/skills/audit/SKILL.md",
+		"---\nname: audit\ndescription: audit code\n---\nAudit the tree.\n")
+	write("plugins/toolkit/commands/scan.md",
+		"---\ndescription: scan\n---\nScan the repo.\n")
+	write("plugins/toolkit/.mcp.json", `{"mcpServers":{"toolkit-srv":{"command":"toolkit-server"}}}`)
+	write("plugins/toolkit/hooks/hooks.json", `{
+		"hooks": {"PreToolUse": [{"matcher": "Write", "hooks": [{"type":"command","command":"toolkit-guard"}]}]}
+	}`)
+	return mpDir
+}
+
+// claudeToolkitPaths are the destination files Claude's projection of the
+// toolkit plugin writes. Each is namespaced by the plugin (issue #211), so they
+// never collide with the plugin's own copies — which is exactly why they
+// DUPLICATE them instead: Claude keeps serving `toolkit:reviewer` from its
+// install dir while these render as `toolkit-reviewer`.
+func claudeToolkitPaths(tmp string) map[string]string {
+	return map[string]string{
+		"subagent": filepath.Join(tmp, ".claude", "agents", "toolkit-reviewer.md"),
+		"skill":    filepath.Join(tmp, ".claude", "skills", "toolkit-audit", "SKILL.md"),
+		"command":  filepath.Join(tmp, ".claude", "commands", "toolkit-scan.md"),
+	}
+}
+
+func mustExist(t *testing.T, label, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected the %s at %s: %v", label, path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, label, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("%s must not be projected to this agent; found %s", label, path)
+	}
+}
+
+// mustReadFile is readFileString's fatal-on-error sibling: these tests always
+// treat a missing file as a test failure, never as a condition to branch on.
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestImportApply_NativePluginIsNotDuplicated is the end-to-end regression for
+// the reported flow: `agentsync import claude` followed by `agentsync apply`,
+// with the plugin still enabled in Claude's own settings.
+//
+// Before the deferral, apply projected the plugin's components into Claude's
+// standalone paths while Claude kept loading its own copies from its install
+// dir — two of every skill, subagent, and command, and a hook handler that fired
+// twice. apply never disables the native plugin (PluginIngester is read-only by
+// design), so the duplicate could only be avoided by not projecting there.
+//
+// The oracle is the ON-DISK RESULT: Claude's destination must hold none of the
+// plugin's projected components, while codex — which does NOT have the plugin
+// natively — must hold all of them, proving the deferral is per-agent and does
+// not disable the plugin outright.
+func TestImportApply_NativePluginIsNotDuplicated(t *testing.T) {
+	tmp, env := importTestEnv(t) // inits + enables claude
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	out, err := runCLI(t, env, "import", "claude:plugin")
+	if err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	// The deferral is reported, not silent: it changes what the next apply
+	// writes, so the user has to be able to see it happen.
+	if !strings.Contains(out, "native_agents=[claude]") {
+		t.Errorf("import should report the seeded deferral; got:\n%s", out)
+	}
+
+	// It is recorded in canonical state — apply reads THIS, never the
+	// destination, so the plan stays reproducible from the dotfiles repo alone.
+	toml := mustReadFile(t, filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml"))
+	if !strings.Contains(toml, `native_agents = ['claude']`) {
+		t.Errorf("plugins/toolkit.toml should record the deferral; got:\n%s", toml)
+	}
+	// The user's own fan-out allowlist is untouched — the deferral is a separate
+	// statement about the world, not a narrowing of their choice.
+	if !strings.Contains(toml, `agents = ['*']`) {
+		t.Errorf("the `agents` allowlist must stay ['*']; got:\n%s", toml)
+	}
+
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	// Claude serves every one of these itself; agentsync must add nothing.
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustNotExist(t, label, path)
+	}
+	// The MCP server and the hook are the two that misbehave rather than merely
+	// clutter — a doubly-registered server id, and a handler that fires twice.
+	if data, err := os.ReadFile(filepath.Join(tmp, ".claude.json")); err == nil {
+		if strings.Contains(string(data), "toolkit-srv") {
+			t.Errorf("the plugin's MCP server must not be projected to claude:\n%s", data)
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(tmp, ".claude", "settings.json")); err == nil {
+		if strings.Contains(string(data), "toolkit-guard") {
+			t.Errorf("the plugin's hook must not be projected to claude (it would fire twice):\n%s", data)
+		}
+	}
+
+	// Codex does not have the plugin natively, so it gets the full fan-out —
+	// which is the entire point of importing the plugin in the first place.
+	mustExist(t, "codex subagent", filepath.Join(tmp, ".codex", "agents", "toolkit-reviewer.toml"))
+	// Codex reads personal skills from the shared ~/.agents/skills dir, not from
+	// under ~/.codex (see internal/adapter/codex/paths.go).
+	mustExist(t, "codex skill", filepath.Join(tmp, ".agents", "skills", "toolkit-audit", "SKILL.md"))
+	if data := mustReadFile(t, filepath.Join(tmp, ".codex", "config.toml")); !strings.Contains(data, "toolkit-srv") {
+		t.Errorf("codex should receive the plugin's MCP server; got:\n%s", data)
+	}
+}
+
+// TestApply_AdoptingANativePluginProjectsItAgain proves the deferral is
+// reversible and that reversing it is a canonical-source edit, not a hidden
+// destination probe: dropping the agent from `native_agents` (what a user does
+// after `/plugin uninstall` in Claude) makes the next apply project the
+// components there, with no re-import and no change to Claude's own config.
+func TestApply_AdoptingANativePluginProjectsItAgain(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustNotExist(t, label, path)
+	}
+
+	// The user uninstalls the plugin in Claude and adopts it into agentsync by
+	// dropping the deferral.
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	adopted := strings.ReplaceAll(mustReadFile(t, tomlPath), "native_agents = ['claude']\n", "")
+	if err := os.WriteFile(tomlPath, []byte(adopted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply after adopting: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustExist(t, label, path)
+	}
+}
+
+// TestApply_DeferralReclaimsPreviouslyProjectedFiles covers the upgrade path in
+// the other direction: a user who already applied (so the duplicates are on
+// disk) and then records the deferral must have those files REMOVED, not
+// orphaned. Leaving them would mean the fix adds nothing — the duplicate stays,
+// it just stops being refreshed.
+//
+// This is the ordinary orphan-reclamation path doing its job: a component that
+// stops rendering leaves no op, and apply reclaims the file it owns in state.
+func TestApply_DeferralReclaimsPreviouslyProjectedFiles(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	// No native marketplace/plugin in Claude's settings: register with agentsync
+	// directly so the first import seeds NO deferral and apply projects to claude.
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustExist(t, label, path)
+	}
+
+	// Now the user installs the plugin in Claude natively and records it.
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
+	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply after deferring: %v\n%s", err, out)
+	}
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustNotExist(t, label, path)
+	}
+}
+
+// TestApply_PluginAgentsAllowlistNarrowsFanOut covers the OTHER gate — the
+// `agents` allowlist that docs have advertised since v1.0 while nothing read it
+// (PluginSpec.Agents was written and preserved but never consulted, so a
+// narrowed allowlist silently fanned out to every agent anyway).
+func TestApply_PluginAgentsAllowlistNarrowsFanOut(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	narrowed := strings.ReplaceAll(mustReadFile(t, tomlPath), "agents = ['*']", "agents = ['codex']")
+	if err := os.WriteFile(tomlPath, []byte(narrowed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	for label, path := range claudeToolkitPaths(tmp) {
+		mustNotExist(t, label, path)
+	}
+	mustExist(t, "codex subagent", filepath.Join(tmp, ".codex", "agents", "toolkit-reviewer.toml"))
+}
+
+// TestApply_HandAuthoredComponentsIgnoreTheAllowlist pins the boundary: the two
+// gates are properties of PLUGIN installation, so a component the user wrote
+// into ~/.agentsync/ renders everywhere regardless of any plugin's targeting.
+// Without this, a filter keyed on the wrong field would quietly stop rendering
+// the user's own components.
+func TestApply_HandAuthoredComponentsIgnoreTheAllowlist(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+
+	// A hand-authored subagent, alongside a plugin deferred away from claude.
+	dir := filepath.Join(tmp, ".agentsync", "subagents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mine.md"),
+		[]byte("---\nname: mine\ndescription: mine\n---\nMy own agent.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+
+	mustExist(t, "hand-authored subagent", filepath.Join(tmp, ".claude", "agents", "mine.md"))
+	mustNotExist(t, "plugin subagent", claudeToolkitPaths(tmp)["subagent"])
+}
+
+// TestStatus_WarnsWhenAgentAlsoInstallsThePluginItself covers the case apply
+// structurally cannot: a plugin declared in agentsync (and projected to claude)
+// that the user LATER installs in Claude natively. apply's plan is a pure
+// function of canonical state and never probes the destination — deliberately,
+// so the same source renders the same way everywhere — which means the
+// resulting duplicate can only be noticed by a command that does read the
+// destination. status and doctor are those commands.
+func TestStatus_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	// Quiet while agentsync is the only source of the components.
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "projected there by agentsync") {
+		t.Errorf("status must not warn before the plugin is installed natively; got:\n%s", out)
+	}
+
+	// The user now installs the same plugin inside Claude Code.
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	out, err = runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "projected there by agentsync") || !strings.Contains(out, "native_agents") {
+		t.Errorf("status should warn about the duplicate and name the remedy; got:\n%s", out)
+	}
+
+	// Recording the deferral resolves it — and the warning goes away without any
+	// change to Claude's own config.
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
+	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "projected there by agentsync") {
+		t.Errorf("recording the deferral should clear the warning; got:\n%s", out)
+	}
+}

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -537,4 +537,69 @@ func TestDoctor_WarnsWhenAgentAlsoInstallsThePluginItself(t *testing.T) {
 	if !strings.Contains(out, "also projected by agentsync") || !strings.Contains(out, "native_agents") {
 		t.Errorf("doctor should report the duplicate and name the remedy; got:\n%s", out)
 	}
+
+	// Recording the deferral resolves it. Without this phase the test would pass
+	// for a doctor that warned unconditionally once any plugin was declared.
+	tomlPath := filepath.Join(tmp, ".agentsync", "plugins", "toolkit.toml")
+	deferred := mustReadFile(t, tomlPath) + "\nnative_agents = ['claude']\n"
+	if err := os.WriteFile(tomlPath, []byte(deferred), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = runCLI(t, env, "doctor")
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "also projected by agentsync") {
+		t.Errorf("recording the deferral should clear doctor's warning; got:\n%s", out)
+	}
+}
+
+// TestPluginExplain_ReportsDeferralRatherThanFailure pins the OTHER renderer of
+// a translation-report row. `plugin explain` has its own emit path, and it fell
+// through to the generic failure mark: a plugin the user had deliberately
+// deferred printed as a red "✗ native  no components" — indistinguishable from
+// an adapter that could not translate anything, and precisely the "why did this
+// render nothing?" confusion the row exists to answer.
+//
+// The wording lives on render.PluginRow.TargetingNote so the two renderers
+// cannot drift; this test is the end-to-end proof that the explain path uses it.
+func TestPluginExplain_ReportsDeferralRatherThanFailure(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
+		t.Fatalf("import claude:plugin: %v\n%s", err, out)
+	}
+
+	out, err := runCLI(t, env, "plugin", "explain", "toolkit")
+	if err != nil {
+		t.Fatalf("plugin explain: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "served natively") {
+		t.Errorf("explain should say WHY claude gets nothing; got:\n%s", out)
+	}
+	// The failure vocabulary must not appear for a deliberate deferral. "✗" is
+	// the adapter-could-not-translate mark; using it here is the bug.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "claude") && strings.Contains(line, "✗") {
+			t.Errorf("a deferred agent was reported as a failure: %q", line)
+		}
+	}
+	// Codex still receives the plugin, so its row is an ordinary coverage row —
+	// the positive control that explain did not simply stop reporting.
+	if !strings.Contains(out, "codex") {
+		t.Errorf("explain should still report the agents that DO receive the plugin; got:\n%s", out)
+	}
+
+	// The --json contract carries the machine-readable form of the same fact.
+	jsonOut, err := runCLI(t, env, "plugin", "explain", "toolkit", "--json")
+	if err != nil {
+		t.Fatalf("plugin explain --json: %v\n%s", err, jsonOut)
+	}
+	if !strings.Contains(jsonOut, `"notTargeted": true`) || !strings.Contains(jsonOut, `"coverage": "native"`) {
+		t.Errorf("--json should expose notTargeted + the native coverage value; got:\n%s", jsonOut)
+	}
 }

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -727,4 +727,32 @@ func TestProjectScope_NativeAgentsIsHonoured(t *testing.T) {
 		t.Fatalf("project apply after deferring: %v\n%s", err, out)
 	}
 	mustNotExist(t, "project-scope plugin subagent", projected)
+
+	// The two pins now DIVERGE: the project defers to claude, the user pin does
+	// not. project.Merge never overlays Plugins, so a duplicate check reading the
+	// merged canonical sees the USER pin while the render above honoured the
+	// PROJECT one — warning about a duplicate this repo does not have. status at
+	// project scope must read what project scope renders from.
+	writeClaudeSettings(t, tmpHome, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+	out, err := runCLI(t, env, "status", "--scope", "project", "--project", proj)
+	if err != nil {
+		t.Fatalf("project status: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "projected there by agentsync") {
+		t.Errorf("project scope defers to claude, so status must not report a duplicate; got:\n%s", out)
+	}
+
+	// And the converse: drop the PROJECT deferral, and the duplicate is real
+	// again — proving the assertion above is about the pin, not about status
+	// having quietly stopped reporting.
+	if err := os.WriteFile(projPin, []byte(pin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = runCLI(t, env, "status", "--scope", "project", "--project", proj)
+	if err != nil {
+		t.Fatalf("project status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "projected there by agentsync") {
+		t.Errorf("with no project deferral the duplicate is real; status should say so; got:\n%s", out)
+	}
 }

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -86,6 +86,15 @@ func duplicatedNativePlugins(c source.Canonical, reg *adapter.Registry, agents [
 	}
 	out := map[string][]untrusted.Text{}
 	for _, name := range agents {
+		// The claim this report makes is about agentsync's OWN projection, so an
+		// agent agentsync does not render to cannot be duplicating anything —
+		// however its native config looks. Checked HERE rather than left to the
+		// caller: `status` passes its selected set but `doctor` passes every
+		// registered adapter, and the difference produced a warning telling users
+		// to uninstall a plugin from an agent agentsync never touches.
+		if !c.Config.Agents[name].Enabled {
+			continue
+		}
 		pi, ok := reg.Lookup(name).(adapter.PluginIngester)
 		if !ok {
 			continue

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -29,9 +29,10 @@ import (
 // means "no plugins discovered", never a failed import.
 func nativePluginOwners(reg *adapter.Registry) map[string][]string {
 	out := map[string][]string{}
-	names := reg.Names()
-	sort.Strings(names)
-	for _, agentName := range names {
+	// reg.Names() is already sorted, so the owner lists this builds are stable
+	// without re-sorting — and stability matters: the list is written into
+	// plugins/<id>.toml, which is usually a committed dotfiles repo.
+	for _, agentName := range reg.Names() {
 		pi, ok := reg.Lookup(agentName).(adapter.PluginIngester)
 		if !ok {
 			continue
@@ -45,6 +46,9 @@ func nativePluginOwners(reg *adapter.Registry) map[string][]string {
 				continue
 			}
 			key := pl.Name.Unverified()
+			// Dedupe by AGENT: one agent can report the same plugin name from
+			// two marketplaces, and `native_agents = ["claude","claude"]` would
+			// be written into a committed file.
 			if !slices.Contains(out[key], agentName) {
 				out[key] = append(out[key], agentName)
 			}

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -1,12 +1,123 @@
 package cli
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/untrusted"
 )
+
+// nativePluginOwners maps a plugin NAME to the agents whose own plugin manager
+// already has it enabled. It is the input to `native_agents`: an agent that
+// installs a plugin itself must not also receive agentsync's projection of that
+// plugin's components, or every skill/subagent/command lands twice and every
+// hook fires twice (the agent serves its own copy from its install dir, which
+// agentsync neither writes nor reads).
+//
+// Every registered PluginIngester is probed, not just the agent being imported
+// from: a plugin can be installed natively in several harnesses, and each of
+// them needs its own deferral. Agents that are not currently enabled in
+// agentsync are probed too — excluding one costs nothing today and is already
+// correct if the user enables it later.
+//
+// Matching is by NAME (the plugins/<id>.toml stem), mirroring
+// undeclaredNativePlugins: the marketplace id an agent records natively can
+// differ from the declared marketplace name agentsync keys its file on. A
+// discovery error is skipped silently — a missing or malformed native config
+// means "no plugins discovered", never a failed import.
+func nativePluginOwners(reg *adapter.Registry) map[string][]string {
+	out := map[string][]string{}
+	names := reg.Names()
+	sort.Strings(names)
+	for _, agentName := range names {
+		pi, ok := reg.Lookup(agentName).(adapter.PluginIngester)
+		if !ok {
+			continue
+		}
+		_, plugins, err := pi.IngestPlugins(adapter.ScopeUser, "")
+		if err != nil {
+			continue
+		}
+		for _, pl := range plugins {
+			if !pl.Enabled {
+				continue
+			}
+			key := pl.Name.Unverified()
+			if !slices.Contains(out[key], agentName) {
+				out[key] = append(out[key], agentName)
+			}
+		}
+	}
+	return out
+}
+
+// duplicatedNativePlugins reports, per agent, the declared plugins that agent
+// installs ITSELF and that agentsync also projects to it — the duplicate: every
+// skill, subagent, and command lands twice (once from the agent's own install
+// dir, once from agentsync's projection into the agent's standalone paths) and
+// every hook handler fires twice.
+//
+// It is the counterpart to undeclaredNativePlugins, and the safety net for a
+// deliberate design choice: apply's output is a pure function of canonical state
+// and never probes the destination, so a plugin installed natively AFTER it was
+// declared in agentsync cannot be noticed at apply time. `import` seeds
+// `native_agents` for what exists at import time; this catches everything after.
+//
+// A plugin is duplicated for an agent when all of:
+//   - the agent's native config has it enabled (matched by NAME, the
+//     plugins/<id>.toml stem, as in undeclaredNativePlugins);
+//   - the canonical source declares it and it is not disabled;
+//   - agentsync projects it to this agent — i.e. the `agents` allowlist targets
+//     the agent and `native_agents` does NOT already defer to it.
+//
+// Read-only and best-effort: a discovery error is skipped, never surfaced as a
+// failure, exactly like the sibling nudge.
+func duplicatedNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]untrusted.Text {
+	declared := make(map[string]source.PluginSpec, len(c.Plugins))
+	for _, pl := range c.Plugins {
+		if !pl.Plugin.Disabled {
+			declared[pl.ID.Unverified()] = pl.Plugin
+		}
+	}
+	if len(declared) == 0 {
+		return nil
+	}
+	out := map[string][]untrusted.Text{}
+	for _, name := range agents {
+		pi, ok := reg.Lookup(name).(adapter.PluginIngester)
+		if !ok {
+			continue
+		}
+		_, plugins, err := pi.IngestPlugins(adapter.ScopeUser, "")
+		if err != nil {
+			continue
+		}
+		var dupes []untrusted.Text
+		seen := map[string]bool{}
+		for _, pl := range plugins {
+			key := pl.Name.Unverified()
+			spec, isDeclared := declared[key]
+			if !pl.Enabled || !isDeclared || seen[key] {
+				continue
+			}
+			// The plugin id is non-empty by construction here (it keys a declared
+			// plugins/<id>.toml), so this asks the real question: does agentsync
+			// project this plugin to this agent?
+			if !source.PluginTargetsAgent(key, spec.Agents, spec.NativeAgents, name) {
+				continue
+			}
+			seen[key] = true
+			dupes = append(dupes, pl.Name)
+		}
+		if len(dupes) > 0 {
+			sort.Slice(dupes, func(i, j int) bool { return dupes[i] < dupes[j] })
+			out[name] = dupes
+		}
+	}
+	return out
+}
 
 // undeclaredNativePlugins reports, per agent, the plugins enabled in that
 // agent's native config that are NOT declared in the canonical source — a

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -105,7 +105,7 @@ func duplicatedNativePlugins(c source.Canonical, reg *adapter.Registry, agents [
 			// The plugin id is non-empty by construction here (it keys a declared
 			// plugins/<id>.toml), so this asks the real question: does agentsync
 			// project this plugin to this agent?
-			if !source.PluginTargetsAgent(key, spec.Agents, spec.NativeAgents, name) {
+			if !source.PluginTargetsAgent(key, spec.Agents, spec.DeferredAgents(), name) {
 				continue
 			}
 			seen[key] = true

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+	"github.com/spxrogers/agentsync/internal/untrusted"
+)
+
+// fakeIngester is a minimal PluginIngester reporting one plugin, enabled or not.
+// Driving the real adapters would need a whole native config on disk per case;
+// this isolates the gate logic, which is what these tests are about. The
+// embedded adapter.Adapter is nil — only Name() and IngestPlugins are called.
+type fakeIngester struct {
+	adapter.Adapter
+	name    string
+	enabled bool
+}
+
+func (f *fakeIngester) Name() string { return f.name }
+
+func (f *fakeIngester) IngestPlugins(adapter.Scope, string) ([]adapter.NativeMarketplace, []adapter.NativePlugin, error) {
+	return nil, []adapter.NativePlugin{{
+		Name: untrusted.Wrap("toolkit"), MarketplaceID: "mp", Enabled: f.enabled,
+	}}, nil
+}
+
+// TestDuplicatedNativePlugins covers every gate deciding whether a plugin is
+// reported as installed-in-an-agent AND projected there. Each gate is a way to
+// produce a FALSE warning — telling a user to uninstall a plugin from an agent
+// where nothing is duplicated — and removing any of them was green under
+// mutation before this test existed.
+//
+// The agent-enabled gate is the one that bit in practice: `status` passes its
+// selected set, but `doctor` passes EVERY registered adapter, so with the check
+// left to the caller doctor warned about agents agentsync does not render to at
+// all, and told the user to uninstall working functionality.
+func TestDuplicatedNativePlugins(t *testing.T) {
+	testenv.RequireContainer(t)
+	claudeOnly := []string{"claude"}
+	cases := []struct {
+		name        string
+		agentOn     bool
+		nativelyOn  bool
+		declared    bool
+		pluginOff   bool
+		nativeAgent *[]string
+		wantWarn    bool
+	}{
+		{name: "installed natively and projected — the duplicate", agentOn: true, nativelyOn: true, declared: true, wantWarn: true},
+		{name: "agent not enabled in agentsync — nothing is projected there", agentOn: false, nativelyOn: true, declared: true},
+		{name: "not installed natively — there is no second copy", agentOn: true, nativelyOn: false, declared: true},
+		{name: "not declared in agentsync — that is the UNDECLARED nudge, not this one", agentOn: true, nativelyOn: true},
+		{name: "plugin disabled in agentsync — it projects nothing anywhere", agentOn: true, nativelyOn: true, declared: true, pluginOff: true},
+		{name: "already deferred — that is the remedy, not the problem", agentOn: true, nativelyOn: true, declared: true, nativeAgent: &claudeOnly},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := source.Canonical{Config: source.Config{
+				Agents: map[string]source.Agent{"claude": {Enabled: tc.agentOn}},
+			}}
+			if tc.declared {
+				c.Plugins = []source.Plugin{{
+					ID: untrusted.Wrap("toolkit"),
+					Plugin: source.PluginSpec{
+						ID:           untrusted.Wrap("toolkit@mp"),
+						Agents:       []string{"*"},
+						NativeAgents: tc.nativeAgent,
+						Disabled:     tc.pluginOff,
+					},
+				}}
+			}
+			reg := adapter.NewRegistry()
+			if err := reg.Register(&fakeIngester{name: "claude", enabled: tc.nativelyOn}); err != nil {
+				t.Fatal(err)
+			}
+			got := duplicatedNativePlugins(c, reg, []string{"claude"})
+			if warned := len(got["claude"]) > 0; warned != tc.wantWarn {
+				t.Errorf("warned = %v, want %v (got %v)", warned, tc.wantWarn, got)
+			}
+		})
+	}
+}
+
+// TestNativePluginOwners_ProbesEveryIngester pins the breadth of the probe that
+// seeds `native_agents`. Restricting it to the agent being imported FROM passed
+// the entire suite: no fixture installs one plugin natively in two harnesses,
+// which is exactly the case the breadth exists for. A plugin installed in both
+// Claude and Codex needs BOTH deferrals — recording only the one you imported
+// from leaves the other duplicating silently.
+func TestNativePluginOwners_ProbesEveryIngester(t *testing.T) {
+	testenv.RequireContainer(t)
+	reg := adapter.NewRegistry()
+	for _, f := range []*fakeIngester{
+		{name: "claude", enabled: true},
+		{name: "codex", enabled: true},
+		{name: "opencode", enabled: false}, // an ingester that does NOT have it
+	} {
+		if err := reg.Register(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := nativePluginOwners(reg)["toolkit"]
+	if len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
+		t.Fatalf("owners = %v, want both harnesses that install it natively [claude codex]", got)
+	}
+}

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -17,14 +17,24 @@ type fakeIngester struct {
 	adapter.Adapter
 	name    string
 	enabled bool
+	// alsoNative are extra plugins this agent installs natively, used to reach
+	// the per-plugin gates: with only ONE plugin, an "undeclared" case exits at
+	// the len(declared)==0 short-circuit and never reaches them.
+	alsoNative []string
 }
 
 func (f *fakeIngester) Name() string { return f.name }
 
 func (f *fakeIngester) IngestPlugins(adapter.Scope, string) ([]adapter.NativeMarketplace, []adapter.NativePlugin, error) {
-	return nil, []adapter.NativePlugin{{
+	out := []adapter.NativePlugin{{
 		Name: untrusted.Wrap("toolkit"), MarketplaceID: "mp", Enabled: f.enabled,
-	}}, nil
+	}}
+	for _, extra := range f.alsoNative {
+		out = append(out, adapter.NativePlugin{
+			Name: untrusted.Wrap(extra), MarketplaceID: "mp", Enabled: true,
+		})
+	}
+	return nil, out, nil
 }
 
 // TestDuplicatedNativePlugins covers every gate deciding whether a plugin is
@@ -81,6 +91,36 @@ func TestDuplicatedNativePlugins(t *testing.T) {
 				t.Errorf("warned = %v, want %v (got %v)", warned, tc.wantWarn, got)
 			}
 		})
+	}
+}
+
+// TestDuplicatedNativePlugins_IgnoresUndeclaredPlugins reaches the per-plugin
+// "is this declared in agentsync?" gate, which the matrix above cannot: with a
+// single undeclared plugin the function short-circuits on an empty declared set
+// long before that gate, so removing it stayed green.
+//
+// A plugin agentsync does not manage is the UNDECLARED nudge's business ("you
+// could import this"), never this warning's — claiming agentsync duplicates a
+// plugin it has never heard of, and telling the user to uninstall it, is the
+// same false "uninstall this" advice the agent-enabled gate produced.
+func TestDuplicatedNativePlugins_IgnoresUndeclaredPlugins(t *testing.T) {
+	testenv.RequireContainer(t)
+	c := source.Canonical{
+		Config: source.Config{Agents: map[string]source.Agent{"claude": {Enabled: true}}},
+		Plugins: []source.Plugin{{
+			ID:     untrusted.Wrap("toolkit"),
+			Plugin: source.PluginSpec{ID: untrusted.Wrap("toolkit@mp"), Agents: []string{"*"}},
+		}},
+	}
+	reg := adapter.NewRegistry()
+	// claude installs the declared plugin AND a foreign one agentsync knows
+	// nothing about.
+	if err := reg.Register(&fakeIngester{name: "claude", enabled: true, alsoNative: []string{"foreign"}}); err != nil {
+		t.Fatal(err)
+	}
+	got := duplicatedNativePlugins(c, reg, []string{"claude"})["claude"]
+	if len(got) != 1 || got[0].Unverified() != "toolkit" {
+		t.Fatalf("only the DECLARED plugin duplicates; got %v", got)
 	}
 }
 

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -124,6 +124,24 @@ func TestDuplicatedNativePlugins_IgnoresUndeclaredPlugins(t *testing.T) {
 	}
 }
 
+// TestNativePluginOwners_DedupesPerAgent pins the dedupe. One agent can report
+// the same plugin NAME from two marketplaces, and the result is written into
+// plugins/<id>.toml — usually a committed dotfiles repo — so a duplicated entry
+// (`native_agents = ["claude","claude"]`) would be committed and shown back to
+// the user on every subsequent install summary.
+func TestNativePluginOwners_DedupesPerAgent(t *testing.T) {
+	testenv.RequireContainer(t)
+	reg := adapter.NewRegistry()
+	// alsoNative repeats "toolkit", i.e. the same plugin name a second time from
+	// this one agent — what two marketplaces carrying the same name looks like.
+	if err := reg.Register(&fakeIngester{name: "claude", enabled: true, alsoNative: []string{"toolkit"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nativePluginOwners(reg)["toolkit"]; len(got) != 1 {
+		t.Fatalf("owners = %v, want one entry per AGENT", got)
+	}
+}
+
 // TestNativePluginOwners_ProbesEveryIngester pins the breadth of the probe that
 // seeds `native_agents`. Restricting it to the agent being imported FROM passed
 // the entire suite: no fixture installs one plugin natively in two harnesses,

--- a/internal/cli/plugin_drift_test.go
+++ b/internal/cli/plugin_drift_test.go
@@ -77,7 +77,7 @@ func TestDoctor_PluginsOKWhenNoneInstalled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doctor: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "no undeclared native plugins") {
+	if !strings.Contains(out, "no undeclared or duplicated native plugins") {
 		t.Fatalf("doctor should report a clean plugin state; got:\n%s", out)
 	}
 }

--- a/internal/cli/plugin_explain.go
+++ b/internal/cli/plugin_explain.go
@@ -275,6 +275,16 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 			// shows "(disabled)", so this row would just duplicate that.
 			continue
 		}
+		// A row that rendered nothing by CONFIGURATION is not a failure, and must
+		// not print like one: falling through to the generic mark rendered a
+		// deliberately deferred plugin as a red "✗ native  no components", which
+		// reads as the very "why did this render nothing?" confusion the row
+		// exists to answer. render owns the wording (PluginRow.TargetingNote) so
+		// this site and the translation report cannot drift.
+		if note := row.TargetingNote(); note != "" {
+			fmt.Fprintf(w, "  %s %s\n", p.Bold(ui.Pad(row.Agent, 10)), p.Faint(note))
+			continue
+		}
 		glyph, color := coverageGlyphAndColor(p, row.Coverage)
 		// Column order matches apply's translation report: agent name (bold
 		// padded), then the colored "<glyph> <coverage>" mark (padded plain
@@ -440,9 +450,9 @@ func skipLabel(s render.SkipDetail) string {
 // helper (matches the existing translation-report vocabulary).
 func coverageGlyphAndColor(p *ui.Printer, cov string) (string, func(string) string) {
 	switch cov {
-	case "full":
+	case render.CoverageFull:
 		return ui.GlyphOK, p.Green
-	case "partial":
+	case render.CoveragePartial:
 		return ui.GlyphPartial, p.Yellow
 	default:
 		return ui.GlyphErr, p.Red

--- a/internal/cli/plugin_explain.go
+++ b/internal/cli/plugin_explain.go
@@ -282,7 +282,10 @@ func emitReportBody(w io.Writer, p *ui.Printer, r render.TranslationReport) {
 		// exists to answer. render owns the wording (PluginRow.TargetingNote) so
 		// this site and the translation report cannot drift.
 		if note := row.TargetingNote(); note != "" {
-			fmt.Fprintf(w, "  %s %s\n", p.Bold(ui.Pad(row.Agent, 10)), p.Faint(note))
+			// Same leading arrow + column widths as an ordinary row, so a
+			// deferred agent lines up with its siblings instead of hanging two
+			// columns left.
+			fmt.Fprintf(w, "  %s %s  %s\n", p.Faint(ui.GlyphArrow), p.Bold(ui.Pad(row.Agent, 10)), p.Faint(note))
 			continue
 		}
 		glyph, color := coverageGlyphAndColor(p, row.Coverage)

--- a/internal/cli/plugin_namespace_test.go
+++ b/internal/cli/plugin_namespace_test.go
@@ -54,6 +54,30 @@ func makeCollidingMarketplace(t *testing.T, dir string) string {
 	return mpDir
 }
 
+// installPluginsViaAgentsync registers a local marketplace and its plugins
+// through agentsync itself, rather than importing them out of an agent's native
+// config.
+//
+// The distinction matters since the `native_agents` deferral landed: a plugin
+// imported FROM an agent is recorded as served natively BY that agent, so apply
+// deliberately projects none of its components there (that projection was the
+// duplicate — Claude keeps loading its own copy from its install dir). These
+// tests are about NAMESPACING, and they observe it in Claude's destination, so
+// they need a plugin agentsync actually owns for Claude. Installing it directly
+// is the honest setup for that: no native copy exists, so nothing is deferred.
+// The deferral itself is covered end to end in plugin_agents_test.go.
+func installPluginsViaAgentsync(t *testing.T, env map[string]string, mpDir string, plugins ...string) {
+	t.Helper()
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	for _, p := range plugins {
+		if out, err := runCLI(t, env, "plugin", "add", p); err != nil {
+			t.Fatalf("plugin add %s: %v\n%s", p, err, out)
+		}
+	}
+}
+
 // TestApply_CrossPluginCollisionsNamespaceApart is the end-to-end regression for
 // issue #211: two installed plugins each shipping a same-named component made
 // `status` and `apply` exit 1, and every remedy the error named was one the user
@@ -75,13 +99,7 @@ func TestApply_CrossPluginCollisionsNamespaceApart(t *testing.T) {
 		t.Fatalf("agent add codex: %v", err)
 	}
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings(
-		"official-mp", mpDir, "feature-dev", "pr-review-toolkit",
-	))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev", "pr-review-toolkit")
 	// The pre-fix failure was here: `status` exited 1 with "codex subagents
 	// \"code-reviewer\" and \"code-reviewer\" resolve to the same agent name".
 	if out, err := runCLI(t, env, "status"); err != nil {
@@ -149,11 +167,7 @@ func TestApply_CrossPluginCollisionsNamespaceApart(t *testing.T) {
 func TestApply_HandAuthoredComponentKeepsBareName(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	// A hand-authored subagent whose name matches what the plugin ships.
 	srcDir := filepath.Join(tmp, ".agentsync", "subagents")
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
@@ -195,11 +209,7 @@ func TestApply_HandAuthoredComponentKeepsBareName(t *testing.T) {
 func TestImport_SkipsPluginProvidedComponents(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -244,13 +254,9 @@ func TestImport_SkipsPluginProvidedComponents(t *testing.T) {
 // plugin-provided component says why rather than silently importing nothing. The
 // user asked for that exact component; "no output" would read as a bug.
 func TestImport_NamedPluginComponentIsAnError(t *testing.T) {
-	tmp, env := importTestEnv(t)
+	_, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -272,11 +278,7 @@ func TestImport_NamedPluginComponentIsAnError(t *testing.T) {
 func TestImport_StillCapturesHandAuthoredAlongsidePlugins(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -311,11 +313,7 @@ func TestImport_StillCapturesHandAuthoredAlongsidePlugins(t *testing.T) {
 func TestReconcile_WriteBackRefusesPluginProvidedComponent(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -389,10 +387,7 @@ func TestApply_NamespacingMigrationReclaimsPreRenameFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("post-rename apply: %v\n%s", err, out)
 	}
@@ -415,11 +410,7 @@ func TestApply_NamespacingMigrationReclaimsPreRenameFiles(t *testing.T) {
 func TestReconcile_WriteBackRefusesPluginSkillBundledFile(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeBundledSkillMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("bundle-mp", mpDir, "bundler"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "bundler")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -494,16 +485,17 @@ func TestProjectScope_PluginNamespacingAndImportFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Install the plugin at USER scope — `import claude:plugin` is user-scope
-	// only, since a plugin is a user-scope concept across every supported
-	// harness — then commit its plugins/<id>.toml into the PROJECT tree. That is
-	// how a project tree actually declares a plugin: the pin travels with the
-	// repo while the fetched cache stays under the user home.
+	// Install the plugin at USER scope — a plugin is a user-scope concept across
+	// every supported harness — then commit its plugins/<id>.toml into the
+	// PROJECT tree. That is how a project tree actually declares a plugin: the
+	// pin travels with the repo while the fetched cache stays under the user
+	// home. (Acquired through agentsync rather than imported out of Claude's
+	// native config, so no `native_agents` deferral is seeded — this test
+	// observes agentsync's own projection in Claude's project destination. Note
+	// the deferral WOULD travel with the pin, which is the intended behavior:
+	// committing a pin commits the statement that Claude serves it natively.)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmpHome, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("user plugin import: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	pin, err := os.ReadFile(filepath.Join(tmpHome, ".agentsync", "plugins", "feature-dev.toml"))
 	if err != nil {
 		t.Fatalf("the user-scope plugin pin should exist: %v", err)
@@ -610,13 +602,9 @@ func TestProjectScope_UserPluginDoesNotShadowProjectComponent(t *testing.T) {
 // "would import" would be worse than useless — it would advertise a capture the
 // real import refuses.
 func TestImport_DryRunSkipsPluginProvidedComponents(t *testing.T) {
-	tmp, env := importTestEnv(t)
+	_, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -672,11 +660,7 @@ func makeServerMarketplace(t *testing.T, dir string) string {
 func TestImport_SkipsPluginProvidedMCPServer(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -703,11 +687,7 @@ func TestImport_SkipsPluginProvidedMCPServer(t *testing.T) {
 func TestImport_SkipsPluginHooksButKeepsYourOwn(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 	// A hand-written handler on the SAME event the plugin contributes to.
 	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
 	if err := os.MkdirAll(hooksSrc, 0o755); err != nil {
@@ -751,11 +731,7 @@ func TestImport_SkipsPluginHooksButKeepsYourOwn(t *testing.T) {
 func TestImport_FailsClosedWhenPluginProjectionFails(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeCollidingMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("official-mp", mpDir, "feature-dev"))
-
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "feature-dev")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -837,10 +813,7 @@ func TestReconcile_HookWriteBackIsRefused(t *testing.T) {
 func TestImport_HookFilterKeysOnFullContent(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 	// SAME event AND SAME matcher as the plugin's handler (PreToolUse / Bash),
 	// differing only in the command.
 	hooksSrc := filepath.Join(tmp, ".agentsync", "hooks")
@@ -877,12 +850,9 @@ func TestImport_HookFilterKeysOnFullContent(t *testing.T) {
 // NAMED hook import matches only plugin-provided handlers: it errors, rather than
 // reporting a successful import of nothing.
 func TestImport_NamedHookEventAllPluginProvided(t *testing.T) {
-	tmp, env := importTestEnv(t)
+	_, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 	if out, err := runCLI(t, env, "apply"); err != nil {
 		t.Fatalf("apply: %v\n%s", err, out)
 	}
@@ -946,10 +916,7 @@ func TestReconcile_OrphanPromptSaysAutoReclaimKindsAreTemporary(t *testing.T) {
 func TestImport_PluginIdenticalHookDoesNotEraseYourOwn(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 
 	// The user's own handler, BYTE-IDENTICAL to what the plugin ships
 	// (PreToolUse / Bash / plugin-guard), plus a second one that is theirs alone
@@ -1057,10 +1024,7 @@ func TestApply_ReclaimsRetiredSubagentSourceID(t *testing.T) {
 func TestImport_CoDeclaredMCPServerStaysRefused(t *testing.T) {
 	tmp, env := importTestEnv(t)
 	mpDir := makeServerMarketplace(t, t.TempDir())
-	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("srv-mp", mpDir, "srv"))
-	if out, err := runCLI(t, env, "import", "claude:plugin"); err != nil {
-		t.Fatalf("import claude:plugin: %v\n%s", err, out)
-	}
+	installPluginsViaAgentsync(t, env, mpDir, "srv")
 	// The user declares the SAME server id, byte-identical to the plugin's, so
 	// checkProjectedConflicts is happy and both coexist in the projection.
 	mcpDir := filepath.Join(tmp, ".agentsync", "mcp")

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -548,6 +548,17 @@ func entryIsLossy(home, id string, mpEntry marketplace.PluginEntry, mpCacheRoot 
 // lossiness decision faithful to what apply will actually render. Skips are
 // structural (independent of resolved secret values), so the templated render
 // is sufficient and no secrets backend is required.
+//
+// KNOWN GAP: the mini canonical is built from raw marketplace.Project output,
+// which is NOT stamped with plugin provenance (that happens in
+// namespaceProjected, on the loadprojected path). So every component here has an
+// empty Plugin, source.PluginTargetsAgent returns true, and render.Plan's
+// per-agent narrowing is a no-op — meaning this probe can report an upgrade as
+// lossy because of a skip on an agent the plugin's `agents` / `native_agents`
+// exclude. It is advisory only (it gates a warning, never a write), and closing
+// it means threading the plugin's two targeting lists down from entryIsLossy's
+// callers. Deliberately deferred; fix it there rather than by re-deriving the
+// gates here, which would be a second place they can drift.
 func projectedSkips(entry marketplace.PluginEntry, cacheDir string, cfg source.Config, reg *adapter.Registry, agents []string, userHome string) (map[string]bool, error) {
 	proj, err := marketplace.Project(entry, cacheDir)
 	if err != nil {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -24,7 +24,11 @@ type pluginTOMLFixture struct {
 		ManifestSHA string   `toml:"manifest_sha"`
 		Update      string   `toml:"update"`
 		Agents      []string `toml:"agents"`
-		Disabled    bool     `toml:"disabled"`
+		// A POINTER, mirroring the production spec: this fixture exists to read
+		// the real artifact, so it must be able to tell "no key" from
+		// "native_agents = []" — the distinction the pointer exists for.
+		NativeAgents *[]string `toml:"native_agents"`
+		Disabled     bool      `toml:"disabled"`
 	} `toml:"plugin"`
 }
 
@@ -837,6 +841,7 @@ version = "0.0.0-stale"
 manifest_sha = "deadbeefstale"
 update = "manual"
 agents = ["claude"]
+native_agents = ["codex"]
 disabled = true
 `)
 
@@ -849,6 +854,16 @@ disabled = true
 	after := readPluginTOMLFixture(t, pluginPath)
 	if !equalStrings(after.Plugin.Agents, []string{"claude"}) {
 		t.Errorf("re-install reset the allowlist on disk: got agents=%v, want [claude]", after.Plugin.Agents)
+	}
+	// native_agents is preserved for the same reason as the allowlist, and its
+	// loss is worse: re-seeding it from what the AGENT currently installs would
+	// silently stop projecting a plugin to an agent the user had adopted. A
+	// POPULATED list needs its own assertion — an implementation that preserved
+	// only the empty list would satisfy every other check here.
+	if after.Plugin.NativeAgents == nil {
+		t.Errorf("re-install dropped native_agents entirely")
+	} else if !equalStrings(*after.Plugin.NativeAgents, []string{"codex"}) {
+		t.Errorf("re-install reset native_agents on disk: got %v, want [codex]", *after.Plugin.NativeAgents)
 	}
 	if after.Plugin.Update != "manual" {
 		t.Errorf("re-install reset update on disk: got %q, want manual", after.Plugin.Update)
@@ -874,6 +889,9 @@ disabled = true
 	}
 	if !strings.Contains(out, "agents=[claude]") {
 		t.Errorf("re-install output did not surface the kept allowlist: %q", out)
+	}
+	if !strings.Contains(out, "native_agents=[codex]") {
+		t.Errorf("re-install output did not surface the kept deferral: %q", out)
 	}
 	if !strings.Contains(out, "update=manual") {
 		t.Errorf("re-install output did not surface the kept update mode: %q", out)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -135,11 +135,11 @@ func newStatusCmd() *cobra.Command {
 			}
 			if len(selected) == 0 {
 				if jsonOut {
-					emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
+					emitStatusWarnings(p, c, reg, s, enabledAgents, selected, sc)
 					return emitJSON(p.Out, statusModel{Agents: []statusAgent{}, Summary: map[string]int{}})
 				}
 				fmt.Fprintln(p.Out, noAgentsEnabledHint(sc, projectRoot))
-				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
+				emitStatusWarnings(p, c, reg, s, enabledAgents, selected, sc)
 				return nil
 			}
 			// apply WRITES (and RecordOpsState HASHES) the secret-RESOLVED
@@ -166,13 +166,13 @@ func newStatusCmd() *cobra.Command {
 				// machine-readable payload cleanly parseable. The --json payload
 				// is never collapsed: it carries every tracked item so scripts
 				// see the same per-file model regardless of the human view.
-				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
+				emitStatusWarnings(p, c, reg, s, enabledAgents, selected, sc)
 				if err := emitJSON(p.Out, model); err != nil {
 					return err
 				}
 			} else {
 				renderStatusText(p, model, statusVerbose(cmd))
-				emitStatusWarnings(p, c, reg, s, enabledAgents, selected)
+				emitStatusWarnings(p, c, reg, s, enabledAgents, selected, sc)
 			}
 			// --exit-code turns status into a CI gate: a non-zero (documented,
 			// stable) exit when any item is not clean/converged, exit 0 when the
@@ -660,7 +660,7 @@ func renderStatusLegend(p *ui.Printer, summary map[string]int) {
 // never mistakes a deselected-but-enabled agent for an orphan; the
 // undeclared-plugin nudge follows the selected set so it stays scoped to what
 // the report shows.
-func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, enabled, selected []string) {
+func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry, s *state.Targets, enabled, selected []string, sc adapter.Scope) {
 	for _, a := range orphanedStateAgents(s, enabled) {
 		p.Warnf("agent %q is not enabled but still owns tracked files/keys in state; its "+
 			"native config is orphaned. Run `agentsync agent disable %q --purge` to remove what agentsync wrote.", a, a)
@@ -686,7 +686,14 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// also projects there, so every component lands twice. apply never reads the
 	// destination (its plan is a pure function of canonical state), so this is
 	// the only place the collision can be noticed once the plugin is declared.
-	duplicated := duplicatedNativePlugins(c, reg, selected)
+	// SCOPED, unlike the nudge above. project.Merge does not overlay Plugins, so
+	// the merged canonical carries the USER pins while a project-scope render
+	// honours the PROJECT ones — reading the wrong pin's `native_agents` here
+	// warns about a duplicate the project does not have, and stays silent about
+	// one it does. reportCanonical is the existing answer to exactly this
+	// mismatch. (The undeclared nudge above is correctly unscoped: "is this
+	// declared anywhere in my source" is a question about the merged view.)
+	duplicated := duplicatedNativePlugins(reportCanonical(c, sc), reg, selected)
 	for _, name := range reg.Names() {
 		dupes := duplicated[name]
 		if len(dupes) == 0 {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -682,6 +682,22 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 			"run `agentsync import %s:plugin` to manage them.",
 			len(missing), name, untrusted.Join(missing, ", "), name)
 	}
+	// Warn: the reverse case — a plugin the agent installs ITSELF that agentsync
+	// also projects there, so every component lands twice. apply never reads the
+	// destination (its plan is a pure function of canonical state), so this is
+	// the only place the collision can be noticed once the plugin is declared.
+	duplicated := duplicatedNativePlugins(c, reg, selected)
+	for _, name := range reg.Names() {
+		dupes := duplicated[name]
+		if len(dupes) == 0 {
+			continue
+		}
+		p.Warnf("%d plugin(s) are installed in %s AND projected there by agentsync (%s), "+
+			"so their skills/subagents/commands land twice and their hooks fire twice. "+
+			"Either uninstall them in %s, or add %q to `native_agents` in plugins/<id>.toml "+
+			"to let %s keep serving them itself.",
+			len(dupes), name, untrusted.Join(dupes, ", "), name, name, name)
+	}
 }
 
 // orphanedStateAgents returns, sorted, the agent names that appear as a state

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -85,6 +85,18 @@ var upgradeNotices = []upgradeNotice{
 		},
 		Path: "/reference/upgrading/",
 	},
+	{
+		ID:       "0.11.0-plugin-native-agents",
+		Since:    "0.11.0",
+		Headline: "a plugin an agent installs itself is no longer projected into that agent",
+		Actions: []string{
+			"plugins/<id>.toml gains `native_agents` — agents whose own plugin manager installs the plugin, so apply skips them",
+			"`agents` in plugins/<id>.toml now actually narrows fan-out; it was documented but never read, so a narrowed list had no effect",
+			"EXISTING installs are unchanged until you act: re-run `agentsync import <agent>:plugin` to record the deferral, or add `native_agents` by hand",
+			"`status` / `doctor` now warn when a plugin is installed in an agent AND projected there — that pair is the duplicate",
+		},
+		Path: "/reference/upgrading/",
+	},
 }
 
 // maybePrintUpgradeNotice shows, at most once per machine, the notices a user

--- a/internal/cli/upgrade_notice.go
+++ b/internal/cli/upgrade_notice.go
@@ -92,7 +92,7 @@ var upgradeNotices = []upgradeNotice{
 		Actions: []string{
 			"plugins/<id>.toml gains `native_agents` — agents whose own plugin manager installs the plugin, so apply skips them",
 			"`agents` in plugins/<id>.toml now actually narrows fan-out; it was documented but never read, so a narrowed list had no effect",
-			"EXISTING installs are unchanged until you act: re-run `agentsync import <agent>:plugin` to record the deferral, or add `native_agents` by hand",
+			"EXISTING installs are unchanged until you act: re-run `agentsync import <agent>:plugin` — it now ASKS per plugin — or add `native_agents` by hand",
 			"`status` / `doctor` now warn when a plugin is installed in an agent AND projected there — that pair is the duplicate",
 		},
 		Path: "/reference/upgrading/",

--- a/internal/cli/upgrade_notice_test.go
+++ b/internal/cli/upgrade_notice_test.go
@@ -86,7 +86,7 @@ func TestUpgradeNotice_ShownOnceOnUpgrade(t *testing.T) {
 	if rec.Version != "0.11.0" {
 		t.Errorf("recorded version = %q, want 0.11.0", rec.Version)
 	}
-	wantIDs := []string{"0.11.0-cli-surface", "0.11.0-plugin-component-namespacing"}
+	wantIDs := []string{"0.11.0-cli-surface", "0.11.0-plugin-component-namespacing", "0.11.0-plugin-native-agents"}
 	if !slices.Equal(rec.NoticesSeen, wantIDs) {
 		t.Fatalf("recorded notice ids = %v, want exactly %v", rec.NoticesSeen, wantIDs)
 	}

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -164,7 +164,7 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 	if perr != nil {
 		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, perr)
 	}
-	namespaceProjected(&proj, id, pl.Plugin.Agents, pl.Plugin.NativeAgents)
+	namespaceProjected(&proj, id, pl.Plugin.Agents, pl.Plugin.DeferredAgents())
 	return proj, true, nil
 }
 

--- a/internal/marketplace/loadprojected.go
+++ b/internal/marketplace/loadprojected.go
@@ -164,7 +164,7 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 	if perr != nil {
 		return ProjectionResult{}, false, fmt.Errorf("project plugin %s: %w", id, perr)
 	}
-	namespaceProjected(&proj, id)
+	namespaceProjected(&proj, id, pl.Plugin.Agents, pl.Plugin.NativeAgents)
 	return proj, true, nil
 }
 
@@ -210,33 +210,51 @@ func projectOnePlugin(fs afero.Fs, home, pluginCacheRoot string, pl source.Plugi
 // refuse to capture one into the canonical source (which would mint a copy that
 // diverges from the plugin's own on its next update). Hooks are stamped per
 // HANDLER, the granularity import has to filter at.
-func namespaceProjected(pr *ProjectionResult, plugin string) {
+//
+// agents and nativeAgents are the plugin's `agents` allowlist and
+// `native_agents` deferral list (PluginSpec), stamped onto EVERY projected
+// component — renamed or not. They travel with the component because the
+// flattened canonical drops the association otherwise; render.Plan is the one
+// place that reads them. See source.PluginTargetsAgent.
+func namespaceProjected(pr *ProjectionResult, plugin string, agents, nativeAgents []string) {
 	if plugin == "" {
 		return
 	}
 	for i := range pr.MCPServers {
 		pr.MCPServers[i].Plugin = plugin
+		pr.MCPServers[i].PluginAgents = agents
+		pr.MCPServers[i].PluginNativeAgents = nativeAgents
 	}
 	for i := range pr.LSPServers {
 		pr.LSPServers[i].Plugin = plugin
+		pr.LSPServers[i].PluginAgents = agents
+		pr.LSPServers[i].PluginNativeAgents = nativeAgents
 	}
 	for i := range pr.Hooks {
 		pr.Hooks[i].Plugin = plugin
+		pr.Hooks[i].PluginAgents = agents
+		pr.Hooks[i].PluginNativeAgents = nativeAgents
 	}
 	for i := range pr.Skills {
 		pr.Skills[i].Plugin = plugin
+		pr.Skills[i].PluginAgents = agents
+		pr.Skills[i].PluginNativeAgents = nativeAgents
 		pr.Skills[i].BaseName = pr.Skills[i].Name
 		pr.Skills[i].Name = source.NamespacedComponentName(plugin, pr.Skills[i].Name)
 		pr.Skills[i].Frontmatter = renameFrontmatter(pr.Skills[i].Frontmatter, pr.Skills[i].Name)
 	}
 	for i := range pr.Subagents {
 		pr.Subagents[i].Plugin = plugin
+		pr.Subagents[i].PluginAgents = agents
+		pr.Subagents[i].PluginNativeAgents = nativeAgents
 		pr.Subagents[i].BaseName = pr.Subagents[i].Name
 		pr.Subagents[i].Name = source.NamespacedComponentName(plugin, pr.Subagents[i].Name)
 		pr.Subagents[i].Frontmatter = renameFrontmatter(pr.Subagents[i].Frontmatter, pr.Subagents[i].Name)
 	}
 	for i := range pr.Commands {
 		pr.Commands[i].Plugin = plugin
+		pr.Commands[i].PluginAgents = agents
+		pr.Commands[i].PluginNativeAgents = nativeAgents
 		pr.Commands[i].BaseName = pr.Commands[i].Name
 		pr.Commands[i].Name = source.NamespacedComponentName(plugin, pr.Commands[i].Name)
 		pr.Commands[i].Frontmatter = renameFrontmatter(pr.Commands[i].Frontmatter, pr.Commands[i].Name)

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -385,3 +385,69 @@ func TestDedupHooks_KeysOnContentNotProvenance(t *testing.T) {
 		t.Fatalf("distinct handlers must not be collapsed; got %d: %+v", len(got), got)
 	}
 }
+
+// TestNamespaceProjected_StampsTargetingOnEveryKind is the mechanical guard for
+// the two targeting lists. It is reflective ON PURPOSE: the stamp is six nearly
+// identical loops, and the failure mode of hand-written per-kind assertions is
+// that a kind quietly goes unasserted — LSP servers and hooks are the ones that
+// look least important and are therefore likeliest to be forgotten, and dropping
+// the LSP stamp broke no test before this existed.
+//
+// Every slice on ProjectionResult is populated, then every element of every
+// slice must carry both lists. A future component kind added to ProjectionResult
+// fails here until namespaceProjected stamps it too — which is the point: an
+// unstamped kind is projected to EVERY agent regardless of the plugin's
+// `agents` / `native_agents`, silently re-creating the duplicate they exist to
+// prevent, for that one kind.
+func TestNamespaceProjected_StampsTargetingOnEveryKind(t *testing.T) {
+	pr := ProjectionResult{
+		Skills:     []source.Skill{{Name: "s"}},
+		Subagents:  []source.Subagent{{Name: "a"}},
+		Commands:   []source.Command{{Name: "c"}},
+		MCPServers: []source.MCPServer{{ID: "m"}},
+		LSPServers: []source.LSPServer{{ID: "l"}},
+		Hooks:      []source.Hook{{Event: "PreToolUse", Command: "x"}},
+	}
+	const plugin = "my-plugin"
+	agents := []string{"codex"}
+	native := []string{"claude"}
+	namespaceProjected(&pr, plugin, agents, native)
+
+	v := reflect.ValueOf(pr)
+	stampedKinds := 0
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Kind() != reflect.Slice {
+			continue
+		}
+		kind := v.Type().Field(i).Name
+		// Every element type on ProjectionResult must carry the targeting pair.
+		// Checking the TYPE (not just the values) is what makes a newly-added
+		// kind fail loudly here instead of silently skipping the assertions.
+		if _, ok := field.Type().Elem().FieldByName("PluginAgents"); !ok {
+			t.Errorf("%s elements carry no PluginAgents field — a projected kind that cannot "+
+				"hold its plugin's targeting renders to every agent unconditionally", kind)
+			continue
+		}
+		if field.Len() == 0 {
+			t.Errorf("%s is empty in the fixture — this test would pass without checking it", kind)
+			continue
+		}
+		stampedKinds++
+		for j := 0; j < field.Len(); j++ {
+			el := field.Index(j)
+			gotAgents := el.FieldByName("PluginAgents").Interface().([]string)
+			gotNative := el.FieldByName("PluginNativeAgents").Interface().([]string)
+			if len(gotAgents) != 1 || gotAgents[0] != "codex" {
+				t.Errorf("%s[%d]: PluginAgents = %v, want %v", kind, j, gotAgents, agents)
+			}
+			if len(gotNative) != 1 || gotNative[0] != "claude" {
+				t.Errorf("%s[%d]: PluginNativeAgents = %v, want %v", kind, j, gotNative, native)
+			}
+		}
+	}
+	if stampedKinds != 6 {
+		t.Fatalf("expected 6 projected kinds to be stamped, walked %d — a kind was added to "+
+			"ProjectionResult without being stamped, or the fixture stopped populating one", stampedKinds)
+	}
+}

--- a/internal/marketplace/namespace_test.go
+++ b/internal/marketplace/namespace_test.go
@@ -22,7 +22,7 @@ func TestNamespaceProjected(t *testing.T) {
 			Subagents: []source.Subagent{{Name: "code-reviewer", Frontmatter: map[string]any{"name": "code-reviewer"}}},
 			Commands:  []source.Command{{Name: "review", Frontmatter: map[string]any{"description": "d"}}},
 		}
-		namespaceProjected(&pr, "feature-dev")
+		namespaceProjected(&pr, "feature-dev", nil, nil)
 		for _, tc := range []struct{ got, want, field string }{
 			{pr.Skills[0].Name, "feature-dev-code-review", "skill Name"},
 			{pr.Skills[0].BaseName, "code-review", "skill BaseName"},
@@ -48,7 +48,7 @@ func TestNamespaceProjected(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{
 			{Name: "reviewer", Frontmatter: map[string]any{"name": "reviewer", "model": "opus"}},
 		}}
-		namespaceProjected(&pr, "pkg")
+		namespaceProjected(&pr, "pkg", nil, nil)
 		if got := pr.Subagents[0].Frontmatter["name"]; got != "pkg-reviewer" {
 			t.Errorf("frontmatter name = %v, want pkg-reviewer", got)
 		}
@@ -64,7 +64,7 @@ func TestNamespaceProjected(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{
 			{Name: "reviewer", Frontmatter: map[string]any{"description": "d"}},
 		}}
-		namespaceProjected(&pr, "pkg")
+		namespaceProjected(&pr, "pkg", nil, nil)
 		if _, ok := pr.Subagents[0].Frontmatter["name"]; ok {
 			t.Errorf("namespacing must not invent a frontmatter name; got %v", pr.Subagents[0].Frontmatter)
 		}
@@ -75,7 +75,7 @@ func TestNamespaceProjected(t *testing.T) {
 	t.Run("does not mutate the caller's frontmatter map", func(t *testing.T) {
 		fm := map[string]any{"name": "reviewer"}
 		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer", Frontmatter: fm}}}
-		namespaceProjected(&pr, "pkg")
+		namespaceProjected(&pr, "pkg", nil, nil)
 		if fm["name"] != "reviewer" {
 			t.Errorf("the caller's map was mutated in place; got %v", fm)
 		}
@@ -90,7 +90,7 @@ func TestNamespaceProjected(t *testing.T) {
 			MCPServers: []source.MCPServer{{ID: "srv"}},
 			LSPServers: []source.LSPServer{{ID: "gopls"}},
 		}
-		namespaceProjected(&pr, "pkg")
+		namespaceProjected(&pr, "pkg", nil, nil)
 		if pr.MCPServers[0].ID != "srv" || pr.LSPServers[0].ID != "gopls" {
 			t.Errorf("id-keyed components must not be namespaced: %+v %+v", pr.MCPServers, pr.LSPServers)
 		}
@@ -111,7 +111,7 @@ func TestNamespaceProjected(t *testing.T) {
 	t.Run("hostile plugin ids namespace without error and are caught downstream", func(t *testing.T) {
 		for _, plugin := range []string{"a:b", "esc\x1b[31m"} {
 			pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
-			namespaceProjected(&pr, plugin)
+			namespaceProjected(&pr, plugin, nil, nil)
 			got := pr.Subagents[0].Name
 			if got != plugin+"-reviewer" {
 				t.Errorf("plugin %q: derived name = %q", plugin, got)
@@ -126,7 +126,7 @@ func TestNamespaceProjected(t *testing.T) {
 	// flow through the same code path untouched.
 	t.Run("empty plugin is a no-op", func(t *testing.T) {
 		pr := ProjectionResult{Subagents: []source.Subagent{{Name: "reviewer"}}}
-		namespaceProjected(&pr, "")
+		namespaceProjected(&pr, "", nil, nil)
 		if pr.Subagents[0].Name != "reviewer" || pr.Subagents[0].Plugin != "" {
 			t.Errorf("an empty plugin id must change nothing; got %+v", pr.Subagents[0])
 		}
@@ -274,7 +274,7 @@ func TestProvenanceInvariant(t *testing.T) {
 		Commands:  []source.Command{{Name: "cmd"}},
 	}
 	const plugin = "my-plugin"
-	namespaceProjected(&pr, plugin)
+	namespaceProjected(&pr, plugin, nil, nil)
 
 	// Reflect over every slice on ProjectionResult, and over every element that
 	// carries all three fields. A component kind with no BaseName (MCP/LSP/hooks
@@ -343,7 +343,7 @@ func TestProvenanceInvariant(t *testing.T) {
 		LSPServers: []source.LSPServer{{ID: "gopls"}},
 		Hooks:      []source.Hook{{Event: untrusted.Wrap("PreToolUse"), Matcher: "Bash", Type: "command", Command: "guard"}},
 	}
-	namespaceProjected(&pr2, plugin)
+	namespaceProjected(&pr2, plugin, nil, nil)
 	if pr2.MCPServers[0].ID != "srv" || pr2.MCPServers[0].Plugin != plugin {
 		t.Errorf("mcp server must be stamped but not renamed; got %+v", pr2.MCPServers[0])
 	}

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -111,7 +111,16 @@ func Plan(r secrets.Resolved, reg *adapter.Registry, agents []string, scope adap
 		if a == nil {
 			return out, fmt.Errorf("adapter %q not registered", name)
 		}
-		ops, skips, err := a.Render(r, scope, project)
+		// Narrow the model to what this agent should receive before the adapter
+		// sees it: a plugin whose `agents` allowlist excludes this agent
+		// contributes nothing here. Enforced once, at the waist — see
+		// secrets.Resolved.ForAgent and source.PluginTargetsAgent for why no
+		// adapter participates. Components dropped this way leave no op, so a
+		// destination file written by an earlier apply is reclaimed by the normal
+		// orphan paths (orphanDeletes for file-backed kinds, orphanCleanupOps for
+		// the key-merge ones) rather than lingering as the duplicate the
+		// allowlist was set to remove.
+		ops, skips, err := a.Render(r.ForAgent(name), scope, project)
 		if err != nil {
 			return out, fmt.Errorf("render %s: %w", name, err)
 		}

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -293,9 +293,10 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 
 // BuildReport constructs a TranslationReport from the canonical model and a
 // RenderPlan: one row per plugin (c.Plugins) × agent. Each row carries the
-// per-agent component inventory (countMCPServers / countLSPServers honour
-// enabled+agent targeting; commands/skills/subagents/hooks are model totals) and
-// the skips from plan.PerAgent[agent].Skips.
+// per-agent component inventory (every kind honours the providing
+// plugin's `agents`/`native_agents` gates; MCP/LSP additionally honour each
+// server's own enabled+agents targeting) and the skips from
+// plan.PerAgent[agent].Skips.
 //
 // coverage = full when skips==0; otherwise partial when the adapter still
 // rendered something for the agent (plan ops non-empty), none when every hosted
@@ -309,7 +310,8 @@ func (r TranslationReport) PrintJSON(w io.Writer) error {
 // projected canonical is flattened with no origin tag. Attribution is therefore
 // the caller's choice of what model+plan to pass:
 //   - apply passes the whole flattened model, so every plugin row carries
-//     the same global counts/skips (the documented summary behavior).
+//     the same global counts/skips for the components that TARGET the agent
+//     (the documented summary behavior).
 //   - `explain <id>` re-projects ONE plugin in isolation
 //     (marketplace.ProjectInstalled) and passes a model+plan holding only that
 //     plugin's components, so its row reflects that plugin alone.

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -55,6 +55,14 @@ type PluginRow struct {
 	// Disabled is true when the plugin is disabled for this scope (e.g. by a
 	// project marker's [plugins] disabled). Its components are not rendered.
 	Disabled bool `json:"disabled,omitempty"`
+	// NotTargeted is true when this plugin contributes nothing to THIS row's
+	// agent: either its `agents` allowlist excludes the agent (Coverage
+	// "not targeted") or its `native_agents` deferral list names the agent,
+	// which serves the plugin from its own plugin manager (Coverage "native").
+	// Unlike Disabled (global to the plugin, one row), both are per-agent — the
+	// row exists so a plugin narrowed away from an agent reads as a deliberate
+	// choice rather than as one that mysteriously rendered nothing.
+	NotTargeted bool `json:"notTargeted,omitempty"`
 }
 
 // SkipDetail names one component an adapter could not translate, with the
@@ -190,6 +198,17 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 				}
 				continue
 			}
+			if row.NotTargeted {
+				note := "(not targeted by this plugin's `agents` allowlist)"
+				if row.Coverage == "native" {
+					note = "(served natively by this agent — listed in `native_agents`)"
+				}
+				if p != nil {
+					note = p.Faint(note)
+				}
+				fmt.Fprintf(w, "  %-10s %s\n", row.Agent, note)
+				continue
+			}
 			mark := coverageMark(row.Coverage)
 			tail := fmt.Sprintf("(%d mcp, %d commands)", row.MCP, row.Commands)
 			if p != nil {
@@ -288,6 +307,28 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			if !ok {
 				continue
 			}
+			// The plan for this agent was rendered from a model this plugin's
+			// components were filtered out of (secrets.Resolved.ForAgent), so its
+			// ops/skips say nothing about this plugin — emit the targeting marker
+			// instead of counts the plugin did not contribute to.
+			if !source.PluginTargetsAgent(plug.ID.Unverified(), plug.Plugin.Agents, plug.Plugin.NativeAgents, agName) {
+				// Name WHICH gate excluded the agent. The two mean different
+				// things to the reader — a narrowed allowlist is a choice they
+				// made, a deferral says the agent installs this plugin itself —
+				// and the remedies differ (widen `agents` vs. uninstall the
+				// native copy and drop the `native_agents` entry).
+				coverage := "native"
+				if !source.AgentTargeted(plug.Plugin.Agents, agName) {
+					coverage = "not targeted"
+				}
+				report.Rows = append(report.Rows, PluginRow{
+					Plugin:      label,
+					Agent:       agName,
+					Coverage:    coverage,
+					NotTargeted: true,
+				})
+				continue
+			}
 			report.Rows = append(report.Rows, reportRow(label, agName, c, res))
 		}
 	}
@@ -367,15 +408,8 @@ func countLSPServers(c source.Canonical, agent string) int {
 }
 
 // targetsAgent reports whether an Agents allowlist includes agent. An empty
-// list or one containing "*" targets every agent.
+// list or one containing "*" targets every agent. It delegates to the exported
+// predicate so this package holds ONE spelling of the rule.
 func targetsAgent(agents []string, agent string) bool {
-	if len(agents) == 0 {
-		return true
-	}
-	for _, a := range agents {
-		if a == "*" || a == agent {
-			return true
-		}
-	}
-	return false
+	return source.AgentTargeted(agents, agent)
 }

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -24,7 +24,13 @@ type PluginRow struct {
 	// marshals RAW to JSON (the --json machine contract owns its own escaping).
 	Plugin untrusted.Text `json:"plugin"`
 	Agent  string         `json:"agent"`
-	// Coverage is "full", "partial", or "none".
+	// Coverage is one of: "full", "partial", "none" (the adapter rendered this
+	// plugin for this agent, with that much of it landing), "disabled" (the
+	// plugin is off for this scope), "not-targeted" (its `agents` allowlist
+	// excludes this agent), or "native" (its `native_agents` list defers to this
+	// agent's own plugin manager). The last three are paired with the Disabled /
+	// NotTargeted booleans below, which are what code should branch on — the
+	// string is for display and for the --json contract.
 	Coverage string `json:"coverage"`
 	// MCP, Commands, Skills, Subagents, Hooks, and LSP count the components the
 	// plugin (or whole model) hosts that target this agent — the inventory, so
@@ -57,7 +63,7 @@ type PluginRow struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// NotTargeted is true when this plugin contributes nothing to THIS row's
 	// agent: either its `agents` allowlist excludes the agent (Coverage
-	// "not targeted") or its `native_agents` deferral list names the agent,
+	// "not-targeted") or its `native_agents` deferral list names the agent,
 	// which serves the plugin from its own plugin manager (Coverage "native").
 	// Unlike Disabled (global to the plugin, one row), both are per-agent — the
 	// row exists so a plugin narrowed away from an agent reads as a deliberate
@@ -110,6 +116,16 @@ func skipDetails(skips []adapter.Skip) []SkipDetail {
 type TranslationReport struct {
 	Rows []PluginRow `json:"rows"`
 }
+
+// Coverage values that are not a render outcome: the plugin contributed nothing
+// to this agent by CONFIGURATION, not because the adapter could not translate
+// it. They are constants so the producer (BuildReport) and the consumer
+// (printText) cannot drift on a string literal — the bug that shipped the
+// hyphen-less "not targeted" in one place and matched "native" in another.
+const (
+	coverageNotTargeted = "not-targeted"
+	coverageNative      = "native"
+)
 
 // coverageMark converts a Coverage string to its display symbol.
 func coverageMark(cov string) string {
@@ -200,7 +216,7 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 			}
 			if row.NotTargeted {
 				note := "(not targeted by this plugin's `agents` allowlist)"
-				if row.Coverage == "native" {
+				if row.Coverage == coverageNative {
 					note = "(served natively by this agent — listed in `native_agents`)"
 				}
 				if p != nil {
@@ -311,15 +327,15 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 			// components were filtered out of (secrets.Resolved.ForAgent), so its
 			// ops/skips say nothing about this plugin — emit the targeting marker
 			// instead of counts the plugin did not contribute to.
-			if !source.PluginTargetsAgent(plug.ID.Unverified(), plug.Plugin.Agents, plug.Plugin.NativeAgents, agName) {
+			if !source.PluginTargetsAgent(plug.ID.Unverified(), plug.Plugin.Agents, plug.Plugin.DeferredAgents(), agName) {
 				// Name WHICH gate excluded the agent. The two mean different
 				// things to the reader — a narrowed allowlist is a choice they
 				// made, a deferral says the agent installs this plugin itself —
 				// and the remedies differ (widen `agents` vs. uninstall the
 				// native copy and drop the `native_agents` entry).
-				coverage := "native"
+				coverage := coverageNative
 				if !source.AgentTargeted(plug.Plugin.Agents, agName) {
-					coverage = "not targeted"
+					coverage = coverageNotTargeted
 				}
 				report.Rows = append(report.Rows, PluginRow{
 					Plugin:      label,

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -408,12 +408,12 @@ func reportRow(label untrusted.Text, agName string, c source.Canonical, res Agen
 // no LSP concept is counted in row.LSP yet renders nothing, so its row is "none").
 func computeCoverage(row PluginRow, rendered bool) string {
 	if row.Skips == 0 {
-		return "full"
+		return CoverageFull
 	}
 	if rendered {
-		return "partial"
+		return CoveragePartial
 	}
-	return "none"
+	return CoverageNone
 }
 
 // countMCPServers counts the canonical MCP servers that render for agent —
@@ -421,10 +421,18 @@ func computeCoverage(row PluginRow, rendered bool) string {
 // merge-json-keys ops, which is always 1 for claude's single .claude.json
 // merge regardless of how many servers it holds, and wrongly also counted
 // hooks/lspServers ops (same strategy) as MCP.
+//
+// It honours BOTH targeting gates. The server's own `agents` list was always
+// checked; the providing PLUGIN's `agents`/`native_agents` must be too, or a
+// deferred plugin's servers are counted under some OTHER plugin's row for the
+// same agent — apply reporting "2 mcp" for an agent that received one.
 func countMCPServers(c source.Canonical, agent string) int {
 	n := 0
 	for _, m := range c.MCPServers {
 		if m.Server.Enabled != nil && !*m.Server.Enabled {
+			continue
+		}
+		if !source.PluginTargetsAgent(m.Plugin, m.PluginAgents, m.PluginNativeAgents, agent) {
 			continue
 		}
 		if targetsAgent(m.Server.Agents, agent) {
@@ -442,6 +450,9 @@ func countLSPServers(c source.Canonical, agent string) int {
 	n := 0
 	for _, l := range c.LSPServers {
 		if l.Spec.Enabled != nil && !*l.Spec.Enabled {
+			continue
+		}
+		if !source.PluginTargetsAgent(l.Plugin, l.PluginAgents, l.PluginNativeAgents, agent) {
 			continue
 		}
 		if targetsAgent(l.Spec.Agents, agent) {

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -71,6 +71,29 @@ type PluginRow struct {
 	NotTargeted bool `json:"notTargeted,omitempty"`
 }
 
+// TargetingNote explains, for a row that rendered nothing by configuration, WHY
+// — or returns "" for an ordinary coverage row.
+//
+// It lives on the row rather than at each print site because there are two print
+// sites in two packages (this package's translation report and
+// `internal/cli`'s `plugin explain`), and the second one silently fell through
+// to the generic "✗ <coverage>" red mark: a plugin the user had deliberately
+// deferred was reported in the same red as one the adapter could not translate.
+// A single accessor makes that class of drift a compile-time concern instead of
+// a matching-on-literals one.
+//
+// The two reasons are kept distinct because their remedies are: widen `agents`
+// versus uninstall the agent's own copy of the plugin.
+func (r PluginRow) TargetingNote() string {
+	if !r.NotTargeted {
+		return ""
+	}
+	if r.Coverage == CoverageNative {
+		return "(served natively by this agent — listed in `native_agents`)"
+	}
+	return "(not targeted by this plugin's `agents` allowlist)"
+}
+
 // SkipDetail names one component an adapter could not translate, with the
 // human reason it was skipped. It mirrors adapter.Skip but carries JSON tags
 // for the report's machine-readable surface.
@@ -117,22 +140,31 @@ type TranslationReport struct {
 	Rows []PluginRow `json:"rows"`
 }
 
-// Coverage values that are not a render outcome: the plugin contributed nothing
-// to this agent by CONFIGURATION, not because the adapter could not translate
-// it. They are constants so the producer (BuildReport) and the consumer
-// (printText) cannot drift on a string literal — the bug that shipped the
-// hyphen-less "not targeted" in one place and matched "native" in another.
+// The Coverage vocabulary. These are EXPORTED because they are the `--json`
+// contract and because `internal/cli` renders the same rows a second way
+// (`plugin explain`) — an unexported constant there means matching on a bare
+// literal, which is exactly how `plugin explain` came to print a red "✗ native"
+// for a plugin that was deliberately not targeted. One owner, no literals.
+//
+// The first three are render OUTCOMES (how much of what the plugin ships this
+// agent got). The last three mean the plugin contributed nothing here by
+// CONFIGURATION, not because the adapter could not translate it — pair them with
+// the Disabled / NotTargeted booleans, which are what code should branch on.
 const (
-	coverageNotTargeted = "not-targeted"
-	coverageNative      = "native"
+	CoverageFull        = "full"
+	CoveragePartial     = "partial"
+	CoverageNone        = "none"
+	CoverageDisabled    = "disabled"
+	CoverageNotTargeted = "not-targeted"
+	CoverageNative      = "native"
 )
 
 // coverageMark converts a Coverage string to its display symbol.
 func coverageMark(cov string) string {
 	switch cov {
-	case "full":
+	case CoverageFull:
 		return "✓ full  "
-	case "partial":
+	case CoveragePartial:
 		return "◐ partial"
 	default:
 		return "✗ none  "
@@ -214,11 +246,7 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 				}
 				continue
 			}
-			if row.NotTargeted {
-				note := "(not targeted by this plugin's `agents` allowlist)"
-				if row.Coverage == coverageNative {
-					note = "(served natively by this agent — listed in `native_agents`)"
-				}
+			if note := row.TargetingNote(); note != "" {
 				if p != nil {
 					note = p.Faint(note)
 				}
@@ -241,9 +269,9 @@ func (r TranslationReport) printText(w io.Writer, p *ui.Printer) {
 // run doesn't shift the column that follows.
 func colorCoverage(p *ui.Printer, cov, mark string) string {
 	switch cov {
-	case "full":
+	case CoverageFull:
 		return p.Green(mark)
-	case "partial":
+	case CoveragePartial:
 		return p.Yellow(mark)
 	default:
 		return p.Red(mark)
@@ -313,7 +341,7 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 		if plug.Plugin.Disabled {
 			report.Rows = append(report.Rows, PluginRow{
 				Plugin:   label,
-				Coverage: "disabled",
+				Coverage: CoverageDisabled,
 				Disabled: true,
 			})
 			continue
@@ -333,9 +361,9 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 				// made, a deferral says the agent installs this plugin itself —
 				// and the remedies differ (widen `agents` vs. uninstall the
 				// native copy and drop the `native_agents` entry).
-				coverage := coverageNative
+				coverage := CoverageNative
 				if !source.AgentTargeted(plug.Plugin.Agents, agName) {
-					coverage = coverageNotTargeted
+					coverage = CoverageNotTargeted
 				}
 				report.Rows = append(report.Rows, PluginRow{
 					Plugin:      label,

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -33,14 +33,20 @@ type PluginRow struct {
 	// string is for display and for the --json contract.
 	Coverage string `json:"coverage"`
 	// MCP, Commands, Skills, Subagents, Hooks, and LSP count the components the
-	// plugin (or whole model) hosts that target this agent — the inventory, so
+	// plugin (or whole model) hosts that TARGET this agent — the inventory, so
 	// the report is descriptive of everything the plugin ships, not just MCP +
-	// commands. MCP and LSP honour each server's `enabled`/`agents` targeting
-	// (a server scoped to other agents is not counted here); the markdown
-	// component kinds (commands/skills/subagents) and hooks have no per-agent
-	// allowlist, so their counts are the model's totals. These describe what is
-	// hosted, NOT what successfully rendered: a hosted component the adapter
-	// cannot translate is still counted here and reported under Skips below.
+	// commands.
+	//
+	// Every kind honours the providing plugin's `agents` / `native_agents`
+	// gates; MCP and LSP additionally honour each server's own `enabled`/`agents`
+	// targeting. The plugin gate matters because apply passes the WHOLE flattened
+	// model: without it a deferred plugin's components are counted under some
+	// OTHER plugin's row for the same agent, so a row could report more commands
+	// than its own mcp count reflected — inconsistent within a single row.
+	//
+	// These describe what is hosted, NOT what successfully rendered: a hosted
+	// component the adapter cannot translate is still counted here and reported
+	// under Skips below.
 	MCP       int `json:"mcp"`
 	Commands  int `json:"commands"`
 	Skills    int `json:"skills"`
@@ -385,14 +391,22 @@ func BuildReport(c source.Canonical, plan RenderPlan, agents []string) Translati
 // plugin); res is that agent's render result.
 func reportRow(label untrusted.Text, agName string, c source.Canonical, res AgentResult) PluginRow {
 	row := PluginRow{
-		Plugin:      label,
-		Agent:       agName,
-		MCP:         countMCPServers(c, agName),
-		LSP:         countLSPServers(c, agName),
-		Commands:    len(c.Commands),
-		Skills:      len(c.Skills),
-		Subagents:   len(c.Subagents),
-		Hooks:       len(c.Hooks),
+		Plugin: label,
+		Agent:  agName,
+		MCP:    countMCPServers(c, agName),
+		LSP:    countLSPServers(c, agName),
+		Commands: countTargeted(c.Commands, agName, func(v source.Command) (string, []string, []string) {
+			return v.Plugin, v.PluginAgents, v.PluginNativeAgents
+		}),
+		Skills: countTargeted(c.Skills, agName, func(v source.Skill) (string, []string, []string) {
+			return v.Plugin, v.PluginAgents, v.PluginNativeAgents
+		}),
+		Subagents: countTargeted(c.Subagents, agName, func(v source.Subagent) (string, []string, []string) {
+			return v.Plugin, v.PluginAgents, v.PluginNativeAgents
+		}),
+		Hooks: countTargeted(c.Hooks, agName, func(v source.Hook) (string, []string, []string) {
+			return v.Plugin, v.PluginAgents, v.PluginNativeAgents
+		}),
 		Skips:       len(res.Skips),
 		SkipDetails: skipDetails(res.Skips),
 	}
@@ -414,6 +428,21 @@ func computeCoverage(row PluginRow, rendered bool) string {
 		return CoveragePartial
 	}
 	return CoverageNone
+}
+
+// countTargeted counts the components of one kind that this agent actually
+// receives, per the providing plugin's gates. The text kinds and hooks have no
+// per-component allowlist of their own, so the plugin gate is the only filter
+// they need — but they DO need it, for the same reason MCP and LSP do.
+func countTargeted[T any](items []T, agent string, provenance func(T) (string, []string, []string)) int {
+	n := 0
+	for _, it := range items {
+		plugin, agents, native := provenance(it)
+		if source.PluginTargetsAgent(plugin, agents, native, agent) {
+			n++
+		}
+	}
+	return n
 }
 
 // countMCPServers counts the canonical MCP servers that render for agent —

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -711,6 +711,12 @@ func TestBuildReport_NotTargetedRows(t *testing.T) {
 				t.Fatalf("expected 1 row, got %d", len(report.Rows))
 			}
 			row := report.Rows[0]
+			// The row's own Agent field, not just the printed line: it is a
+			// --json field, and blanking it survived a mutation that the
+			// PrintText assertion could not see.
+			if row.Agent != tc.agent {
+				t.Errorf("Agent = %q, want %q", row.Agent, tc.agent)
+			}
 			if row.Coverage != tc.wantCoverage {
 				t.Errorf("Coverage = %q, want %q", row.Coverage, tc.wantCoverage)
 			}

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -658,3 +658,91 @@ func TestBuildReport_CountsHonorTargeting(t *testing.T) {
 		t.Errorf("codex counts = mcp %d lsp %d; want mcp 1 lsp 1", g.MCP, g.LSP)
 	}
 }
+
+// TestBuildReport_NotTargetedRows pins the two per-agent "contributed nothing"
+// outcomes. They matter because their row is built from a plan the plugin's
+// components were FILTERED OUT of — so the ordinary counting path would report
+// the whole model's totals under this plugin's name, telling the user a plugin
+// rendered components it did not. And the two are distinguished on purpose: a
+// narrowed allowlist is a choice the user made, while a deferral says the agent
+// installs the plugin itself, and the remedies differ.
+func TestBuildReport_NotTargetedRows(t *testing.T) {
+	claudeOnly := []string{"claude"}
+	cases := []struct {
+		name         string
+		spec         source.PluginSpec
+		agent        string
+		wantCoverage string
+		wantFlag     bool
+	}{
+		{
+			name:         "allowlist excludes this agent",
+			spec:         source.PluginSpec{ID: "toolkit@mp", Agents: []string{"codex"}},
+			agent:        "claude",
+			wantCoverage: "not-targeted",
+			wantFlag:     true,
+		},
+		{
+			name:         "deferral names this agent",
+			spec:         source.PluginSpec{ID: "toolkit@mp", Agents: []string{"*"}, NativeAgents: &claudeOnly},
+			agent:        "claude",
+			wantCoverage: "native",
+			wantFlag:     true,
+		},
+		{
+			name:         "targeted normally — an ordinary coverage row",
+			spec:         source.PluginSpec{ID: "toolkit@mp", Agents: []string{"*"}},
+			agent:        "claude",
+			wantCoverage: "full",
+			wantFlag:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := source.Canonical{
+				MCPServers: []source.MCPServer{{ID: "srv"}},
+				Plugins:    []source.Plugin{{ID: "toolkit", Plugin: tc.spec}},
+			}
+			plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+				tc.agent: {Ops: []adapter.FileOp{{Action: "write", Path: "/home/.claude.json"}}},
+			}}
+			report := render.BuildReport(c, plan, []string{tc.agent})
+			if len(report.Rows) != 1 {
+				t.Fatalf("expected 1 row, got %d", len(report.Rows))
+			}
+			row := report.Rows[0]
+			if row.Coverage != tc.wantCoverage {
+				t.Errorf("Coverage = %q, want %q", row.Coverage, tc.wantCoverage)
+			}
+			if row.NotTargeted != tc.wantFlag {
+				t.Errorf("NotTargeted = %v, want %v", row.NotTargeted, tc.wantFlag)
+			}
+			// A row for a plugin that contributed nothing must not carry counts
+			// borrowed from the rest of the model — that is the misreport this
+			// row exists to prevent.
+			if tc.wantFlag && row.MCP != 0 {
+				t.Errorf("a non-contributing row reported %d MCP servers; it rendered none", row.MCP)
+			}
+		})
+	}
+}
+
+// TestPrintText_NotTargetedRowsExplainThemselves pins the human output. The row
+// carries no coverage mark, so without a dedicated line it would print as a bare
+// agent name with an empty status — indistinguishable from a bug. Each variant
+// must say WHICH gate excluded the agent, because the remedies differ.
+func TestPrintText_NotTargetedRowsExplainThemselves(t *testing.T) {
+	report := render.TranslationReport{Rows: []render.PluginRow{
+		{Plugin: "toolkit@mp", Agent: "claude", Coverage: "native", NotTargeted: true},
+		{Plugin: "toolkit@mp", Agent: "codex", Coverage: "not-targeted", NotTargeted: true},
+	}}
+	var buf bytes.Buffer
+	report.PrintText(&buf)
+	got := buf.String()
+	if !strings.Contains(got, "served natively") || !strings.Contains(got, "native_agents") {
+		t.Errorf("the deferral row must name the deferral as the reason; got:\n%s", got)
+	}
+	if !strings.Contains(got, "`agents` allowlist") {
+		t.Errorf("the allowlist row must name the allowlist as the reason; got:\n%s", got)
+	}
+}

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -727,10 +727,11 @@ func TestBuildReport_NotTargetedRows(t *testing.T) {
 	}
 }
 
-// TestBuildReport_CoverageOutcomes pins the three RENDER outcomes. Nothing
-// asserted "partial" or "none" anywhere, so the constants promoted for them were
-// unpinned: changing their values passed the whole suite. They are the --json
-// contract, so a silent value change is a silent contract break.
+// TestBuildReport_CoverageOutcomes pins the three RENDER outcomes together with
+// the MARK each prints. Other tests already assert the coverage strings; what
+// nothing covered was the printed vocabulary, so a constant's value could change
+// and only the JSON contract would notice. They are the --json contract too, so
+// a silent value change is a silent contract break.
 func TestBuildReport_CoverageOutcomes(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -786,6 +787,14 @@ func TestBuildReport_CountsHonourPluginTargeting(t *testing.T) {
 		LSPServers: []source.LSPServer{
 			{ID: "alpha-lsp", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly},
 		},
+		// The text kinds and hooks have no per-component allowlist of their own,
+		// so the plugin gate is the ONLY thing that can exclude them — and it was
+		// missed for all four when MCP/LSP were fixed, leaving a row that
+		// reported more commands than its own mcp count reflected.
+		Commands:  []source.Command{{Name: "beta-c", Plugin: "beta", PluginAgents: []string{"*"}}, {Name: "alpha-c", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly}},
+		Skills:    []source.Skill{{Name: "alpha-s", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly}},
+		Subagents: []source.Subagent{{Name: "alpha-a", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly}},
+		Hooks:     []source.Hook{{Event: "PreToolUse", Command: "alpha-h", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly}},
 		Plugins: []source.Plugin{
 			{ID: "beta", Plugin: source.PluginSpec{ID: "beta@mp", Agents: []string{"*"}}},
 		},
@@ -802,6 +811,21 @@ func TestBuildReport_CountsHonourPluginTargeting(t *testing.T) {
 	}
 	if got := report.Rows[0].LSP; got != 0 {
 		t.Errorf("LSP count = %d, want 0 — the only LSP server belongs to the deferred plugin", got)
+	}
+	if got := report.Rows[0].Commands; got != 1 {
+		t.Errorf("Commands count = %d, want 1 — the deferred plugin's command must not be counted", got)
+	}
+	for _, tc := range []struct {
+		kind string
+		got  int
+	}{
+		{"Skills", report.Rows[0].Skills},
+		{"Subagents", report.Rows[0].Subagents},
+		{"Hooks", report.Rows[0].Hooks},
+	} {
+		if tc.got != 0 {
+			t.Errorf("%s count = %d, want 0 — every one belongs to the deferred plugin", tc.kind, tc.got)
+		}
 	}
 }
 
@@ -822,5 +846,13 @@ func TestPrintText_NotTargetedRowsExplainThemselves(t *testing.T) {
 	}
 	if !strings.Contains(got, "`agents` allowlist") {
 		t.Errorf("the allowlist row must name the allowlist as the reason; got:\n%s", got)
+	}
+	// The agent NAME must be on the line. Without this the row says "something
+	// was deferred" without saying for whom — and blanking Agent survived
+	// mutation because nothing here read it.
+	for _, agent := range []string{"claude", "codex"} {
+		if !strings.Contains(got, agent) {
+			t.Errorf("the row must name the agent it is about; %q missing from:\n%s", agent, got)
+		}
 	}
 }

--- a/internal/render/report_test.go
+++ b/internal/render/report_test.go
@@ -727,6 +727,84 @@ func TestBuildReport_NotTargetedRows(t *testing.T) {
 	}
 }
 
+// TestBuildReport_CoverageOutcomes pins the three RENDER outcomes. Nothing
+// asserted "partial" or "none" anywhere, so the constants promoted for them were
+// unpinned: changing their values passed the whole suite. They are the --json
+// contract, so a silent value change is a silent contract break.
+func TestBuildReport_CoverageOutcomes(t *testing.T) {
+	cases := []struct {
+		name     string
+		skips    []adapter.Skip
+		ops      []adapter.FileOp
+		want     string
+		wantMark string
+	}{
+		{name: "no skips", ops: []adapter.FileOp{{Action: "write", Path: "/x"}}, want: "full", wantMark: "✓ full"},
+		{
+			name:  "skipped something but still rendered",
+			skips: []adapter.Skip{{Component: "lsp", Name: "l", Reason: "no concept"}},
+			ops:   []adapter.FileOp{{Action: "write", Path: "/x"}},
+			want:  "partial", wantMark: "◐ partial",
+		},
+		{
+			name:  "skipped everything, rendered nothing",
+			skips: []adapter.Skip{{Component: "lsp", Name: "l", Reason: "no concept"}},
+			want:  "none", wantMark: "✗ none",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := source.Canonical{MCPServers: []source.MCPServer{{ID: "srv"}}}
+			plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+				"claude": {Ops: tc.ops, Skips: tc.skips},
+			}}
+			report := render.BuildReport(c, plan, []string{"claude"})
+			if got := report.Rows[0].Coverage; got != tc.want {
+				t.Errorf("Coverage = %q, want %q", got, tc.want)
+			}
+			var buf bytes.Buffer
+			report.PrintText(&buf)
+			if !strings.Contains(buf.String(), tc.wantMark) {
+				t.Errorf("printed report should carry %q; got:\n%s", tc.wantMark, buf.String())
+			}
+		})
+	}
+}
+
+// TestBuildReport_CountsHonourPluginTargeting pins that the per-agent inventory
+// respects the plugin gates. The counts are computed over the WHOLE model, so a
+// deferred plugin's MCP/LSP servers were attributed to whatever other plugin's
+// row happened to be printed for that agent — apply reporting "2 mcp" to an
+// agent that received one.
+func TestBuildReport_CountsHonourPluginTargeting(t *testing.T) {
+	claudeOnly := []string{"claude"}
+	c := source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "beta-srv", Plugin: "beta", PluginAgents: []string{"*"}},
+			{ID: "alpha-srv", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly},
+		},
+		LSPServers: []source.LSPServer{
+			{ID: "alpha-lsp", Plugin: "alpha", PluginAgents: []string{"*"}, PluginNativeAgents: claudeOnly},
+		},
+		Plugins: []source.Plugin{
+			{ID: "beta", Plugin: source.PluginSpec{ID: "beta@mp", Agents: []string{"*"}}},
+		},
+	}
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{{Action: "write", Path: "/x"}}},
+	}}
+	report := render.BuildReport(c, plan, []string{"claude"})
+	if len(report.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(report.Rows))
+	}
+	if got := report.Rows[0].MCP; got != 1 {
+		t.Errorf("MCP count = %d, want 1 — the deferred plugin's server must not be counted here", got)
+	}
+	if got := report.Rows[0].LSP; got != 0 {
+		t.Errorf("LSP count = %d, want 0 — the only LSP server belongs to the deferred plugin", got)
+	}
+}
+
 // TestPrintText_NotTargetedRowsExplainThemselves pins the human output. The row
 // carries no coverage mark, so without a dedicated line it would print as a bare
 // agent name with an empty status — indistinguishable from a bug. Each variant

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -56,6 +56,35 @@ func ForRender(c source.Canonical) Resolved { return Resolved{c: c} }
 // stop — you almost certainly want capture.Capture instead.
 func (r Resolved) Canonical() source.Canonical { return r.c }
 
+// ForAgent returns a Resolved narrowed to what the named agent should render:
+// every component provided by a plugin whose `agents` allowlist excludes this
+// agent, or whose `native_agents` deferral list names it, is dropped.
+// Hand-authored components (no Plugin stamp) always survive.
+//
+// It is the render-side entry to source.FilterForAgent, which holds the actual
+// rule (import's capture-refusal filter is the other caller — the two must agree
+// exactly). This wrapper exists for a fence reason and a design reason:
+//
+//   - Fence: render.Plan cannot reach the underlying source.Canonical (the
+//     secrets.Resolved.Canonical forbidigo rule confines that to adapter Render),
+//     so the narrowing has to be a method on the wrapper. It reads the private
+//     canonical directly and returns another Resolved — no writable model is
+//     ever exposed, so this adds no laundering seam.
+//   - Design: doing it once at the dispatch waist means no adapter can forget.
+//     An allowlist honoured in ten adapters × six component kinds is sixty
+//     chances to silently render the duplicate the allowlist exists to prevent.
+//
+// It never touches secret material — targeting is a pure include/exclude over
+// already-resolved components — so a narrowed Resolved carries exactly the
+// substitutions its parent did.
+//
+// The result SHARES component values with the receiver (the filter rebuilds
+// slices, it does not deep-copy). That matches what Render already gets today:
+// adapters read the model and build their own output, they never mutate it.
+func (r Resolved) ForAgent(agent string) Resolved {
+	return Resolved{c: source.FilterForAgent(r.c, agent)}
+}
+
 // ComponentID is a (kind, name) pair for a component id an adapter joins into a
 // destination path. For a TEXT component (subagent/command/skill) the Name is the
 // canonical Name that becomes a destination filename stem at Render. For an MCP or

--- a/internal/secrets/resolved.go
+++ b/internal/secrets/resolved.go
@@ -62,8 +62,12 @@ func (r Resolved) Canonical() source.Canonical { return r.c }
 // Hand-authored components (no Plugin stamp) always survive.
 //
 // It is the render-side entry to source.FilterForAgent, which holds the actual
-// rule (import's capture-refusal filter is the other caller — the two must agree
-// exactly). This wrapper exists for a fence reason and a design reason:
+// rule and has this as its ONLY caller. Note that import's capture-refusal
+// filter deliberately does NOT narrow the same way — its refusal set is wider
+// than the render set on purpose, because the destination can still hold
+// un-reclaimed output from before a deferral was recorded. Do not "restore
+// symmetry" between the two; see source.FilterForAgent. This wrapper exists for
+// a fence reason and a design reason:
 //
 //   - Fence: render.Plan cannot reach the underlying source.Canonical (the
 //     secrets.Resolved.Canonical forbidigo rule confines that to adapter Render),

--- a/internal/secrets/walk_test.go
+++ b/internal/secrets/walk_test.go
@@ -30,6 +30,13 @@ var walkerCovered = map[string]map[string]bool{
 		"Matcher": false, // glob/regex, not a credential
 		"Type":    false, // always "command"
 		"Plugin":  false, // derived provenance; see MCPServer.Plugin below
+		// PluginAgents / PluginNativeAgents are the providing plugin's
+		// source-only targeting lists, stamped at projection alongside Plugin.
+		// Both hold agent NAMES (claude, codex, …) — never a credential — and
+		// like Plugin both are derived state that is never serialized back to
+		// the canonical source.
+		"PluginAgents":       false,
+		"PluginNativeAgents": false,
 	},
 	"LSPServerSpec": {
 		"Command": true,
@@ -48,10 +55,17 @@ var walkerCovered = map[string]map[string]bool{
 		// credential. It exists so import/reconcile can refuse to capture a
 		// plugin-owned server; nothing resolves or re-references it.
 		"Plugin": false,
+		// PluginAgents / PluginNativeAgents: source-only targeting lists stamped
+		// beside Plugin — agent names, never a credential, never serialized.
+		// See Hook above.
+		"PluginAgents":       false,
+		"PluginNativeAgents": false,
 	},
 	"LSPServer": {
-		"ID":     false, // filename identifier, never a secret
-		"Plugin": false, // derived provenance; see MCPServer.Plugin above
+		"ID":                 false, // filename identifier, never a secret
+		"Plugin":             false, // derived provenance; see MCPServer.Plugin above
+		"PluginAgents":       false, // targeting allowlist; see MCPServer above
+		"PluginNativeAgents": false, // deferral list; see MCPServer above
 	},
 }
 

--- a/internal/source/provenance.go
+++ b/internal/source/provenance.go
@@ -139,6 +139,14 @@ func AgentTargeted(agents []string, agent string) bool {
 // A component with no Plugin (hand-authored) always targets every agent: both
 // gates are properties of plugin installation, and both fields are empty for
 // anything loaded from ~/.agentsync/.
+//
+// NOTE the asymmetry in how the two lists read a "*" entry. `agents` is an
+// ALLOWLIST, so AgentTargeted treats "*" as the documented wildcard. The
+// deferral list is a set of specific agents that install the plugin themselves,
+// matched EXACTLY — a literal "*" there names no real agent and defers to
+// nobody. That is deliberate: "every agent serves this natively" is not a
+// deferral, it is `disabled = true`, which the projection already honours and
+// which says what it means.
 func PluginTargetsAgent(plugin string, pluginAgents, pluginNativeAgents []string, agent string) bool {
 	if plugin == "" {
 		return true

--- a/internal/source/provenance.go
+++ b/internal/source/provenance.go
@@ -73,6 +73,87 @@ func NamespacedComponentName(plugin, base string) string {
 	return plugin + ComponentNamespaceSeparator + base
 }
 
+// AgentTargeted reports whether an `agents` allowlist includes the named agent.
+// An empty/nil list or one containing "*" targets every agent — the documented
+// default, so an omitted key means "all agents".
+//
+// This is the exported home for a predicate the adapters each keep a local copy
+// of (agentTargeted, for the per-server MCPServerSpec.Agents / LSPServerSpec.Agents
+// fields). New code outside an adapter uses this one.
+func AgentTargeted(agents []string, agent string) bool {
+	if len(agents) == 0 {
+		return true
+	}
+	for _, a := range agents {
+		if a == "*" || a == agent {
+			return true
+		}
+	}
+	return false
+}
+
+// PluginTargetsAgent reports whether a component provided by a plugin should be
+// rendered for the named agent. Two independent gates, both stamped onto each
+// projected component at projection time:
+//
+//   - the plugin's `agents` allowlist (PluginSpec.Agents → PluginAgents) — the
+//     user's own fan-out choice;
+//   - the plugin's `native_agents` deferral list (PluginSpec.NativeAgents →
+//     PluginNativeAgents) — agents whose own plugin manager already installs
+//     this plugin, where projecting would duplicate every component and
+//     double-fire every hook.
+//
+// A component renders only if the allowlist targets the agent AND the deferral
+// list does not claim it. See PluginSpec.NativeAgents for why the deferral is
+// its own key rather than a subtraction folded into the allowlist.
+//
+// # Why the allowlist is stamped per component rather than looked up
+//
+// The projected canonical is FLATTENED: loadProjected appends every enabled
+// plugin's components into one set of slices. A consumer holding a component
+// therefore cannot rejoin it to its Plugins entry without re-deriving the same
+// id the projection stamped — and that id is not the plugins/<id>.toml stem but
+// the name part of `<name>@<marketplace>`, with a fallback. Two derivations of
+// one id is exactly the drift this codebase avoids elsewhere, so the allowlist
+// travels WITH the component, stamped once at the same site that stamps Plugin.
+//
+// # Why it is separate from MCPServerSpec.Agents / LSPServerSpec.Agents
+//
+// Those are the SERVER's own targeting, declared by whoever wrote the server
+// (the user in mcp/<id>.toml, or the plugin in its .mcp.json). The plugin
+// allowlist is the PLUGIN's targeting, declared by the user in
+// plugins/<id>.toml. They compose as an intersection — a component renders for
+// an agent only if both target it — and keeping them apart means neither
+// silently rewrites the other's declared value. Text components (skill,
+// subagent, command) and hooks have no per-component allowlist at all, so for
+// them this is the only targeting there is.
+//
+// # Where it is enforced
+//
+// ONCE, at the single dispatch waist: render.Plan narrows the model per agent
+// (secrets.Resolved.ForAgent) before handing it to that agent's Render. No
+// adapter consults PluginAgents, and none should — an adapter that forgot would
+// silently re-introduce the duplicate this field exists to prevent, across every
+// component kind it renders. One waist beats ten adapters that can drift.
+//
+// A component with no Plugin (hand-authored) always targets every agent: both
+// gates are properties of plugin installation, and both fields are empty for
+// anything loaded from ~/.agentsync/.
+func PluginTargetsAgent(plugin string, pluginAgents, pluginNativeAgents []string, agent string) bool {
+	if plugin == "" {
+		return true
+	}
+	if !AgentTargeted(pluginAgents, agent) {
+		return false
+	}
+	for _, native := range pluginNativeAgents {
+		if native == agent {
+			return false
+		}
+	}
+	return true
+}
+
 // Namespacing performs NO validation of the derived name, deliberately. An
 // earlier revision did, and it was a regression: the check used a stricter rune
 // set than the projection's own validateProjectedName, and loadProjected

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -135,6 +135,17 @@ type MCPServer struct {
 	// PluginTargetsAgent (provenance.go) for why they are carried per COMPONENT
 	// rather than looked up from Canonical.Plugins, and why PluginAgents is
 	// separate from Server.Agents (the two compose as an intersection).
+	//
+	// Collapsing these (with Plugin/BaseName) into one PluginProvenance struct
+	// across all six component types was considered and deferred. The honest
+	// reason is churn: every read site would change, for no behavioural gain.
+	// There IS a secondary argument, but only for the structs the secret-field
+	// guard walks — MCPServer, LSPServer, Hook. TestNewSecretFieldGuard's
+	// isStringShaped returns false for a struct and the loop does not recurse,
+	// so a nested provenance struct's string fields would escape classification
+	// on exactly those three. It does NOT apply to Skill/Subagent/Command, which
+	// the guard does not walk at all. If this is ever collapsed, teach
+	// isStringShaped to recurse first.
 	PluginAgents       []string `toml:"-"`
 	PluginNativeAgents []string `toml:"-"`
 }
@@ -238,6 +249,12 @@ type PluginSpec struct {
 	//
 	// `import` populates it by probing each PluginIngester adapter; the user
 	// edits it by hand after uninstalling the native copy.
+	//
+	// Entries are NOT validated against the agent registry. A typo defers to
+	// nobody, and for an agent whose adapter implements PluginIngester (claude,
+	// codex) the symptom surfaces: the plugin still projects there, so
+	// status/doctor report it as installed-and-projected. For any other agent
+	// there is no such signal — a misspelled entry is simply inert.
 	// It is a POINTER so the three on-disk states stay distinguishable, per the
 	// "models must stay faithful to their on-disk artifacts" rule: an ABSENT key
 	// (nil — never decided, so `import` asks), an EXPLICITLY EMPTY list

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -130,6 +130,13 @@ type MCPServer struct {
 	// NamespacedComponentName (provenance.go) and walkerCovered
 	// (internal/secrets/walk_test.go).
 	Plugin string `toml:"-"`
+	// PluginAgents / PluginNativeAgents are the providing plugin's `agents`
+	// allowlist and `native_agents` deferral list, stamped at projection. See
+	// PluginTargetsAgent (provenance.go) for why they are carried per COMPONENT
+	// rather than looked up from Canonical.Plugins, and why PluginAgents is
+	// separate from Server.Agents (the two compose as an intersection).
+	PluginAgents       []string `toml:"-"`
+	PluginNativeAgents []string `toml:"-"`
 }
 
 type MCPServerSpec struct {
@@ -166,6 +173,10 @@ type Skill struct {
 	// (provenance.go) for what they mean and why they are never serialized.
 	Plugin   string `toml:"-"`
 	BaseName string `toml:"-"`
+	// PluginAgents / PluginNativeAgents carry the providing plugin's targeting;
+	// see PluginTargetsAgent (provenance.go). Never serialized.
+	PluginAgents       []string `toml:"-"`
+	PluginNativeAgents []string `toml:"-"`
 }
 
 // SkillFile is one bundled resource inside a skill directory (e.g.
@@ -204,6 +215,30 @@ type PluginSpec struct {
 	ManifestSHA string         `toml:"manifest_sha,omitempty"`
 	Update      string         `toml:"update,omitempty"` // pinned | track | manual
 	Agents      []string       `toml:"agents,omitempty"`
+	// NativeAgents lists agents whose OWN plugin manager already has this plugin
+	// installed, so agentsync must not project its components there — the agent
+	// serves them from its own install dir and a projection would duplicate
+	// every skill, subagent, and command, and double-fire every hook.
+	//
+	// It is a DEFERRAL record, not targeting, and that is why it is a separate
+	// key from Agents rather than a subtraction baked into it:
+	//
+	//   - Agents is the user's own fan-out choice ("only send this to codex").
+	//     NativeAgents is a statement about the world ("claude already has it").
+	//     Editing one should never silently rewrite the other.
+	//   - A subtraction would have to be materialized as a positive list, which
+	//     freezes the agent set: enable a new agent later and it would silently
+	//     NOT receive a plugin the user never excluded. With the deferral held
+	//     separately, Agents stays ["*"] and the new agent is covered.
+	//   - The degenerate case has an honest encoding. When every enabled agent
+	//     serves the plugin natively, this lists them all and Agents stays ["*"]
+	//     — where a positive allowlist would have to write `agents = []`, which
+	//     already means "every agent" (an empty allowlist is the documented
+	//     default), inverting the user's intent.
+	//
+	// `import` populates it by probing each PluginIngester adapter; the user
+	// edits it (or runs `plugin adopt`) after uninstalling the native copy.
+	NativeAgents []string `toml:"native_agents,omitempty"`
 	// Disabled, when true, suppresses the plugin's projection during
 	// marketplace.LoadProjected. `agentsync plugin disable <id>` sets this.
 	// Without honouring it there, the CLI's TOML write would be a no-op:
@@ -248,6 +283,10 @@ type Subagent struct {
 	// (provenance.go) for what they mean and why they are never serialized.
 	Plugin   string
 	BaseName string
+	// PluginAgents / PluginNativeAgents carry the providing plugin's targeting;
+	// see PluginTargetsAgent (provenance.go). Never serialized.
+	PluginAgents       []string
+	PluginNativeAgents []string
 }
 
 // Command mirrors commands/<name>.md (frontmatter + body).
@@ -261,6 +300,10 @@ type Command struct {
 	// (provenance.go) for what they mean and why they are never serialized.
 	Plugin   string
 	BaseName string
+	// PluginAgents / PluginNativeAgents carry the providing plugin's targeting;
+	// see PluginTargetsAgent (provenance.go). Never serialized.
+	PluginAgents       []string
+	PluginNativeAgents []string
 }
 
 // Hook represents a single hook entry for an event.
@@ -284,6 +327,11 @@ type Hook struct {
 	// handlers alongside the plugin's. Never serialized (WriteHooks emits an
 	// explicit hookEntryOut), never secret-bearing — see MCPServer.Plugin.
 	Plugin string
+	// PluginAgents / PluginNativeAgents carry the providing plugin's targeting,
+	// per HANDLER for the same reason Plugin is; see PluginTargetsAgent
+	// (provenance.go). Never serialized, never secret-bearing.
+	PluginAgents       []string
+	PluginNativeAgents []string
 }
 
 // LSPServer mirrors lsp/<id>.toml.
@@ -293,6 +341,10 @@ type LSPServer struct {
 	// Plugin mirrors MCPServer.Plugin — provenance only, never namespaced, never
 	// serialized, never secret-bearing. See MCPServer.Plugin.
 	Plugin string `toml:"-"`
+	// PluginAgents / PluginNativeAgents mirror MCPServer's; see
+	// PluginTargetsAgent (provenance.go).
+	PluginAgents       []string `toml:"-"`
+	PluginNativeAgents []string `toml:"-"`
 }
 
 // LSPServerSpec holds the server configuration for an LSP server.

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -250,6 +250,8 @@ type PluginSpec struct {
 	// `import` populates it by probing each PluginIngester adapter; the user
 	// edits it by hand after uninstalling the native copy.
 	//
+	// # Unvalidated entries
+	//
 	// Entries are NOT validated against the agent registry. A typo defers to
 	// nobody, and for an agent whose adapter implements PluginIngester (claude,
 	// codex) the symptom surfaces: the plugin still projects there, so

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -237,14 +237,35 @@ type PluginSpec struct {
 	//     default), inverting the user's intent.
 	//
 	// `import` populates it by probing each PluginIngester adapter; the user
-	// edits it (or runs `plugin adopt`) after uninstalling the native copy.
-	NativeAgents []string `toml:"native_agents,omitempty"`
+	// edits it by hand after uninstalling the native copy.
+	// It is a POINTER so the three on-disk states stay distinguishable, per the
+	// "models must stay faithful to their on-disk artifacts" rule: an ABSENT key
+	// (nil — never decided, so `import` asks), an EXPLICITLY EMPTY list
+	// (`native_agents = []` — decided, "defer to nobody", so `import` stops
+	// asking), and a populated list. A plain []string cannot express the middle
+	// state through a write: `omitempty` drops an empty slice, so the key
+	// vanished on the next rewrite and the decision was silently reverted.
+	// Read it through DeferredAgents, which is nil-safe.
+	NativeAgents *[]string `toml:"native_agents,omitempty"`
 	// Disabled, when true, suppresses the plugin's projection during
 	// marketplace.LoadProjected. `agentsync plugin disable <id>` sets this.
 	// Without honouring it there, the CLI's TOML write would be a no-op:
 	// projection would still surface the plugin's MCP servers / skills / etc.
 	// into the canonical model and apply would ship them.
 	Disabled bool `toml:"disabled,omitempty"`
+}
+
+// DeferredAgents returns the agents this plugin is NOT projected to because they
+// install it themselves. It flattens the absent/empty distinction that only the
+// on-disk representation needs: to every CONSUMER (the projection stamp, the
+// duplicate report, the translation report) "no key" and "empty list" mean the
+// same thing — defer to nobody. Only the `import` prompt gate reads the pointer
+// itself, to tell "never decided" from "decided: nobody".
+func (p PluginSpec) DeferredAgents() []string {
+	if p.NativeAgents == nil {
+		return nil
+	}
+	return *p.NativeAgents
 }
 
 // Marketplace mirrors marketplaces/<name>.toml.

--- a/internal/source/targeting.go
+++ b/internal/source/targeting.go
@@ -1,0 +1,79 @@
+package source
+
+// FilterForAgent returns c narrowed to the components the named agent should
+// receive: every component provided by a plugin that does not target this agent
+// (PluginTargetsAgent — the `agents` allowlist and the `native_agents` deferral)
+// is dropped. Hand-authored components always survive.
+//
+// This is the ONE implementation of "what does this agent get". Two callers need
+// it, and they must never disagree:
+//
+//   - render.Plan, via secrets.Resolved.ForAgent, narrows the model before the
+//     adapter renders it — the enforcement point.
+//   - import's pluginProvided narrows the projection before deciding which
+//     native components it must refuse to capture.
+//
+// The second is not an optimization, it is correctness. That filter exists
+// because an adapter's Ingest cannot tell a file agentsync rendered from a
+// plugin apart from one the user hand-wrote, so import refuses to capture a
+// component apply projects. If it used the UNfiltered projection it would refuse
+// components this agent never receives — a plugin deferred to Claude's own
+// plugin manager would block the user from importing their own same-named file
+// out of Claude. The refusal set has to be exactly the render set, per agent.
+//
+// The result SHARES component values with c (the filter rebuilds slices, it does
+// not deep-copy), so callers must treat both as read-only — which every caller
+// already does.
+func FilterForAgent(c Canonical, agent string) Canonical {
+	out := c
+	out.MCPServers = filterSlice(c.MCPServers, func(m MCPServer) bool {
+		return PluginTargetsAgent(m.Plugin, m.PluginAgents, m.PluginNativeAgents, agent)
+	})
+	out.LSPServers = filterSlice(c.LSPServers, func(l LSPServer) bool {
+		return PluginTargetsAgent(l.Plugin, l.PluginAgents, l.PluginNativeAgents, agent)
+	})
+	out.Hooks = filterSlice(c.Hooks, func(h Hook) bool {
+		return PluginTargetsAgent(h.Plugin, h.PluginAgents, h.PluginNativeAgents, agent)
+	})
+	out.Skills = filterSlice(c.Skills, func(s Skill) bool {
+		return PluginTargetsAgent(s.Plugin, s.PluginAgents, s.PluginNativeAgents, agent)
+	})
+	out.Subagents = filterSlice(c.Subagents, func(s Subagent) bool {
+		return PluginTargetsAgent(s.Plugin, s.PluginAgents, s.PluginNativeAgents, agent)
+	})
+	out.Commands = filterSlice(c.Commands, func(cmd Command) bool {
+		return PluginTargetsAgent(cmd.Plugin, cmd.PluginAgents, cmd.PluginNativeAgents, agent)
+	})
+	// The project overlay is merged into the top-level slices before render
+	// (project.Merge), so filtering it is belt-and-suspenders for a caller
+	// holding an unmerged model — but it must stay in step: an overlay left
+	// unfiltered would hand an adapter the very component the top level dropped.
+	if c.Project != nil {
+		p := FilterForAgent(*c.Project, agent)
+		out.Project = &p
+	}
+	return out
+}
+
+// filterSlice returns the elements of in satisfying keep, preserving order. A
+// nil input stays nil, and a slice that loses nothing is returned as-is, so the
+// common case (no plugins, or every plugin targeting every agent) allocates
+// nothing.
+func filterSlice[T any](in []T, keep func(T) bool) []T {
+	drop := 0
+	for _, v := range in {
+		if !keep(v) {
+			drop++
+		}
+	}
+	if drop == 0 {
+		return in
+	}
+	out := make([]T, 0, len(in)-drop)
+	for _, v := range in {
+		if keep(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/source/targeting.go
+++ b/internal/source/targeting.go
@@ -5,21 +5,16 @@ package source
 // (PluginTargetsAgent — the `agents` allowlist and the `native_agents` deferral)
 // is dropped. Hand-authored components always survive.
 //
-// This is the ONE implementation of "what does this agent get". Two callers need
-// it, and they must never disagree:
+// This is the ONE implementation of "what does this agent get", and it has
+// exactly ONE caller: render.Plan, via secrets.Resolved.ForAgent, narrowing the
+// model before the adapter renders it. That is the enforcement point.
 //
-//   - render.Plan, via secrets.Resolved.ForAgent, narrows the model before the
-//     adapter renders it — the enforcement point.
-//   - import's pluginProvided narrows the projection before deciding which
-//     native components it must refuse to capture.
-//
-// The second is not an optimization, it is correctness. That filter exists
-// because an adapter's Ingest cannot tell a file agentsync rendered from a
-// plugin apart from one the user hand-wrote, so import refuses to capture a
-// component apply projects. If it used the UNfiltered projection it would refuse
-// components this agent never receives — a plugin deferred to Claude's own
-// plugin manager would block the user from importing their own same-named file
-// out of Claude. The refusal set has to be exactly the render set, per agent.
+// import's capture-refusal filter (pluginProvided) deliberately does NOT use it.
+// Symmetry is tempting — refuse exactly what you render — but the destination
+// can still hold agentsync's own un-reclaimed output from before a deferral was
+// recorded, and a narrowed refusal set would capture that back into the
+// canonical source as if the user had written it. See the note at that call
+// site; the asymmetry is load-bearing, not an oversight.
 //
 // The result SHARES component values with c (the filter rebuilds slices, it does
 // not deep-copy), so callers must treat both as read-only — which every caller

--- a/internal/source/targeting_test.go
+++ b/internal/source/targeting_test.go
@@ -1,0 +1,211 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// pluginComponentSet builds a canonical holding one component of every kind,
+// each stamped as provided by `plugin` with the given targeting, plus one
+// hand-authored component of every kind (no Plugin stamp). Both halves matter:
+// the filter must drop the first when the agent is not targeted and must NEVER
+// drop the second.
+func pluginComponentSet(plugin string, agents, native []string) source.Canonical {
+	return source.Canonical{
+		MCPServers: []source.MCPServer{
+			{ID: "mine"},
+			{ID: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+		LSPServers: []source.LSPServer{
+			{ID: "mine"},
+			{ID: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+		Hooks: []source.Hook{
+			{Event: "PreToolUse", Command: "mine"},
+			{Event: "PreToolUse", Command: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+		Skills: []source.Skill{
+			{Name: "mine"},
+			{Name: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+		Subagents: []source.Subagent{
+			{Name: "mine"},
+			{Name: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+		Commands: []source.Command{
+			{Name: "mine"},
+			{Name: "theirs", Plugin: plugin, PluginAgents: agents, PluginNativeAgents: native},
+		},
+	}
+}
+
+// counts returns, per kind, how many components survived — as a flat slice in a
+// fixed order so a single mismatch names the kind.
+func counts(c source.Canonical) map[string]int {
+	return map[string]int{
+		"mcp":      len(c.MCPServers),
+		"lsp":      len(c.LSPServers),
+		"hook":     len(c.Hooks),
+		"skill":    len(c.Skills),
+		"subagent": len(c.Subagents),
+		"command":  len(c.Commands),
+	}
+}
+
+// TestFilterForAgent covers the two gates across every component kind at once.
+// Per-kind coverage is the point: the filter is six near-identical closures, and
+// the way it breaks is one kind silently not being filtered — which projects
+// that kind to an agent the plugin was narrowed away from, re-creating the
+// duplicate for exactly one component type.
+func TestFilterForAgent(t *testing.T) {
+	cases := []struct {
+		name        string
+		agents      []string
+		native      []string
+		target      string
+		wantSurvive int // per kind: 2 = plugin component kept, 1 = only the hand-authored one
+	}{
+		{
+			name:   "no targeting — the plugin reaches every agent",
+			agents: nil, native: nil, target: "claude", wantSurvive: 2,
+		},
+		{
+			name:   "wildcard allowlist reaches every agent",
+			agents: []string{"*"}, target: "claude", wantSurvive: 2,
+		},
+		{
+			name:   "allowlist naming this agent",
+			agents: []string{"claude", "codex"}, target: "claude", wantSurvive: 2,
+		},
+		{
+			name:   "allowlist excluding this agent",
+			agents: []string{"codex"}, target: "claude", wantSurvive: 1,
+		},
+		{
+			name:   "deferral naming this agent — it installs the plugin itself",
+			agents: []string{"*"}, native: []string{"claude"}, target: "claude", wantSurvive: 1,
+		},
+		{
+			name:   "deferral naming a DIFFERENT agent leaves this one alone",
+			agents: []string{"*"}, native: []string{"codex"}, target: "claude", wantSurvive: 2,
+		},
+		{
+			name:   "both gates must pass — allowlist ok, deferral claims it",
+			agents: []string{"claude"}, native: []string{"claude"}, target: "claude", wantSurvive: 1,
+		},
+		{
+			name:   `"*" in the deferral list is a literal, not a wildcard`,
+			agents: []string{"*"}, native: []string{"*"}, target: "claude", wantSurvive: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := source.FilterForAgent(pluginComponentSet("toolkit", tc.agents, tc.native), tc.target)
+			for kind, n := range counts(got) {
+				if n != tc.wantSurvive {
+					t.Errorf("%s: %d survived, want %d", kind, n, tc.wantSurvive)
+				}
+			}
+			// The hand-authored half must survive every case, unconditionally —
+			// the gates are properties of PLUGIN installation.
+			if len(got.Skills) == 0 || got.Skills[0].Name != "mine" {
+				t.Errorf("a hand-authored component was filtered: %+v", got.Skills)
+			}
+		})
+	}
+}
+
+// TestFilterForAgent_FiltersTheProjectOverlay pins the recursion. The overlay is
+// merged into the top-level slices before render, so this looks redundant — and
+// it is exactly the kind of "belt and suspenders" that rots silently. A caller
+// holding an UNMERGED project model would otherwise be handed the very component
+// the top level just dropped.
+func TestFilterForAgent_FiltersTheProjectOverlay(t *testing.T) {
+	overlay := pluginComponentSet("toolkit", []string{"codex"}, nil)
+	c := pluginComponentSet("toolkit", []string{"codex"}, nil)
+	c.Project = &overlay
+
+	got := source.FilterForAgent(c, "claude")
+	if got.Project == nil {
+		t.Fatal("the overlay was dropped entirely, not filtered")
+	}
+	for kind, n := range counts(*got.Project) {
+		if n != 1 {
+			t.Errorf("project overlay %s: %d survived, want 1 (only the hand-authored one)", kind, n)
+		}
+	}
+}
+
+// TestFilterForAgent_NoOpSharesTheInput documents the aliasing contract: when
+// nothing is filtered the slices are returned as-is rather than copied. Callers
+// must treat both models as read-only. If this ever needs to change, the change
+// is a deliberate one — not something to discover from a mutation bug.
+func TestFilterForAgent_NoOpSharesTheInput(t *testing.T) {
+	c := pluginComponentSet("toolkit", []string{"*"}, nil)
+	got := source.FilterForAgent(c, "claude")
+	if len(got.Skills) != len(c.Skills) {
+		t.Fatalf("nothing should have been filtered; got %d of %d skills", len(got.Skills), len(c.Skills))
+	}
+	c.Skills[0].Name = "mutated"
+	if got.Skills[0].Name != "mutated" {
+		t.Error("the no-op path is expected to share backing storage with its input; " +
+			"if that changed deliberately, update this test and the FilterForAgent doc")
+	}
+}
+
+// TestAgentTargeted covers the allowlist predicate on its own, including the
+// documented default that an empty/absent list means every agent.
+func TestAgentTargeted(t *testing.T) {
+	cases := []struct {
+		name   string
+		agents []string
+		agent  string
+		want   bool
+	}{
+		{name: "nil means all", agents: nil, agent: "claude", want: true},
+		{name: "empty means all", agents: []string{}, agent: "claude", want: true},
+		{name: "wildcard", agents: []string{"*"}, agent: "claude", want: true},
+		{name: "named", agents: []string{"codex", "claude"}, agent: "claude", want: true},
+		{name: "not named", agents: []string{"codex"}, agent: "claude", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := source.AgentTargeted(tc.agents, tc.agent); got != tc.want {
+				t.Errorf("AgentTargeted(%v, %q) = %v, want %v", tc.agents, tc.agent, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPluginTargetsAgent_HandAuthoredAlwaysTargets pins the exemption at the
+// predicate level, where it is one early return that a refactor could drop
+// without any per-kind test noticing: a hand-authored component has no Plugin,
+// so neither gate applies to it.
+func TestPluginTargetsAgent_HandAuthoredAlwaysTargets(t *testing.T) {
+	// Deliberately hostile inputs: an allowlist that excludes the agent AND a
+	// deferral that claims it. With no plugin, neither may bite.
+	if !source.PluginTargetsAgent("", []string{"codex"}, []string{"claude"}, "claude") {
+		t.Error("a component with no providing plugin must render for every agent")
+	}
+	if source.PluginTargetsAgent("toolkit", []string{"codex"}, []string{"claude"}, "claude") {
+		t.Error("the same targeting must bite when a plugin DOES provide the component")
+	}
+}
+
+// TestPluginSpec_DeferredAgents pins the accessor that flattens the on-disk
+// absent/empty distinction for consumers. Only the import prompt gate reads the
+// pointer itself; everything else must see both as "defer to nobody".
+func TestPluginSpec_DeferredAgents(t *testing.T) {
+	empty := []string{}
+	populated := []string{"claude"}
+	if got := (source.PluginSpec{}).DeferredAgents(); got != nil {
+		t.Errorf("absent key: got %v, want nil", got)
+	}
+	if got := (source.PluginSpec{NativeAgents: &empty}).DeferredAgents(); len(got) != 0 {
+		t.Errorf("explicitly empty: got %v, want no agents", got)
+	}
+	if got := (source.PluginSpec{NativeAgents: &populated}).DeferredAgents(); len(got) != 1 || got[0] != "claude" {
+		t.Errorf("populated: got %v, want [claude]", got)
+	}
+}

--- a/website/src/content/docs/getting-started/existing-configs.mdx
+++ b/website/src/content/docs/getting-started/existing-configs.mdx
@@ -78,11 +78,20 @@ write without touching `~/.agentsync/`.
 	paths, you would get two of every skill, subagent and command, and its hooks
 	would fire twice.
 
-	`import` therefore records `native_agents = ["claude"]` in
-	`plugins/<id>.toml` and tells you it did. Claude keeps serving the plugin
-	itself; **every other enabled agent gets the full fan-out**, which is the
-	reason to import it. To hand it over to agentsync completely, uninstall it in
-	Claude and remove that agent from `native_agents`.
+	`import` therefore **asks**, per plugin: *"Let claude keep serving this
+	plugin? [Y]es / [n]o, project it there too"*. Accepting records
+	`native_agents = ["claude"]` in `plugins/<id>.toml`. Claude keeps serving the
+	plugin itself; **every other enabled agent gets the full fan-out**, which is
+	the reason to import it.
+
+	Declining warns you that agentsync will duplicate the plugin's content in
+	Claude, and that you should disable or uninstall it there now that agentsync
+	manages it. Under `--no-input`, or when stdin is not a terminal, the deferral
+	is recorded without asking — a scripted import must not silently produce two
+	of everything.
+
+	To hand a plugin over to agentsync completely, uninstall it in Claude and
+	remove that agent from `native_agents`.
 </Aside>
 
 <Aside type="caution" title="The first apply on a populated machine">

--- a/website/src/content/docs/getting-started/existing-configs.mdx
+++ b/website/src/content/docs/getting-started/existing-configs.mdx
@@ -71,6 +71,20 @@ write without touching `~/.agentsync/`.
 	add it with `agentsync marketplace add <source>` and re-import.
 </Aside>
 
+<Aside type="note" title="An imported plugin is not projected back into the agent it came from">
+	Importing a plugin out of Claude means Claude has it installed — and `apply`
+	deliberately never disables a plugin inside another tool's plugin manager. So
+	if agentsync also projected that plugin's components into Claude's standalone
+	paths, you would get two of every skill, subagent and command, and its hooks
+	would fire twice.
+
+	`import` therefore records `native_agents = ["claude"]` in
+	`plugins/<id>.toml` and tells you it did. Claude keeps serving the plugin
+	itself; **every other enabled agent gets the full fan-out**, which is the
+	reason to import it. To hand it over to agentsync completely, uninstall it in
+	Claude and remove that agent from `native_agents`.
+</Aside>
+
 <Aside type="caution" title="The first apply on a populated machine">
 	On a machine that already has native config, the **first** `apply` sees files it
 	didn't write and treats them as a `foreign-collision`: it **backs each one up**

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -76,7 +76,7 @@ Two keys in a plugin's TOML decide which agents its components render to:
 [plugin]
 id            = "atlassian@anthropic"
 agents        = ["claude"]   # only fan this plugin out to Claude
-native_agents = []           # agents that install it themselves (see below)
+# native_agents = ["claude"] # OMIT unless an agent installs this itself (see below)
 ```
 
 `agents` is your allowlist — `["*"]`, or omitted, means every enabled agent. It

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -95,12 +95,18 @@ agent here stops the projection for that agent only.
 A component renders for an agent when `agents` targets it **and**
 `native_agents` does not claim it.
 
-<Aside type="tip" title="`import` fills this in for you">
-	`agentsync import claude:plugin` records `native_agents = ["claude"]` — it
-	just discovered the plugin installed there — and says so on the import line.
-	Every other enabled agent still gets the full fan-out. To hand the plugin over
-	to agentsync completely, uninstall it in the agent and drop that agent from
-	the list.
+<Aside type="tip" title="`import` asks about this, per plugin">
+	`agentsync import claude:plugin` just discovered the plugin installed in
+	Claude, so it offers the deferral: *"Let claude keep serving this plugin?
+	[Y]es / [n]o, project it there too"*. Accepting records
+	`native_agents = ["claude"]`; every other enabled agent still gets the full
+	fan-out. Declining warns that agentsync will duplicate the plugin's content
+	there and that you should disable it inside Claude yourself. Under
+	`--no-input` or a non-TTY stdin the deferral is recorded without asking, so a
+	scripted import never silently produces two of everything.
+
+	To hand the plugin over to agentsync completely, uninstall it in the agent and
+	drop that agent from the list.
 
 	Because `apply` never inspects your agents' installed plugins (that is what
 	keeps a render reproducible from your dotfiles repo alone), a plugin you

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -123,8 +123,11 @@ A component renders for an agent when `agents` targets it **and**
 	`plugin disable`/`enable` and re-running `plugin add` on an
 	already-registered plugin **preserve** its `agents` allowlist and
 	`native_agents` list (and its `update` mode and `disabled` state) — they never
-	silently re-broaden a narrowed plugin back to every agent, and a re-import
-	never re-adds an agent you deliberately adopted. Only
+	silently re-broaden a narrowed plugin back to every agent. Adopting a plugin
+	(uninstalling it in the agent, then dropping that agent from `native_agents`)
+	sticks, because the agent no longer reports the plugin as installed — and if
+	you drop the entry WITHOUT uninstalling it there, the next import asks again
+	rather than silently re-deferring. Only
 	`id`/`version`/`manifest_sha` are refreshed by a re-install (from the fresh
 	fetch); when a re-install keeps non-default targeting, the command says so
 	(e.g. `(kept agents=[claude], update=pinned)`).

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -70,30 +70,58 @@ agentsync plugin explain atlassian@anthropic --json
 
 ## Controlling per-plugin fan-out
 
-Limit a plugin to specific agents with an `agents = [...]` allowlist in its TOML
-file:
+Two keys in a plugin's TOML decide which agents its components render to:
 
 ```toml title="~/.agentsync/plugins/atlassian.toml"
-id     = "atlassian@anthropic"
-agents = ["claude"]   # only fan this plugin out to Claude
+[plugin]
+id            = "atlassian@anthropic"
+agents        = ["claude"]   # only fan this plugin out to Claude
+native_agents = []           # agents that install it themselves (see below)
 ```
+
+`agents` is your allowlist — `["*"]`, or omitted, means every enabled agent. It
+is a deliberate, security-relevant choice: a plugin's MCP servers, hooks, and
+skills can carry `${secret:…}` credentials, so `agents = ["claude"]` keeps that
+blast radius scoped to Claude only.
+
+`native_agents` is different in kind — not a preference but a fact about your
+machine. An agent whose own plugin manager installs a plugin (you ran
+`/plugin install` in Claude Code) already serves its components. agentsync never
+disables a plugin inside another tool's plugin manager, so projecting the same
+components into that agent's standalone paths would simply duplicate them: two
+of every skill, subagent and command, and every hook firing twice. Listing the
+agent here stops the projection for that agent only.
+
+A component renders for an agent when `agents` targets it **and**
+`native_agents` does not claim it.
+
+<Aside type="tip" title="`import` fills this in for you">
+	`agentsync import claude:plugin` records `native_agents = ["claude"]` — it
+	just discovered the plugin installed there — and says so on the import line.
+	Every other enabled agent still gets the full fan-out. To hand the plugin over
+	to agentsync completely, uninstall it in the agent and drop that agent from
+	the list.
+
+	Because `apply` never inspects your agents' installed plugins (that is what
+	keeps a render reproducible from your dotfiles repo alone), a plugin you
+	install natively *after* declaring it in agentsync goes unnoticed at apply
+	time — `agentsync status` and `agentsync doctor` report that pair instead.
+</Aside>
 
 <Aside type="caution" title="Per-component overrides are not wired in v1">
 	A per-component `[plugin.overrides.<agent>]` table was specced but the projector
-	**does not consult it** in v1 — use the `agents` allowlist instead.
+	**does not consult it** in v1 — use the keys above.
 </Aside>
 
-The allowlist is a deliberate, security-relevant choice: a plugin's MCP servers,
-hooks, and skills can carry `${secret:…}` credentials, so `agents = ["claude"]`
-keeps that blast radius scoped to Claude only.
-
-<Aside type="note" title="Lifecycle commands preserve your allowlist">
+<Aside type="note" title="Lifecycle commands preserve your targeting">
 	`plugin disable`/`enable` and re-running `plugin add` on an
-	already-registered plugin **preserve** its `agents` allowlist (and its `update`
-	mode and `disabled` state) — they never silently re-broaden a narrowed plugin
-	back to every agent. Only `id`/`version`/`manifest_sha` are refreshed by a
-	re-install (from the fresh fetch); when a re-install keeps non-default
-	targeting, the command says so (e.g. `(kept agents=[claude], update=pinned)`).
+	already-registered plugin **preserve** its `agents` allowlist and
+	`native_agents` list (and its `update` mode and `disabled` state) — they never
+	silently re-broaden a narrowed plugin back to every agent, and a re-import
+	never re-adds an agent you deliberately adopted. Only
+	`id`/`version`/`manifest_sha` are refreshed by a re-install (from the fresh
+	fetch); when a re-install keeps non-default targeting, the command says so
+	(e.g. `(kept agents=[claude], update=pinned)`).
 </Aside>
 
 ## Plugin lifecycle
@@ -108,7 +136,8 @@ agentsync plugin list
 ```
 
 `disable`/`enable` flip only the `disabled` bit and `install` refreshes only the
-fetched fields — so your `agents` allowlist survives the full lifecycle untouched.
+fetched fields — so your `agents` and `native_agents` targeting survives the
+full lifecycle untouched.
 
 <LinkCard
 	title="Agent capability matrix"

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -383,6 +383,15 @@ machine-readable output (rows for plugin/agent coverage — each with a
 `skipDetails` array of `{component, name, reason, kind}`, where `kind` is
 `"reduced"` or `"dropped"` and `component` is the plain kind).
 
+A row's `coverage` is one of `"full"`, `"partial"`, `"none"` — how much of what
+the plugin ships this agent got — or one of three values meaning it contributed
+nothing here by CONFIGURATION rather than by failed translation: `"disabled"`
+(the plugin is off for this scope, paired with `disabled: true`),
+`"not-targeted"` (its `agents` allowlist excludes this agent) or `"native"`
+(its `native_agents` list defers to this agent's own plugin manager). The last
+two are paired with `notTargeted: true`; branch on the booleans rather than the
+strings.
+
 ```bash
 agentsync plugin explain atlassian@anthropic
 agentsync plugin explain atlassian@anthropic superpowers@obra

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -34,6 +34,70 @@ newest first. It is what the CLI's one-time upgrade notice links to.
 
 ## 0.11.0
 
+### A plugin an agent installs itself is no longer projected into that agent
+
+If you ran `agentsync import claude` and then `agentsync apply` while a plugin
+was still enabled inside Claude Code, you ended up with two of everything that
+plugin ships. Claude kept serving its own copy from its install dir, and
+agentsync projected the same components into Claude's standalone paths. Because
+those components are namespaced, the two sets did not collide — they coexisted:
+
+| | Claude's own copy | agentsync's projection |
+|---|---|---|
+| skill | `/feature-dev:code-review` | `/feature-dev-code-review` |
+| subagent | `feature-dev:code-reviewer` | `@agent-feature-dev-code-reviewer` |
+| hook | runs | runs **again** |
+
+`apply` never writes plugin enablement back into an agent's config — that is a
+deliberate invariant, so agentsync never fights the agent's own `/plugin`
+UI — and it never removed it either. So the fix is not to project there.
+
+`plugins/<id>.toml` gains **`native_agents`**: the agents whose own plugin
+manager installs this plugin.
+
+```toml
+[plugin]
+id            = "feature-dev@claude-plugins-official"
+agents        = ["*"]        # your fan-out choice
+native_agents = ["claude"]   # claude installs this itself — don't project there
+```
+
+`agentsync import claude:plugin` now records `native_agents = ["claude"]` for
+what it finds and says so on the import line. Every other enabled agent still
+receives the full fan-out — that is the reason to import a plugin in the first
+place.
+
+**What you need to do.** Existing installs are unchanged until you act: your
+`plugins/*.toml` have no `native_agents`, so apply keeps projecting exactly as
+before. Either re-run `agentsync import <agent>:plugin` to record the deferral,
+or add the key by hand. `agentsync status` and `agentsync doctor` now warn when
+a plugin is installed in an agent *and* projected there, so you can see which
+ones are affected.
+
+**To hand a plugin over to agentsync completely**, uninstall it in the agent
+(`/plugin uninstall` in Claude Code) and remove that agent from `native_agents`.
+The next apply projects the components there.
+
+<Aside type="note" title="Why this is recorded rather than detected">
+	`apply` does not look at what your agents have installed. If it did, the same
+	`~/.agentsync/` would render differently on two machines and `agentsync diff`
+	would stop being reproducible — and agentsync's drift detection compares your
+	source against what it last wrote, on the assumption that the source does not
+	depend on the destination. `import` reads native state once and writes the
+	conclusion into your canonical source; every later apply reads only that.
+</Aside>
+
+### `agents` in `plugins/<id>.toml` now actually narrows fan-out
+
+The `agents` allowlist has been documented since v1.0 and was never read: a
+plugin with `agents = ["codex"]` still fanned out to every enabled agent. It now
+works, and it composes with `native_agents` — a plugin renders for an agent only
+if `agents` targets it and `native_agents` does not claim it.
+
+If you narrowed a plugin's allowlist expecting it to take effect, check it now:
+it will start being honoured on your next apply, and components that were
+previously written to the excluded agents are removed.
+
 ### Plugin-provided components are namespaced by their plugin
 
 A subagent, skill, or slash command that comes from an installed plugin now

--- a/website/src/content/docs/reference/upgrading.mdx
+++ b/website/src/content/docs/reference/upgrading.mdx
@@ -62,10 +62,23 @@ agents        = ["*"]        # your fan-out choice
 native_agents = ["claude"]   # claude installs this itself — don't project there
 ```
 
-`agentsync import claude:plugin` now records `native_agents = ["claude"]` for
-what it finds and says so on the import line. Every other enabled agent still
+`agentsync import claude:plugin` now **asks**, per plugin:
+
+```
+ℹ INFO   claude already installs the plugin "feature-dev".
+         agentsync can leave those components to claude, or project its own copy alongside them.
+  Let claude keep serving this plugin? [Y]es / [n]o, project it there too:
+```
+
+Accepting records `native_agents = ["claude"]`. Every other enabled agent still
 receives the full fan-out — that is the reason to import a plugin in the first
 place.
+
+Declining is allowed, and warns you what it means: agentsync will duplicate the
+plugin's content in that harness, so you should disable or uninstall the plugin
+there now that agentsync manages it. Under `--no-input` or a non-TTY stdin the
+deferral is recorded without asking, so a scripted import never silently
+produces two of everything.
 
 **What you need to do.** Existing installs are unchanged until you act: your
 `plugins/*.toml` have no `native_agents`, so apply keeps projecting exactly as


### PR DESCRIPTION
## Summary

`agentsync import claude` followed by `agentsync apply`, with the plugin still enabled inside Claude Code, produced a **duplicate of every component that plugin ships**.

`apply` deliberately never writes plugin enablement back into an agent's config (the `PluginIngester` read-only invariant) — but it never *removed* it either. So Claude kept serving its own copy from its install dir while agentsync projected the same components into Claude's standalone paths. Namespacing (`<plugin>-<name>`, #211) meant the two sets coexisted rather than collided:

| | Claude's own copy | agentsync's projection |
|---|---|---|
| skill | `/feature-dev:code-review` | `/feature-dev-code-review` |
| subagent | `feature-dev:code-reviewer` | `@agent-feature-dev-code-reviewer` |
| MCP server | plugin `.mcp.json` id | same id in `~/.claude.json` |
| hook | runs | runs **again** |

**`plugins/<id>.toml` gains `native_agents`** — the agents whose own plugin manager installs this plugin, where agentsync must not project. `import` asks per plugin and records it; every *other* enabled agent still gets the full fan-out, which is the reason to import a plugin at all.

It is a separate key from `agents` rather than a subtraction folded into it. `agents` is the user's fan-out choice; `native_agents` is a statement about the machine. A materialized subtraction would also freeze the agent set (a newly-enabled agent would silently miss a plugin nobody excluded), and has no honest encoding for the degenerate case — every enabled agent serving the plugin natively would have to write `agents = []`, which already means *every* agent.

**Also fixes `agents` itself**, documented since v1.0 and never read: `projectOnePlugin` honoured only `disabled`, so a narrowed allowlist silently fanned out everywhere.

### Two properties are load-bearing

- **Declared, never inferred.** `apply` does not probe the destination. If it did, the same `~/.agentsync/` would render differently on two machines, `diff` would stop being reproducible, and the 3-way drift classifier compares source / last-applied / destination on the assumption that the first doesn't depend on the third. `import` reads native state once and writes the conclusion into canonical source.
- **One enforcement point.** `source.FilterForAgent`, reached via `secrets.Resolved.ForAgent` in `render.Plan` — never inside an adapter. Ten adapters × six component kinds is sixty places to forget, each omission silently re-creating the duplicate for one kind on one agent.

`import`'s capture-refusal filter deliberately does **not** narrow the same way. Symmetry is tempting and wrong: between recording a deferral and the apply that reclaims the files, the destination still holds agentsync's own rendered output, and a narrowed refusal set captures it back as hand-authored. Over-refusal fails loudly naming the plugin; under-refusal fails silently and permanently.

`status` and `doctor` warn when a plugin is installed natively in an agent **and** projected there — the case `apply` cannot see by construction.

## Type of change

- [x] Bug fix
- [x] New feature / enhancement
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

Five rounds of four-lens adversarial review (correctness / adversarial / API design / test rigor), converging on 2-of-3 `CLEAN — ship it`. Every non-trivial fix was **break-verified** against a reverted implementation in a throwaway clone.

What the loop caught, beyond the original bug:

- **`native_agents = []` was erased on every rewrite.** `omitempty` drops an empty slice, so the documented "defer to nobody" escape hatch decoded fine and vanished on the next write — after which the next import re-seeded the deferral, silently, and under `--no-input` without asking. Both the canonical field and the CLI's copy are `*[]string` now, so all three on-disk states round-trip.
- **`import` could capture agentsync's own output as hand-authored** (the narrowing described above; reverted).
- **`plugin explain` reported a deferred plugin as a failure** — a red `✗ native  no components`. A second renderer of the same rows; the wording now lives on `render.PluginRow.TargetingNote()` and the `Coverage` vocabulary is exported so `cli` matches constants, not literals.
- **`apply`'s report over-counted** — the per-agent inventory ignored plugin gates, so a deferred plugin's components were counted under another plugin's row.
- **`doctor` warned about agents agentsync doesn't render to**, recommending the user uninstall working functionality. The enablement gate moved inside the check.
- **`status --scope project` read the user pin** while a project render honours the project one.
- Plus invalid TOML in the opt-out remedy for ≥2 agents, unsanitized on-disk values reaching the terminal, `--dry-run` promising an outcome the prompt may decline, and several stale/false doc claims — including one that would have led a reader to reintroduce the capture bug.

New tests (~40) anchor to the **on-disk artifact**, per the fidelity rule: fixtures ship a plugin with a subagent, skill, command, MCP server and hook, and the oracle is the rendered file tree. The stamping guard is reflective over `ProjectionResult`, so a *future* component kind fails until it's stamped too.

- [ ] `just test-release` is green (the release bar) — **not run here**; this environment can't start the hermetic container. Verified instead: `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` green, and `-race` green on the touched packages.
- [x] `just lint` is clean — `golangci-lint@v2.12.2` reports **0 issues**; `go mod tidy` produces no diff.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them.
  - `secrets.Resolved.ForAgent` reads the private canonical and returns another `Resolved` — no new unwrap seam, forbidigo fence untouched, `capture.Capture` unchanged. The six new stamped fields are `[]string` and therefore string-shaped, so `TestNewSecretFieldGuard` forced an explicit classification of each; all six are `false` with rationale.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed — `docs/{concepts,architecture,components,user-guide,capability-matrix}.md`, `CHANGELOG.md`, an `upgradeNotices` entry, and the matching website pages.

## Upgrade impact

Existing installs are **unchanged until the user acts**: no `plugins/*.toml` carries `native_agents`, so apply keeps projecting exactly as before. Re-run `agentsync import <agent>:plugin` (it now asks) or add the key by hand; `status`/`doctor` point at the affected plugins. A one-time upgrade notice ships with the matching `upgrading.mdx` section.

## Known residuals — both deliberate, both advisory-only, neither affects what `apply` writes

1. `plugin outdated --lossless` builds its projection unstamped, so the per-agent narrowing is inert there; it can decline an upgrade over a skip on an agent the plugin never reaches. Fails in the safe direction. Documented in place; closing it means threading targeting lists through two signatures.
2. The duplicate warning follows `selected` rather than `enabled`, so `--agents` narrowing can over-report on a deselected-but-enabled agent.

Happy to file both as follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5yJVbFg6QL5cBsqG6t23x)_