### PR TITLE
fix(cli): say what --lossless and a narrowed duplicate check did not consider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,27 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   the plugin is not projected to still refuses the upgrade. The refusal is safe
   (it declines rather than performs) but was undiagnosable — an upgrade blocked
   over an agent the user knows does not receive the plugin, with nothing to
-  search for. Both `plugin upgrade --lossless` and `plugin outdated --lossless`
-  now name the gap, point at `plugin explain <id>` to check, and say to re-run
-  without the flag if the affected agent does not receive the plugin. The
-  underlying gap is unchanged.
+  search for. Both forms that take the flag — `plugin upgrade <id> --lossless`
+  and `plugin upgrade --all --lossless` — now name the gap, point at
+  `plugin explain <id>` to check, and say to re-run without the flag if the
+  affected agent does not receive the plugin. The underlying gap is unchanged.
+  (`plugin outdated` does not define `--lossless`; the flag only filters what
+  gets applied.)
+- **`--lossless` no longer reports an unevaluable bump as a lossy one.**
+  `plugin upgrade --all --lossless` excluded fetch/parse failures conservatively
+  — correct — but folded them in with measured losses, so a bump nothing had
+  judged was announced as "candidate version drops translation for an agent".
+  Those are now reported as what they are, and the targeting caveat above is
+  attached only to bumps a render actually judged lossy: its advice ("the loss
+  may fall on an agent this plugin is not projected to; re-run without
+  `--lossless`") is wrong for a bump that was never measured. Which bumps get
+  applied is unchanged.
 - **`status --agents` says which agents its duplicate check skipped.** The
   installed-natively-AND-projected warning follows the selected set, which is
   correct — a narrowed report should not discuss agents it excluded — but it
   made silence ambiguous between "no duplicates" and "duplicates on an agent you
-  narrowed away". A narrowed run now reports how many enabled agents went
-  unexamined, whether or not a duplicate was found.
-
+  narrowed away". A narrowed run now names the enabled agents that install
+  plugins natively and went unexamined, whether or not a duplicate was found.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   may fall on an agent this plugin is not projected to; re-run without
   `--lossless`") is wrong for a bump that was never measured. Which bumps get
   applied is unchanged.
+- **A `--lossless` run that excluded everything no longer reports success.**
+  `plugin upgrade --all --lossless` ended with `all plugins are up to date`
+  even when every pending bump had just been refused — contradicting the
+  refusals it had printed a line earlier. It now says how many bumps were
+  excluded instead.
 - **`status --agents` says which agents its duplicate check skipped.** The
   installed-natively-AND-projected warning follows the selected set, which is
   correct — a narrowed report should not discuss agents it excluded — but it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 - **A `--lossless` run that excluded everything no longer reports success.**
   `plugin upgrade --all --lossless` ended with `all plugins are up to date`
   even when every pending bump had just been refused — contradicting the
-  refusals it had printed a line earlier. It now says how many bumps were
-  excluded instead.
+  refusals it had printed a line earlier. It now reports the exclusion instead,
+  on stdout with the result rather than among the diagnostics.
 - **`status --agents` says which agents its duplicate check skipped.** The
   installed-natively-AND-projected warning follows the selected set, which is
   correct — a narrowed report should not discuss agents it excluded — but it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ## [Unreleased]
 
+### Changed
+
+- **`--lossless` now says what its check did not consider.** The lossiness probe
+  renders every enabled agent from a canonical carrying no plugin provenance, so
+  it does not honour a plugin's `agents` / `native_agents`: a skip on an agent
+  the plugin is not projected to still refuses the upgrade. The refusal is safe
+  (it declines rather than performs) but was undiagnosable — an upgrade blocked
+  over an agent the user knows does not receive the plugin, with nothing to
+  search for. Both `plugin upgrade --lossless` and `plugin outdated --lossless`
+  now name the gap, point at `plugin explain <id>` to check, and say to re-run
+  without the flag if the affected agent does not receive the plugin. The
+  underlying gap is unchanged.
+- **`status --agents` says which agents its duplicate check skipped.** The
+  installed-natively-AND-projected warning follows the selected set, which is
+  correct — a narrowed report should not discuss agents it excluded — but it
+  made silence ambiguous between "no duplicates" and "duplicates on an agent you
+  narrowed away". A narrowed run now reports how many enabled agents went
+  unexamined, whether or not a duplicate was found.
+
+
 ### Added
 
 - **`status --legend`** prints a standalone glossary explaining all nine drift

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -646,17 +646,21 @@ narrowed allowlist or an adopted plugin is never silently reset.
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read
 it, and warn when a plugin is installed in an agent *and* projected there. Under
-`--agents`, that check follows the agents you selected — so a narrowed run tells
-you how many enabled agents it did not examine, rather than letting silence read
-as a clean bill of health.
+`--agents`, that check follows the agents you selected — so a narrowed run names
+the enabled agents with a native plugin manager that it did not examine, rather
+than letting silence read as a clean bill of health.
 
-One caveat on `--lossless`: the check that decides whether an upgrade would lose
-something in translation renders every *enabled* agent and does **not** honour a
-plugin's `agents` / `native_agents`. So it can decline an upgrade over a loss
-that falls on an agent this plugin is never projected to. It errs toward
-declining, never toward upgrading; run `agentsync plugin explain <id>` to see
-which agents actually receive the plugin, and re-run without `--lossless` if the
-affected one is not among them.
+One caveat on `--lossless` (`plugin upgrade <id> --lossless` and
+`plugin upgrade --all --lossless`; `plugin outdated` does not take the flag):
+the check that decides whether an upgrade would lose something in translation
+renders every *enabled* agent and does **not** honour a plugin's `agents` /
+`native_agents`. So it can decline an upgrade over a loss that falls on an agent
+this plugin is never projected to. It errs toward declining, never toward
+upgrading; run `agentsync plugin explain <id>` to see which agents actually
+receive the plugin, and re-run without `--lossless` if the affected one is not
+among them. A bump the check could not evaluate at all is also excluded, but
+reported separately — that refusal is not about targeting, and dropping the flag
+is not the answer to it.
 
 (A per-component `[plugin.overrides.<agent>]` table was specced but is **not
 wired in v1** — the projector does not consult it; use the keys above.)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -645,7 +645,18 @@ narrowed allowlist or an adopted plugin is never silently reset.
 
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read
-it, and warn when a plugin is installed in an agent *and* projected there.
+it, and warn when a plugin is installed in an agent *and* projected there. Under
+`--agents`, that check follows the agents you selected — so a narrowed run tells
+you how many enabled agents it did not examine, rather than letting silence read
+as a clean bill of health.
+
+One caveat on `--lossless`: the check that decides whether an upgrade would lose
+something in translation renders every *enabled* agent and does **not** honour a
+plugin's `agents` / `native_agents`. So it can decline an upgrade over a loss
+that falls on an agent this plugin is never projected to. It errs toward
+declining, never toward upgrading; run `agentsync plugin explain <id>` to see
+which agents actually receive the plugin, and re-run without `--lossless` if the
+affected one is not among them.
 
 (A per-component `[plugin.overrides.<agent>]` table was specced but is **not
 wired in v1** — the projector does not consult it; use the keys above.)

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -456,6 +456,7 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 		case isLossy:
 			diag(cmd, ui.LevelInfo,
 				"lossless: skipping lossy upgrade %s (candidate version drops translation for an agent)", id)
+			detail(cmd, "%s", losslessTargetingCaveat)
 			return nil
 		}
 	}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -436,7 +436,9 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 	// renders the installed cache and a throwaway fetch of the candidate and
 	// compares skip identities; a candidate that adds one is reported and the
 	// upgrade is refused, leaving cache + TOML exactly as they were. An
-	// evaluation failure is conservatively lossy, matching --all's filter.
+	// evaluation failure is conservatively EXCLUDED too, matching --all's filter
+	// — but as its own outcome, not as a measured loss: it hard-errors here and
+	// carries no targeting caveat, exactly as --all's `unevaluable` bucket does.
 	if lossless {
 		userHome := paths.HomeDir(paths.OSEnv{})
 		c, cerr := source.Load(afero.NewOsFs(), home)

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -437,8 +437,10 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 	// compares skip identities; a candidate that adds one is reported and the
 	// upgrade is refused, leaving cache + TOML exactly as they were. An
 	// evaluation failure is conservatively EXCLUDED too, matching --all's filter
-	// — but as its own outcome, not as a measured loss: it hard-errors here and
-	// carries no targeting caveat, exactly as --all's `unevaluable` bucket does.
+	// — but as its own outcome, not as a measured loss. The two paths report it
+	// differently (this one hard-errors; --all warns and drops the bump into its
+	// `unevaluable` bucket) and agree on what matters: neither treats it as a
+	// measured loss, and neither carries the targeting caveat.
 	if lossless {
 		userHome := paths.HomeDir(paths.OSEnv{})
 		c, cerr := source.Load(afero.NewOsFs(), home)

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -883,6 +883,12 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if !strings.Contains(out, "claude also installs plugins natively") {
 		t.Errorf("the note must name the unexamined agent, not just count it; got:\n%s", out)
 	}
+	// The SINGULAR verb. Its plural mirror is asserted on the two-agent run at
+	// the end of this test; pinning only one of the pair leaves the other free
+	// to regress, which is exactly what a sweep found after the first fix.
+	if !strings.Contains(out, "was not examined") {
+		t.Errorf("one unexamined agent takes the singular verb; got:\n%s", out)
+	}
 	// Silence-qualifying half: this run found nothing, and the lead clause must
 	// say so. Without it the sentence reads as if a duplicate had been reported.
 	if !strings.Contains(out, "no duplicate was reported above, but this check covered only") {

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -803,4 +803,104 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if !strings.Contains(out, "were not examined") {
 		t.Errorf("silence under --agents must say which agents went unchecked; got:\n%s", out)
 	}
+	// The note NAMES the unexamined agents rather than counting them: "claude"
+	// is the one that could have carried a duplicate, and it is the whole point
+	// of the sentence.
+	if !strings.Contains(out, "claude also install plugins natively") {
+		t.Errorf("the note must name the unexamined agent, not just count it; got:\n%s", out)
+	}
+	// Silence-qualifying half: this run found nothing, and the lead clause must
+	// say so. Without it the sentence reads as if a duplicate had been reported.
+	if !strings.Contains(out, "no duplicates found, but this check covered only") {
+		t.Errorf("a narrowed run that found nothing must lead with that; got:\n%s", out)
+	}
+
+	// Narrowed to the agent WITH the duplicate: the warning fires, so the note
+	// must NOT claim nothing was found — the other half of the `warned` switch.
+	// Pinning both halves is what makes inverting the condition a test failure.
+	out, err = runCLI(t, env, "status", "--agents", "claude")
+	if err != nil {
+		t.Fatalf("status --agents claude: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "projected there by agentsync") {
+		t.Fatalf("setup: narrowing to claude should still report the duplicate; got:\n%s", out)
+	}
+	if !strings.Contains(out, "were not examined") {
+		t.Errorf("a narrowed run must be qualified whether or not it warned; got:\n%s", out)
+	}
+	if strings.Contains(out, "no duplicates found") {
+		t.Errorf("a run that DID report a duplicate must not also say none was found; got:\n%s", out)
+	}
+}
+
+// TestStatus_ScopingNoteStaysSilentWhenNothingWasHidden pins the note's guard,
+// on the two conditions that make a narrowing harmless.
+//
+// The note qualifies duplicatedNativePlugins' silence, so it must fire on the
+// same conditions that check runs on. Round 1 of the review loop reproduced the
+// alternative in both directions: a note that blames the narrowing for a
+// silence the narrowing did not cause, and a note that stays quiet when the
+// narrowing really did hide a duplicate.
+//
+// Both subtests are chosen to FAIL against the predicate this replaced
+// (`len(c.Plugins) > 0` plus a bare `len(enabled)-len(selected)` count) — a
+// guard test that passes either way pins nothing.
+func TestStatus_ScopingNoteStaysSilentWhenNothingWasHidden(t *testing.T) {
+	t.Run("declared but disabled", func(t *testing.T) {
+		tmp, env := importTestEnv(t)
+		if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+			t.Fatalf("agent add codex: %v", err)
+		}
+		mpDir := makeFanOutMarketplace(t, t.TempDir())
+		if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+			t.Fatalf("marketplace add: %v\n%s", err, out)
+		}
+		if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+			t.Fatalf("plugin add: %v\n%s", err, out)
+		}
+		// Disabled: still IN c.Plugins, but not effectively declared — so
+		// duplicatedNativePlugins returns having examined nothing.
+		if out, err := runCLI(t, env, "plugin", "disable", "toolkit"); err != nil {
+			t.Fatalf("plugin disable: %v\n%s", err, out)
+		}
+		writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+		out, err := runCLI(t, env, "status", "--agents", "codex")
+		if err != nil {
+			t.Fatalf("status --agents codex: %v\n%s", err, out)
+		}
+		if strings.Contains(out, "were not examined") {
+			t.Errorf("a disabled plugin is not checked for duplication, so there is no "+
+				"narrowed check to qualify; got:\n%s", out)
+		}
+	})
+
+	t.Run("narrowed-away agent has no plugin manager", func(t *testing.T) {
+		tmp, env := importTestEnv(t)
+		// opencode has no native plugin concept, so narrowing it away cannot
+		// hide a duplicate — there is nothing to report.
+		if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+			t.Fatalf("agent add opencode: %v", err)
+		}
+		mpDir := makeFanOutMarketplace(t, t.TempDir())
+		if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+			t.Fatalf("marketplace add: %v\n%s", err, out)
+		}
+		if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+			t.Fatalf("plugin add: %v\n%s", err, out)
+		}
+		writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+		out, err := runCLI(t, env, "status", "--agents", "claude")
+		if err != nil {
+			t.Fatalf("status --agents claude: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "projected there by agentsync") {
+			t.Fatalf("setup: claude should still report the duplicate; got:\n%s", out)
+		}
+		if strings.Contains(out, "were not examined") {
+			t.Errorf("opencode installs no plugins natively; narrowing it away hid nothing "+
+				"and must not be reported as a gap; got:\n%s", out)
+		}
+	})
 }

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -884,7 +885,7 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	}
 	// Silence-qualifying half: this run found nothing, and the lead clause must
 	// say so. Without it the sentence reads as if a duplicate had been reported.
-	if !strings.Contains(out, "no duplicates found, but this check covered only") {
+	if !strings.Contains(out, "no duplicate was reported above, but this check covered only") {
 		t.Errorf("a narrowed run that found nothing must lead with that; got:\n%s", out)
 	}
 
@@ -901,25 +902,63 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if !strings.Contains(out, "not examined for duplicate plugin projection") {
 		t.Errorf("a narrowed run must be qualified whether or not it warned; got:\n%s", out)
 	}
-	if strings.Contains(out, "no duplicates found") {
+	if strings.Contains(out, "no duplicate was reported") {
 		t.Errorf("a run that DID report a duplicate must not also say none was found; got:\n%s", out)
 	}
 
-	// Two ingester agents narrowed away at once: the names are listed in a
-	// DETERMINISTIC order. `enabled` comes from a map, so without the sort this
-	// line reorders between runs — the kind of churn that makes CLI output
-	// untestable and diffs noisy. One unexamined agent cannot catch it.
+	// Two ingester agents narrowed away at once, to pin the PLURAL inflection
+	// end-to-end. Ordering is pinned deterministically by
+	// TestUnexaminedPluginAgents instead of by repeating this run and hoping map
+	// iteration varies — it does not vary enough to be a test.
 	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
 		t.Fatalf("agent add opencode: %v", err)
 	}
-	for i := range 8 {
-		out, err = runCLI(t, env, "status", "--agents", "opencode")
-		if err != nil {
-			t.Fatalf("status --agents opencode (run %d): %v\n%s", i, err, out)
-		}
-		if !strings.Contains(out, "claude, codex also install plugins natively") {
-			t.Fatalf("unexamined agents must be listed sorted and stably (run %d); got:\n%s", i, out)
-		}
+	out, err = runCLI(t, env, "status", "--agents", "opencode")
+	if err != nil {
+		t.Fatalf("status --agents opencode: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "claude, codex also install plugins natively") {
+		t.Errorf("both unexamined ingester agents must be named; got:\n%s", out)
+	}
+	// The verbs must agree with the count. Asserting only the number-invariant
+	// tail (which sits AFTER the verb) leaves both inflections unpinned.
+	if !strings.Contains(out, "were not examined") {
+		t.Errorf("two unexamined agents take the plural verb; got:\n%s", out)
+	}
+}
+
+// TestStatus_JSONStaysParseableWhenNarrowed pins stdout purity for the note.
+//
+// emitStatusWarnings runs on the --json path too, so a diagnostic accidentally
+// written to Out instead of Err corrupts the payload for every scripted
+// consumer. Nothing else asserts this for the scoping note, and the failure is
+// silent: the human-readable run looks identical.
+func TestStatus_JSONStaysParseableWhenNarrowed(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	stdout, stderr, err := runCLISplit(t, env, "status", "--json", "--agents", "codex")
+	if err != nil {
+		t.Fatalf("status --json --agents codex: %v\n%s", err, stderr)
+	}
+	// Setup guard: the note must actually be firing, or stdout staying clean
+	// proves nothing.
+	if !strings.Contains(stderr, "not examined for duplicate plugin projection") {
+		t.Fatalf("setup: the narrowed note should have fired on stderr; got:\n%s", stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("--json stdout must be parseable; got %v for:\n%s", err, stdout)
 	}
 }
 

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -757,6 +757,79 @@ func TestProjectScope_NativeAgentsIsHonoured(t *testing.T) {
 	}
 }
 
+// TestProjectScope_ScopingNoteFollowsTheScopedCanonical pins the half of the
+// note's guard that user-scope tests structurally cannot reach.
+//
+// The guard asks "was there anything to check?" via declaredPlugins(rc), where
+// rc is reportCanonical(c, sc). At USER scope rc == c, so swapping one for the
+// other changes nothing and every user-scope test stays green — a mutation
+// sweep confirmed exactly that. Only at PROJECT scope do they diverge, because
+// project.Merge never overlays Plugins: the merged canonical carries the USER
+// pins while a project-scope render honours the PROJECT ones.
+//
+// Here the project declares NO plugin while the user does. Nothing was checked,
+// so a narrowed run has no silence to qualify — and a guard reading the merged
+// canonical would announce a narrowed check that never happened.
+func TestProjectScope_ScopingNoteFollowsTheScopedCanonical(t *testing.T) {
+	tmpHome := t.TempDir()
+	proj := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+
+	for _, args := range [][]string{
+		{"init"},
+		{"agent", "add", "claude"},
+		{"agent", "add", "codex"},
+		{"init", "--scope", "project", "--project", proj},
+		{"agent", "add", "claude", "--scope", "project", "--project", proj},
+		{"agent", "add", "codex", "--scope", "project", "--project", proj},
+	} {
+		if out, err := runCLI(t, env, args...); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	// A plugin at USER scope only — the project tree declares none.
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	writeClaudeSettings(t, tmpHome, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	// Narrowed to codex, so claude (an ingester) goes unexamined — the note's
+	// other precondition is satisfied and only the canonical decides.
+	out, err := runCLI(t, env, "status", "--scope", "project", "--project", proj, "--agents", "codex")
+	if err != nil {
+		t.Fatalf("project status --agents codex: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "not examined for duplicate plugin projection") {
+		t.Errorf("the project declares no plugin, so no duplicate check ran and there is "+
+			"nothing for the narrowing to have hidden; got:\n%s", out)
+	}
+
+	// Converse: commit the pin into the project and the note becomes correct —
+	// proving the assertion above is about the scoped canonical, not about the
+	// note having quietly stopped working.
+	pin := mustReadFile(t, filepath.Join(tmpHome, ".agentsync", "plugins", "toolkit.toml"))
+	projPlugins := filepath.Join(proj, ".agentsync", "plugins")
+	if err := os.MkdirAll(projPlugins, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projPlugins, "toolkit.toml"), []byte(pin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = runCLI(t, env, "status", "--scope", "project", "--project", proj, "--agents", "codex")
+	if err != nil {
+		t.Fatalf("project status after committing the pin: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "not examined for duplicate plugin projection") {
+		t.Errorf("the project now declares the plugin, so the narrowed check must be "+
+			"qualified; got:\n%s", out)
+	}
+}
+
 // TestStatus_NarrowedDuplicateCheckSaysSo pins the `--agents` scoping note.
 //
 // Following the selected set is correct — a narrowed report should not talk
@@ -787,7 +860,7 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if !strings.Contains(out, "projected there by agentsync") {
 		t.Fatalf("setup: the unnarrowed run should report the duplicate; got:\n%s", out)
 	}
-	if strings.Contains(out, "were not examined") {
+	if strings.Contains(out, "not examined for duplicate plugin projection") {
 		t.Errorf("an unnarrowed run examined every agent; it must not claim otherwise:\n%s", out)
 	}
 
@@ -800,13 +873,13 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if strings.Contains(out, "projected there by agentsync") {
 		t.Errorf("a narrowed report must not talk about the agent it excluded; got:\n%s", out)
 	}
-	if !strings.Contains(out, "were not examined") {
+	if !strings.Contains(out, "not examined for duplicate plugin projection") {
 		t.Errorf("silence under --agents must say which agents went unchecked; got:\n%s", out)
 	}
 	// The note NAMES the unexamined agents rather than counting them: "claude"
 	// is the one that could have carried a duplicate, and it is the whole point
 	// of the sentence.
-	if !strings.Contains(out, "claude also install plugins natively") {
+	if !strings.Contains(out, "claude also installs plugins natively") {
 		t.Errorf("the note must name the unexamined agent, not just count it; got:\n%s", out)
 	}
 	// Silence-qualifying half: this run found nothing, and the lead clause must
@@ -825,11 +898,28 @@ func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
 	if !strings.Contains(out, "projected there by agentsync") {
 		t.Fatalf("setup: narrowing to claude should still report the duplicate; got:\n%s", out)
 	}
-	if !strings.Contains(out, "were not examined") {
+	if !strings.Contains(out, "not examined for duplicate plugin projection") {
 		t.Errorf("a narrowed run must be qualified whether or not it warned; got:\n%s", out)
 	}
 	if strings.Contains(out, "no duplicates found") {
 		t.Errorf("a run that DID report a duplicate must not also say none was found; got:\n%s", out)
+	}
+
+	// Two ingester agents narrowed away at once: the names are listed in a
+	// DETERMINISTIC order. `enabled` comes from a map, so without the sort this
+	// line reorders between runs — the kind of churn that makes CLI output
+	// untestable and diffs noisy. One unexamined agent cannot catch it.
+	if _, err := runCLI(t, env, "agent", "add", "opencode"); err != nil {
+		t.Fatalf("agent add opencode: %v", err)
+	}
+	for i := range 8 {
+		out, err = runCLI(t, env, "status", "--agents", "opencode")
+		if err != nil {
+			t.Fatalf("status --agents opencode (run %d): %v\n%s", i, err, out)
+		}
+		if !strings.Contains(out, "claude, codex also install plugins natively") {
+			t.Fatalf("unexamined agents must be listed sorted and stably (run %d); got:\n%s", i, out)
+		}
 	}
 }
 
@@ -869,7 +959,7 @@ func TestStatus_ScopingNoteStaysSilentWhenNothingWasHidden(t *testing.T) {
 		if err != nil {
 			t.Fatalf("status --agents codex: %v\n%s", err, out)
 		}
-		if strings.Contains(out, "were not examined") {
+		if strings.Contains(out, "not examined for duplicate plugin projection") {
 			t.Errorf("a disabled plugin is not checked for duplication, so there is no "+
 				"narrowed check to qualify; got:\n%s", out)
 		}
@@ -898,7 +988,7 @@ func TestStatus_ScopingNoteStaysSilentWhenNothingWasHidden(t *testing.T) {
 		if !strings.Contains(out, "projected there by agentsync") {
 			t.Fatalf("setup: claude should still report the duplicate; got:\n%s", out)
 		}
-		if strings.Contains(out, "were not examined") {
+		if strings.Contains(out, "not examined for duplicate plugin projection") {
 			t.Errorf("opencode installs no plugins natively; narrowing it away hid nothing "+
 				"and must not be reported as a gap; got:\n%s", out)
 		}

--- a/internal/cli/plugin_agents_test.go
+++ b/internal/cli/plugin_agents_test.go
@@ -756,3 +756,51 @@ func TestProjectScope_NativeAgentsIsHonoured(t *testing.T) {
 		t.Errorf("with no project deferral the duplicate is real; status should say so; got:\n%s", out)
 	}
 }
+
+// TestStatus_NarrowedDuplicateCheckSaysSo pins the `--agents` scoping note.
+//
+// Following the selected set is correct — a narrowed report should not talk
+// about agents it excluded — but it makes SILENCE ambiguous: "no duplicates"
+// and "duplicates on an agent you narrowed away" look identical. The note is
+// what separates them, and it matters most in the case where the warning loop
+// prints nothing at all.
+func TestStatus_NarrowedDuplicateCheckSaysSo(t *testing.T) {
+	tmp, env := importTestEnv(t)
+	if _, err := runCLI(t, env, "agent", "add", "codex"); err != nil {
+		t.Fatalf("agent add codex: %v", err)
+	}
+	mpDir := makeFanOutMarketplace(t, t.TempDir())
+	if out, err := runCLI(t, env, "marketplace", "add", mpDir); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	if out, err := runCLI(t, env, "plugin", "add", "toolkit"); err != nil {
+		t.Fatalf("plugin add: %v\n%s", err, out)
+	}
+	// The duplicate is on CLAUDE; the narrowed run below looks only at codex.
+	writeClaudeSettings(t, tmp, directoryMarketplaceSettings("fanout-mp", mpDir, "toolkit"))
+
+	// Unnarrowed: the warning fires and there is nothing to qualify.
+	out, err := runCLI(t, env, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "projected there by agentsync") {
+		t.Fatalf("setup: the unnarrowed run should report the duplicate; got:\n%s", out)
+	}
+	if strings.Contains(out, "were not examined") {
+		t.Errorf("an unnarrowed run examined every agent; it must not claim otherwise:\n%s", out)
+	}
+
+	// Narrowed to the agent WITHOUT the duplicate: the warning correctly does
+	// not fire, and that silence must be qualified rather than read as clean.
+	out, err = runCLI(t, env, "status", "--agents", "codex")
+	if err != nil {
+		t.Fatalf("status --agents codex: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "projected there by agentsync") {
+		t.Errorf("a narrowed report must not talk about the agent it excluded; got:\n%s", out)
+	}
+	if !strings.Contains(out, "were not examined") {
+		t.Errorf("silence under --agents must say which agents went unchecked; got:\n%s", out)
+	}
+}

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -60,7 +60,7 @@ func nativePluginOwners(reg *adapter.Registry) map[string][]string {
 // declaredPlugins returns the plugins a canonical EFFECTIVELY declares — every
 // non-disabled entry, keyed by the plugins/<id>.toml stem.
 //
-// Exported as a helper because two call sites must agree on it exactly:
+// Extracted as a helper because two call sites must agree on it exactly:
 // duplicatedNativePlugins returns nil (having checked nothing) when this set is
 // empty, and status's `--agents` scoping note exists to qualify that very
 // silence. A note computing "did we have anything to check?" its own way — off

--- a/internal/cli/plugin_drift.go
+++ b/internal/cli/plugin_drift.go
@@ -57,6 +57,27 @@ func nativePluginOwners(reg *adapter.Registry) map[string][]string {
 	return out
 }
 
+// declaredPlugins returns the plugins a canonical EFFECTIVELY declares — every
+// non-disabled entry, keyed by the plugins/<id>.toml stem.
+//
+// Exported as a helper because two call sites must agree on it exactly:
+// duplicatedNativePlugins returns nil (having checked nothing) when this set is
+// empty, and status's `--agents` scoping note exists to qualify that very
+// silence. A note computing "did we have anything to check?" its own way — off
+// the merged canonical rather than the scoped one, or counting disabled pins —
+// disagrees with the check in both directions: it claims a narrowed check that
+// never ran, and it stays quiet when narrowing really did hide a duplicate.
+// Callers must pass the SAME canonical they pass to duplicatedNativePlugins.
+func declaredPlugins(c source.Canonical) map[string]source.PluginSpec {
+	declared := make(map[string]source.PluginSpec, len(c.Plugins))
+	for _, pl := range c.Plugins {
+		if !pl.Plugin.Disabled {
+			declared[pl.ID.Unverified()] = pl.Plugin
+		}
+	}
+	return declared
+}
+
 // duplicatedNativePlugins reports, per agent, the declared plugins that agent
 // installs ITSELF and that agentsync also projects to it — the duplicate: every
 // skill, subagent, and command lands twice (once from the agent's own install
@@ -79,12 +100,7 @@ func nativePluginOwners(reg *adapter.Registry) map[string][]string {
 // Read-only and best-effort: a discovery error is skipped, never surfaced as a
 // failure, exactly like the sibling nudge.
 func duplicatedNativePlugins(c source.Canonical, reg *adapter.Registry, agents []string) map[string][]untrusted.Text {
-	declared := make(map[string]source.PluginSpec, len(c.Plugins))
-	for _, pl := range c.Plugins {
-		if !pl.Plugin.Disabled {
-			declared[pl.ID.Unverified()] = pl.Plugin
-		}
-	}
+	declared := declaredPlugins(c)
 	if len(declared) == 0 {
 		return nil
 	}

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -163,5 +164,31 @@ func TestNativePluginOwners_ProbesEveryIngester(t *testing.T) {
 	got := nativePluginOwners(reg)["toolkit"]
 	if len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
 		t.Fatalf("owners = %v, want both harnesses that install it natively [claude codex]", got)
+	}
+}
+
+// TestLosslessTargetingCaveat pins the wording of the `--lossless` caveat.
+//
+// It is the whole point of the change: the refusal itself was already correct
+// and already safe, but undiagnosable — a user saw an upgrade blocked over an
+// agent they knew did not receive the plugin, with nothing in the message to
+// search for. So the caveat has to name the gap (targeting is not honoured),
+// give a way to check (`plugin explain`), and give a way out (drop the flag).
+// A caveat missing any one of those is back to being a dead end.
+func TestLosslessTargetingCaveat(t *testing.T) {
+	for _, want := range []string{
+		"native_agents",  // the gap: targeting is not honoured
+		"agents",         // ...both keys, since either can exclude the agent
+		"plugin explain", // how to check whether the agent even receives it
+		"--lossless",     // how to proceed once you know
+	} {
+		if !strings.Contains(losslessTargetingCaveat, want) {
+			t.Errorf("the caveat must mention %q; got:\n%s", want, losslessTargetingCaveat)
+		}
+	}
+	// It must not read as a bug report about the plugin: the refusal is safe,
+	// and the user's upgrade may be perfectly fine.
+	if strings.Contains(strings.ToLower(losslessTargetingCaveat), "error") {
+		t.Errorf("the caveat qualifies a safe refusal; it should not read as an error:\n%s", losslessTargetingCaveat)
 	}
 }

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -175,10 +175,17 @@ func TestNativePluginOwners_ProbesEveryIngester(t *testing.T) {
 // search for. So the caveat has to name the gap (targeting is not honoured),
 // give a way to check (`plugin explain`), and give a way out (drop the flag).
 // A caveat missing any one of those is back to being a dead end.
+//
+// This half pins only what the const SAYS. That the const actually reaches the
+// user is TestLosslessCaveatReachesTheUser (package cli_test), which keys on
+// the `plugin explain` token required below — neither test is sufficient alone,
+// and dropping either reopens a gap a deletion sweep found in both.
 func TestLosslessTargetingCaveat(t *testing.T) {
 	for _, want := range []string{
-		"native_agents",  // the gap: targeting is not honoured
-		"agents",         // ...both keys, since either can exclude the agent
+		// Both keys, as one phrase. Asserting "agents" separately would be
+		// vacuous — it is a substring of "native_agents", so it passes on a
+		// caveat that never mentions the allowlist at all.
+		"`agents` / `native_agents`",
 		"plugin explain", // how to check whether the agent even receives it
 		"--lossless",     // how to proceed once you know
 	} {

--- a/internal/cli/plugin_drift_internal_test.go
+++ b/internal/cli/plugin_drift_internal_test.go
@@ -167,6 +167,60 @@ func TestNativePluginOwners_ProbesEveryIngester(t *testing.T) {
 	}
 }
 
+// fakePlain is an adapter with NO native plugin manager: it does not implement
+// adapter.PluginIngester, so it can never be serving a plugin natively and can
+// never be hiding a duplicate.
+type fakePlain struct {
+	adapter.Adapter
+	name string
+}
+
+func (f *fakePlain) Name() string { return f.name }
+
+// TestUnexaminedPluginAgents pins both properties of the scoping note's input
+// set, DETERMINISTICALLY.
+//
+// The ordering half was previously pinned end-to-end by running `status` in a
+// loop and hoping map iteration varied. It does not vary enough: Go's iteration
+// over the small agents map is biased, so a sweep measured a dropped
+// sort.Strings escaping ~36% of isolated runs — a coin flip dressed as a
+// regression test. Calling the function directly with a REVERSED `enabled`
+// makes the sort load-bearing on every run instead of most of them.
+func TestUnexaminedPluginAgents(t *testing.T) {
+	testenv.RequireContainer(t)
+	reg := adapter.NewRegistry()
+	for _, a := range []adapter.Adapter{
+		&fakeIngester{name: "claude", enabled: true},
+		&fakeIngester{name: "codex", enabled: true},
+		&fakePlain{name: "opencode"},
+	} {
+		if err := reg.Register(a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// `enabled` deliberately arrives UNSORTED, as it does in status.go where it
+	// is built by ranging a map. "opencode" is selected (so excluded as
+	// examined); the other two are narrowed away.
+	got := unexaminedPluginAgents(reg, []string{"codex", "opencode", "claude"}, []string{"opencode"})
+	want := []string{"claude", "codex"}
+	if len(got) != len(want) {
+		t.Fatalf("unexamined = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexamined = %v, want %v (sorted); position %d differs", got, want, i)
+		}
+	}
+
+	// The capability filter: a selected-away agent with no plugin manager is not
+	// a gap, so it must not appear even though it was narrowed away.
+	got = unexaminedPluginAgents(reg, []string{"claude", "opencode"}, []string{"claude"})
+	if len(got) != 0 {
+		t.Fatalf("opencode has no native plugin manager and cannot hide a duplicate; got %v", got)
+	}
+}
+
 // TestLosslessTargetingCaveat pins the wording of the `--lossless` caveat.
 //
 // It is the whole point of the change: the refusal itself was already correct

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -149,14 +149,11 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// the delta is exactly the bump's effect. An excluded bump is REPORTED, never
 	// silently dropped. Evaluation failures are excluded too (conservative), but
 	// reported as what they are rather than as measured losses.
+	var excluded int
 	if o.lossless {
 		safe, lossy, unevaluable := filterSafeBumps(home, bumps, fetched, c.Config, userHome, warnW)
 		for _, b := range lossy {
 			p.Infof("lossless: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)",
-				b.ID, b.From, b.To)
-		}
-		for _, b := range unevaluable {
-			p.Infof("lossless: skipping bump %s %s → %s (could not be evaluated; see the warning above)",
 				b.ID, b.From, b.To)
 		}
 		// Printed ONCE for the whole run rather than per bump: the caveat is a
@@ -169,14 +166,32 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 		// could not be evaluated — there is no identified loss and no agent — and
 		// telling that user to drop the flag would invert a refusal that exists
 		// precisely because nothing is known.
+		//
+		// Emitted between the two loops, not after both. Detailf is an UNLABELED
+		// continuation line that hangs under whatever diagnostic precedes it, so
+		// printing it last would render it attached to an unevaluable bump — the
+		// very misattribution the gate above exists to prevent. Gating and
+		// placement have to agree.
 		if len(lossy) > 0 {
 			p.Detailf("%s", losslessTargetingCaveat)
 		}
+		for _, b := range unevaluable {
+			p.Infof("lossless: skipping bump %s %s → %s (could not be evaluated; see the warning above)",
+				b.ID, b.From, b.To)
+		}
+		excluded = len(lossy) + len(unevaluable)
 		bumps = safe
 	}
 
 	if len(bumps) == 0 {
-		p.Successf(ui.EmojiSuccess, "all plugins are up to date")
+		// "up to date" is only true if nothing was held back. Announcing refusals
+		// and then reporting success contradicts them — and undoes the point of
+		// saying why the upgrade was declined in the first place.
+		if excluded > 0 {
+			p.Infof("no upgrades applied: --lossless excluded all %d pending bump(s), reported above", excluded)
+		} else {
+			p.Successf(ui.EmojiSuccess, "all plugins are up to date")
+		}
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "\npending bumps (%d):\n", len(bumps))
 		for _, b := range bumps {
@@ -570,7 +585,10 @@ func entryIsLossy(home, id string, mpEntry marketplace.PluginEntry, mpCacheRoot 
 	return false, nil
 }
 
-// losslessTargetingCaveat qualifies every `--lossless` refusal.
+// losslessTargetingCaveat qualifies every `--lossless` refusal that a render
+// actually judged lossy. A bump excluded because it could not be EVALUATED does
+// not carry it: there is no identified loss and no affected agent, so neither
+// half of the caveat's advice applies.
 //
 // The lossiness probe renders the plugin for every ENABLED agent, from a
 // canonical that carries no plugin provenance (see the KNOWN GAP on
@@ -585,7 +603,10 @@ func entryIsLossy(home, id string, mpEntry marketplace.PluginEntry, mpCacheRoot 
 // on the probe's canonical, which means threading the plugin's targeting lists
 // down through entryIsLossy's callers; until then the honest thing is to say
 // what the check did and did not consider.
-const losslessTargetingCaveat = "this check renders every ENABLED agent and does not honour the plugin's " +
+// The text opens capitalized: Detailf is UNLABELED, so unlike Warnf/Infof no
+// level label supplies the sentence start (cf. the sibling prose Detailf in
+// revert.go).
+const losslessTargetingCaveat = "This check renders every ENABLED agent and does not honour the plugin's " +
 	"`agents` / `native_agents` targeting, so the loss may fall on an agent this plugin is not " +
 	"projected to. Check `agentsync plugin explain <id>`; if the affected agent is not listed as " +
 	"receiving it, the upgrade is safe for you — re-run without --lossless."

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -187,8 +187,18 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 		// "up to date" is only true if nothing was held back. Announcing refusals
 		// and then reporting success contradicts them — and undoes the point of
 		// saying why the upgrade was declined in the first place.
+		//
+		// Written to Out, not via Infof: this is the command's terminal RESULT,
+		// the sibling of the "up to date" line below and of the pending-bumps
+		// list, not a diagnostic about it (see the Infof doc in internal/ui).
+		// Plain rather than Successf because the emoji vocabulary has no glyph
+		// for "held back", and ✅ would restate the contradiction this replaces.
 		if excluded > 0 {
-			p.Infof("no upgrades applied: --lossless excluded all %d pending bump(s), reported above", excluded)
+			what := fmt.Sprintf("all %d pending bumps", excluded)
+			if excluded == 1 {
+				what = "the only pending bump"
+			}
+			fmt.Fprintf(p.Out, "no upgrades applied: --lossless excluded %s\n", what)
 		} else {
 			p.Successf(ui.EmojiSuccess, "all plugins are up to date")
 		}

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -154,6 +154,12 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 			p.Infof("lossless: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)",
 				b.ID, b.From, b.To)
 		}
+		// Printed ONCE for the whole run rather than per bump: the caveat is a
+		// property of the check, not of any one bump, and repeating it per line
+		// would bury the bumps it is meant to qualify.
+		if len(lossy) > 0 {
+			p.Detailf("%s", losslessTargetingCaveat)
+		}
 		bumps = safe
 	}
 
@@ -540,6 +546,26 @@ func entryIsLossy(home, id string, mpEntry marketplace.PluginEntry, mpCacheRoot 
 	}
 	return false, nil
 }
+
+// losslessTargetingCaveat qualifies every `--lossless` refusal.
+//
+// The lossiness probe renders the plugin for every ENABLED agent, from a
+// canonical that carries no plugin provenance (see the KNOWN GAP on
+// projectedSkips), so `render.Plan`'s per-agent narrowing does not run: a skip
+// on an agent this plugin's `agents` / `native_agents` exclude still counts as
+// loss and still refuses the upgrade. That refusal is safe — it declines rather
+// than performs — but on its own it is undiagnosable, because the user sees an
+// upgrade blocked over an agent they know does not receive this plugin, with
+// nothing in the message to search for.
+//
+// Naming the caveat is deliberately NOT a fix. The fix is to stamp provenance
+// on the probe's canonical, which means threading the plugin's targeting lists
+// down through entryIsLossy's callers; until then the honest thing is to say
+// what the check did and did not consider.
+const losslessTargetingCaveat = "this check renders every ENABLED agent and does not honour the plugin's " +
+	"`agents` / `native_agents` targeting, so the loss may fall on an agent this plugin is not " +
+	"projected to. Check `agentsync plugin explain <id>`; if the affected agent is not listed as " +
+	"receiving it, the upgrade is safe for you — re-run without --lossless."
 
 // projectedSkips projects a plugin via marketplace.Project — the SAME single
 // projector apply now uses (marketplace.LoadProjected) — and returns the set of

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -147,16 +147,28 @@ func pollPluginsRun(cmd *cobra.Command, o pollOpts) error {
 	// candidate manifest and diffing the skip identities a render emits;
 	// comparing both under identical conditions makes any render quirk cancel, so
 	// the delta is exactly the bump's effect. An excluded bump is REPORTED, never
-	// silently dropped. Evaluation failures are treated as lossy (conservative).
+	// silently dropped. Evaluation failures are excluded too (conservative), but
+	// reported as what they are rather than as measured losses.
 	if o.lossless {
-		safe, lossy := filterSafeBumps(home, bumps, fetched, c.Config, userHome, warnW)
+		safe, lossy, unevaluable := filterSafeBumps(home, bumps, fetched, c.Config, userHome, warnW)
 		for _, b := range lossy {
 			p.Infof("lossless: skipping lossy bump %s %s → %s (candidate version drops translation for an agent)",
+				b.ID, b.From, b.To)
+		}
+		for _, b := range unevaluable {
+			p.Infof("lossless: skipping bump %s %s → %s (could not be evaluated; see the warning above)",
 				b.ID, b.From, b.To)
 		}
 		// Printed ONCE for the whole run rather than per bump: the caveat is a
 		// property of the check, not of any one bump, and repeating it per line
 		// would bury the bumps it is meant to qualify.
+		//
+		// Gated on `lossy` alone, NOT on everything excluded: the caveat says the
+		// loss may fall on an agent this plugin is not projected to, and offers
+		// re-running without --lossless. Neither sentence is true of a bump that
+		// could not be evaluated — there is no identified loss and no agent — and
+		// telling that user to drop the flag would invert a refusal that exists
+		// precisely because nothing is known.
 		if len(lossy) > 0 {
 			p.Detailf("%s", losslessTargetingCaveat)
 		}
@@ -452,11 +464,22 @@ func swapDir(src, dst string) error {
 	return os.Rename(src, dst)
 }
 
-// filterSafeBumps partitions bumps into those whose candidate version adds no
-// new translation losses (safe) and those that do (lossy), for `plugin upgrade
-// --all --lossless`. An evaluation error is conservatively treated as lossy so
-// a fetch/parse failure can never cause a lossy bump to slip through.
-func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]map[string]marketplace.PluginEntry, cfg source.Config, userHome string, warn io.Writer) (safe, lossy []marketplace.Bump) {
+// filterSafeBumps partitions bumps for `plugin upgrade --all --lossless` into
+// three sets: those whose candidate version adds no new translation losses
+// (safe), those a render judged to add one (lossy), and those that could not be
+// evaluated at all (unevaluable). Only `safe` is applied — an evaluation error
+// is still excluded conservatively, so a fetch/parse failure can never let a
+// lossy bump slip through.
+//
+// unevaluable is kept SEPARATE from lossy rather than folded into it, even
+// though both are excluded, because the two have opposite explanations: a lossy
+// bump was measured and found to drop translation, while an unevaluable one was
+// never measured. Reporting them as one set produced a "candidate version drops
+// translation for an agent" line for a bump nothing had judged, and attached
+// losslessTargetingCaveat — whose advice is "the affected agent may not receive
+// this plugin; re-run without --lossless" — to a refusal that had no affected
+// agent and was not about targeting at all.
+func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]map[string]marketplace.PluginEntry, cfg source.Config, userHome string, warn io.Writer) (safe, lossy, unevaluable []marketplace.Bump) {
 	reg := registryFactory()
 	var agents []string
 	for name, ag := range cfg.Agents {
@@ -468,7 +491,7 @@ func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]m
 		isLossy, err := bumpIsLossy(home, b, fetched, cfg, reg, agents, userHome)
 		if err != nil {
 			fmt.Fprintf(warn, "warning: lossless: cannot evaluate %s (%v); excluding to be safe\n", b.ID, err)
-			lossy = append(lossy, b)
+			unevaluable = append(unevaluable, b)
 			continue
 		}
 		if isLossy {
@@ -477,7 +500,7 @@ func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]m
 			safe = append(safe, b)
 		}
 	}
-	return safe, lossy
+	return safe, lossy, unevaluable
 }
 
 // bumpIsLossy reports whether applying b introduces a new adapter Skip (a
@@ -581,10 +604,14 @@ const losslessTargetingCaveat = "this check renders every ENABLED agent and does
 // empty Plugin, source.PluginTargetsAgent returns true, and render.Plan's
 // per-agent narrowing is a no-op — meaning this probe can report an upgrade as
 // lossy because of a skip on an agent the plugin's `agents` / `native_agents`
-// exclude. It is advisory only (it gates a warning, never a write), and closing
-// it means threading the plugin's two targeting lists down from entryIsLossy's
-// callers. Deliberately deferred; fix it there rather than by re-deriving the
-// gates here, which would be a second place they can drift.
+// exclude. This GATES BEHAVIOUR, not just a warning: pluginUpgradeRun returns
+// without upgrading and filterSafeBumps drops the bump. It errs safe (it
+// declines rather than performs), but a user can be blocked over an agent that
+// never receives this plugin — which is why every such refusal carries
+// losslessTargetingCaveat. Closing the gap means threading the plugin's two
+// targeting lists down from entryIsLossy's callers. Deliberately deferred; fix
+// it there rather than by re-deriving the gates here, which would be a second
+// place they can drift.
 func projectedSkips(entry marketplace.PluginEntry, cacheDir string, cfg source.Config, reg *adapter.Registry, agents []string, userHome string) (map[string]bool, error) {
 	proj, err := marketplace.Project(entry, cacheDir)
 	if err != nil {

--- a/internal/cli/plugin_verbs_test.go
+++ b/internal/cli/plugin_verbs_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -181,6 +182,174 @@ func TestPluginUpgrade_Lossless(t *testing.T) {
 	if strings.Contains(lossyTOML, "2.0.0") {
 		t.Errorf("single-id --lossless upgraded a lossy plugin anyway:\n%s", lossyTOML)
 	}
+}
+
+// TestLosslessCaveatReachesTheUser is the OUTPUT half of the caveat contract.
+//
+// TestLosslessTargetingCaveat (internal package) pins what the const must SAY,
+// but it reads the const directly — so it stays green even if nothing ever
+// prints it. A deletion sweep proved that gap was real: removing the `detail()`
+// call in pluginUpgradeRun, removing the once-per-run `Detailf` in
+// pollPluginsRun, and gutting `detail()` itself ALL left the suite green. This
+// test closes it by asserting on what the commands actually write.
+//
+// It keys on "plugin explain", one of the tokens the internal test REQUIRES the
+// const to contain. That makes the pair load-bearing in both directions: drop
+// the const's pointer to `plugin explain` and the internal test fails; stop
+// emitting the const and this one does.
+func TestLosslessCaveatReachesTheUser(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "agent", "add", "opencode")
+
+	// TWO lossy plugins, deliberately. With one, "printed once per run" and
+	// "printed once per bump" produce byte-identical output, so the count
+	// assertion below would pass either way — a break-verification sweep caught
+	// exactly that against the shared single-lossy fixture.
+	mpDir := makeTwoLossyMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "add", "lossy1@as2-mp")
+	mustRun(t, env, "plugin", "add", "lossy2@as2-mp")
+	mustRun(t, env, "apply")
+	// 2.0.0: both gain an opencode-skipped LSP server, so both bumps are lossy.
+	_ = makeTwoLossyMarketplace(t, base, "2.0.0")
+
+	// The --all form runs FIRST, as in TestPluginUpgrade_Lossless: it is the path
+	// that re-fetches the marketplace, and the single-id form below compares
+	// against that refreshed cache. Reversed, the single-id run sees no candidate
+	// and upgrades happily, which makes the refusal — and this whole test —
+	// silently vacuous.
+	//
+	// It prints the caveat ONCE for the run, not once per bump. Counting is the
+	// assertion: a per-bump emission would still contain the substring, so
+	// `Contains` alone could not tell the two apart.
+	out, err := runCLI(t, env, "plugin", "upgrade", "--all", "--lossless")
+	if err != nil {
+		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, out)
+	}
+	for _, id := range []string{"lossy1", "lossy2"} {
+		if !strings.Contains(out, "skipping lossy bump "+id) {
+			t.Fatalf("setup: the --all run should have excluded %s; got:\n%s", id, out)
+		}
+	}
+	if n := strings.Count(out, "plugin explain"); n != 1 {
+		t.Errorf("the caveat is a property of the check, not of a bump: want exactly 1 emission "+
+			"across 2 lossy bumps, got %d:\n%s", n, out)
+	}
+
+	// The single-id refusal must carry it too: this is the path where a user
+	// sees one plugin blocked and has nothing to search for.
+	out, err = runCLI(t, env, "plugin", "upgrade", "lossy1", "--lossless")
+	if err != nil {
+		t.Fatalf("plugin upgrade lossy1 --lossless: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "skipping lossy upgrade lossy1") {
+		t.Fatalf("setup: the single-id refusal should have fired; got:\n%s", out)
+	}
+	if !strings.Contains(out, "plugin explain") {
+		t.Errorf("the single-id --lossless refusal must carry the targeting caveat; got:\n%s", out)
+	}
+}
+
+// TestLossless_UnevaluableIsNotReportedAsLossy pins the partition itself.
+//
+// --lossless excludes a bump it cannot evaluate, which is right — a fetch or
+// parse failure must never let a lossy bump through. But an unevaluable bump
+// and a measured one have opposite explanations, and folding them together
+// announced "candidate version drops translation for an agent" about a bump
+// nothing had judged, then attached the targeting caveat to it. The caveat's
+// advice — the loss may fall on an agent this plugin is not projected to,
+// re-run without --lossless — is wrong for a bump that was never measured, and
+// following it would perform the upgrade the refusal existed to prevent.
+func TestLossless_UnevaluableIsNotReportedAsLossy(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "agent", "add", "opencode")
+
+	mpDir := makeTwoLossyMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "add", "lossy1@as2-mp")
+	mustRun(t, env, "plugin", "add", "lossy2@as2-mp")
+	mustRun(t, env, "apply")
+
+	// lossy1's 2.0.0 is genuinely lossy; lossy2's manifest is unparseable, so
+	// its bump can be seen but not judged.
+	_ = makeTwoLossyMarketplace(t, base, "2.0.0")
+	corrupt := filepath.Join(mpDir, "plugins", "lossy2", ".claude-plugin", "plugin.json")
+	if err := os.WriteFile(corrupt, []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "plugin", "upgrade", "--all", "--lossless")
+	if err != nil {
+		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "cannot evaluate lossy2") {
+		t.Fatalf("setup: lossy2's manifest should have failed evaluation; got:\n%s", out)
+	}
+	// The measured one keeps the measured wording; the unevaluable one must not
+	// borrow it.
+	if !strings.Contains(out, "skipping lossy bump lossy1") {
+		t.Errorf("the measured bump should still be reported as lossy; got:\n%s", out)
+	}
+	if strings.Contains(out, "skipping lossy bump lossy2") {
+		t.Errorf("an unevaluable bump was never judged lossy; it must not be announced as "+
+			"dropping translation; got:\n%s", out)
+	}
+	if !strings.Contains(out, "skipping bump lossy2") {
+		t.Errorf("an excluded bump must still be REPORTED, as what it actually is; got:\n%s", out)
+	}
+	// Neither bump was applied: excluding conservatively is unchanged.
+	home := filepath.Join(tmp, ".agentsync")
+	for _, id := range []string{"lossy1", "lossy2"} {
+		pinned, _ := readFileString(t, filepath.Join(home, "plugins", id+".toml"))
+		if strings.Contains(pinned, "2.0.0") {
+			t.Errorf("%s should not have been upgraded under --lossless:\n%s", id, pinned)
+		}
+	}
+}
+
+// makeTwoLossyMarketplace is makeLosslessMarketplace with TWO lossy plugins and
+// no clean one. It exists so a "printed once per run" assertion can be made by
+// COUNTING: against a single-lossy fixture, once-per-run and once-per-bump emit
+// the same bytes and the count cannot tell them apart.
+//
+// Both plugins ship an MCP server at every version and ALSO an LSP server at
+// 2.0.0 — which opencode skips — so both 1.0.0→2.0.0 bumps are lossy.
+func makeTwoLossyMarketplace(t *testing.T, dir, version string) string {
+	t.Helper()
+	mpDir := filepath.Join(dir, "fixture-twolossy-mp")
+	mpcp := filepath.Join(mpDir, ".claude-plugin")
+	if err := os.MkdirAll(mpcp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mpJSON := `{"name":"as2-mp","owner":{"name":"t"},"plugins":[` +
+		`{"name":"lossy1","source":"./plugins/lossy1","version":"` + version + `"},` +
+		`{"name":"lossy2","source":"./plugins/lossy2","version":"` + version + `"}]}`
+	if err := os.WriteFile(filepath.Join(mpcp, "marketplace.json"), []byte(mpJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"lossy1", "lossy2"} {
+		pluginJSON := `{"name":"` + name + `","version":"` + version + `","mcpServers":{"svc":{"command":"echo"}}}`
+		if version == "2.0.0" {
+			pluginJSON = `{"name":"` + name + `","version":"2.0.0","mcpServers":{"svc":{"command":"echo"}},` +
+				`"lspServers":{"gopls":{"command":"gopls"}}}`
+		}
+		d := filepath.Join(mpDir, "plugins", name, ".claude-plugin")
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "plugin.json"), []byte(pluginJSON), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return mpDir
 }
 
 // TestUpdateIsGone pins the ratified alias policy for the LAST command that had

--- a/internal/cli/plugin_verbs_test.go
+++ b/internal/cli/plugin_verbs_test.go
@@ -305,6 +305,18 @@ func TestLossless_UnevaluableIsNotReportedAsLossy(t *testing.T) {
 	if !strings.Contains(out, "skipping bump lossy2") {
 		t.Errorf("an excluded bump must still be REPORTED, as what it actually is; got:\n%s", out)
 	}
+	// ORDER, not just presence. Detailf is an unlabeled continuation line that
+	// hangs under whatever precedes it, so a caveat printed after the unevaluable
+	// line renders as if it qualified THAT bump — the misattribution the gate
+	// exists to prevent. Gating alone cannot catch this; position can.
+	caveatAt := strings.Index(out, "plugin explain")
+	unevalAt := strings.Index(out, "skipping bump lossy2")
+	if caveatAt < 0 || unevalAt < 0 {
+		t.Fatalf("setup: expected both the caveat and the unevaluable line; got:\n%s", out)
+	}
+	if caveatAt > unevalAt {
+		t.Errorf("the caveat must hang under the LOSSY line, not the unevaluable one; got:\n%s", out)
+	}
 	// Neither bump was applied: excluding conservatively is unchanged.
 	home := filepath.Join(tmp, ".agentsync")
 	for _, id := range []string{"lossy1", "lossy2"} {
@@ -312,6 +324,58 @@ func TestLossless_UnevaluableIsNotReportedAsLossy(t *testing.T) {
 		if strings.Contains(pinned, "2.0.0") {
 			t.Errorf("%s should not have been upgraded under --lossless:\n%s", id, pinned)
 		}
+	}
+}
+
+// TestLossless_UnevaluableOnlyRunCarriesNoCaveat is the case the mixed-bump test
+// above cannot reach: NOTHING was judged lossy.
+//
+// With one lossy bump present the caveat prints either way, so a gate on
+// `len(lossy)` and a gate on "anything was excluded" are indistinguishable —
+// the assertion passes on the bug. Here every exclusion is an evaluation
+// failure, so the caveat must be absent entirely. This is the run where its
+// advice is actively wrong: "re-run without --lossless" would perform the
+// upgrade the refusal exists to prevent, on a bump nobody has measured.
+func TestLossless_UnevaluableOnlyRunCarriesNoCaveat(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "agent", "add", "opencode")
+
+	mpDir := makeTwoLossyMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "add", "lossy1@as2-mp")
+	mustRun(t, env, "plugin", "add", "lossy2@as2-mp")
+	mustRun(t, env, "apply")
+
+	// BOTH candidates unparseable: every pending bump is unevaluable.
+	_ = makeTwoLossyMarketplace(t, base, "2.0.0")
+	for _, id := range []string{"lossy1", "lossy2"} {
+		corrupt := filepath.Join(mpDir, "plugins", id, ".claude-plugin", "plugin.json")
+		if err := os.WriteFile(corrupt, []byte("{ not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := runCLI(t, env, "plugin", "upgrade", "--all", "--lossless")
+	if err != nil {
+		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "cannot evaluate lossy1") || !strings.Contains(out, "cannot evaluate lossy2") {
+		t.Fatalf("setup: both candidates should have failed evaluation; got:\n%s", out)
+	}
+	if strings.Contains(out, "plugin explain") {
+		t.Errorf("nothing was judged lossy, so the targeting caveat must not appear — its "+
+			"advice would undo a refusal made because nothing is known; got:\n%s", out)
+	}
+	// And the run must not then claim everything is fine.
+	if strings.Contains(out, "all plugins are up to date") {
+		t.Errorf("every bump was excluded; reporting success contradicts the refusals; got:\n%s", out)
+	}
+	if !strings.Contains(out, "excluded all 2 pending bump(s)") {
+		t.Errorf("an all-excluded run must say so; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/plugin_verbs_test.go
+++ b/internal/cli/plugin_verbs_test.go
@@ -374,8 +374,54 @@ func TestLossless_UnevaluableOnlyRunCarriesNoCaveat(t *testing.T) {
 	if strings.Contains(out, "all plugins are up to date") {
 		t.Errorf("every bump was excluded; reporting success contradicts the refusals; got:\n%s", out)
 	}
-	if !strings.Contains(out, "excluded all 2 pending bump(s)") {
+	if !strings.Contains(out, "excluded all 2 pending bumps") {
 		t.Errorf("an all-excluded run must say so; got:\n%s", out)
+	}
+}
+
+// TestLossless_AllExcludedRunReportsOnStdout pins the terminal outcome of a run
+// that applied nothing: which STREAM it lands on, and its singular inflection.
+//
+// Both were unpinned by the tests above because runCLI merges stdout and
+// stderr, and because every other fixture excludes two bumps at once. The
+// stream matters: internal/ui states that an informational line which is part
+// of the RESULT is not a diagnostic and belongs on Out — the "up to date" line
+// this one replaces is a Successf on Out, so routing its sibling to Err would
+// split one command's two terminal outcomes across two streams and leave
+// `plugin upgrade --all --lossless > log` recording only one of them.
+func TestLossless_AllExcludedRunReportsOnStdout(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	base := t.TempDir()
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "agent", "add", "opencode")
+
+	// ONLY the lossy plugin, so exactly one bump exists and it is excluded.
+	mpDir := makeLosslessMarketplace(t, base, "1.0.0")
+	mustRun(t, env, "marketplace", "add", mpDir)
+	mustRun(t, env, "plugin", "add", "lossyp@as-mp")
+	mustRun(t, env, "apply")
+	_ = makeLosslessMarketplace(t, base, "2.0.0")
+
+	stdout, stderr, err := runCLISplit(t, env, "plugin", "upgrade", "--all", "--lossless")
+	if err != nil {
+		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "skipping lossy bump lossyp") {
+		t.Fatalf("setup: the only bump should have been excluded; stderr:\n%s", stderr)
+	}
+	// One excluded bump reads as one, not as "all 1".
+	if !strings.Contains(stdout, "excluded the only pending bump") {
+		t.Errorf("a single exclusion must read naturally; stdout:\n%s", stdout)
+	}
+	if strings.Contains(stderr, "no upgrades applied") {
+		t.Errorf("the terminal outcome is the command's result and belongs on stdout, "+
+			"not among the diagnostics; stderr:\n%s", stderr)
+	}
+	// And it must never be the contradictory success line.
+	if strings.Contains(stdout, "all plugins are up to date") || strings.Contains(stderr, "all plugins are up to date") {
+		t.Errorf("every bump was refused; claiming success contradicts that:\n%s\n%s", stdout, stderr)
 	}
 }
 

--- a/internal/cli/plugin_verbs_test.go
+++ b/internal/cli/plugin_verbs_test.go
@@ -226,31 +226,44 @@ func TestLosslessCaveatReachesTheUser(t *testing.T) {
 	// It prints the caveat ONCE for the run, not once per bump. Counting is the
 	// assertion: a per-bump emission would still contain the substring, so
 	// `Contains` alone could not tell the two apart.
-	out, err := runCLI(t, env, "plugin", "upgrade", "--all", "--lossless")
+	// Streams are checked separately: the caveat is a continuation line hanging
+	// under a stderr diagnostic, so landing it on stdout would both detach it
+	// from its headline and pollute a redirected result — the same defect the
+	// all-excluded line had. Merged output cannot see either.
+	stdout, stderr, err := runCLISplit(t, env, "plugin", "upgrade", "--all", "--lossless")
 	if err != nil {
-		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, out)
+		t.Fatalf("plugin upgrade --all --lossless: %v\n%s", err, stderr)
 	}
 	for _, id := range []string{"lossy1", "lossy2"} {
-		if !strings.Contains(out, "skipping lossy bump "+id) {
-			t.Fatalf("setup: the --all run should have excluded %s; got:\n%s", id, out)
+		if !strings.Contains(stderr, "skipping lossy bump "+id) {
+			t.Fatalf("setup: the --all run should have excluded %s; got:\n%s", id, stderr)
 		}
 	}
-	if n := strings.Count(out, "plugin explain"); n != 1 {
+	if n := strings.Count(stderr, "plugin explain"); n != 1 {
 		t.Errorf("the caveat is a property of the check, not of a bump: want exactly 1 emission "+
-			"across 2 lossy bumps, got %d:\n%s", n, out)
+			"across 2 lossy bumps, got %d:\n%s", n, stderr)
+	}
+	if strings.Contains(stdout, "plugin explain") {
+		t.Errorf("the caveat is a diagnostic and must not reach stdout; got:\n%s", stdout)
 	}
 
 	// The single-id refusal must carry it too: this is the path where a user
-	// sees one plugin blocked and has nothing to search for.
-	out, err = runCLI(t, env, "plugin", "upgrade", "lossy1", "--lossless")
+	// sees one plugin blocked and has nothing to search for. This is also the
+	// ONLY caller of the `detail()` helper, so it is what pins that helper's
+	// choice of stream.
+	stdout, stderr, err = runCLISplit(t, env, "plugin", "upgrade", "lossy1", "--lossless")
 	if err != nil {
-		t.Fatalf("plugin upgrade lossy1 --lossless: %v\n%s", err, out)
+		t.Fatalf("plugin upgrade lossy1 --lossless: %v\n%s", err, stderr)
 	}
-	if !strings.Contains(out, "skipping lossy upgrade lossy1") {
-		t.Fatalf("setup: the single-id refusal should have fired; got:\n%s", out)
+	if !strings.Contains(stderr, "skipping lossy upgrade lossy1") {
+		t.Fatalf("setup: the single-id refusal should have fired; got:\n%s", stderr)
 	}
-	if !strings.Contains(out, "plugin explain") {
-		t.Errorf("the single-id --lossless refusal must carry the targeting caveat; got:\n%s", out)
+	if !strings.Contains(stderr, "plugin explain") {
+		t.Errorf("the single-id --lossless refusal must carry the targeting caveat; got:\n%s", stderr)
+	}
+	if strings.Contains(stdout, "plugin explain") {
+		t.Errorf("detail() writes a continuation under a stderr diagnostic; on stdout it "+
+			"detaches from its headline; got:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -256,6 +256,14 @@ func diag(cmd *cobra.Command, level ui.Level, format string, args ...any) {
 	printerOn(cmd, w).Fdiagf(w, level, format, args...)
 }
 
+// detail writes an unlabeled continuation line under the preceding diag(),
+// hanging at the same column as its message. Use it for the "why / what now"
+// half of a diagnostic, so the headline stays one scannable line.
+func detail(cmd *cobra.Command, format string, args ...any) {
+	w := cmd.ErrOrStderr()
+	printerOn(cmd, w).Fdetailf(w, format, args...)
+}
+
 // emitJSON writes v as indented JSON to w. Used by the --json output modes,
 // which print only the structured payload to stdout (diagnostics go to stderr)
 // so the result is cleanly parseable.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -866,7 +866,13 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// the agents beats a bare count, and lets the note fall silent when nothing
 	// examinable was narrowed away.
 	if unexamined := unexaminedPluginAgents(reg, enabled, selected); len(unexamined) > 0 && len(declaredPlugins(rc)) > 0 {
-		lead := "no duplicates found, but this"
+		// "reported above" rather than "found": duplicatedNativePlugins skips an
+		// agent whose IngestPlugins probe errors, so an absent warning means
+		// nothing was REPORTED, which is not the same as nothing being there.
+		// Before this note the distinction did not surface — the failure mode was
+		// silence — but an affirmative sentence would turn that silence into a
+		// claim, which is the exact defect this note exists to remove.
+		lead := "no duplicate was reported above, but this"
 		if warned {
 			lead = "this"
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -832,7 +832,8 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// one it does. reportCanonical is the existing answer to exactly this
 	// mismatch. (The undeclared nudge above is correctly unscoped: "is this
 	// declared anywhere in my source" is a question about the merged view.)
-	duplicated := duplicatedNativePlugins(reportCanonical(c, sc), reg, selected)
+	rc := reportCanonical(c, sc)
+	duplicated := duplicatedNativePlugins(rc, reg, selected)
 	warned := false
 	for _, name := range reg.Names() {
 		dupes := duplicated[name]
@@ -855,15 +856,54 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// Emitted whether or not a warning fired: "I checked 1 of 3 agents and found
 	// nothing" is the case most likely to be misread, and it is the case where
 	// the loop above prints nothing at all.
-	if narrowed := len(enabled) - len(selected); narrowed > 0 && len(c.Plugins) > 0 {
-		verb := "no duplicates found, but this"
+	//
+	// Both halves of the guard mirror the check itself rather than re-deriving
+	// it. `rc` is the same canonical duplicatedNativePlugins was given (see the
+	// scope comment above) and declaredPlugins applies the same !Disabled filter
+	// it early-returns on, so the note cannot claim a check that never ran. And
+	// only agents with a native plugin manager can duplicate anything, so an
+	// agent without one going unexamined is not a gap worth reporting — naming
+	// the agents beats a bare count, and lets the note fall silent when nothing
+	// examinable was narrowed away.
+	if unexamined := unexaminedPluginAgents(reg, enabled, selected); len(unexamined) > 0 && len(declaredPlugins(rc)) > 0 {
+		lead := "no duplicates found, but this"
 		if warned {
-			verb = "this"
+			lead = "this"
 		}
-		p.Infof("%s check covered only the %d agent(s) --agents selected; %d other enabled "+
-			"agent(s) were not examined for duplicate plugin projection.",
-			verb, len(selected), narrowed)
+		// Agent names are trusted registry ids (as in the warning above, where
+		// only the plugin names needed untrusted.Join).
+		p.Infof("%s check covered only the agent(s) --agents selected; %s also install plugins "+
+			"natively and were not examined for duplicate plugin projection.",
+			lead, strings.Join(unexamined, ", "))
 	}
+}
+
+// unexaminedPluginAgents returns the enabled agents a `--agents`-narrowed run
+// left out of the duplicate check AND that could actually have carried a
+// duplicate — i.e. those whose adapter implements adapter.PluginIngester, the
+// same capability duplicatedNativePlugins requires before it examines an agent.
+//
+// Filtering on it is what keeps the scoping note honest. An agent with no
+// native plugin concept can never duplicate a plugin, so counting it would
+// inflate the note into a warning about a risk that does not exist — and, worse,
+// would make the note fire on a narrowing that hid nothing.
+func unexaminedPluginAgents(reg *adapter.Registry, enabled, selected []string) []string {
+	sel := make(map[string]bool, len(selected))
+	for _, n := range selected {
+		sel[n] = true
+	}
+	var out []string
+	for _, n := range enabled {
+		if sel[n] {
+			continue
+		}
+		if _, ok := reg.Lookup(n).(adapter.PluginIngester); !ok {
+			continue
+		}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // orphanedStateAgents returns, sorted, the agent names that appear as a state

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -872,9 +872,11 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 		}
 		// Agent names are trusted registry ids (as in the warning above, where
 		// only the plugin names needed untrusted.Join).
-		p.Infof("%s check covered only the agent(s) --agents selected; %s also install plugins "+
-			"natively and were not examined for duplicate plugin projection.",
-			lead, strings.Join(unexamined, ", "))
+		n := len(unexamined)
+		p.Infof("%s check covered only the agent(s) --agents selected; %s also %s plugins "+
+			"natively and %s not examined for duplicate plugin projection.",
+			lead, strings.Join(unexamined, ", "),
+			plural(n, "installs", "install"), plural(n, "was", "were"))
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -833,16 +833,36 @@ func emitStatusWarnings(p *ui.Printer, c source.Canonical, reg *adapter.Registry
 	// mismatch. (The undeclared nudge above is correctly unscoped: "is this
 	// declared anywhere in my source" is a question about the merged view.)
 	duplicated := duplicatedNativePlugins(reportCanonical(c, sc), reg, selected)
+	warned := false
 	for _, name := range reg.Names() {
 		dupes := duplicated[name]
 		if len(dupes) == 0 {
 			continue
 		}
+		warned = true
 		p.Warnf("%d plugin(s) are installed in %s AND projected there by agentsync (%s), "+
 			"so their skills/subagents/commands land twice and their hooks fire twice. "+
 			"Either uninstall them in %s, or add %q to `native_agents` in plugins/<id>.toml "+
 			"to let %s keep serving them itself.",
 			len(dupes), name, untrusted.Join(dupes, ", "), name, name, name)
+	}
+	// Following `selected` is correct — a narrowed report should not talk about
+	// agents it excluded, exactly as the undeclared nudge above does not. But
+	// silence then carries two meanings: "no duplicates" and "duplicates on an
+	// agent you narrowed away". Say which, so an absent warning is never read as
+	// a clean bill of health for agents this run never looked at.
+	//
+	// Emitted whether or not a warning fired: "I checked 1 of 3 agents and found
+	// nothing" is the case most likely to be misread, and it is the case where
+	// the loop above prints nothing at all.
+	if narrowed := len(enabled) - len(selected); narrowed > 0 && len(c.Plugins) > 0 {
+		verb := "no duplicates found, but this"
+		if warned {
+			verb = "this"
+		}
+		p.Infof("%s check covered only the %d agent(s) --agents selected; %d other enabled "+
+			"agent(s) were not examined for duplicate plugin projection.",
+			verb, len(selected), narrowed)
 	}
 }
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -382,6 +382,14 @@ when the candidate version introduces no *new* translation loss (an adapter
 skip) for an enabled agent — an excluded upgrade is reported, never silently
 dropped. `--scope`/`--project` resolve exactly as `apply` does.
 
+The check renders every *enabled* agent and does **not** honour a plugin's
+`agents` / `native_agents`, so it can decline over a loss falling on an agent
+the plugin is never projected to. Every refusal says so and points at
+`agentsync plugin explain <id>`; if the affected agent is not listed there, the
+upgrade is safe for you and you can re-run without the flag. A bump that could
+not be *evaluated* is excluded too, but reported separately — that refusal is
+not about targeting, and dropping the flag is not the answer to it.
+
 ```bash
 agentsync plugin outdated
 agentsync plugin upgrade --all --lossless

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -384,11 +384,13 @@ dropped. `--scope`/`--project` resolve exactly as `apply` does.
 
 The check renders every *enabled* agent and does **not** honour a plugin's
 `agents` / `native_agents`, so it can decline over a loss falling on an agent
-the plugin is never projected to. Every refusal says so and points at
+the plugin is never projected to. A refusal on that basis says so and points at
 `agentsync plugin explain <id>`; if the affected agent is not listed there, the
-upgrade is safe for you and you can re-run without the flag. A bump that could
-not be *evaluated* is excluded too, but reported separately — that refusal is
-not about targeting, and dropping the flag is not the answer to it.
+upgrade is safe for you and you can re-run without the flag. (Under `--all` that
+note prints once for the run, not once per bump.) A bump that could not be
+*evaluated* is excluded too, but reported separately and without that note —
+such a refusal is not about targeting, and dropping the flag is not the answer
+to it.
 
 ```bash
 agentsync plugin outdated


### PR DESCRIPTION
## Summary

Follow-up to #223, covering the two residuals it left. **Neither underlying behaviour changes** — both were already correct and already safe. What they weren't was *diagnosable*: each stayed silent about a limit the user had no way to see.

Then a five-round adversarial review loop found real defects in the messaging itself, and the PR grew to fix those too. See **What review changed** below.

### 1. `--lossless` didn't say what it skipped

The lossiness probe renders every **enabled** agent from a canonical carrying no plugin provenance, so it doesn't honour a plugin's `agents` / `native_agents`. A skip on an agent the plugin is never projected to still refuses the upgrade.

The refusal errs in the safe direction — it declines rather than performs — but a user saw an upgrade blocked over an agent they *knew* didn't receive the plugin, with nothing in the message to search for. Both forms that take the flag — `plugin upgrade <id> --lossless` and `plugin upgrade --all --lossless` — now name the gap, point at `plugin explain <id>` to check which agents actually receive it, and say to re-run without the flag if the affected agent isn't among them. (`plugin outdated` does **not** define `--lossless`; an earlier draft of this description claimed it did.)

Under `--all` it prints **once per run**, not per bump: the caveat is a property of the check, not of any one bump.

### 2. A narrowed duplicate check didn't say it was narrowed

`status`'s installed-natively-**and**-projected warning follows the selected set. That's correct — a `--agents`-narrowed report shouldn't discuss agents it excluded, exactly as the undeclared-plugin nudge doesn't.

But it made **silence** ambiguous between *"no duplicates"* and *"duplicates on an agent you narrowed away"* — and the second is precisely the case where the warning loop prints nothing at all. A narrowed run now names the enabled agents that install plugins natively and went unexamined, whether or not a duplicate was found.

### Not a fix, deliberately

The `--lossless` caveat is wording, not a repair. The actual fix is to stamp provenance on the probe's canonical, which means threading the plugin's targeting lists down through `entryIsLossy`'s callers. That's a real change with real churn on a rare path; until someone wants it, the honest move is for the tool to say what it did and didn't consider. The `KNOWN GAP` comment on `projectedSkips` says the same thing to the next maintainer.

## What review changed

Five rounds of four independent read-only lenses (correctness / adversarial / API design / test rigor), converging with all four CLEAN and a 42-mutation sweep at 42/42 caught. The substantive findings, all against code this PR added:

- **The scoping note's guard read a different canonical than the check it qualifies.** It tested `len(c.Plugins)` while `duplicatedNativePlugins` ran on `reportCanonical(c, sc)` filtered by `!Disabled`. Both failure directions were reproduced at project scope — the note claiming a narrowed check that never ran, and staying silent when narrowing really *did* hide a duplicate, the exact ambiguity it exists to remove. A shared `declaredPlugins` helper now makes the two impossible to disagree.
- **The caveat fired on evaluation failures.** `filterSafeBumps` folded fetch/parse errors in with measured losses, so a bump nothing had judged was announced as dropping translation *and* told the user to re-run without `--lossless` — which would perform the very upgrade the refusal existed to prevent. The partition is now three-way. Which bumps get applied is unchanged.
- **The caveat was gated correctly but *placed* wrong.** `Detailf` writes an unlabeled continuation that hangs under whatever precedes it, so printing it after the unevaluable loop rendered it attached to an unevaluable bump. Gating and placement have to agree.
- **A run that refused every bump still reported `all plugins are up to date`**, contradicting the refusals one line earlier. It now reports the exclusion — and on **stdout**, since `internal/ui` states that a line which is part of the *result* is not a diagnostic.
- **"no duplicates found" was an overclaim this PR introduced.** `duplicatedNativePlugins` silently skips an agent whose `IngestPlugins` probe errors, so an absent warning means nothing was *reported*, not that nothing is there. Before this note that was silence; the sentence turned it into a claim.
- **False comments and prose**, several of them made stale by this PR's own commits: a `KNOWN GAP` calling the gap "advisory only (it gates a warning, never a write)" when it gates the refusal itself; `declaredPlugins` documented as "Exported" when it isn't; the caveat const claiming it qualifies *every* refusal; and the CHANGELOG's `plugin outdated --lossless`.

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

Both messages are tested, because an untested message is one that rots. The test suite is larger than the production diff, and that is the point: a deletion sweep in round 1 found the **entire `--lossless` half was unpinned** — removing either emission, or gutting `detail()`, left the suite green, because the test read the const rather than the output.

Notable pins, each added because a mutation escaped without it:

- `TestLosslessTargetingCaveat` (const wording) is deliberately **paired** with `TestLosslessCaveatReachesTheUser` (output): the first pins that the const says `plugin explain`, the second that it reaches the user. Neither alone is sufficient, and dropping either fails the other.
- The caveat's "once per run" claim is pinned by **counting**, against a **two-lossy** fixture — with one lossy bump, once-per-run and once-per-bump emit identical bytes and the assertion passes on the bug.
- An **unevaluable-only** run asserts the caveat is *absent* — the mixed fixture prints it under either gate.
- A **project-scope** test covers the note's guard, because `rc` and `c` are identical at user scope and swapping them leaves every user-scope test green.
- Stream placement is pinned via `runCLISplit` for both caveat emissions, `detail()`, and the terminal line.
- Ordering is pinned by a **direct unit test** on `unexaminedPluginAgents`. It replaced an 8-iteration end-to-end loop that a sweep measured at only ~64% detection — Go's iteration over the small agents map is biased, so that loop was a coin flip presented as a regression test.

- [ ] `just test-release` is green (the release bar) — **not run here**; this environment can't start the hermetic container. Verified instead: `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` green. CI's hermetic gate has passed on every pushed commit.
- [x] `just lint` is clean — the justfile's exact recipe (`gofmt -s`, the **pinned** `gofumpt v0.10.0`, `go mod tidy`, `golangci-lint@v2.12.2`): **0 issues**.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path — it doesn't; message text, one `detail()` helper, one extracted `declaredPlugins` helper, and one added `status` line.
- [x] Docs updated — `CHANGELOG.md`, `docs/user-guide.md`, and `website/src/content/docs/reference/cli.mdx`, all re-verified against the current wording after five rounds of message changes.

## Known residuals

- `unexaminedPluginAgents` lives in `status.go` while the other two functions encoding the `adapter.PluginIngester` capability rule live in `plugin_drift.go`. Zero-behaviour move; deliberately left for a follow-up.
- `duplicatedNativePlugins` still swallows an `IngestPlugins` error silently. Addressed here by wording (the note no longer asserts absence) rather than by plumbing the error out, which would reach into the helper `doctor` shares.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5yJVbFg6QL5cBsqG6t23x)_