### PR TITLE
refactor(state): introduce typed, injective state keys (schema_version 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,37 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   --purge`, `plugin`, `marketplace`) rewrites them in place. Ownership is
   preserved either way, so no destination is re-adopted or backed up; a
   read-only `status`/`diff`/`explain` simply leaves the v1 file as it found it.
-  Three consequences worth knowing: an **older** agentsync binary will refuse the
-  upgraded file (it already refuses any newer `schema_version` — remove
-  `~/.agentsync/.state/targets.json` to start that binary fresh); in the rare
-  case where a pre-upgrade key cannot be read unambiguously — only possible when
-  a project root or destination path contains `:` — agentsync refuses the load
-  and names the entry rather than guessing; and a destination whose path is not
-  valid UTF-8 is now refused when state is written, naming the path, instead of
-  being silently mangled (the v1 format mangled it into permanent
-  foreign-collision churn). `targets.json` holds no configuration, so the remedy
-  for the second case is to delete the named entries (or the file); the next
-  `apply` re-adopts each destination, backing up any pre-existing content first.
+  Two other consequences worth knowing: in the rare case where a pre-upgrade key
+  cannot be read unambiguously — only possible when a project root or destination
+  path contains `:` — agentsync refuses the load and names the entry rather than
+  guessing (a key needing more than 64 candidate readings to resolve is refused
+  the same way, without enumerating them: reading such a key is superlinear work
+  driven by a hand-editable file, and past a few KB it could exhaust memory);
+  and a destination whose path is not valid UTF-8 is now refused when
+  state is written, naming the path, instead of being silently mangled (the v1
+  format mangled it into permanent foreign-collision churn). `targets.json` holds
+  no configuration, so the remedy for the first is to delete the named entries
+  (or the file); the next `apply` re-adopts each destination, backing up any
+  pre-existing content first.
+- **BACK UP `~/.agentsync/.state/targets.json` BEFORE DOWNGRADING to a
+  pre-`schema_version: 2` build.** Rolling back is *not* safe, and the failure is
+  silent. Most commands do refuse the upgraded file — `status`, `diff`, `apply`,
+  `reconcile`, `explain`, `migrate`, `plugin`, `agent disable --purge` all exit
+  non-zero with "state schema_version=2 is newer than this binary supports", and
+  `doctor` reports it as a corrupt state file; none of them touch the file. But
+  **`agentsync marketplace add`** on those builds discards that error, falls back
+  to an empty state and then SAVES it: it exits 0, prints
+  `✅ added marketplace …`, and leaves `targets.json` replaced by a
+  `schema_version: 1` file holding nothing but the marketplace just added. Every
+  ownership entry (`files`/`keys`), every plugin pin and every other marketplace
+  record is gone. `agentsync import` reaches the same code path when it registers
+  a plugin's marketplace. Nothing outside `targets.json` is lost — the canonical
+  `~/.agentsync/` tree and the native agent files are untouched — and the next
+  `apply` re-adopts every destination, backing up any pre-existing content to
+  `.state/backups/` first; but that is a full re-adopt of every managed file, not
+  a no-op. Old binaries cannot be patched, so the only protections are the backup
+  above or deleting `targets.json` so the older build starts fresh. Builds from
+  this release on skip the record and warn instead.
 - **`--lossless` now says what its check did not consider.** The lossiness probe
   renders every enabled agent from a canonical carrying no plugin provenance, so
   it does not honour a plugin's `agents` / `native_agents`: a skip on an agent
@@ -122,7 +142,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   owned nothing and backed up every managed destination as a foreign collision.
   The fetch record is now skipped when state cannot be read, exactly as
   `marketplace remove` already did; the next successful add or update fills it
-  back in.
+  back in. Both commands now also **warn** when they skip, naming
+  `targets.json` and the read error — skipping silently left the user with a
+  success line while `status`, `apply`, `diff` and `doctor` were all already
+  failing on the same file, with nothing connecting the two.
 - **`apply`'s translation report no longer over-counts.** Every per-agent count
   honours the providing plugin's gates now; previously none did, so a deferred
   plugin's components were counted under another plugin's row for the same agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   reporting `purged … deleted 1 file(s)`. State entries are now addressed by a
   typed, length-prefixed key that cannot be confused with a neighbour's, and
   every consumer compares fields rather than string prefixes.
+- **`marketplace add` no longer replaces an unreadable `targets.json` with an
+  empty one.** State is loaded best-effort so a fresh home works, but a *real*
+  read failure — a permissions problem, corruption, or a state file agentsync
+  refuses (an ambiguous pre-upgrade key, a destination path that is not valid
+  UTF-8) — fell through to a blank state and then SAVED it, discarding every
+  ownership record, plugin pin, and other marketplace. The next `apply` then
+  owned nothing and backed up every managed destination as a foreign collision.
+  The fetch record is now skipped when state cannot be read, exactly as
+  `marketplace remove` already did; the next successful add or update fills it
+  back in.
 - **`apply`'s translation report no longer over-counts.** Every per-agent count
   honours the providing plugin's gates now; previously none did, so a deferred
   plugin's components were counted under another plugin's row for the same agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
+  and requires nothing: the first command you run rewrites the keys in place and
+  ownership is preserved, so no destination is re-adopted or backed up. Three
+  consequences worth knowing: an **older** agentsync binary will refuse the
+  upgraded file (it already refuses any newer `schema_version` — remove
+  `~/.agentsync/.state/targets.json` to start that binary fresh); in the rare
+  case where a pre-upgrade key cannot be read unambiguously — only possible when
+  a project root or destination path contains `:` — agentsync refuses the load
+  and names the entry rather than guessing; and a destination whose path is not
+  valid UTF-8 is now refused when state is written, naming the path, instead of
+  being silently mangled (the v1 format mangled it into permanent
+  foreign-collision churn). `targets.json` holds no configuration, so the remedy
+  for the second case is to delete the named entries (or the file); the next
+  `apply` re-adopts each destination, backing up any pre-existing content first.
 - **`--lossless` now says what its check did not consider.** The lossiness probe
   renders every enabled agent from a canonical carrying no plugin provenance, so
   it does not honour a plugin's `agents` / `native_agents`: a skip on an agent
@@ -85,6 +99,17 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **A project root containing `:` no longer costs a sibling project its state.**
+  `targets.json` keys were `agent:scope:project:path[:pointer]` strings, and `:`
+  is a legal byte in a POSIX path — so a repo at `~/work/app:staging` produced
+  keys that string-prefixed those of a repo at `~/work/app`. Applying the shorter
+  one deleted the longer one's ownership, and its next apply then treated every
+  destination as a foreign collision: backed up to `.state/backups/` and
+  rewritten. The same mismatch made `agent disable --purge` extract a mangled
+  path — deleting the state entry while the destination file survived, then
+  reporting `purged … deleted 1 file(s)`. State entries are now addressed by a
+  typed, length-prefixed key that cannot be confused with a neighbour's, and
+  every consumer compares fields rather than string prefixes.
 - **`apply`'s translation report no longer over-counts.** Every per-agent count
   honours the providing plugin's gates now; previously none did, so a deferred
   plugin's components were counted under another plugin's row for the same agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   Two other consequences worth knowing: in the rare case where a pre-upgrade key
   cannot be read unambiguously — only possible when a project root or destination
   path contains `:` — agentsync refuses the load and names the entry rather than
-  guessing (a key needing more than 64 candidate readings to resolve is refused
-  the same way, without enumerating them: reading such a key is superlinear work
-  driven by a hand-editable file, and past a few KB it could exhaust memory);
-  and a destination whose path is not valid UTF-8 is now refused when
-  state is written, naming the path, instead of being silently mangled (the v1
-  format mangled it into permanent foreign-collision churn). `targets.json` holds
+  guessing (a key packing more than 64 candidate readings is refused too, but for
+  a different reason and with its own message: enumerating them is superlinear
+  work driven by a hand-editable file, and past a few KB it could exhaust memory,
+  so agentsync stops counting and refuses the key *unread* — it does not claim
+  such a key was ambiguous, because it never finds out whether the key had one
+  reading, several or none); and a destination whose path is not valid UTF-8 is
+  now refused when state is written, naming the path, instead of being silently
+  mangled (the v1 format mangled it into permanent foreign-collision churn).
+  `targets.json` holds
   no configuration, so the remedy for the first is to delete the named entries
   (or the file); the next `apply` re-adopts each destination, backing up any
   pre-existing content first.
@@ -47,7 +50,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `.state/backups/` first; but that is a full re-adopt of every managed file, not
   a no-op. Old binaries cannot be patched, so the only protections are the backup
   above or deleting `targets.json` so the older build starts fresh. Builds from
-  this release on skip the record and warn instead.
+  this release on skip the record and warn instead, for `marketplace remove` as
+  well as `add`; and the refusing half of that list is now pinned by a test that
+  drives `status`, `diff`, `apply` (plain and `--dry-run`), `reconcile`,
+  `explain`, `plugin outdated`, `agent disable --purge`, `migrate subagents` and
+  `doctor` against an unreadable `targets.json` and asserts each one exits
+  non-zero *and* leaves the file byte-for-byte unchanged.
 - **`--lossless` now says what its check did not consider.** The lossiness probe
   renders every enabled agent from a canonical carrying no plugin provenance, so
   it does not honour a plugin's `agents` / `native_agents`: a skip on an agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 ### Changed
 
 - **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
-  and requires nothing: the first command you run rewrites the keys in place and
-  ownership is preserved, so no destination is re-adopted or backed up. Three
-  consequences worth knowing: an **older** agentsync binary will refuse the
+  and requires nothing: every command reads the old keys, and the first command
+  that WRITES state (`apply`, `import`, `reconcile`, `migrate`, `agent disable
+  --purge`, `plugin`, `marketplace`) rewrites them in place. Ownership is
+  preserved either way, so no destination is re-adopted or backed up; a
+  read-only `status`/`diff`/`explain` simply leaves the v1 file as it found it.
+  Three consequences worth knowing: an **older** agentsync binary will refuse the
   upgraded file (it already refuses any newer `schema_version` — remove
   `~/.agentsync/.state/targets.json` to start that binary fresh); in the rare
   case where a pre-upgrade key cannot be read unambiguously — only possible when

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -943,10 +943,12 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
 8. **Injective state keys** (`internal/state/key.go`) — every entry in
    `targets.json` is addressed by a typed `state.Key`
    (agent · scope · portable project root · portable dest path · JSON pointer),
-   which is the Go **map key type** of `Targets.Files` / `Targets.Keys`. Building
-   a key by hand is therefore a compile error, and the format has exactly one
-   owner instead of being a `fmt.Sprintf` contract spread across `render`, `cli`
-   and one adapter. The wire form is length-prefixed —
+   which is the Go **map key type** of `Targets.Files` / `Targets.Keys`. A
+   hand-rolled `fmt.Sprintf` key is therefore a compile error, and the format has
+   exactly one owner instead of a string contract spread across `render`, `cli`
+   and one adapter. (A `state.Key{…}` composite literal still compiles — it just
+   bypasses `NewFileKey`'s `paths.HomeRelative`, which is how tests plant keys in
+   a specific portable spelling.) The wire form is length-prefixed —
    `as1|6:claude|4:user|0:|29:${HOME}/.claude/settings.json|0:` — the same
    technique `hookSignature` uses, so decoding never interprets a field's bytes
    and `ParseKey` is a total left inverse of `String()`: two distinct
@@ -959,14 +961,20 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    possible reading **refuses the load**, naming the key and the remedy, rather
    than guessing and recording it under the wrong project. Disambiguation leans
    on one property — every adapter joins its project-scope destinations onto the
-   project root — so the containment test normalizes `\` as well as `/`: a
-   Windows project root outside `%USERPROFILE%` is stored verbatim, drive colon
-   and backslashes included, and a slash-only test would find no contained
-   reading and refuse every such file. At `schema_version: 2` each key is
-   role-checked as well as parsed — a `files` key must carry no JSON pointer, a
-   `keys` key must carry one — so a hand-edited file cannot be laxer than the v1
-   format it replaced. An older binary already refuses a newer `schema_version`,
-   which is the downgrade story.
+   project root, so the reading agentsync *actually wrote* is always contained,
+   and a competing reading can only push the contained count to two and force a
+   refusal, never take the acceptance for itself. Keeping that true makes the
+   containment test a per-component filter: it treats `\` as a separator
+   alongside `/` (a Windows project root outside `%USERPROFILE%` is stored
+   verbatim, drive colon and backslashes included, and a slash-only test would
+   find no contained reading and refuse every such file), and it deliberately
+   does **not** collapse `..`. `path.Clean` did, and that collapse could drop the
+   true reading out of the contained set and leave a false one alone in it —
+   accepted silently under the wrong project, the very bug this format removes.
+   At `schema_version: 2` each key is role-checked as well as parsed — a `files`
+   key must carry no JSON pointer, a `keys` key must carry one — so a
+   hand-edited file cannot be laxer than the v1 format it replaced. An older
+   binary already refuses a newer `schema_version`, which is the downgrade story.
    One boundary is narrower than the encoding: `targets.json` is JSON, and
    `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which
    would break a length prefix and make the next `Load` refuse the file — with

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -962,8 +962,11 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    project root — so the containment test normalizes `\` as well as `/`: a
    Windows project root outside `%USERPROFILE%` is stored verbatim, drive colon
    and backslashes included, and a slash-only test would find no contained
-   reading and refuse every such file. An older binary already refuses a newer
-   `schema_version`, which is the downgrade story.
+   reading and refuse every such file. At `schema_version: 2` each key is
+   role-checked as well as parsed — a `files` key must carry no JSON pointer, a
+   `keys` key must carry one — so a hand-edited file cannot be laxer than the v1
+   format it replaced. An older binary already refuses a newer `schema_version`,
+   which is the downgrade story.
    One boundary is narrower than the encoding: `targets.json` is JSON, and
    `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which
    would break a length prefix and make the next `Load` refuse the file — with

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -977,12 +977,19 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    misdecoding any key whose true root **is** `/`. Over-refusal is the cheap
    failure here and misrecovery the expensive one, so the trade is refused;
    `TestLegacyContainmentProperties` pins the invariant over a generated corpus
-   (79,632 keys: zero misrecoveries as written, 24 with the exclusion).
-   Enumeration is also **capped**: the candidate readings are a product of the
+   of 20,628 (root, destination) pairs — 41,256 keys, file and pointer — of which
+   about 70% decode and none decodes under a project other than the root it was
+   built from. (The counterfactual for the zero-component exclusion is not in
+   that test: it comes from a throwaway sweep recorded in `legacy.go`'s comment,
+   which says so.)
+   Enumeration is also **capped**. The candidate readings are a product of the
    `:` and `:/` counts and the tie-break walks all of them, so an uncapped key of
-   a few KB could OOM-kill any command that loads state; past 64 candidate
-   readings the key is refused with the same fail-closed message and the same
-   cheap remedy.
+   a few KB could OOM-kill any command that loads state; on the 65th candidate
+   agentsync stops counting and refuses the key. That cap bounds *enumeration*,
+   not ambiguity — it fires mid-count, so a key it refuses may have had many
+   readings, exactly one, or none — so the refusal carries its own sentinel and
+   its own remedy paragraph, and never claims the key was ambiguous. The remedy
+   itself is the same cheap delete-and-re-adopt.
    At `schema_version: 2` each key is role-checked as well as parsed — a `files`
    key must carry no JSON pointer, a `keys` key must carry one — so a
    hand-edited file cannot be laxer than the v1 format it replaced.
@@ -1007,8 +1014,27 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    `~/.agentsync/.state/targets.json` before downgrading, or delete it so the
    older build starts fresh. The read guard is now in place going forward
    (`internal/cli/marketplace.go`, pinned by
-   `TestMarketplaceAdd_DoesNotClobberUnreadableState`), which protects a
-   *future* downgrade past this release but nothing already shipped.
+   `TestMarketplaceAdd_DoesNotClobberUnreadableState` and its `remove` twin),
+   which protects a *future* downgrade past this release but nothing already
+   shipped.
+
+   **Refusing an unreadable state file is pinned, not merely intended.** The
+   paragraph above describes *pre*-schema-2 builds, which no test in this tree
+   can drive; what it says about this build is what makes a downgrade past *this*
+   release survivable, and that half is now enforced. It needed to be: the
+   tempting regression at any of the 15 `state.Load` call sites — `if err != nil
+   { s = state.New() }`, exactly the `marketplace add` bug — is silent, turning a
+   refusal into an apply against an empty state, which owns nothing and backs up
+   every managed destination as a foreign collision.
+   `TestCommandsRefuseUnreadableState` drives each command in-process against an
+   unreadable `targets.json` and asserts both halves: a non-zero exit carrying
+   the migration refusal, and the file byte-for-byte unchanged. It covers
+   `status`, `diff`, `apply` (plain and `--dry-run`), `reconcile`, `explain`,
+   `plugin outdated`, `agent disable --purge`, `migrate subagents` and `doctor`.
+   The five remaining `state.Load` sites deliberately warn and continue instead
+   of refusing: `marketplace add`/`remove`, pinned by the two tests named above,
+   and `import`'s two sites plus opencode's `Ingest`, which emit a `warning: `
+   line into `ui.WarnWriter`.
 
    One boundary is narrower than the encoding: `targets.json` is JSON, and
    `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -971,10 +971,45 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    does **not** collapse `..`. `path.Clean` did, and that collapse could drop the
    true reading out of the contained set and leave a false one alone in it —
    accepted silently under the wrong project, the very bug this format removes.
+   For the same reason a root that normalizes to *zero* components (`/`) stays
+   contained even though it discriminates nothing: excluding it would recover a
+   handful of keys whose false split happens to be `/`, at the price of
+   misdecoding any key whose true root **is** `/`. Over-refusal is the cheap
+   failure here and misrecovery the expensive one, so the trade is refused;
+   `TestLegacyContainmentProperties` pins the invariant over a generated corpus
+   (79,632 keys: zero misrecoveries as written, 24 with the exclusion).
+   Enumeration is also **capped**: the candidate readings are a product of the
+   `:` and `:/` counts and the tie-break walks all of them, so an uncapped key of
+   a few KB could OOM-kill any command that loads state; past 64 candidate
+   readings the key is refused with the same fail-closed message and the same
+   cheap remedy.
    At `schema_version: 2` each key is role-checked as well as parsed — a `files`
    key must carry no JSON pointer, a `keys` key must carry one — so a
-   hand-edited file cannot be laxer than the v1 format it replaced. An older
-   binary already refuses a newer `schema_version`, which is the downgrade story.
+   hand-edited file cannot be laxer than the v1 format it replaced.
+
+   **Downgrading is not safe, and the docs used to say it was.** `migrate` does
+   refuse a newer `schema_version`, but refusing at the migrate layer is not the
+   same as being safe at the layer the user experiences — the question is what
+   each *caller* does with that error. On a pre-schema-2 build, `status`,
+   `diff`, `apply`, `reconcile`, `explain`, `migrate`, `plugin` and
+   `agent disable --purge` return it (non-zero exit) and `doctor` reports a
+   corrupt state file; none of them touch `targets.json`. But those builds'
+   `addMarketplaceSource` did `st, _ := state.Load(...)`, so `marketplace add`
+   (and `import`, which registers a plugin's marketplace through the same
+   function) fell through to `state.New()` and **saved it**: exit 0, a
+   `✅ added marketplace …` line, and `targets.json` replaced by a
+   `schema_version: 1` document holding only the marketplace just added — every
+   `files`/`keys` ownership entry, every plugin pin and every other marketplace
+   record destroyed. The canonical tree and the native files are untouched, and
+   the next `apply` re-adopts each destination (backing up pre-existing content
+   to `.state/backups/` first), but that is a full re-adopt, not a no-op. Old
+   binaries cannot be patched: the mitigation is to back up
+   `~/.agentsync/.state/targets.json` before downgrading, or delete it so the
+   older build starts fresh. The read guard is now in place going forward
+   (`internal/cli/marketplace.go`, pinned by
+   `TestMarketplaceAdd_DoesNotClobberUnreadableState`), which protects a
+   *future* downgrade past this release but nothing already shipped.
+
    One boundary is narrower than the encoding: `targets.json` is JSON, and
    `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which
    would break a length prefix and make the next `Load` refuse the file — with
@@ -1341,7 +1376,9 @@ exception: its `Ingest` reads the apply-state file (`internal/state`) to build a
 never hand-authored siblings in OpenCode's shared `agents/`/`commands/` dirs (issue
 #148). This is a deliberate, opencode-scoped dependency — the general fix (threading
 the owned-path set in from the CLI caller so no adapter touches `state`) is a
-class-wide follow-up, since no other adapter filters ingest ownership yet. The state
-**key format** the filter reconstructs is not silently duplicated: the round-trip
-test seeds ownership through the real `render.RecordOpsState`, so any drift in the
-key scheme breaks that test rather than silently under-capturing.
+class-wide follow-up, since no other adapter filters ingest ownership yet. The filter
+does not duplicate the state **key format**: it calls `state.NewFileKey`, the same
+constructor `render.RecordOpsState` uses, so the two agree structurally rather than by
+convention — and the round-trip test seeds ownership through the real
+`render.RecordOpsState`, so a divergence in what either side *passes* that constructor
+breaks that test rather than silently under-capturing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -789,7 +789,8 @@ only through the secret backend, so an unresolvable env ref stays a warning.)
 key:
 
 - `H_src` — computed now from the canonical source
-- `H_applied` — recorded last apply in `targets.json`
+- `H_applied` — recorded last apply in `targets.json`, under a typed
+  `state.Key` (agent · scope · project · path · pointer) — see §7.8
 - `H_dest` — current on-disk content (or nil)
 
 | `H_applied` vs `H_src` | `H_applied` vs `H_dest` | Class | `apply` behavior |
@@ -939,6 +940,33 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    `secrets.Resolved.ComponentIDs()` accessor), never unwrapping the resolved model
    to a writable `source.Canonical`, so the guard doesn't cross the secrets lint
    fence (§8).
+8. **Injective state keys** (`internal/state/key.go`) — every entry in
+   `targets.json` is addressed by a typed `state.Key`
+   (agent · scope · portable project root · portable dest path · JSON pointer),
+   which is the Go **map key type** of `Targets.Files` / `Targets.Keys`. Building
+   a key by hand is therefore a compile error, and the format has exactly one
+   owner instead of being a `fmt.Sprintf` contract spread across `render`, `cli`
+   and one adapter. The wire form is length-prefixed —
+   `as1|6:claude|4:user|0:|29:${HOME}/.claude/settings.json|0:` — the same
+   technique `hookSignature` uses, so decoding never interprets a field's bytes
+   and `ParseKey` is a total left inverse of `String()`: two distinct
+   destinations can never share a key. The v1 `agent:scope:project:path[:ptr]`
+   encoding could: `:` is legal in a POSIX path, so a project root containing
+   one produced keys that string-prefixed a *sibling* project's, and a
+   prefix-scoped prune deleted the sibling's ownership (issue #227). Every
+   consumer now compares **fields**, never string prefixes. `state.Load`
+   upgrades `schema_version` 0/1 → 2 on read; a legacy key with more than one
+   possible reading **refuses the load**, naming the key and the remedy, rather
+   than guessing and recording it under the wrong project. An older binary
+   already refuses a newer `schema_version`, which is the downgrade story.
+   One boundary is narrower than the encoding: `targets.json` is JSON, and
+   `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which
+   would break a length prefix and make the next `Load` refuse the file — with
+   no way out, since the next apply rebuilds the same key. `state.Save` therefore
+   refuses a key whose any field is not valid UTF-8 (`state.ErrNonUTF8Key`)
+   before writing, naming the offending destination path. Linux paths are byte
+   strings, so this is reachable; failing closed at the moment the key is created
+   is what makes it actionable.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -957,8 +957,13 @@ All present in v1.0 (`internal/iox`, `internal/render`, `internal/state`):
    consumer now compares **fields**, never string prefixes. `state.Load`
    upgrades `schema_version` 0/1 → 2 on read; a legacy key with more than one
    possible reading **refuses the load**, naming the key and the remedy, rather
-   than guessing and recording it under the wrong project. An older binary
-   already refuses a newer `schema_version`, which is the downgrade story.
+   than guessing and recording it under the wrong project. Disambiguation leans
+   on one property — every adapter joins its project-scope destinations onto the
+   project root — so the containment test normalizes `\` as well as `/`: a
+   Windows project root outside `%USERPROFILE%` is stored verbatim, drive colon
+   and backslashes included, and a slash-only test would find no contained
+   reading and refuse every such file. An older binary already refuses a newer
+   `schema_version`, which is the downgrade story.
    One boundary is narrower than the encoding: `targets.json` is JSON, and
    `encoding/json` rewrites an invalid UTF-8 byte in a string to U+FFFD, which
    would break a length prefix and make the next `Load` refuse the file — with

--- a/docs/components.md
+++ b/docs/components.md
@@ -404,16 +404,20 @@ Pure 3-way classifier — no IO.
 
 ### `internal/state`
 Persists last-applied hashes and plugin/marketplace pins to
-`.state/targets.json`; schema-versioned with migrators. Also owns the
-per-machine run record `.state/last-run.json`, which backs the one-time
+`.state/targets.json`; schema-versioned with migrators. Owns the `targets.json`
+**key format**: `Key` is a typed, length-prefixed, injective identifier
+(agent · scope · portable project root · portable dest path · JSON pointer), so
+no other package has to build or take apart a key by hand (issue #227). Also
+owns the per-machine run record `.state/last-run.json`, which backs the one-time
 first-run-after-upgrade notice — a SEPARATE file on purpose: it must be
 writable by read-only commands and must never gate on (or bump) the drift
 state's `SchemaVersion`.
-- **Key:** `SchemaVersion`; `Targets` (`Files`, `Keys`, `Marketplaces`,
+- **Key:** `SchemaVersion`; `Key` (+ `NewFileKey`, `NewPointerKey`, `ParseKey`,
+  `String`, `AbsPath`, `InTree`); `Targets` (`Files`, `Keys`, `Marketplaces`,
   `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`;
   `LastRun`/`LoadLastRun`/`SaveLastRun`.
-- **Depends on:** iox. **Files:** `schema.go`, `store.go`, `migrate.go`,
-  `lastrun.go`.
+- **Depends on:** iox, paths. **Files:** `schema.go`, `store.go`, `key.go`,
+  `migrate.go`, `lastrun.go`.
 
 ### `internal/marketplace`
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin

--- a/docs/components.md
+++ b/docs/components.md
@@ -407,8 +407,13 @@ Persists last-applied hashes and plugin/marketplace pins to
 `.state/targets.json`; schema-versioned with migrators. Owns the `targets.json`
 **key format**: `Key` is a typed, length-prefixed, injective identifier
 (agent · scope · portable project · portable dest path · JSON pointer) used as
-the Go map key of `Files`/`Keys`, so no other package can build or parse one
-(issue #227). Also owns the per-machine run record `.state/last-run.json`, which
+the Go map key of `Files`/`Keys`, so a hand-rolled `fmt.Sprintf` key is a
+compile error rather than a convention (issue #227). The *encoding* has exactly
+one owner — `String`/`ParseKey` live here and nothing else formats or decodes it
+— but neither is sealed: `ParseKey` is exported (below), and a `state.Key{…}`
+composite literal compiles anywhere, which is how `render`'s and `cli`'s tests
+plant keys in a specific portable spelling instead of going through
+`NewFileKey`. Also owns the per-machine run record `.state/last-run.json`, which
 backs the one-time first-run-after-upgrade notice — a SEPARATE file on purpose:
 it must be writable by read-only commands and must never gate on (or bump) the
 drift state's `SchemaVersion`.

--- a/docs/components.md
+++ b/docs/components.md
@@ -417,7 +417,8 @@ state's `SchemaVersion`.
   `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`;
   `LastRun`/`LoadLastRun`/`SaveLastRun`.
 - **Depends on:** iox, paths. **Files:** `schema.go`, `store.go`, `key.go`,
-  `migrate.go`, `lastrun.go`.
+  `legacy.go` (the v1 key parser, used only by `migrate`), `migrate.go`,
+  `lastrun.go`.
 
 ### `internal/marketplace`
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin

--- a/docs/components.md
+++ b/docs/components.md
@@ -406,19 +406,20 @@ Pure 3-way classifier — no IO.
 Persists last-applied hashes and plugin/marketplace pins to
 `.state/targets.json`; schema-versioned with migrators. Owns the `targets.json`
 **key format**: `Key` is a typed, length-prefixed, injective identifier
-(agent · scope · portable project root · portable dest path · JSON pointer), so
-no other package has to build or take apart a key by hand (issue #227). Also
-owns the per-machine run record `.state/last-run.json`, which backs the one-time
-first-run-after-upgrade notice — a SEPARATE file on purpose: it must be
-writable by read-only commands and must never gate on (or bump) the drift
-state's `SchemaVersion`.
-- **Key:** `SchemaVersion`; `Key` (+ `NewFileKey`, `NewPointerKey`, `ParseKey`,
-  `String`, `AbsPath`, `InTree`); `Targets` (`Files`, `Keys`, `Marketplaces`,
-  `Plugins`); `FileEntry`; `KeyEntry`; `Load`/`Save`; `migrate`;
-  `LastRun`/`LoadLastRun`/`SaveLastRun`.
+(agent · scope · portable project · portable dest path · JSON pointer) used as
+the Go map key of `Files`/`Keys`, so no other package can build or parse one
+(issue #227). Also owns the per-machine run record `.state/last-run.json`, which
+backs the one-time first-run-after-upgrade notice — a SEPARATE file on purpose:
+it must be writable by read-only commands and must never gate on (or bump) the
+drift state's `SchemaVersion`.
+- **Key:** `SchemaVersion` (currently 2); `Key` (+ `NewFileKey`,
+  `NewPointerKey`, `ParseKey`, `String`, `AbsPath`, `InTree`); `Targets`
+  (`Files`, `Keys`, `Marketplaces`, `Plugins`); `FileEntry`; `KeyEntry`;
+  `Load`/`Save`; `ErrNonUTF8Key` (`Save` refuses a key JSON cannot carry
+  losslessly); `migrate` (v1 keys → typed keys); `LastRun`/`LoadLastRun`/
+  `SaveLastRun`.
 - **Depends on:** iox, paths. **Files:** `schema.go`, `store.go`, `key.go`,
-  `legacy.go` (the v1 key parser, used only by `migrate`), `migrate.go`,
-  `lastrun.go`.
+  `legacy.go`, `migrate.go`, `lastrun.go`.
 
 ### `internal/marketplace`
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -173,8 +173,9 @@ environment. The public **recipient** key is safe to commit; the private
 ### State (`~/.agentsync/.state/`)
 Gitignored bookkeeping: `targets.json` (the last-applied hashes that make drift
 detection possible), the apply lock, the two-phase write staging dir, first-apply
-backups, and the marketplace/plugin cache. Keys are stored `${HOME}`-relative so
-state is portable across machines.
+backups, and the marketplace/plugin cache. Each entry is addressed by an opaque,
+injective key that stores the project root and destination path `${HOME}`-relative,
+so state stays portable across machines.
 
 ### Destination git backup (rollback history)
 Optionally, each **user-scope destination dir** (`~/.claude`, `~/.codex`, …) gets

--- a/docs/superpowers/specs/2026-05-04-agentsync-design.md
+++ b/docs/superpowers/specs/2026-05-04-agentsync-design.md
@@ -439,8 +439,9 @@ agentsync explain <path>[#<pointer>] [--pointer …] [--json]  # dest provenance
 > **Superseded (2026-08-31, issue #227).** The `files`/`keys` map keys shown
 > below are the `schema_version: 1` encoding. They are now length-prefixed
 > `state.Key` encodings at `schema_version: 2` — see
-> [`2026-08-31-typed-state-keys.md`](2026-08-31-typed-state-keys.md). The entry
-> payloads and the `marketplaces`/`plugins` keys are unchanged.
+> [`docs/architecture.md` §7 item 8](../../architecture.md#7-safety-primitives)
+> for the encoding and the migration, and issue #227 for the bug that motivated
+> them. The entry payloads and the `marketplaces`/`plugins` keys are unchanged.
 
 ```json
 {

--- a/docs/superpowers/specs/2026-05-04-agentsync-design.md
+++ b/docs/superpowers/specs/2026-05-04-agentsync-design.md
@@ -436,6 +436,12 @@ agentsync explain <path>[#<pointer>] [--pointer …] [--json]  # dest provenance
 
 ## State on disk (`~/.agentsync/.state/`, gitignored)
 
+> **Superseded (2026-08-31, issue #227).** The `files`/`keys` map keys shown
+> below are the `schema_version: 1` encoding. They are now length-prefixed
+> `state.Key` encodings at `schema_version: 2` — see
+> [`2026-08-31-typed-state-keys.md`](2026-08-31-typed-state-keys.md). The entry
+> payloads and the `marketplaces`/`plugins` keys are unchanged.
+
 ```json
 {
   "schema_version": 1,

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/adapter/claude"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
-	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -246,10 +245,9 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 // (<target-root>/.agentsync); an AGENTSYNC_HOME relocated outside TargetRoot is
 // not honored here.
 func (a *Adapter) destOwned(st *state.Targets, scope adapter.Scope, project, destPath string) bool {
-	home := a.opts.TargetRoot
-	key := fmt.Sprintf("opencode:%s:%s:%s", scope.String(),
-		paths.HomeRelative(home, project), paths.HomeRelative(home, destPath))
-	_, ok := st.Files[key]
+	// The key format is owned by internal/state (the documented opencode -> state
+	// layering exception, issue #148); this must never rebuild it by hand.
+	_, ok := st.Files[state.NewFileKey(a.opts.TargetRoot, "opencode", scope.String(), project, destPath)]
 	return ok
 }
 

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -229,13 +229,14 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 // ~/.config/opencode/{agents,commands}/ directories, never a user's
 // hand-authored files sitting alongside them.
 //
-// The state key mirrors render.RecordOpsState exactly —
-// "<agent>:<scope>:<home-rel-project>:<home-rel-path>" — so a file apply wrote
-// is recognized here. Home-relativization uses the adapter's configured
-// TargetRoot, the SAME base ResolvePaths uses for every other path, so the read
-// side agrees with the write side in production (the CLI registry constructs
-// every adapter with TargetRoot = paths.HomeDir, the same value apply feeds
-// RecordOpsState).
+// The state key mirrors render.RecordOpsState exactly — both build it with
+// state.NewFileKey(userHome, agent, scope, project, dest), the typed
+// agent · scope · home-rel project · home-rel path · pointer tuple — so a file
+// apply wrote is recognized here. Home-relativization uses the adapter's
+// configured TargetRoot, the SAME base ResolvePaths uses for every other path,
+// so the read side agrees with the write side in production (the CLI registry
+// constructs every adapter with TargetRoot = paths.HomeDir, the same value
+// apply feeds RecordOpsState).
 //
 // Scope note: filtering ingest by ownership is currently OpenCode-only — no
 // other deep adapter filters its Ingest yet (a known class-wide gap tracked for

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -605,66 +605,30 @@ func agentDisableRun(cmd *cobra.Command, args []string, purge bool) error {
 	return purgeAgentDests(cmd, name, home, sc, projectRoot)
 }
 
-// purgeKeyRest reports whether a state key ("agent:scope:project:path[:ptr]")
-// belongs to the purge set and, if so, returns the key's remainder after the
-// dest-identifying prefix (the path, or "path:ptr" for a Keys entry). At user
-// scope the purge keeps its historical cleanup-everything semantics: every
-// entry of the named agent, across all scopes and projects. At project scope it
-// matches only the agent's entries for THAT project root — purging a project
-// must not delete the user's machine-wide destinations or another repo's
-// rendered files. The project-scope match compares the full literal prefix
-// (like render.PruneStaleState's key prefixes) instead of colon-split fields:
-// a portable project root is not guaranteed colon-free (a root outside $HOME
-// stays an absolute path), and field-splitting would silently mismatch it.
-func purgeKeyRest(key, agent string, sc adapter.Scope, portableProject string) (rest string, ok bool) {
-	if sc == adapter.ScopeProject {
-		prefix := agent + ":" + adapter.ScopeProject.String() + ":" + portableProject + ":"
-		if !strings.HasPrefix(key, prefix) {
-			return "", false
-		}
-		return key[len(prefix):], true
+// purgeMatches reports whether a state key belongs to the purge set for the
+// named agent.
+//
+// RATIFIED POLICY (issue #171): a USER-scope `--purge` is intentionally
+// cross-scope — it is the machine-wide "remove everything this agent ever
+// wrote" affordance, so it spans every scope/project pair for the agent,
+// including project-scope destinations in checked-out repos. A PROJECT-scope
+// purge stays isolated to that repo: purging a project must not delete the
+// user's machine-wide destinations or another repo's rendered files.
+//
+// portableProject is the ${HOME}-relative root (paths.HomeRelative), matching
+// what state.NewFileKey stores. The v1 matcher this replaces compared string
+// prefixes and colon-split fields and could not tell a sibling project apart
+// when a root contained ':' (issue #227); state.Key compares fields, so that
+// whole class — and the shared-file guard's matching "accepted residual" —
+// is gone.
+func purgeMatches(k state.Key, agent string, sc adapter.Scope, portableProject string) bool {
+	if k.Agent != agent {
+		return false
 	}
-	if !strings.HasPrefix(key, agent+":") {
-		return "", false
+	if sc != adapter.ScopeProject {
+		return true
 	}
-	// RATIFIED POLICY (issue #171, decision confirmed): a USER-scope `--purge` is
-	// intentionally cross-scope — it is the machine-wide "remove everything this
-	// agent ever wrote" affordance, so it spans every scope:project pair for the
-	// agent (including project-scope dest files in checked-out repos). It matches by
-	// the `agent:` prefix and takes the 4th colon field as the remainder. That is
-	// exact for user-scope keys (empty project segment) and colon-free project
-	// roots; a colon-bearing root mangles it — an accepted residual, safe because
-	// otherFilesKeyPath mangles identically, keeping the shared-file guard aligned.
-	// (Project-scope `--purge --scope project` stays isolated to that repo, above.)
-	parts := strings.SplitN(key, ":", 4)
-	if len(parts) < 4 {
-		return "", false
-	}
-	return parts[3], true
-}
-
-// otherFilesKeyPath extracts the dest path from a Files key that is NOT part
-// of the purge set, for the shared-file guard. A key whose project segment
-// matches the purge's own portableProject is stripped colon-safely by literal
-// prefix — a co-owned dest under the same project root is exactly the case the
-// guard protects, and the root is not guaranteed colon-free. Every other key
-// falls back to the 4th colon field: user-scope keys carry an empty (colon-
-// free) project segment there, and a DIFFERENT project's dest can never
-// collide with this purge's paths, so a mangled extraction cannot cause a
-// false unprotected delete (it can only fail to match, which is the status
-// quo for keys that were never candidates).
-func otherFilesKeyPath(key, portableProject string) string {
-	if i := strings.Index(key, ":"); i >= 0 {
-		marker := ":" + adapter.ScopeProject.String() + ":" + portableProject + ":"
-		if tail := key[i:]; strings.HasPrefix(tail, marker) {
-			return tail[len(marker):]
-		}
-	}
-	parts := strings.SplitN(key, ":", 4)
-	if len(parts) < 4 {
-		return ""
-	}
-	return parts[3]
+	return k.Scope == adapter.ScopeProject.String() && k.Project == portableProject
 }
 
 // purgeAgentDests deletes the destination files owned solely by the named
@@ -688,21 +652,19 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 
 	// File-owned dests (whole-file replace ops, e.g. ~/.claude/skills/<n>/
 	// SKILL.md): the whole file is agentsync's, so a whole-file delete is
-	// correct — unless another agent still owns the same shared file. The
-	// dest path is field index 3 in a Files key ("agent:scope:project:path").
+	// correct — unless another agent still owns the same shared file.
 	purgedFilePaths := map[string]bool{}
 	otherFilePaths := map[string]bool{}
 	for key := range s.Files {
-		if path, ok := purgeKeyRest(key, name, sc, portableProject); ok {
-			if path != "" {
-				purgedFilePaths[path] = true
-			}
+		if key.Path == "" {
+			continue
+		}
+		if purgeMatches(key, name, sc, portableProject) {
+			purgedFilePaths[key.Path] = true
 			continue
 		}
 		// Not ours: record the path so shared files stay protected below.
-		if path := otherFilesKeyPath(key, portableProject); path != "" {
-			otherFilePaths[path] = true
-		}
+		otherFilePaths[key.Path] = true
 	}
 
 	// Key-owned dests (merge-key pointers within a possibly-shared file, e.g.
@@ -712,16 +674,13 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 	// this agent's owned pointers per path so we can remove ONLY them.
 	purgedKeyPtrs := map[string][]string{}
 	for key := range s.Keys {
-		rest, ok := purgeKeyRest(key, name, sc, portableProject)
-		if !ok {
+		if key.Path == "" || key.Pointer == "" {
 			continue
 		}
-		// rest is "path:ptr" for a Keys entry.
-		parts := strings.SplitN(rest, ":", 2)
-		if len(parts) < 2 || parts[0] == "" {
+		if !purgeMatches(key, name, sc, portableProject) {
 			continue
 		}
-		purgedKeyPtrs[parts[0]] = append(purgedKeyPtrs[parts[0]], parts[1])
+		purgedKeyPtrs[key.Path] = append(purgedKeyPtrs[key.Path], key.Pointer)
 	}
 
 	reg := registryFactory()
@@ -772,12 +731,12 @@ func purgeAgentDests(cmd *cobra.Command, name, home string, sc adapter.Scope, pr
 
 	// Remove the matching state entries for this agent.
 	for key := range s.Files {
-		if _, ok := purgeKeyRest(key, name, sc, portableProject); ok {
+		if purgeMatches(key, name, sc, portableProject) {
 			delete(s.Files, key)
 		}
 	}
 	for key := range s.Keys {
-		if _, ok := purgeKeyRest(key, name, sc, portableProject); ok {
+		if purgeMatches(key, name, sc, portableProject) {
 			delete(s.Keys, key)
 		}
 	}

--- a/internal/cli/agent_internal_test.go
+++ b/internal/cli/agent_internal_test.go
@@ -4,129 +4,81 @@ import (
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
-// TestPurgeKeyRest pins the purge state-key matcher, in particular the
-// colon-safety of the project-scope match: a portable project root is not
-// guaranteed colon-free (a root outside $HOME stays an absolute path), so the
-// matcher compares a full literal prefix instead of colon-split fields.
-func TestPurgeKeyRest(t *testing.T) {
+// TestPurgeMatches pins the purge state-key matcher. Under the v1 string key
+// this needed a literal-prefix match plus a colon-split fallback, and a
+// colon-bearing project root mangled the extracted path — an accepted residual
+// that made `--purge` under-delete while reporting success (issue #227). The
+// typed key compares fields, so a colon-bearing root is now ordinary.
+func TestPurgeMatches(t *testing.T) {
 	testenv.RequireContainer(t)
 	cases := []struct {
 		name            string
-		key             string
+		key             state.Key
 		agent           string
 		sc              adapter.Scope
 		portableProject string
-		wantOK          bool
-		wantRest        string
+		want            bool
 	}{
 		{
 			name:  "user scope matches every scope and project of the agent",
-			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			key:   state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/proj", Path: "${HOME}/proj/.mcp.json"},
 			agent: "claude", sc: adapter.ScopeUser,
-			wantOK: true, wantRest: "${HOME}/proj/.mcp.json",
+			want: true,
 		},
 		{
 			name:  "user scope binds the agent name exactly, not as a sub-prefix",
-			key:   "claude2:user::${HOME}/.claude.json",
+			key:   state.Key{Agent: "claude2", Scope: "user", Path: "${HOME}/.claude.json"},
 			agent: "claude", sc: adapter.ScopeUser,
-			wantOK: false,
+			want: false,
 		},
 		{
 			name:  "project scope matches only that project root",
-			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			key:   state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/proj", Path: "${HOME}/proj/.mcp.json"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
-			wantOK: true, wantRest: "${HOME}/proj/.mcp.json",
+			want: true,
 		},
 		{
 			name:  "project scope rejects another project's keys",
-			key:   "claude:project:${HOME}/other:${HOME}/other/.mcp.json",
+			key:   state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/other", Path: "${HOME}/other/.mcp.json"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
-			wantOK: false,
+			want: false,
 		},
 		{
 			name:  "project scope rejects the agent's user-scope keys",
-			key:   "claude:user::${HOME}/.claude.json",
+			key:   state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
-			wantOK: false,
+			want: false,
 		},
 		{
-			name:  "project scope survives a colon-bearing project root",
-			key:   "claude:project:/mnt/we:ird/proj:/mnt/we:ird/proj/.mcp.json",
+			name:  "project scope handles a colon-bearing project root",
+			key:   state.Key{Agent: "claude", Scope: "project", Project: "/mnt/we:ird/proj", Path: "/mnt/we:ird/proj/.mcp.json"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "/mnt/we:ird/proj",
-			wantOK: true, wantRest: "/mnt/we:ird/proj/.mcp.json",
+			want: true,
 		},
 		{
-			name:  "keys entry remainder keeps the path:ptr tail",
-			key:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json:/mcpServers/x",
+			name: "project scope rejects a SIBLING root that merely shares a prefix",
+			key: state.Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/work/app:staging", Path: "${HOME}/work/app:staging/.mcp.json",
+			},
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/work/app",
+			want: false,
+		},
+		{
+			name:  "pointer keys match on the same legs",
+			key:   state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/proj", Path: "${HOME}/proj/.mcp.json", Pointer: "/mcpServers/x"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "${HOME}/proj",
-			wantOK: true, wantRest: "${HOME}/proj/.mcp.json:/mcpServers/x",
-		},
-		{
-			name:  "user-scope keys entry remainder keeps the path:ptr tail",
-			key:   "claude:user::${HOME}/.claude.json:/mcpServers/x",
-			agent: "claude", sc: adapter.ScopeUser,
-			wantOK: true, wantRest: "${HOME}/.claude.json:/mcpServers/x",
+			want: true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rest, ok := purgeKeyRest(tc.key, tc.agent, tc.sc, tc.portableProject)
-			if ok != tc.wantOK {
-				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
-			}
-			if ok && rest != tc.wantRest {
-				t.Fatalf("rest = %q, want %q", rest, tc.wantRest)
-			}
-		})
-	}
-}
-
-// TestOtherFilesKeyPath pins the shared-file guard's path extraction: keys
-// under the purge's OWN project root are stripped colon-safely (they are the
-// candidates for a co-owned dest), everything else falls back to the 4th colon
-// field. Both sides of the guard must extract a same-root dest identically, or
-// a co-owned file under a colon-bearing root would lose its protection and be
-// deleted without backup.
-func TestOtherFilesKeyPath(t *testing.T) {
-	testenv.RequireContainer(t)
-	cases := []struct {
-		name            string
-		key             string
-		portableProject string
-		want            string
-	}{
-		{
-			name:            "same project root, colon-bearing, extracts the exact path",
-			key:             "opencode:project:/mnt/we:ird/proj:/mnt/we:ird/proj/x/SKILL.md",
-			portableProject: "/mnt/we:ird/proj",
-			want:            "/mnt/we:ird/proj/x/SKILL.md",
-		},
-		{
-			name:            "same project root, plain, extracts the path",
-			key:             "opencode:project:${HOME}/proj:${HOME}/proj/.mcp.json",
-			portableProject: "${HOME}/proj",
-			want:            "${HOME}/proj/.mcp.json",
-		},
-		{
-			name:            "user-scope key falls back to the exact 4th field",
-			key:             "opencode:user::${HOME}/.claude.json",
-			portableProject: "${HOME}/proj",
-			want:            "${HOME}/.claude.json",
-		},
-		{
-			name:            "malformed short key yields nothing",
-			key:             "opencode:user",
-			portableProject: "${HOME}/proj",
-			want:            "",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := otherFilesKeyPath(tc.key, tc.portableProject); got != tc.want {
-				t.Fatalf("otherFilesKeyPath(%q) = %q, want %q", tc.key, got, tc.want)
+			if got := purgeMatches(tc.key, tc.agent, tc.sc, tc.portableProject); got != tc.want {
+				t.Fatalf("purgeMatches(%+v) = %v, want %v", tc.key, got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/agent_internal_test.go
+++ b/internal/cli/agent_internal_test.go
@@ -54,6 +54,17 @@ func TestPurgeMatches(t *testing.T) {
 			want: false,
 		},
 		{
+			// The scope leg is load-bearing exactly when portableProject is
+			// empty: a user-scope key's Project field is "" too, so without
+			// `k.Scope == adapter.ScopeProject.String()` a project-scope purge
+			// rooted at "" would sweep up the agent's USER-scope ownership,
+			// deleting user-scope destinations under a project-scoped command.
+			name:  "project scope with an empty root still rejects user-scope keys",
+			key:   state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json"},
+			agent: "claude", sc: adapter.ScopeProject, portableProject: "",
+			want: false,
+		},
+		{
 			name:  "project scope handles a colon-bearing project root",
 			key:   state.Key{Agent: "claude", Scope: "project", Project: "/mnt/we:ird/proj", Path: "/mnt/we:ird/proj/.mcp.json"},
 			agent: "claude", sc: adapter.ScopeProject, portableProject: "/mnt/we:ird/proj",

--- a/internal/cli/apply_internal_test.go
+++ b/internal/cli/apply_internal_test.go
@@ -58,7 +58,7 @@ func TestSaveBestEffortState_OnlyRecordsWrittenPaths(t *testing.T) {
 
 func fileKeyRecorded(st *state.Targets, nameSubstr string) bool {
 	for k := range st.Files {
-		if strings.Contains(k, nameSubstr) {
+		if strings.Contains(k.Path, nameSubstr) {
 			return true
 		}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -201,12 +201,33 @@ func checkStateDir(p *ui.Printer, home string) int {
 	// already quotes every key with %q, which escapes the whole strip set
 	// (controls, bidi overrides, zero-width) — so this call is a BACKSTOP, not
 	// the only defense, and no state.Load error reaching it today carries a raw
-	// escape. It stays because doctor prints its diagnostics inline while every
-	// OTHER state.Load error in the CLI is returned and printed by reportErrorTo,
-	// which sanitizes the same way: doctor must not be the one print site where a
-	// future unquoted interpolation reaches the terminal raw. sanitizeLines rather
-	// than untrusted.Wrap because the refusal is multi-line and ui.Sanitize STRIPS
-	// newlines — wrapping would run the remedy paragraphs together.
+	// escape.
+	//
+	// It stays because doctor prints its diagnostic inline rather than returning
+	// it, and the rule is that EVERY state.Load error that can reach a terminal
+	// passes through a sanitizer on the way. As of this comment there are 15
+	// state.Load call sites and they take one of four routes — this is the
+	// fourth, not an exception:
+	//
+	//   - returned to main (status, diff, apply, reconcile, explain, migrate,
+	//     agent disable --purge, plugin's two poll sites): reportErrorTo
+	//     sanitizeLines the whole chain;
+	//   - warned as a "warning: " sentinel line into ui.WarnWriter, whose emit
+	//     sanitizes the body (TestWarnWriterSanitizesAdapterText): import's
+	//     hook-disown and state-seed sites via importIO.warnf, and opencode's
+	//     Ingest, which cannot call ui.Sanitize itself — an adapter must not
+	//     import ui, which is the whole reason that sentinel exists;
+	//   - warned inline by `marketplace add`/`remove`, whose p.Warnf and diag
+	//     sinks reach fmt.Fprintf WITHOUT sanitizing: sanitizeLines is applied at
+	//     those two call sites instead, so the warning is covered whichever sink
+	//     the caller passed;
+	//   - printed inline here.
+	//
+	// Adding a 16th site means picking one of those four, not inventing a fifth.
+	//
+	// sanitizeLines rather than untrusted.Wrap because the refusal is multi-line
+	// and ui.Sanitize STRIPS newlines — wrapping would run the remedy paragraphs
+	// together.
 	if _, err := state.Load(filepath.Join(stateDir, "targets.json")); err != nil {
 		failCheck(p, "state file ", fmt.Sprintf("corrupt: %s", sanitizeLines(err.Error())))
 		return 1

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -194,15 +194,19 @@ func checkStateDir(p *ui.Printer, home string) int {
 	// check that ignores it would falsely report healthy. A missing file is
 	// fine (state.Load returns an empty state on a fresh install).
 	//
-	// sanitizeLines, not a raw %v: a migration refusal interpolates map keys read
+	// sanitizeLines, not a raw %v. A migration refusal interpolates map keys read
 	// verbatim from targets.json, which the schema-2 remedy explicitly expects may
-	// be hand-edited, so a crafted key could smuggle a terminal escape into this
-	// line and forge a passing check below it (#93/#171). Every OTHER state.Load
-	// error in the CLI is returned and printed by reportErrorTo, which already
-	// sanitizes the same way; doctor prints its diagnostics inline, so it has to
-	// sanitize here. sanitizeLines rather than untrusted.Wrap because the refusal
-	// is multi-line and ui.Sanitize STRIPS newlines — wrapping would run the
-	// remedy paragraphs together.
+	// be hand-edited, so a crafted key could otherwise smuggle a terminal escape
+	// into this line and forge a passing check below it (#93/#171). migrate
+	// already quotes every key with %q, which escapes the whole strip set
+	// (controls, bidi overrides, zero-width) — so this call is a BACKSTOP, not
+	// the only defense, and no state.Load error reaching it today carries a raw
+	// escape. It stays because doctor prints its diagnostics inline while every
+	// OTHER state.Load error in the CLI is returned and printed by reportErrorTo,
+	// which sanitizes the same way: doctor must not be the one print site where a
+	// future unquoted interpolation reaches the terminal raw. sanitizeLines rather
+	// than untrusted.Wrap because the refusal is multi-line and ui.Sanitize STRIPS
+	// newlines — wrapping would run the remedy paragraphs together.
 	if _, err := state.Load(filepath.Join(stateDir, "targets.json")); err != nil {
 		failCheck(p, "state file ", fmt.Sprintf("corrupt: %s", sanitizeLines(err.Error())))
 		return 1

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -193,8 +193,18 @@ func checkStateDir(p *ui.Printer, home string) int {
 	// do. A corrupt state file makes every real command exit 1, so a readiness
 	// check that ignores it would falsely report healthy. A missing file is
 	// fine (state.Load returns an empty state on a fresh install).
+	//
+	// sanitizeLines, not a raw %v: a migration refusal interpolates map keys read
+	// verbatim from targets.json, which the schema-2 remedy explicitly expects may
+	// be hand-edited, so a crafted key could smuggle a terminal escape into this
+	// line and forge a passing check below it (#93/#171). Every OTHER state.Load
+	// error in the CLI is returned and printed by reportErrorTo, which already
+	// sanitizes the same way; doctor prints its diagnostics inline, so it has to
+	// sanitize here. sanitizeLines rather than untrusted.Wrap because the refusal
+	// is multi-line and ui.Sanitize STRIPS newlines — wrapping would run the
+	// remedy paragraphs together.
 	if _, err := state.Load(filepath.Join(stateDir, "targets.json")); err != nil {
-		failCheck(p, "state file ", fmt.Sprintf("corrupt: %v", err))
+		failCheck(p, "state file ", fmt.Sprintf("corrupt: %s", sanitizeLines(err.Error())))
 		return 1
 	}
 	okCheck(p, "state file ", "ok")

--- a/internal/cli/doctor_state_test.go
+++ b/internal/cli/doctor_state_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,5 +30,52 @@ func TestDoctor_DetectsCorruptState(t *testing.T) {
 	}
 	if _, err := runCLI(t, env, "doctor"); err == nil {
 		t.Fatal("doctor reported healthy on a corrupt state file (should exit nonzero)")
+	}
+}
+
+// TestDoctor_SanitizesCorruptStateDiagnostic pins the print boundary for the
+// schema-2 migration refusal.
+//
+// The refusal names each unreadable key by interpolating the map key read
+// VERBATIM from targets.json (migrate's `bad` list) — and the remedy that error
+// carries explicitly contemplates the user hand-editing that file. A key holding
+// a terminal escape would therefore reach the terminal raw: the #93/#171 class,
+// where crafted config repaints the screen or forges a passing check line.
+//
+// Every other state.Load error in the CLI is returned and printed by
+// reportErrorTo, which sanitizes per line. doctor prints its checks inline, so
+// it must sanitize at its own print site; this asserts it does.
+func TestDoctor_SanitizesCorruptStateDiagnostic(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	if _, err := runCLI(t, env, "apply"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// A v1 key whose SCOPE field carries an ESC. "\u001b" is how JSON must spell a
+	// control byte, so json.Unmarshal hands migrate a map key holding a real one.
+	// "[2J" (clear screen) is used rather than a color code so the assertion below
+	// cannot collide with the printer's own styling.
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	const corrupt = `{"schema_version":1,"files":{"claude:no\u001b[2Jpe::x":{"sha256":"a"}}}`
+	if err := os.WriteFile(statePath, []byte(corrupt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "doctor")
+	if err == nil {
+		t.Fatal("doctor must fail on a state file it cannot load")
+	}
+	if strings.Contains(out, "\x1b[2J") {
+		t.Fatalf("doctor echoed a raw terminal escape from targets.json:\n%s", out)
+	}
+	// The key is still NAMED — sanitizing strips the escape, it does not hide the
+	// diagnostic.
+	if !strings.Contains(out, "[2Jpe") {
+		t.Fatalf("doctor must still name the offending key (escape stripped):\n%s", out)
 	}
 }

--- a/internal/cli/doctor_state_test.go
+++ b/internal/cli/doctor_state_test.go
@@ -33,19 +33,24 @@ func TestDoctor_DetectsCorruptState(t *testing.T) {
 	}
 }
 
-// TestDoctor_SanitizesCorruptStateDiagnostic pins the print boundary for the
-// schema-2 migration refusal.
+// TestDoctor_CorruptStateDiagnosticCarriesNoRawEscape pins the OUTPUT of the
+// schema-2 migration refusal: whatever doctor prints, a terminal escape read
+// verbatim out of targets.json must not survive into it.
 //
 // The refusal names each unreadable key by interpolating the map key read
-// VERBATIM from targets.json (migrate's `bad` list) — and the remedy that error
-// carries explicitly contemplates the user hand-editing that file. A key holding
-// a terminal escape would therefore reach the terminal raw: the #93/#171 class,
+// VERBATIM from that file (migrate's `bad` list) — and the remedy the error
+// carries explicitly contemplates the user hand-editing it. A key holding a
+// terminal escape would otherwise reach the terminal raw: the #93/#171 class,
 // where crafted config repaints the screen or forges a passing check line.
 //
-// Every other state.Load error in the CLI is returned and printed by
-// reportErrorTo, which sanitizes per line. doctor prints its checks inline, so
-// it must sanitize at its own print site; this asserts it does.
-func TestDoctor_SanitizesCorruptStateDiagnostic(t *testing.T) {
+// It is deliberately an END-TO-END assertion and does NOT pin any one layer.
+// Two things stand between the key and the terminal — migrate's %q, which
+// escapes the whole of ui.Sanitize's strip set (controls, bidi overrides,
+// zero-width), and doctor's own sanitizeLines call — so no input can isolate
+// the second: removing it leaves this test green. That is the honest state of
+// affairs, and doctor.go says why the backstop stays anyway. Claiming this test
+// pins sanitizeLines specifically would be a lie.
+func TestDoctor_CorruptStateDiagnosticCarriesNoRawEscape(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	if _, err := runCLI(t, env, "init"); err != nil {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1783,7 +1783,7 @@ func importPlugins(io *importIO, home, agentName string, a adapter.Adapter, name
 			resolved[mpID] = mpID
 			return mpID, true
 		}
-		mpName, _, ferr := addMarketplaceSource(home, src, rawURL)
+		mpName, _, ferr := addMarketplaceSource(home, src, rawURL, io.warnf)
 		if ferr != nil {
 			io.warnf("skipping marketplace %q: %v", mpID, ferr)
 			resolved[mpID] = ""

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -488,15 +488,11 @@ func retireRefusedHookEvents(io *importIO, agentsyncHome, srcHome string, a adap
 	// DISOWN the retired events' key-state entries — for EVERY agent, at exactly
 	// this scope+project (see the cross-agent note above; a user-scope retirement
 	// must not disown project-scope keys whose canonical overlay file survives,
-	// and vice versa). Key shape: "<agent>:<scope>:<project>:<file>:<pointer>"
-	// (render.RecordOpsState); agent names carry no ':' and the scope/project
-	// legs are matched as one exact ":"-delimited run right after the agent leg.
-	// Residual (accepted): a project path that itself contains ':' can prefix-
-	// match a sibling project's run — bounded to a benign over-disown (the key
-	// is re-recorded by that project's next apply), and the key format offers
-	// no unambiguous parse to do better.
+	// and vice versa). The state key is typed (state.Key), so the scope and
+	// project legs are compared field-by-field: a project root containing ':'
+	// can no longer prefix-match a sibling project's entries (issue #227).
 	userHome := paths.HomeDir(paths.OSEnv{})
-	scopeMid := ":" + sc.String() + ":" + paths.HomeRelative(userHome, projectRoot) + ":"
+	portableProject := paths.HomeRelative(userHome, projectRoot)
 	statePath := filepath.Join(agentsyncHome, ".state", "targets.json")
 	st, serr := state.Load(statePath)
 	if serr != nil {
@@ -520,8 +516,9 @@ func retireRefusedHookEvents(io *importIO, agentsyncHome, srcHome string, a adap
 	// until the next apply re-records it — and if the user deletes the
 	// canonical file inside that window, the now-unowned native entry is left
 	// behind for good (never clobbered, though). Aliases are NOT id-gated the
-	// way retired events are, but a ':'-bearing native spelling still cannot
-	// cross a key boundary: canonical pointers never contain ':'.
+	// way retired events are; the pointer is matched exactly against the typed
+	// key's Pointer field, so a ':'-bearing native spelling cannot reach a
+	// neighbouring key.
 	var aliases []string
 	for _, event := range retired {
 		aliases = append(aliases, event)
@@ -537,12 +534,11 @@ func retireRefusedHookEvents(io *importIO, agentsyncHome, srcHome string, a adap
 	}
 	changed := false
 	for key := range st.Keys {
-		agentEnd := strings.Index(key, ":")
-		if agentEnd < 0 || !strings.HasPrefix(key[agentEnd:], scopeMid) {
+		if key.Scope != sc.String() || key.Project != portableProject {
 			continue
 		}
 		for _, alias := range aliases {
-			if strings.HasSuffix(key, ":/hooks/"+alias) {
+			if key.Pointer == "/hooks/"+alias {
 				delete(st.Keys, key)
 				changed = true
 			}

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -1623,10 +1623,13 @@ func TestImport_RetireDisownIsScopeExact(t *testing.T) {
 	// MUST use the exact spelling render.RecordOpsState emits — the
 	// "${HOME}/…" form paths.HomeRelative produces — or the survival
 	// assertion is trivially true against a spelling the disown could never
-	// match anyway. What this pins is the SCOPE leg (dropping sc.String()
-	// from the comparison disowns this key and fails the test); the project
-	// leg is now a compared field, so the scope and project legs are both
-	// exact.
+	// match anyway. What this pins is the SCOPE leg: dropping sc.String() from
+	// the comparison disowns this key and fails the test. The PROJECT leg
+	// cannot be exercised from a user-scope import — every user-scope key's
+	// Project field is "" and so is portableProject, so the comparison is
+	// vacuously true either way — and is pinned instead by
+	// TestImport_RetireDisownIsProjectExact below, along with the exactness of
+	// the pointer match.
 	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
 	st, err := state.Load(statePath)
 	if err != nil {
@@ -1661,6 +1664,103 @@ func TestImport_RetireDisownIsScopeExact(t *testing.T) {
 		if key.Agent == "claude" && key.Scope == "user" && key.Pointer == "/hooks/PreToolUse" {
 			t.Fatalf("user-scope key should have been disowned by the retirement: %s", key)
 		}
+	}
+}
+
+// TestImport_RetireDisownIsProjectExact is the PROJECT-scope half of the test
+// above, and it is what makes the retirement's other two comparisons
+// load-bearing. At user scope every key's Project field is "" and every hook
+// pointer is "/hooks/<event>", so neither the project leg nor the exactness of
+// the pointer match can fail there.
+//
+// Both planted survivors are shapes the v1 string key got wrong or only
+// happened to get right: a SIBLING project root whose portable spelling extends
+// this project's with ':' (the #227 collision — the old scope+project prefix
+// match swallowed it), and a pointer that merely ENDS with the retired event's
+// (the old match was strings.HasSuffix(key, ":/hooks/"+alias)).
+func TestImport_RetireDisownIsProjectExact(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+
+	// A project INSIDE the target root, so its portable spelling is
+	// "${HOME}/proj" — the form paths.HomeRelative produces and the disown
+	// compares against.
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, env, "init", "--scope", "project", "--project", proj)
+
+	settings := filepath.Join(proj, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	clean := `{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}]}}`
+	if err := os.WriteFile(settings, []byte(clean), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude:hook:PreToolUse", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("import: %v\n%s", err, out)
+	}
+
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	st, err := state.Load(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The key the import seeded for THIS project — the one the retirement must
+	// disown. Assert it is there, or the disown assertion below is vacuous.
+	target := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/proj",
+		Path:    "${HOME}/proj/.claude/settings.json",
+		Pointer: "/hooks/PreToolUse",
+	}
+	if _, ok := st.Keys[target]; !ok {
+		t.Fatalf("premise broken: import did not seed %+v; keys = %v", target, st.Keys)
+	}
+	sibling := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/proj:staging",
+		Path:    "${HOME}/proj:staging/.claude/settings.json",
+		Pointer: "/hooks/PreToolUse",
+	}
+	nested := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/proj",
+		Path:    "${HOME}/proj/.claude/settings.json",
+		Pointer: "/nested/hooks/PreToolUse",
+	}
+	st.Keys[sibling] = state.KeyEntry{SHA256: "deadbeef", SourceID: "hooks/PreToolUse.toml"}
+	st.Keys[nested] = state.KeyEntry{SHA256: "deadbeef", SourceID: "hooks/PreToolUse.toml"}
+	if err := state.Save(statePath, st); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the event unrepresentable so ingest refuses it and the canonical file
+	// is retired, which is what triggers the disown.
+	enriched := `{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi", "timeout": 30}]}]}}`
+	if err := os.WriteFile(settings, []byte(enriched), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "import", "claude", "--scope", "project", "--project", proj); err != nil {
+		t.Fatalf("re-import: %v\n%s", err, out)
+	}
+
+	st2, err := state.Load(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := st2.Keys[target]; ok {
+		t.Fatal("this project's own key should have been disowned by the retirement")
+	}
+	if _, ok := st2.Keys[sibling]; !ok {
+		t.Fatal("the retirement disowned a SIBLING project's key: the project leg must be compared exactly")
+	}
+	if _, ok := st2.Keys[nested]; !ok {
+		t.Fatal("the retirement disowned a key whose pointer merely ENDS with the retired event's: the pointer must be compared exactly")
 	}
 }
 

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -1624,16 +1624,20 @@ func TestImport_RetireDisownIsScopeExact(t *testing.T) {
 	// "${HOME}/…" form paths.HomeRelative produces — or the survival
 	// assertion is trivially true against a spelling the disown could never
 	// match anyway. What this pins is the SCOPE leg (dropping sc.String()
-	// from scopeMid disowns this key and fails the test); at user scope the
-	// project leg is empty on both sides, so the project-leg distinction
-	// between two different projects is exercised only via the scope word —
-	// the accepted residual documented on retireRefusedHookEvents.
+	// from the comparison disowns this key and fails the test); the project
+	// leg is now a compared field, so the scope and project legs are both
+	// exact.
 	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
 	st, err := state.Load(statePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	const projectKey = "claude:project:${HOME}/proj:${HOME}/proj/.claude/settings.json:/hooks/PreToolUse"
+	projectKey := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/proj",
+		Path:    "${HOME}/proj/.claude/settings.json",
+		Pointer: "/hooks/PreToolUse",
+	}
 	st.Keys[projectKey] = state.KeyEntry{SHA256: "deadbeef", SourceID: "hooks/PreToolUse.toml"}
 	if err := state.Save(statePath, st); err != nil {
 		t.Fatal(err)
@@ -1654,7 +1658,7 @@ func TestImport_RetireDisownIsScopeExact(t *testing.T) {
 		t.Fatal("user-scope retirement disowned a PROJECT-scope key whose canonical overlay file survives")
 	}
 	for key := range st2.Keys {
-		if strings.HasPrefix(key, "claude:user:") && strings.HasSuffix(key, ":/hooks/PreToolUse") {
+		if key.Agent == "claude" && key.Scope == "user" && key.Pointer == "/hooks/PreToolUse" {
 			t.Fatalf("user-scope key should have been disowned by the retirement: %s", key)
 		}
 	}

--- a/internal/cli/iss227_internal_test.go
+++ b/internal/cli/iss227_internal_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestStatus_OwnershipSurvivesLegacyStateMigration is the assertion that the
+// schema 1 -> 2 key migration preserved MEANING, not just shape.
+//
+// A user upgrading into this binary has a v1 targets.json on disk. If the
+// migration produced keys that no longer match what stateFileKey computes, every
+// managed destination would classify as `foreign-collision` on the next run:
+// agentsync would back up and rewrite the user's entire config. So: seed a real
+// v1 file, load it through the real state.Load, and assert `status` sees the
+// destination as CLEAN.
+func TestStatus_OwnershipSurvivesLegacyStateMigration(t *testing.T) {
+	userHome := t.TempDir()
+	dest := filepath.Join(userHome, ".claude", "CLAUDE.md")
+	const content = "# managed by agentsync\n"
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A schema_version 1 file, keyed the way every pre-upgrade agentsync wrote it.
+	legacy := fmt.Sprintf(
+		`{"schema_version":1,"files":{"claude:user::${HOME}/.claude/CLAUDE.md":`+
+			`{"sha256":%q,"mode":420,"applied_at":"2026-05-04T10:00:00Z","source_id":"memory/AGENTS.md"}}}`,
+		hashContent([]byte(content)),
+	)
+	statePath := filepath.Join(t.TempDir(), "targets.json")
+	if err := os.WriteFile(statePath, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: the fixture really is the v1 shape. Read the BYTES back from the
+	// file state.Load will open, so the oracle is what is on disk rather than
+	// the string this test happens to hold.
+	onDisk, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(onDisk, &probe); err != nil || probe.SchemaVersion != 1 {
+		t.Fatalf("fixture is not a schema_version 1 document: %v %+v", err, probe)
+	}
+
+	s, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("Load legacy state: %v", err)
+	}
+	if s.SchemaVersion != state.SchemaVersion {
+		t.Fatalf("state was not migrated: schema_version=%d", s.SchemaVersion)
+	}
+
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude": {Ops: []adapter.FileOp{
+			{Action: "write", Path: dest, Content: []byte(content), Mode: 0o644, SourceID: "memory/AGENTS.md"},
+		}},
+	}}
+	model := buildStatusModel(plan, []string{"claude"}, s, userHome, adapter.ScopeUser, "")
+	if got := model.Summary["clean"]; got != 1 {
+		t.Fatalf("a destination owned in a MIGRATED v1 state must classify clean, "+
+			"not force a foreign-collision backup of the user's whole config; summary=%v",
+			model.Summary)
+	}
+}

--- a/internal/cli/iss227_internal_test.go
+++ b/internal/cli/iss227_internal_test.go
@@ -31,6 +31,14 @@ func TestStatus_OwnershipSurvivesLegacyStateMigration(t *testing.T) {
 	if err := os.WriteFile(dest, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// os.WriteFile's mode is masked by the process umask, so under a non-022
+	// umask the file lands 0600 while the seeded state below records mode 420
+	// (0o644). buildStatusModel compares the exact permission bits, so the item
+	// would classify `drift` and this test would fail for a reason that has
+	// nothing to do with the key migration it is asserting. Chmod is not masked.
+	if err := os.Chmod(dest, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// A schema_version 1 file, keyed the way every pre-upgrade agentsync wrote it.
 	legacy := fmt.Sprintf(

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -184,9 +184,27 @@ func addMarketplaceSource(home string, src marketplace.Source, rawURL string, wa
 		// doctor — is already failing on the same unreadable file, and nothing
 		// connects the two. Name the file and the underlying error so the fix is
 		// findable; the add itself succeeded, so this is a warning, not an error.
-		warnf("marketplace %s was added but not recorded in %s, which could not be read: %v; "+
+		//
+		// sanitizeLines, not a raw %v — the same backstop, and for the same
+		// reason, as cli/doctor.go's state-file check: a state.Load failure
+		// interpolates map keys read VERBATIM from a targets.json whose own
+		// schema-2 remedy invites the user to hand-edit it, and the #93/#171 class
+		// is a crafted key repainting the terminal around the success line this
+		// warning sits beside.
+		//
+		// Applied HERE rather than left to the sink, because the two callers do
+		// not agree: `marketplace add` passes p.Warnf, which reaches fmt.Fprintf
+		// through ui.Fdiagf untouched, while `import` passes importIO.warnf, whose
+		// "warning: " line ui.WarnWriter happens to sanitize. One call site covers
+		// both without depending on which sink was supplied.
+		//
+		// migrate already %q-quotes every key, so nothing reaching here today
+		// carries a raw escape; this is what keeps that true if a future error
+		// constructor forgets. Per line, because the refusal is multi-line and
+		// ui.Sanitize STRIPS newlines.
+		warnf("marketplace %s was added but not recorded in %s, which could not be read: %s; "+
 			"run `agentsync doctor` — the record is restored by the next successful "+
-			"`agentsync marketplace add`/`update`", mpName, statePath, lerr)
+			"`agentsync marketplace add`/`update`", mpName, statePath, sanitizeLines(lerr.Error()))
 	}
 
 	return mpName, result.HeadSHA, nil
@@ -245,8 +263,11 @@ func marketplaceRemoveRun(cmd *cobra.Command, args []string) error {
 		delete(st.Marketplaces, name)
 		_ = state.Save(statePath, st)
 	} else {
+		// sanitizeLines for the same reason as the add twin above: diag reaches
+		// fmt.Fprintf through ui.Fdiagf without sanitizing, and this error
+		// interpolates hand-editable targets.json keys.
 		diag(cmd, ui.LevelWarn, "marketplace %s was removed but its record remains in %s, "+
-			"which could not be read: %v; run `agentsync doctor`", name, statePath, lerr)
+			"which could not be read: %s; run `agentsync doctor`", name, statePath, sanitizeLines(lerr.Error()))
 	}
 
 	success(cmd, ui.EmojiRemoved, "removed marketplace %s", name)

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -83,7 +83,7 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 	}
 
 	stopSpin := p.Spin(fmt.Sprintf("fetching marketplace %s", rawURL))
-	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL)
+	mpName, headSHA, err := addMarketplaceSource(home, src, rawURL, p.Warnf)
 	stopSpin()
 	if err != nil {
 		return err
@@ -101,8 +101,10 @@ func marketplaceAddRun(cmd *cobra.Command, args []string) error {
 //
 // It does not print a success line or acquire the global lock — callers do.
 // Both `marketplace add` and `import` use it so the two produce byte-identical
-// canonical artifacts.
-func addMarketplaceSource(home string, src marketplace.Source, rawURL string) (mpName, headSHA string, err error) {
+// canonical artifacts. warnf is the caller's warning sink (p.Warnf for
+// `marketplace add`, importIO.warnf for `import`): the state record is
+// best-effort and its only failure mode is invisible otherwise.
+func addMarketplaceSource(home string, src marketplace.Source, rawURL string, warnf func(string, ...any)) (mpName, headSHA string, err error) {
 	// Derive a slug for the marketplace.
 	slug := deriveMarketplaceSlug(rawURL)
 	cacheDir := marketplaceCacheDir(home, slug)
@@ -176,6 +178,15 @@ func addMarketplaceSource(home string, src marketplace.Source, rawURL string) (m
 			FetchedAt: time.Now().UTC(),
 		}
 		_ = state.Save(statePath, st) // best-effort; don't fail add on state write errors
+	} else {
+		// Skipping the record is right, but doing it SILENTLY is not: the user
+		// gets a success line while every other command — status, apply, diff,
+		// doctor — is already failing on the same unreadable file, and nothing
+		// connects the two. Name the file and the underlying error so the fix is
+		// findable; the add itself succeeded, so this is a warning, not an error.
+		warnf("marketplace %s was added but not recorded in %s, which could not be read: %v; "+
+			"run `agentsync doctor` — the record is restored by the next successful "+
+			"`agentsync marketplace add`/`update`", mpName, statePath, lerr)
 	}
 
 	return mpName, result.HeadSHA, nil
@@ -225,11 +236,17 @@ func marketplaceRemoveRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("remove cache %s: %w", cacheDir, err)
 	}
 
-	// Remove from state.json (best-effort).
+	// Remove from state.json (best-effort). Same rule as addMarketplaceSource:
+	// keep an unreadable targets.json rather than replace it with an empty one,
+	// but say so — a silent skip leaves a stale marketplace record behind while
+	// the success line claims a clean removal.
 	statePath := filepath.Join(home, ".state", "targets.json")
-	if st, err := state.Load(statePath); err == nil {
+	if st, lerr := state.Load(statePath); lerr == nil {
 		delete(st.Marketplaces, name)
 		_ = state.Save(statePath, st)
+	} else {
+		diag(cmd, ui.LevelWarn, "marketplace %s was removed but its record remains in %s, "+
+			"which could not be read: %v; run `agentsync doctor`", name, statePath, lerr)
 	}
 
 	success(cmd, ui.EmojiRemoved, "removed marketplace %s", name)

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -157,17 +157,26 @@ func addMarketplaceSource(home string, src marketplace.Source, rawURL string) (m
 	}
 
 	// Update state.json so the update command can track fetch timestamps and SHAs.
+	//
+	// The read guard is load-bearing, not defensive noise: Load already returns a
+	// FRESH EMPTY state with no error for an absent file, so a non-nil error here
+	// means targets.json exists and could not be read — a refused migration (an
+	// ambiguous v1 key, a v2 role violation, a non-UTF-8 key), a permissions
+	// problem, corruption. Substituting state.New() there and saving would
+	// OVERWRITE targets.json with an empty state, discarding every Files/Keys/
+	// Plugins entry and every other marketplace; the next apply would then see no
+	// ownership at all and back up every managed destination as a foreign
+	// collision. Skipping the record instead costs only a stale fetch timestamp,
+	// which the next successful add/update repairs. Mirrors marketplaceRemoveRun.
 	statePath := filepath.Join(home, ".state", "targets.json")
-	st, _ := state.Load(statePath) // best-effort; ignore read errors on fresh home
-	if st == nil {
-		st = state.New()
+	if st, lerr := state.Load(statePath); lerr == nil {
+		st.Marketplaces[mpName] = state.Marketplace{
+			URL:       rawURL,
+			HeadSHA:   result.HeadSHA,
+			FetchedAt: time.Now().UTC(),
+		}
+		_ = state.Save(statePath, st) // best-effort; don't fail add on state write errors
 	}
-	st.Marketplaces[mpName] = state.Marketplace{
-		URL:       rawURL,
-		HeadSHA:   result.HeadSHA,
-		FetchedAt: time.Now().UTC(),
-	}
-	_ = state.Save(statePath, st) // best-effort; don't fail add on state write errors
 
 	return mpName, result.HeadSHA, nil
 }

--- a/internal/cli/marketplace_state_test.go
+++ b/internal/cli/marketplace_state_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/spxrogers/agentsync/internal/state"
 )
 
 // writeMarketplaceFixture lays down a minimal local marketplace directory that
@@ -39,30 +37,15 @@ func writeMarketplaceFixture(t *testing.T, dir, name string) string {
 // Skipping SILENTLY would be its own defect, so the test also pins the warning:
 // without it the user reads a success line while status/apply/diff/doctor are
 // all already failing on the same file, with nothing connecting the two.
+// (Those commands' half of the contract — refuse outright — is
+// TestCommandsRefuseUnreadableState.)
 func TestMarketplaceAdd_DoesNotClobberUnreadableState(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	fixture := writeMarketplaceFixture(t, filepath.Join(tmp, "fixture-mp"), "test-mp")
 	mustRun(t, env, "init")
 
-	// A v1 key with more than one possible reading — issue #227's colon-bearing
-	// project root is exactly the user who hits this — alongside REAL ownership
-	// and marketplace records that must survive.
-	const refused = `{"schema_version":1,` +
-		`"files":{"claude:project:${HOME}/a:${HOME}/b:${HOME}/c":{"sha256":"deadbeef"}},` +
-		`"marketplaces":{"other-mp":{"url":"https://example.invalid/mp","head_sha":"cafe"}}}`
-	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
-	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(statePath, []byte(refused), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// Guard the premise: if Load ever stops refusing this document the test is
-	// no longer exercising the unreadable-state branch at all.
-	if _, err := state.Load(statePath); err == nil {
-		t.Fatal("premise broken: state.Load must refuse this targets.json")
-	}
+	statePath := writeUnreadableState(t, tmp)
 
 	out, err := runCLI(t, env, "marketplace", "add", fixture)
 	if err != nil {
@@ -83,7 +66,121 @@ func TestMarketplaceAdd_DoesNotClobberUnreadableState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != refused {
-		t.Fatalf("marketplace add rewrote an unreadable targets.json, destroying its records:\n got: %s\nwant: %s", got, refused)
+	if string(got) != unreadableStateJSON {
+		t.Fatalf("marketplace add rewrote an unreadable targets.json, destroying its records:\n got: %s\nwant: %s", got, unreadableStateJSON)
+	}
+}
+
+// TestMarketplaceRemove_DoesNotClobberUnreadableState is the `remove` twin of
+// the test above, and exists for the same reason: `marketplace remove` deletes
+// marketplaces/<name>.toml and the cache, then edits the state record
+// best-effort. Falling back to an empty state there would save away every
+// ownership entry exactly as `add` once did, so the record is skipped — and,
+// because the success line otherwise claims a clean removal while a stale
+// record survives, the skip warns.
+//
+// Without this the warn half was unpinned: deleting the diagnostic left
+// ./internal/cli/ green while its `add` twin stayed covered.
+func TestMarketplaceRemove_DoesNotClobberUnreadableState(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := writeMarketplaceFixture(t, filepath.Join(tmp, "fixture-mp"), "test-mp")
+	mustRun(t, env, "init")
+	// Register it while the state file is still readable, so `remove` has
+	// something to remove and reaches the state edit.
+	mustRun(t, env, "marketplace", "add", fixture)
+
+	statePath := writeUnreadableState(t, tmp)
+
+	out, err := runCLI(t, env, "marketplace", "remove", "test-mp")
+	if err != nil {
+		t.Fatalf("marketplace remove: %v\n%s", err, out)
+	}
+	for _, want := range []string{"WARN", "record remains", "targets.json", "agentsync doctor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("skipping the state record must warn and mention %q; got:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "removed marketplace") {
+		t.Errorf("the removal still succeeded and must still say so; got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != unreadableStateJSON {
+		t.Fatalf("marketplace remove rewrote an unreadable targets.json, destroying its records:\n got: %s\nwant: %s", got, unreadableStateJSON)
+	}
+}
+
+// TestMarketplaceStateWarnings_CarryNoRawEscape sweeps the two warn sites above
+// for the terminal-escape class (#93/#171). The warning interpolates a
+// state.Load error, which names each unreadable key by copying the map key
+// VERBATIM out of a targets.json the schema-2 remedy explicitly invites the user
+// to hand-edit — and neither sink sanitizes on its own (p.Warnf and diag both
+// reach fmt.Fprintf through ui.Fdiagf untouched), which is why marketplace.go
+// calls sanitizeLines at both call sites.
+//
+// Like TestDoctor_CorruptStateDiagnosticCarriesNoRawEscape, this is an
+// END-TO-END assertion and pins no single layer: migrate's %q already escapes
+// the whole of ui.Sanitize's strip set, so removing sanitizeLines leaves this
+// test green. That is the honest state of affairs — the sanitizeLines calls are
+// the backstop for a future error constructor that forgets the %q, and
+// marketplace.go says so.
+func TestMarketplaceStateWarnings_CarryNoRawEscape(t *testing.T) {
+	// A v1 key whose SCOPE field carries an ESC. "\u001b" is how JSON must
+	// spell a control byte, so json.Unmarshal hands migrate a map key holding a real
+	// one. "[2J" (clear screen) rather than a color code, so the assertion cannot
+	// collide with the printer's own styling.
+	const corrupt = `{"schema_version":1,"files":{"claude:no\u001b[2Jpe::x":{"sha256":"a"}}}`
+
+	tests := []struct {
+		name string
+		// args is run once the corrupt state is in place; setup runs before.
+		args  []string
+		setup func(t *testing.T, tmp string, env map[string]string, fixture string)
+	}{
+		{
+			name: "marketplace add",
+			args: nil, // filled in below: the fixture path is per-test
+		},
+		{
+			name: "marketplace remove",
+			args: []string{"marketplace", "remove", "test-mp"},
+			setup: func(t *testing.T, _ string, env map[string]string, fixture string) {
+				t.Helper()
+				mustRun(t, env, "marketplace", "add", fixture)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp, "NO_COLOR": "1"}
+			fixture := writeMarketplaceFixture(t, filepath.Join(tmp, "fixture-mp"), "test-mp")
+			mustRun(t, env, "init")
+			if tc.setup != nil {
+				tc.setup(t, tmp, env, fixture)
+			}
+			statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+			if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(statePath, []byte(corrupt), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			args := tc.args
+			if args == nil {
+				args = []string{"marketplace", "add", fixture}
+			}
+			out, err := runCLI(t, env, args...)
+			if err != nil {
+				t.Fatalf("%v: %v\n%s", args, err, out)
+			}
+			// The command succeeded and warned; the warning must name the key
+			// with its escape stripped, not pass it through.
+			assertSanitized(t, out, "[2Jpe")
+		})
 	}
 }

--- a/internal/cli/marketplace_state_test.go
+++ b/internal/cli/marketplace_state_test.go
@@ -1,0 +1,73 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// writeMarketplaceFixture lays down a minimal local marketplace directory that
+// `marketplace add <path>` can fetch without touching the network.
+func writeMarketplaceFixture(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"name": "` + name + `", "owner": {"name": "x"}, "plugins": []}`
+	if err := os.WriteFile(filepath.Join(dir, ".claude-plugin", "marketplace.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestMarketplaceAdd_DoesNotClobberUnreadableState pins that a targets.json
+// agentsync CANNOT read is left alone rather than replaced with an empty state.
+//
+// state.Load returns a fresh empty state with NO error for an ABSENT file, so a
+// non-nil error means the file exists and is unreadable — which the typed-key
+// migration made materially more reachable (an ambiguous v1 key, a v2 role
+// violation, a non-UTF-8 key), and whose remedy text invites the user to keep
+// running commands meanwhile. Falling back to state.New() and saving would
+// discard every Files/Keys/Plugins entry and every other marketplace; the next
+// apply would then own nothing and back up every managed destination as a
+// foreign collision — the exact mass-backup failure the typed key exists to
+// prevent. The record must be skipped instead.
+func TestMarketplaceAdd_DoesNotClobberUnreadableState(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	fixture := writeMarketplaceFixture(t, filepath.Join(tmp, "fixture-mp"), "test-mp")
+	mustRun(t, env, "init")
+
+	// A v1 key with more than one possible reading — issue #227's colon-bearing
+	// project root is exactly the user who hits this — alongside REAL ownership
+	// and marketplace records that must survive.
+	const refused = `{"schema_version":1,` +
+		`"files":{"claude:project:${HOME}/a:${HOME}/b:${HOME}/c":{"sha256":"deadbeef"}},` +
+		`"marketplaces":{"other-mp":{"url":"https://example.invalid/mp","head_sha":"cafe"}}}`
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, []byte(refused), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Guard the premise: if Load ever stops refusing this document the test is
+	// no longer exercising the unreadable-state branch at all.
+	if _, err := state.Load(statePath); err == nil {
+		t.Fatal("premise broken: state.Load must refuse this targets.json")
+	}
+
+	if out, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != refused {
+		t.Fatalf("marketplace add rewrote an unreadable targets.json, destroying its records:\n got: %s\nwant: %s", got, refused)
+	}
+}

--- a/internal/cli/marketplace_state_test.go
+++ b/internal/cli/marketplace_state_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/state"
@@ -34,6 +35,10 @@ func writeMarketplaceFixture(t *testing.T, dir, name string) string {
 // apply would then own nothing and back up every managed destination as a
 // foreign collision — the exact mass-backup failure the typed key exists to
 // prevent. The record must be skipped instead.
+//
+// Skipping SILENTLY would be its own defect, so the test also pins the warning:
+// without it the user reads a success line while status/apply/diff/doctor are
+// all already failing on the same file, with nothing connecting the two.
 func TestMarketplaceAdd_DoesNotClobberUnreadableState(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
@@ -59,8 +64,19 @@ func TestMarketplaceAdd_DoesNotClobberUnreadableState(t *testing.T) {
 		t.Fatal("premise broken: state.Load must refuse this targets.json")
 	}
 
-	if out, err := runCLI(t, env, "marketplace", "add", fixture); err != nil {
+	out, err := runCLI(t, env, "marketplace", "add", fixture)
+	if err != nil {
 		t.Fatalf("marketplace add: %v\n%s", err, out)
+	}
+	// The add itself succeeded, so this is a warning beside the success line —
+	// not a failure. It must name the file, or the user has nothing to go on.
+	for _, want := range []string{"WARN", "not recorded", "targets.json", "agentsync doctor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("skipping the state record must warn and mention %q; got:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "added marketplace") {
+		t.Errorf("the add still succeeded and must still say so; got:\n%s", out)
 	}
 
 	got, err := os.ReadFile(statePath)

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -236,8 +236,9 @@ func rewriteSubagentStateIDs(userAgentsyncHome string, sc adapter.Scope, project
 	portableProject := paths.HomeRelative(userHome, projectRoot)
 
 	changed := false
+	scopeName := sc.String()
 	for key, entry := range st.Files {
-		if !stateKeyInTree(key, sc, portableProject) {
+		if key.Scope != scopeName || key.Project != portableProject {
 			continue
 		}
 		if id, ok := migratedSourceID(entry.SourceID); ok {
@@ -247,7 +248,7 @@ func rewriteSubagentStateIDs(userAgentsyncHome string, sc adapter.Scope, project
 		}
 	}
 	for key, entry := range st.Keys {
-		if !stateKeyInTree(key, sc, portableProject) {
+		if key.Scope != scopeName || key.Project != portableProject {
 			continue
 		}
 		if id, ok := migratedSourceID(entry.SourceID); ok {
@@ -260,22 +261,6 @@ func rewriteSubagentStateIDs(userAgentsyncHome string, sc adapter.Scope, project
 		return nil
 	}
 	return state.Save(statePath, st)
-}
-
-// stateKeyInTree reports whether a state key ("<agent>:<scope>:<project>:…")
-// belongs to the tree identified by scope + portable project root. Both the
-// project root and the dest path may themselves contain ':' (a Windows drive
-// letter), so only the first two fields are split off positionally and the
-// project root is matched as a prefix of the remainder.
-func stateKeyInTree(key string, sc adapter.Scope, portableProject string) bool {
-	parts := strings.SplitN(key, ":", 3)
-	if len(parts) < 3 {
-		return false
-	}
-	if parts[1] != sc.String() {
-		return false
-	}
-	return strings.HasPrefix(parts[2], portableProject+":")
 }
 
 // migratedSourceID rewrites a legacy `agents/<name>.md` SourceID to the

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -739,13 +739,13 @@ func collectOrphanFileItems(plan render.RenderPlan, reg *adapter.Registry, s *st
 }
 
 // pruneStateFilesForPath removes every agent's Files state entry for a single
-// dest path (after the user removes an orphan). The path is the last
-// colon-delimited field of a Files key, so a suffix match is exact even when
-// the path itself contains ':'.
+// dest path (after the user removes an orphan). The path is its own field of the
+// typed state key, so the match is exact for any path — including one containing
+// ':', which the previous suffix match only happened to get right.
 func pruneStateFilesForPath(s *state.Targets, userHome, absPath string) {
-	suffix := ":" + paths.HomeRelative(userHome, absPath)
+	portable := paths.HomeRelative(userHome, absPath)
 	for key := range s.Files {
-		if strings.HasSuffix(key, suffix) {
+		if key.Path == portable {
 			delete(s.Files, key)
 		}
 	}

--- a/internal/cli/reconcile_prune_internal_test.go
+++ b/internal/cli/reconcile_prune_internal_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestPruneStateFilesForPath_MatchesThePathExactly pins that the orphan prune
+// compares the typed key's Path FIELD for equality rather than suffix-matching
+// the encoded key, which is what the v1 string key forced
+// (strings.HasSuffix(key, ":"+portable)).
+//
+// The two destinations below are both real and both reachable on one machine:
+// paths.HomeRelative rewrites a path INSIDE $HOME to "${HOME}/…" but returns one
+// OUTSIDE it verbatim, so a project at /opt/cfg and a project at $HOME/opt/cfg
+// are stored as "/opt/cfg/.mcp.json" and "${HOME}/opt/cfg/.mcp.json" — and the
+// first is a proper SUFFIX of the second. Pruning the orphan at /opt/cfg must
+// not take the other project's ownership with it: a state entry deleted while
+// its file survives makes the next apply treat that file as a foreign collision
+// and back it up before overwriting.
+func TestPruneStateFilesForPath_MatchesThePathExactly(t *testing.T) {
+	const userHome = "/home/alice"
+	orphan := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "/opt/cfg", Path: "/opt/cfg/.mcp.json",
+	}
+	sibling := state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/opt/cfg", Path: "${HOME}/opt/cfg/.mcp.json",
+	}
+	s := state.New()
+	s.Files[orphan] = state.FileEntry{SHA256: "a"}
+	s.Files[sibling] = state.FileEntry{SHA256: "b"}
+
+	pruneStateFilesForPath(s, userHome, "/opt/cfg/.mcp.json")
+
+	if _, ok := s.Files[orphan]; ok {
+		t.Fatal("the removed orphan's own state entry must be pruned")
+	}
+	if _, ok := s.Files[sibling]; !ok {
+		t.Fatalf("pruning %q also disowned %q — the match must be on the whole Path field, not a suffix",
+			orphan.Path, sibling.Path)
+	}
+}

--- a/internal/cli/state_unreadable_test.go
+++ b/internal/cli/state_unreadable_test.go
@@ -1,0 +1,155 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// unreadableStateJSON is a targets.json agentsync CANNOT read, used by every
+// test in this file and by the marketplace pair in marketplace_state_test.go.
+//
+// The files key is a v1 key with more than one possible reading — issue #227's
+// colon-bearing project root is exactly the user who hits this — and it sits
+// alongside REAL ownership and marketplace records, so a test can tell "left
+// alone" apart from "rewritten with the same bytes by luck".
+const unreadableStateJSON = `{"schema_version":1,` +
+	`"files":{"claude:project:${HOME}/a:${HOME}/b:${HOME}/c":{"sha256":"deadbeef"}},` +
+	`"marketplaces":{"other-mp":{"url":"https://example.invalid/mp","head_sha":"cafe"}}}`
+
+// stateRefusalMarker is the line migrate produces for unreadableStateJSON. A
+// test asserting only "the command failed" would pass for any reason at all —
+// a bad argument, a missing home — so every row also proves the failure it got
+// is the state refusal it was after.
+const stateRefusalMarker = "could not be read at schema_version=1"
+
+// writeUnreadableState lays unreadableStateJSON down as tmp's targets.json and
+// returns its path, guarding the premise: if state.Load ever stops refusing this
+// document, every test built on it silently stops testing anything.
+func writeUnreadableState(t *testing.T, tmp string) string {
+	t.Helper()
+	statePath := filepath.Join(tmp, ".agentsync", ".state", "targets.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, []byte(unreadableStateJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.Load(statePath); err == nil {
+		t.Fatal("premise broken: state.Load must refuse this targets.json")
+	}
+	return statePath
+}
+
+// TestCommandsRefuseUnreadableState pins the behaviour docs/architecture.md §7.8
+// and the CHANGELOG's downgrade note both assert: a targets.json agentsync
+// cannot read stops the command, and the file is left exactly as it was found.
+//
+// It is the generalization of TestMarketplaceAdd_DoesNotClobberUnreadableState.
+// state.Load returns a fresh EMPTY state with no error for an ABSENT file, so
+// the tempting shape at each of these call sites is
+//
+//	s, err := state.Load(statePath)
+//	if err != nil { s = state.New() }
+//
+// which is the bug round 1 fixed in addMarketplaceSource — and, before this
+// test, regressing status.go or apply.go to exactly that passed the entire
+// ./internal/... suite. For `apply` it is the worst of the family: an empty
+// state owns nothing, so every managed destination is treated as unowned and
+// backed up as a foreign collision on the next run — the mass-backup failure
+// the typed key exists to prevent.
+//
+// The list is the eight commands the docs name, plus doctor. Every command that
+// reads state is covered except the five that deliberately do NOT fail on it:
+// `marketplace add`/`remove` skip the record and warn (their own tests in
+// marketplace_state_test.go pin that, including the untouched file), and
+// import's two sites plus opencode's Ingest warn and continue for the same
+// reason. Nothing that reads state is left unpinned in one direction or the
+// other.
+func TestCommandsRefuseUnreadableState(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		// setup runs after `init` + `agent add claude` and before the state file
+		// is written, for the rows that need more than a bare home.
+		setup func(t *testing.T, tmp string)
+	}{
+		{name: "status", args: []string{"status"}},
+		{name: "diff", args: []string{"diff"}},
+		{name: "apply", args: []string{"apply"}},
+		{name: "apply --dry-run", args: []string{"apply", "--dry-run"}},
+		{name: "reconcile", args: []string{"reconcile"}},
+		{name: "explain", args: []string{"explain", "~/.claude/CLAUDE.md"}},
+		{name: "plugin outdated", args: []string{"plugin", "outdated"}},
+		{
+			// This one flips `enabled = false` in agentsync.toml BEFORE reaching
+			// the purge, so it is not atomic — but the purge itself needs state to
+			// know which destinations the agent owns, and it refuses rather than
+			// deleting against an empty one. targets.json is untouched either way,
+			// which is what this test is about.
+			name: "agent disable --purge",
+			args: []string{"agent", "disable", "claude", "--purge"},
+		},
+		{
+			// `migrate subagents` short-circuits with "nothing to migrate" (exit 0)
+			// when agents/ holds no *.md, never reaching state at all — so the row
+			// needs a file to move. It moves agents/ → subagents/ and THEN refuses
+			// at the state rewrite, which is why the assertion is on targets.json
+			// rather than on the tree.
+			name: "migrate subagents",
+			args: []string{"migrate", "subagents"},
+			setup: func(t *testing.T, tmp string) {
+				t.Helper()
+				dir := filepath.Join(tmp, ".agentsync", "agents")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				body := "---\nname: rev\ndescription: d\n---\nbody\n"
+				if err := os.WriteFile(filepath.Join(dir, "rev.md"), []byte(body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			// doctor is the one that reports rather than returns: it prints the
+			// refusal as a failing check and exits non-zero through its own issue
+			// count, so the marker lands on stdout instead of in the error.
+			name: "doctor",
+			args: []string{"doctor"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+			mustRun(t, env, "init")
+			mustRun(t, env, "agent", "add", "claude")
+			if tc.setup != nil {
+				tc.setup(t, tmp)
+			}
+			statePath := writeUnreadableState(t, tmp)
+
+			out, err := runCLI(t, env, tc.args...)
+			if err == nil {
+				t.Fatalf("%v must refuse an unreadable targets.json, not proceed against an empty state; got:\n%s", tc.args, out)
+			}
+			// Prove the refusal is the state one. Search the command's output AND
+			// its error: the returning commands carry it in the error, doctor
+			// prints it.
+			if hay := out + "\n" + err.Error(); !strings.Contains(hay, stateRefusalMarker) {
+				t.Fatalf("%v failed for some other reason than the state refusal (%v); got:\n%s", tc.args, err, out)
+			}
+			got, rerr := os.ReadFile(statePath)
+			if rerr != nil {
+				t.Fatalf("targets.json is gone after %v: %v", tc.args, rerr)
+			}
+			if string(got) != unreadableStateJSON {
+				t.Fatalf("%v rewrote an unreadable targets.json, destroying its records:\n got: %s\nwant: %s",
+					tc.args, got, unreadableStateJSON)
+			}
+		})
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -914,28 +914,25 @@ func unexaminedPluginAgents(reg *adapter.Registry, enabled, selected []string) [
 	return out
 }
 
-// orphanedStateAgents returns, sorted, the agent names that appear as a state
-// key prefix ("agent:scope:…") but are not in the enabled set — i.e. agents
-// whose rendered native config and state entries linger after a `remove` or a
-// `disable` without `--purge`.
+// orphanedStateAgents returns, sorted, the agent names recorded in a state key
+// that are not in the enabled set — i.e. agents whose rendered native config and
+// state entries linger after a `remove` or a `disable` without `--purge`.
 func orphanedStateAgents(s *state.Targets, enabled []string) []string {
 	en := make(map[string]bool, len(enabled))
 	for _, n := range enabled {
 		en[n] = true
 	}
 	found := map[string]bool{}
-	collect := func(key string) {
-		if i := strings.IndexByte(key, ':'); i > 0 {
-			if a := key[:i]; !en[a] {
-				found[a] = true
-			}
+	collect := func(agent string) {
+		if agent != "" && !en[agent] {
+			found[agent] = true
 		}
 	}
 	for k := range s.Files {
-		collect(k)
+		collect(k.Agent)
 	}
 	for k := range s.Keys {
-		collect(k)
+		collect(k.Agent)
 	}
 	out := make([]string, 0, len(found))
 	for a := range found {
@@ -945,20 +942,18 @@ func orphanedStateAgents(s *state.Targets, enabled []string) []string {
 	return out
 }
 
-// stateFileKey builds the state Files map key matching render.RecordOpsState.
-// Format: "agent:scope:portableProject:portablePath" (project and path are
-// HOME-relative against the user's $HOME so keys are portable across
-// machines — userHome must be paths.HomeDir, NOT the agentsync home).
-func stateFileKey(userHome, agent string, sc adapter.Scope, projectRoot, path string) string {
-	return fmt.Sprintf("%s:%s:%s:%s", agent, sc.String(),
-		paths.HomeRelative(userHome, projectRoot), paths.HomeRelative(userHome, path))
+// stateFileKey builds the state Files map key for a destination. It exists only
+// to convert adapter.Scope to the plain string internal/state takes (state sits
+// below adapter in the package layering); the format itself is owned by
+// state.Key, so this can no longer drift from render.RecordOpsState.
+func stateFileKey(userHome, agent string, sc adapter.Scope, projectRoot, path string) state.Key {
+	return state.NewFileKey(userHome, agent, sc.String(), projectRoot, path)
 }
 
-// stateKeyKey builds the state Keys map key matching render.RecordOpsState.
-// Format: "agent:scope:portableProject:portablePath:ptr".
-func stateKeyKey(userHome, agent string, sc adapter.Scope, projectRoot, path, ptr string) string {
-	return fmt.Sprintf("%s:%s:%s:%s:%s", agent, sc.String(),
-		paths.HomeRelative(userHome, projectRoot), paths.HomeRelative(userHome, path), ptr)
+// stateKeyKey builds the state Keys map key for one JSON pointer inside a
+// shared destination file. Same conversion-only role as stateFileKey.
+func stateKeyKey(userHome, agent string, sc adapter.Scope, projectRoot, path, ptr string) state.Key {
+	return state.NewPointerKey(userHome, agent, sc.String(), projectRoot, path, ptr)
 }
 
 func hashContent(b []byte) string {

--- a/internal/render/iss162_test.go
+++ b/internal/render/iss162_test.go
@@ -127,13 +127,13 @@ func TestRecordOpsState_MergeTomlNumericNoFalseDrift(t *testing.T) {
 			if len(st.Keys) != 1 {
 				t.Fatalf("want exactly one recorded key, got %d: %v", len(st.Keys), st.Keys)
 			}
-			var gotKey string
+			var gotKey state.Key
 			var gotEntry state.KeyEntry
 			for k, e := range st.Keys {
 				gotKey, gotEntry = k, e
 			}
-			if !strings.HasSuffix(gotKey, ":"+tc.wantPtr) {
-				t.Errorf("recorded key %q does not end with pointer %q", gotKey, tc.wantPtr)
+			if gotKey.Pointer != tc.wantPtr {
+				t.Errorf("recorded key %+v does not carry pointer %q", gotKey, tc.wantPtr)
 			}
 			// No false drift (the actual #162 bug class): the recorded hash is taken
 			// from the TOML-decoded dest value, while status/diff hash the JSON-decoded

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -220,25 +220,14 @@ func PreviewApply(
 // ownedKeysFor returns the JSON-pointer strings owned by agentsync for a given
 // agent+scope+project+path combination, as recorded in state.Keys.
 func ownedKeysFor(s *state.Targets, agent string, scope adapter.Scope, project, path, userHome string) []string {
-	prefix := fmt.Sprintf("%s:%s:%s:%s:", agent, scope.String(),
-		paths.HomeRelative(userHome, project), paths.HomeRelative(userHome, path))
+	portableProject := paths.HomeRelative(userHome, project)
+	portablePath := paths.HomeRelative(userHome, path)
 	var out []string
 	for k := range s.Keys {
-		if !strings.HasPrefix(k, prefix) {
+		if !k.InTree(agent, scope.String(), portableProject) || k.Path != portablePath {
 			continue
 		}
-		ptr := strings.TrimPrefix(k, prefix)
-		// The remainder must be a JSON pointer, which always begins with '/'.
-		// If it doesn't, this key belongs to a DIFFERENT dest path that merely
-		// shares a colon-delimited string prefix with `path` (e.g. dest "a" vs
-		// "a:b", realistic only for a Windows drive-letter path stored
-		// absolute). Claiming it would inject a foreign pointer into this op's
-		// OwnedKeys and corrupt ownership — the same colon-ambiguity class
-		// PruneStaleState and orphanCleanupOps already guard against.
-		if !strings.HasPrefix(ptr, "/") {
-			continue
-		}
-		out = append(out, ptr)
+		out = append(out, k.Pointer)
 	}
 	return out
 }
@@ -323,37 +312,23 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 	}
 
 	// Group owned pointers by their portable dest path from state.Keys.
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	scopeName := scope.String()
+	portableProject := paths.HomeRelative(userHome, project)
 	ownedByPath := map[string][]string{}
 	var order []string
 	for k := range s.Keys {
-		if !strings.HasPrefix(k, prefix) {
+		if !k.InTree(agent, scopeName, portableProject) {
 			continue
 		}
-		rest := strings.TrimPrefix(k, prefix)
-		// rest = "<portablePath>:<pointer>". The pointer is a JSON pointer
-		// that always starts with '/', so the ":/" sequence marks the
-		// boundary. This is reliable for the realistic path shapes: portable
-		// "${HOME}/..." paths and POSIX absolute paths contain no ':', and
-		// Windows absolute paths use '\' (so a drive is "C:\", not "C:/").
-		// In the pathological case where a path or pointer-key still contains
-		// a literal ":/", a mis-split yields a path that fails the os.Stat
-		// existence check below and is harmlessly skipped (the orphan simply
-		// isn't cleaned that run) — it never deletes the wrong data.
-		i := strings.Index(rest, ":/")
-		if i < 0 {
-			continue
-		}
-		path, ptr := rest[:i], rest[i+1:]
-		if secs, ok := renderedSections[path]; ok {
-			if _, sectionRendered := secs[firstPointerSegment(ptr)]; sectionRendered {
+		if secs, ok := renderedSections[k.Path]; ok {
+			if _, sectionRendered := secs[firstPointerSegment(k.Pointer)]; sectionRendered {
 				continue // a real op for this section handles its own removals
 			}
 		}
-		if _, seen := ownedByPath[path]; !seen {
-			order = append(order, path)
+		if _, seen := ownedByPath[k.Path]; !seen {
+			order = append(order, k.Path)
 		}
-		ownedByPath[path] = append(ownedByPath[path], ptr)
+		ownedByPath[k.Path] = append(ownedByPath[k.Path], k.Pointer)
 	}
 
 	var cleanup []adapter.FileOp

--- a/internal/render/pipeline_test.go
+++ b/internal/render/pipeline_test.go
@@ -390,7 +390,7 @@ func TestPipeline_OwnedKeysInjected(t *testing.T) {
 
 	// Pre-populate state with one owned pointer in HOME-relative form.
 	s := state.New()
-	key := "claude:user::${HOME}/.claude.json:/mcpServers/github"
+	key := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/github"}
 	s.Keys[key] = state.KeyEntry{SHA256: "abc123", AppliedAt: time.Now()}
 
 	plan, err := render.Plan(secrets.ForRender(source.Canonical{}), reg, []string{"claude"}, adapter.ScopeUser, "", s, home)

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -41,7 +41,8 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 	if s == nil {
 		return
 	}
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	scopeName := scope.String()
+	portableProject := paths.HomeRelative(userHome, project)
 
 	// Build the set of paths and per-path pointer sets that this agent's
 	// current plan still produces. Paths are normalized to HOME-relative
@@ -74,11 +75,10 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 	}
 
 	for key, entry := range s.Files {
-		if !strings.HasPrefix(key, prefix) {
+		if !key.InTree(agent, scopeName, portableProject) {
 			continue
 		}
-		path := strings.TrimPrefix(key, prefix)
-		if _, ok := currentFiles[path]; ok {
+		if _, ok := currentFiles[key.Path]; ok {
 			continue
 		}
 		// Keep tracking a reclaimable destination that is STILL ON DISK.
@@ -105,39 +105,22 @@ func PruneStaleState(s *state.Targets, userHome, agent string, scope adapter.Sco
 			// Lstat, not Stat: a DANGLING SYMLINK is a destination that is still
 			// there (os.Remove can clear it) but that Stat reports as absent,
 			// which would prune the entry and strand the link forever.
-			if _, err := os.Lstat(paths.FromHomeRelative(userHome, path)); !errors.Is(err, fs.ErrNotExist) {
+			if _, err := os.Lstat(key.AbsPath(userHome)); !errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 		}
 		delete(s.Files, key)
 	}
 	for key := range s.Keys {
-		if !strings.HasPrefix(key, prefix) {
+		if !key.InTree(agent, scopeName, portableProject) {
 			continue
 		}
-		rest := strings.TrimPrefix(key, prefix)
-		// rest = "<path>:<pointer>", and BOTH path and pointer can contain
-		// ':' (e.g. a Windows "C:"-drive dest path), so the split point is
-		// ambiguous. Test every currentKeys path whose "path:" prefixes rest
-		// and keep the key if ANY of them owns the remaining pointer. We must
-		// NOT stop at the first prefix match: when one path is a colon-
-		// delimited string-prefix of another, the first candidate (map order
-		// is random) may be the wrong one, and breaking there would prune a
-		// live key.
-		matched := false
-		for path, ptrs := range currentKeys {
-			if !strings.HasPrefix(rest, path+":") {
+		if ptrs, ok := currentKeys[key.Path]; ok {
+			if _, owned := ptrs[key.Pointer]; owned {
 				continue
 			}
-			ptr := strings.TrimPrefix(rest, path+":")
-			if _, ok := ptrs[ptr]; ok {
-				matched = true
-				break
-			}
 		}
-		if !matched {
-			delete(s.Keys, key)
-		}
+		delete(s.Keys, key)
 	}
 }
 
@@ -151,7 +134,8 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 	if s == nil {
 		return nil
 	}
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	scopeName := scope.String()
+	portableProject := paths.HomeRelative(userHome, project)
 	current := map[string]struct{}{}
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
@@ -164,12 +148,11 @@ func OrphanFiles(s *state.Targets, userHome, agent string, scope adapter.Scope, 
 	}
 	var out []string
 	for key := range s.Files {
-		if !strings.HasPrefix(key, prefix) {
+		if !key.InTree(agent, scopeName, portableProject) {
 			continue
 		}
-		path := strings.TrimPrefix(key, prefix)
-		if _, ok := current[path]; !ok {
-			out = append(out, paths.FromHomeRelative(userHome, path))
+		if _, ok := current[key.Path]; !ok {
+			out = append(out, key.AbsPath(userHome))
 		}
 	}
 	sort.Strings(out)
@@ -268,7 +251,8 @@ func orphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope
 	if s == nil {
 		return nil
 	}
-	prefix := fmt.Sprintf("%s:%s:%s:", agent, scope.String(), paths.HomeRelative(userHome, project))
+	scopeName := scope.String()
+	portableProject := paths.HomeRelative(userHome, project)
 	rendered := map[string]struct{}{}
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
@@ -281,19 +265,18 @@ func orphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope
 	}
 	var out []adapter.FileOp
 	for key, entry := range s.Files {
-		if !strings.HasPrefix(key, prefix) {
+		if !key.InTree(agent, scopeName, portableProject) {
 			continue
 		}
 		if !isOrphanReclaimable(entry.SourceID) {
 			continue
 		}
-		path := strings.TrimPrefix(key, prefix)
-		if _, ok := rendered[path]; ok {
+		if _, ok := rendered[key.Path]; ok {
 			continue
 		}
 		out = append(out, adapter.FileOp{
 			Action:   "delete",
-			Path:     paths.FromHomeRelative(userHome, path),
+			Path:     key.AbsPath(userHome),
 			SourceID: entry.SourceID,
 			Mode:     entry.Mode,
 		})
@@ -314,12 +297,11 @@ func orphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope
 // the base leaves every key machine-absolute and unportable.
 func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scope, project string, ops []adapter.FileOp) error {
 	now := time.Now().UTC()
-	portableProject := paths.HomeRelative(userHome, project)
+	scopeName := scope.String()
 	for _, op := range ops {
 		if op.Action != "" && op.Action != "write" {
 			continue
 		}
-		portablePath := paths.HomeRelative(userHome, op.Path)
 		switch op.MergeStrategy {
 		case "merge-json-keys", "merge-jsonc-keys", "merge-toml-keys":
 			// Re-read final on-disk content and record per pointer. The
@@ -361,8 +343,7 @@ func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scop
 				// (no data loss). A hard guard here was removed — it wrongly FAILED
 				// apply on ordinary numeric passthrough (e.g. a codex MCP timeout).
 				hash := hashAny(v)
-				key := fmt.Sprintf("%s:%s:%s:%s:%s", agent, scope.String(), portableProject, portablePath, ptr)
-				s.Keys[key] = state.KeyEntry{
+				s.Keys[state.NewPointerKey(userHome, agent, scopeName, project, op.Path, ptr)] = state.KeyEntry{
 					SHA256:    hash,
 					AppliedAt: now,
 					SourceID:  op.SourceID,
@@ -374,8 +355,7 @@ func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scop
 				return fmt.Errorf("read post-apply %s: %w", op.Path, err)
 			}
 			sum := sha256.Sum256(data)
-			key := fmt.Sprintf("%s:%s:%s:%s", agent, scope.String(), portableProject, portablePath)
-			s.Files[key] = state.FileEntry{
+			s.Files[state.NewFileKey(userHome, agent, scopeName, project, op.Path)] = state.FileEntry{
 				SHA256:    hex.EncodeToString(sum[:]),
 				Mode:      op.Mode,
 				AppliedAt: now,

--- a/internal/render/state_apply_internal_test.go
+++ b/internal/render/state_apply_internal_test.go
@@ -39,8 +39,8 @@ func TestRecordOpsState_SkipsAbsentMergePointers(t *testing.T) {
 		t.Fatalf("RecordOpsState: %v", err)
 	}
 
-	wantOwned := "claude:user::" + dest + ":/mcpServers/a"
-	wantAbsent := "claude:user::" + dest + ":/mcpServers/b"
+	wantOwned := state.Key{Agent: "claude", Scope: "user", Path: dest, Pointer: "/mcpServers/a"}
+	wantAbsent := state.Key{Agent: "claude", Scope: "user", Path: dest, Pointer: "/mcpServers/b"}
 	if _, ok := s.Keys[wantOwned]; !ok {
 		t.Fatalf("present pointer /mcpServers/a was not recorded as owned; keys=%v", s.Keys)
 	}

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -361,3 +361,36 @@ func TestOrphanReclaimedPrefixes_RetiredAliasDoesNotOverMatch(t *testing.T) {
 		t.Error("a non-component SourceID must not be reclaimable")
 	}
 }
+
+// TestPruneStaleState_SiblingColonProjectRootSurvives is the direct regression
+// for issue #227. Two project roots differ only by a ':'-suffixed variant:
+//
+//	${HOME}/work/app          and  ${HOME}/work/app:staging
+//
+// Under the v1 string key the second project's entry began with the first's
+// prefix ("claude:project:${HOME}/work/app:"), so an apply of the SHORTER root
+// pruned the LONGER root's ownership — and the next apply of that project
+// classified its .mcp.json as a foreign collision, backing it up and rewriting
+// it. The typed key compares Project as a field, so the sibling is untouched.
+func TestPruneStaleState_SiblingColonProjectRootSurvives(t *testing.T) {
+	const userHome = "/home/alice"
+	shortRoot := filepath.Join(userHome, "work", "app")
+	longRoot := filepath.Join(userHome, "work", "app:staging")
+
+	s := state.New()
+	shortKey := state.NewFileKey(userHome, "claude", "project", shortRoot, filepath.Join(shortRoot, ".mcp.json"))
+	longKey := state.NewFileKey(userHome, "claude", "project", longRoot, filepath.Join(longRoot, ".mcp.json"))
+	s.Files[shortKey] = state.FileEntry{SHA256: "a"}
+	s.Files[longKey] = state.FileEntry{SHA256: "b"}
+
+	// Apply the SHORT project with no ops at all: everything it owns is stale.
+	render.PruneStaleState(s, userHome, "claude", adapter.ScopeProject, shortRoot, nil)
+
+	if _, ok := s.Files[shortKey]; ok {
+		t.Fatal("the short project's own stale entry should have been pruned")
+	}
+	if _, ok := s.Files[longKey]; !ok {
+		t.Fatalf("a SIBLING project whose root merely shares a ':'-delimited prefix "+
+			"must keep its ownership; have %+v", s.Files)
+	}
+}

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -2,7 +2,6 @@ package render_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	_ "github.com/spxrogers/agentsync/internal/adapter/noop"
-	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
@@ -36,15 +34,9 @@ func TestRecordState_FilesAndKeys(t *testing.T) {
 	}
 
 	// Expect a key entry for /mcpServers/github keyed by ${HOME}/.claude.json.
-	wantKey := "claude:user::${HOME}/.claude.json:/mcpServers/github"
-	var found bool
-	for k := range s.Keys {
-		if k == wantKey {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("missing key %q; have: %+v", wantKey, s.Keys)
+	wantKey := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/github"}
+	if _, found := s.Keys[wantKey]; !found {
+		t.Fatalf("missing key %+v; have: %+v", wantKey, s.Keys)
 	}
 	_ = json.RawMessage{}
 }
@@ -67,10 +59,10 @@ func TestRecordState_FileReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key := "claude:user::${HOME}/CLAUDE.md"
+	key := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/CLAUDE.md"}
 	fe, ok := s.Files[key]
 	if !ok {
-		t.Fatalf("missing file entry %q; have: %+v", key, s.Files)
+		t.Fatalf("missing file entry %+v; have: %+v", key, s.Files)
 	}
 	if fe.SHA256 == "" {
 		t.Fatal("SHA256 must not be empty")
@@ -83,9 +75,9 @@ func TestRecordState_FileReplace(t *testing.T) {
 func TestPruneStaleState_DropsRemovedFiles(t *testing.T) {
 	s := state.New()
 	home := "/home/me"
-	keep := "claude:user::${HOME}/.claude/agents/keep.md"
-	drop := "claude:user::${HOME}/.claude/agents/dropme.md"
-	otherAgent := "opencode:user::${HOME}/.config/opencode/agent/keep.md"
+	keep := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude/agents/keep.md"}
+	drop := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude/agents/dropme.md"}
+	otherAgent := state.Key{Agent: "opencode", Scope: "user", Path: "${HOME}/.config/opencode/agent/keep.md"}
 	s.Files[keep] = state.FileEntry{SHA256: "a"}
 	s.Files[drop] = state.FileEntry{SHA256: "b"}
 	s.Files[otherAgent] = state.FileEntry{SHA256: "c"}
@@ -108,8 +100,8 @@ func TestPruneStaleState_DropsRemovedKeys(t *testing.T) {
 	s := state.New()
 	home := "/home/me"
 	clauJSON := "/home/me/.claude.json"
-	keepKey := "claude:user::${HOME}/.claude.json:/mcpServers/keep"
-	dropKey := "claude:user::${HOME}/.claude.json:/mcpServers/dropme"
+	keepKey := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/keep"}
+	dropKey := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/dropme"}
 	s.Keys[keepKey] = state.KeyEntry{SHA256: "a"}
 	s.Keys[dropKey] = state.KeyEntry{SHA256: "b"}
 
@@ -151,14 +143,14 @@ func TestState_PortableAcrossHomes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotKey := "claude:user::${HOME}/.claude.json"
+	gotKey := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json"}
 	if _, ok := s.Files[gotKey]; !ok {
-		t.Fatalf("RecordOpsState did not produce a portable key %q; have %v", gotKey, s.Files)
+		t.Fatalf("RecordOpsState did not produce a portable key %+v; have %v", gotKey, s.Files)
 	}
 	// The machine-absolute path must NOT appear anywhere in the keys.
 	for k := range s.Files {
-		if strings.Contains(k, macHome) {
-			t.Fatalf("state key embeds machine-absolute path %q: %q", macHome, k)
+		if strings.Contains(k.String(), macHome) {
+			t.Fatalf("state key embeds machine-absolute path %q: %q", macHome, k.String())
 		}
 	}
 
@@ -174,29 +166,26 @@ func TestState_PortableAcrossHomes(t *testing.T) {
 	}
 }
 
-// TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey is the regression for
-// the prune bug where the Keys loop broke after the FIRST path whose
-// "path:" prefixed the key, even when that path's pointer set didn't match.
-// When one dest path is a colon-delimited string-prefix of another (e.g. a
-// Windows "C:"-drive path, or any path containing ':'), the wrong candidate
-// could be picked first (map order is random) and a live key pruned —
-// dropping ownership and forcing a needless foreign-collision backup next
-// apply. Looped to defeat map-iteration randomness: the old code failed
-// ~half the time, the fix passes every time.
+// TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey pins that a dest path
+// which is a colon-delimited string-prefix of another ("a" vs "a:b") never
+// costs the longer path its ownership. Since the state key became typed
+// (issue #227) this holds BY CONSTRUCTION — Path is its own field and is
+// compared for equality, never as a string prefix — but the case stays as a
+// regression against anyone reintroducing string matching.
 func TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey(t *testing.T) {
 	ops := []adapter.FileOp{
 		{Action: "write", Path: "a", MergeStrategy: "merge-json-keys", Content: []byte(`{"x":1}`)},
 		{Action: "write", Path: "a:b", MergeStrategy: "merge-json-keys", Content: []byte(`{"realptr":1}`)},
 	}
-	const liveKey = "claude:user::a:b:/realptr"
+	liveKey := state.Key{Agent: "claude", Scope: "user", Path: "a:b", Pointer: "/realptr"}
 	for i := 0; i < 64; i++ {
 		s := state.New()
 		s.Keys[liveKey] = state.KeyEntry{SHA256: "deadbeef"}
-		s.Keys["claude:user::a:/x"] = state.KeyEntry{SHA256: "feed"}
+		s.Keys[state.Key{Agent: "claude", Scope: "user", Path: "a", Pointer: "/x"}] = state.KeyEntry{SHA256: "feed"}
 		// userHome "" so HomeRelative leaves the colon-bearing paths intact.
 		render.PruneStaleState(s, "", "claude", adapter.ScopeUser, "", ops)
 		if _, ok := s.Keys[liveKey]; !ok {
-			t.Fatalf("iteration %d: live key %q wrongly pruned (ambiguous path prefix)", i, liveKey)
+			t.Fatalf("iteration %d: live key %+v wrongly pruned (ambiguous path prefix)", i, liveKey)
 		}
 	}
 }
@@ -244,27 +233,26 @@ func TestPruneStaleState_ReclaimableOrphanRetention(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
 	st := state.New()
 	for path, srcID := range map[string]string{
 		present:        "subagents/still-here.md",
 		gone:           "subagents/reclaimed.md",
 		notReclaimable: "memory/AGENTS.md",
 	} {
-		st.Files[prefix+paths.HomeRelative(tmp, path)] = state.FileEntry{SHA256: "old", SourceID: srcID}
+		st.Files[state.NewFileKey(tmp, "claude", "user", "", path)] = state.FileEntry{SHA256: "old", SourceID: srcID}
 	}
 
 	// No ops at all: every entry is "no longer rendered".
 	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", nil)
 
-	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, present)]; !ok {
+	if _, ok := st.Files[state.NewFileKey(tmp, "claude", "user", "", present)]; !ok {
 		t.Error("a reclaimable destination that is still on disk must keep its entry, " +
 			"so a skipped delete is retried rather than forgotten")
 	}
-	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, gone)]; ok {
+	if _, ok := st.Files[state.NewFileKey(tmp, "claude", "user", "", gone)]; ok {
 		t.Error("a reclaimable destination that is gone must still be pruned")
 	}
-	if _, ok := st.Files[prefix+paths.HomeRelative(tmp, notReclaimable)]; ok {
+	if _, ok := st.Files[state.NewFileKey(tmp, "claude", "user", "", notReclaimable)]; ok {
 		t.Error("the exemption must apply only to reclaimable SourceIDs; " +
 			"a non-reclaimable entry must prune as before")
 	}
@@ -292,9 +280,8 @@ func TestPruneStaleState_DanglingSymlinkIsKept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
 	st := state.New()
-	key := prefix + paths.HomeRelative(tmp, link)
+	key := state.NewFileKey(tmp, "claude", "user", "", link)
 	st.Files[key] = state.FileEntry{SHA256: "old", SourceID: "subagents/dangling.md"}
 
 	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", nil)
@@ -328,9 +315,8 @@ func TestPruneStaleState_RetiredSubagentSourceIDIsReclaimable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prefix := fmt.Sprintf("claude:user:%s:", paths.HomeRelative(tmp, ""))
 	st := state.New()
-	key := prefix + paths.HomeRelative(tmp, legacy)
+	key := state.NewFileKey(tmp, "claude", "user", "", legacy)
 	// The RETIRED spelling, as a pre-upgrade state file carries it.
 	st.Files[key] = state.FileEntry{SHA256: "old", SourceID: "agents/code-reviewer.md"}
 

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -420,8 +420,7 @@ func (w *Writer) backupOrphanIfDrifted(op adapter.FileOp) (safeToDelete bool, er
 		// returned, because it is not a reason to fail the run (see Delete).
 		return false, nil
 	}
-	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
-		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
+	stateKey := state.NewFileKey(w.userHome, w.agent, w.scope.String(), w.project, op.Path)
 	if entry, owned := w.state.Files[stateKey]; owned {
 		sum := sha256.Sum256(existing)
 		if hex.EncodeToString(sum[:]) == entry.SHA256 {
@@ -472,8 +471,7 @@ func (w *Writer) maybeBackup(op adapter.FileOp, finalBytes []byte) error {
 }
 
 func (w *Writer) maybeBackupFileOp(op adapter.FileOp, finalBytes []byte) error {
-	stateKey := fmt.Sprintf("%s:%s:%s:%s", w.agent, w.scope.String(),
-		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
+	stateKey := state.NewFileKey(w.userHome, w.agent, w.scope.String(), w.project, op.Path)
 	if _, owned := w.state.Files[stateKey]; owned {
 		return nil
 	}
@@ -513,8 +511,6 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 	}
 
 	var backupPath string
-	portableProject := paths.HomeRelative(w.userHome, w.project)
-	portablePath := paths.HomeRelative(w.userHome, op.Path)
 
 	// Foreign type-mismatch at an owned top-level key. agentsync owns a
 	// section (mcpServers/hooks/lspServers/mcp) at child-object granularity,
@@ -549,7 +545,7 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 	}
 
 	for _, ptr := range CollectPointers(ours, "") {
-		stateKey := fmt.Sprintf("%s:%s:%s:%s:%s", w.agent, w.scope.String(), portableProject, portablePath, ptr)
+		stateKey := state.NewPointerKey(w.userHome, w.agent, w.scope.String(), w.project, op.Path, ptr)
 		if _, owned := w.state.Keys[stateKey]; owned {
 			continue
 		}
@@ -583,10 +579,10 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 // so we conservatively back up the whole file once if state has no entries
 // claiming the path.
 func (w *Writer) maybeBackupFileOpForJSONCFallback(op adapter.FileOp) error {
-	stateKeyPrefix := fmt.Sprintf("%s:%s:%s:%s:", w.agent, w.scope.String(),
-		paths.HomeRelative(w.userHome, w.project), paths.HomeRelative(w.userHome, op.Path))
+	portableProject := paths.HomeRelative(w.userHome, w.project)
+	portablePath := paths.HomeRelative(w.userHome, op.Path)
 	for k := range w.state.Keys {
-		if strings.HasPrefix(k, stateKeyPrefix) {
+		if k.InTree(w.agent, w.scope.String(), portableProject) && k.Path == portablePath {
 			return nil // state owns at least one pointer here; trust the merge
 		}
 	}

--- a/internal/render/writer_internal_test.go
+++ b/internal/render/writer_internal_test.go
@@ -3,6 +3,7 @@ package render
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -78,22 +79,13 @@ func TestOwnedKeysFor_DisambiguatesColonPaths(t *testing.T) {
 
 	got := ownedKeysFor(s, "claude", adapter.ScopeUser, "", "a", "")
 
-	for _, k := range got {
-		if k == "b:/realptr" {
-			t.Fatalf("ownedKeysFor wrongly claimed a foreign path's pointer: %v", got)
-		}
-		if !strings.HasPrefix(k, "/") {
-			t.Fatalf("ownedKeysFor returned a non-pointer remainder %q: %v", k, got)
-		}
-	}
-	found := false
-	for _, k := range got {
-		if k == "/legit" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("ownedKeysFor dropped the legitimate pointer /legit: %v", got)
+	// The assertion is on the EXACT set, not "contains" plus a shape check.
+	// ownedKeysFor feeds the key-merge writer's prune, so a pointer it wrongly
+	// claims for path "a" is a pointer DELETED out of a file this op does not
+	// own — and dropping the Path comparison returns a perfectly well-shaped
+	// "/realptr" alongside "/legit", which only an exact-set check catches.
+	if want := []string{"/legit"}; !slices.Equal(got, want) {
+		t.Fatalf("ownedKeysFor = %v, want exactly %v — a different dest path's pointer must not be claimed", got, want)
 	}
 }
 

--- a/internal/render/writer_internal_test.go
+++ b/internal/render/writer_internal_test.go
@@ -64,15 +64,17 @@ func TestPruneEmptySkillDirs_KeepsNonEmptyDirs(t *testing.T) {
 // ownedKeysFor was not: a state key whose dest path is a colon-delimited
 // string prefix of another path (realistic for a Windows drive path stored
 // absolute) must not be claimed as an owned pointer for the shorter path.
-// The remainder after the prefix is a JSON pointer, which always begins with
-// '/'. ownedKeysFor must reject any remainder that does not.
+// Since the state key became typed (issue #227) Path is its own field and is
+// compared for equality, so this holds by construction — the case stays as a
+// regression against anyone reintroducing string matching.
 func TestOwnedKeysFor_DisambiguatesColonPaths(t *testing.T) {
 	s := state.New()
 	// A real owned pointer for path "a".
-	s.Keys["claude:user::a:/legit"] = state.KeyEntry{SHA256: "x"}
-	// A pointer for the DIFFERENT path "a:b" — its key shares the "...:a:"
-	// prefix but the remainder ("b:/realptr") is not a pointer for "a".
-	s.Keys["claude:user::a:b:/realptr"] = state.KeyEntry{SHA256: "y"}
+	s.Keys[state.Key{Agent: "claude", Scope: "user", Path: "a", Pointer: "/legit"}] = state.KeyEntry{SHA256: "x"}
+	// A pointer for the DIFFERENT path "a:b". Under the v1 string key its
+	// encoding shared the "...:a:" prefix of the shorter path's; the typed key
+	// keeps Path in its own field, so this can no longer be misattributed.
+	s.Keys[state.Key{Agent: "claude", Scope: "user", Path: "a:b", Pointer: "/realptr"}] = state.KeyEntry{SHA256: "y"}
 
 	got := ownedKeysFor(s, "claude", adapter.ScopeUser, "", "a", "")
 

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -2,14 +2,12 @@ package render_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
-	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -313,8 +311,7 @@ func TestWriter_NoCollisionWhenAlreadyOwned(t *testing.T) {
 	st := state.New()
 	// State keys are HOME-relative against the user's $HOME (here tmp), so an
 	// owned dest under tmp is recorded as "${HOME}/<rel>".
-	rel, _ := filepath.Rel(tmp, dest)
-	st.Files["claude:user::${HOME}/"+filepath.ToSlash(rel)] = state.FileEntry{SHA256: "anything"}
+	st.Files[state.NewFileKey(tmp, "claude", "user", "", dest)] = state.FileEntry{SHA256: "anything"}
 
 	w := render.NewWriter(st, home, tmp, adapter.ScopeUser, "", "claude")
 	op := adapter.FileOp{Action: "write", Path: dest, Content: []byte("ours-v2"), Mode: 0o644}
@@ -714,7 +711,7 @@ func TestApply_UnreadableOrphanIsSkippedNotDeleted(t *testing.T) {
 	live := filepath.Join(tmp, ".claude", "agents", "live.md")
 
 	st := state.New()
-	st.Files[fmt.Sprintf("claude:user:%s:%s", paths.HomeRelative(tmp, ""), paths.HomeRelative(tmp, orphan))] = state.FileEntry{SHA256: "stale", SourceID: "subagents/gone.md", Mode: 0o644}
+	st.Files[state.NewFileKey(tmp, "claude", "user", "", orphan)] = state.FileEntry{SHA256: "stale", SourceID: "subagents/gone.md", Mode: 0o644}
 
 	reg := adapter.NewRegistry()
 	_ = reg.Register(&fakeJSONApply{name: "claude"})
@@ -740,7 +737,7 @@ func TestApply_UnreadableOrphanIsSkippedNotDeleted(t *testing.T) {
 	// vanish here, orphanDeletes could never synthesize the delete again, and the
 	// one warning would never repeat. The stale file would live forever, which is
 	// the leftover-duplicate failure reclamation exists to prevent.
-	stateKey := fmt.Sprintf("claude:user:%s:%s", paths.HomeRelative(tmp, ""), paths.HomeRelative(tmp, orphan))
+	stateKey := state.NewFileKey(tmp, "claude", "user", "", orphan)
 	render.PruneStaleState(st, tmp, "claude", adapter.ScopeUser, "", plan.PerAgent["claude"].Ops)
 	if _, stillOwned := st.Files[stateKey]; !stillOwned {
 		t.Fatal("a skipped orphan must keep its state entry so the next apply retries and re-warns")

--- a/internal/state/key.go
+++ b/internal/state/key.go
@@ -139,8 +139,14 @@ func ParseKey(s string) (Key, error) {
 func (k Key) MarshalText() ([]byte, error) { return []byte(k.String()), nil }
 
 // UnmarshalText is the inverse of MarshalText, so a map[Key]V round-trips
-// through encoding/json. A key that does not decode fails the whole unmarshal —
-// the fail-closed behavior Load wants.
+// through encoding/json (TestKey_IsAJSONObjectKey); a key that does not decode
+// fails the whole unmarshal.
+//
+// It exists to complete the encoding.TextMarshaler/TextUnmarshaler pair, not to
+// guard Load: nothing in production unmarshals into a map[Key]V. Load decodes
+// targets.json into rawTargets — string-keyed, because a v1 document's keys
+// could not unmarshal into map[Key]V at all — and migrate re-keys it through
+// ParseKey/parseCurrentKey, which is where the fail-closed role check lives.
 func (k *Key) UnmarshalText(b []byte) error {
 	parsed, err := ParseKey(string(b))
 	if err != nil {

--- a/internal/state/key.go
+++ b/internal/state/key.go
@@ -131,6 +131,11 @@ func ParseKey(s string) (Key, error) {
 // MarshalText lets Key be a JSON object key: encoding/json renders a map[Key]V
 // as an ordinary string-keyed object, sorted by the marshalled text, so
 // targets.json keeps the shape it has always had and stays byte-deterministic.
+//
+// The ENCODING is byte-safe, but the JSON container is narrower than the
+// encoding: encoding/json rewrites an invalid UTF-8 byte in a string to U+FFFD,
+// which would break the length prefix. Save refuses such a key before it ever
+// reaches this boundary — see ErrNonUTF8Key.
 func (k Key) MarshalText() ([]byte, error) { return []byte(k.String()), nil }
 
 // UnmarshalText is the inverse of MarshalText, so a map[Key]V round-trips

--- a/internal/state/key.go
+++ b/internal/state/key.go
@@ -1,0 +1,160 @@
+package state
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spxrogers/agentsync/internal/paths"
+)
+
+// keyFormatMarker prefixes every encoded state key. It versions the KEY
+// ENCODING and is deliberately independent of SchemaVersion: a future
+// state-schema bump for an unrelated reason must not be forced to change the key
+// format, and a key-format change must not masquerade as a schema change. It
+// also gives a legacy (v1) or hand-edited key a loud, immediate parse failure
+// instead of a silent misreading.
+const keyFormatMarker = "as1"
+
+// Key identifies one managed destination in targets.json: a whole file
+// (Pointer == "", stored in Targets.Files) or one JSON-pointer-addressable key
+// inside a shared file (Pointer != "", stored in Targets.Keys).
+//
+// Project and Path are ${HOME}-relative (paths.HomeRelative) so targets.json is
+// portable across machines whose $HOME differs. Scope is a plain string —
+// adapter.Scope.String(), i.e. "user" or "project" — because internal/state sits
+// below internal/adapter in the package layering and must not import it.
+//
+// Key is the ONLY way to name a state entry: Targets.Files and Targets.Keys are
+// keyed by it, so building a key with fmt.Sprintf is a compile error rather than
+// a convention someone has to remember. See String for why the encoding is what
+// it is.
+type Key struct {
+	Agent   string
+	Scope   string
+	Project string
+	Path    string
+	Pointer string
+}
+
+// NewFileKey builds the whole-file key for a destination. project and dest are
+// ABSOLUTE paths; both are portabilized against userHome — the user's $HOME
+// (paths.HomeDir), NOT the agentsync home, because destination files live under
+// $HOME. An empty project (user scope) portabilizes to "".
+func NewFileKey(userHome, agent, scope, project, dest string) Key {
+	return Key{
+		Agent:   agent,
+		Scope:   scope,
+		Project: paths.HomeRelative(userHome, project),
+		Path:    paths.HomeRelative(userHome, dest),
+	}
+}
+
+// NewPointerKey builds the key for one JSON pointer inside a shared destination
+// file. Arguments match NewFileKey; pointer is a JSON pointer
+// ("/mcpServers/github") and is stored verbatim.
+func NewPointerKey(userHome, agent, scope, project, dest, pointer string) Key {
+	k := NewFileKey(userHome, agent, scope, project, dest)
+	k.Pointer = pointer
+	return k
+}
+
+// String encodes k as the targets.json map key.
+//
+// Fields are LENGTH-PREFIXED rather than joined by a separator — the same
+// technique, for the same reason, as the hook-handler join key in internal/cli.
+// The v1 format "agent:scope:project:path[:pointer]" assumed ':' could not occur
+// inside a field, but ':' is a legal byte in a POSIX path: a project root
+// containing one produced keys that string-prefixed a SIBLING project's keys, and
+// a prefix-scoped prune then deleted the sibling's ownership (issue #227).
+//
+// Length prefixes make the encoding injective for ANY byte content: decoding
+// reads a decimal length, a ':', then exactly that many bytes, never
+// interpreting the bytes themselves. ParseKey is a total left inverse of String,
+// which is what makes String injective.
+func (k Key) String() string {
+	var b strings.Builder
+	b.WriteString(keyFormatMarker)
+	for _, f := range [5]string{k.Agent, k.Scope, k.Project, k.Path, k.Pointer} {
+		b.WriteByte('|')
+		b.WriteString(strconv.Itoa(len(f)))
+		b.WriteByte(':')
+		b.WriteString(f)
+	}
+	return b.String()
+}
+
+// ParseKey decodes a key produced by String. It is strict: a legacy (v1) key, a
+// non-canonical length ("06"), a truncated payload, or trailing bytes are all
+// errors, never a best-effort reading. Load relies on that — a key it cannot
+// decode exactly means the state file was hand-edited or corrupted, and
+// agentsync refuses rather than silently disowning a destination.
+func ParseKey(s string) (Key, error) {
+	rest, ok := strings.CutPrefix(s, keyFormatMarker)
+	if !ok {
+		return Key{}, fmt.Errorf("state key %q: not an agentsync state key (missing %q marker)", s, keyFormatMarker)
+	}
+	var fields [5]string
+	for i := range fields {
+		body, ok := strings.CutPrefix(rest, "|")
+		if !ok {
+			return Key{}, fmt.Errorf("state key %q: field %d: missing '|' separator", s, i)
+		}
+		colon := strings.IndexByte(body, ':')
+		if colon < 0 {
+			return Key{}, fmt.Errorf("state key %q: field %d: missing length prefix", s, i)
+		}
+		digits := body[:colon]
+		n, err := strconv.Atoi(digits)
+		if err != nil || n < 0 || digits != strconv.Itoa(n) {
+			return Key{}, fmt.Errorf("state key %q: field %d: bad length prefix %q", s, i, digits)
+		}
+		body = body[colon+1:]
+		if len(body) < n {
+			return Key{}, fmt.Errorf("state key %q: field %d: truncated (want %d bytes, have %d)", s, i, n, len(body))
+		}
+		fields[i] = body[:n]
+		rest = body[n:]
+	}
+	if rest != "" {
+		return Key{}, fmt.Errorf("state key %q: %d trailing byte(s) after the last field", s, len(rest))
+	}
+	return Key{
+		Agent:   fields[0],
+		Scope:   fields[1],
+		Project: fields[2],
+		Path:    fields[3],
+		Pointer: fields[4],
+	}, nil
+}
+
+// MarshalText lets Key be a JSON object key: encoding/json renders a map[Key]V
+// as an ordinary string-keyed object, sorted by the marshalled text, so
+// targets.json keeps the shape it has always had and stays byte-deterministic.
+func (k Key) MarshalText() ([]byte, error) { return []byte(k.String()), nil }
+
+// UnmarshalText is the inverse of MarshalText, so a map[Key]V round-trips
+// through encoding/json. A key that does not decode fails the whole unmarshal —
+// the fail-closed behavior Load wants.
+func (k *Key) UnmarshalText(b []byte) error {
+	parsed, err := ParseKey(string(b))
+	if err != nil {
+		return err
+	}
+	*k = parsed
+	return nil
+}
+
+// AbsPath expands k.Path back to an absolute filesystem path. Callers that turn
+// a state entry into a real file operation MUST route through this so they never
+// operate on the literal "${HOME}/..." string.
+func (k Key) AbsPath(userHome string) string { return paths.FromHomeRelative(userHome, k.Path) }
+
+// InTree reports whether k was recorded by agent at scope for the given project
+// tree. project is the PORTABLE (${HOME}-relative) root — "" at user scope —
+// matching what NewFileKey stores, so callers hoist paths.HomeRelative out of
+// their loop. This replaces the v1 "does the key string start with this prefix"
+// test, which could not tell a sibling project apart when a root contained ':'.
+func (k Key) InTree(agent, scope, project string) bool {
+	return k.Agent == agent && k.Scope == scope && k.Project == project
+}

--- a/internal/state/key_test.go
+++ b/internal/state/key_test.go
@@ -161,9 +161,15 @@ func TestKey_ParseRejectsMalformed(t *testing.T) {
 	}
 }
 
-// TestKey_ConstructorsPortabilize pins that the constructors — the ONLY place
-// paths.HomeRelative is called for a state key — produce the portable form, and
-// that AbsPath is its inverse.
+// TestKey_ConstructorsPortabilize pins that the constructors produce the
+// portable form and that AbsPath is its inverse.
+//
+// They are the only place a Key's fields are portabilized on the way IN, but not
+// the only paths.HomeRelative call that has to agree with them: every caller
+// that COMPARES against a stored key portabilizes its own operand first
+// (render.PruneStaleState, render.ownedKeysFor, cli's import/migrate/reconcile/
+// agent-purge InTree loops all hoist paths.HomeRelative out of the loop). This
+// test pins the spelling those callers have to match.
 func TestKey_ConstructorsPortabilize(t *testing.T) {
 	const userHome = "/home/alice"
 	k := state.NewFileKey(userHome, "claude", "user", "", "/home/alice/.claude.json")

--- a/internal/state/key_test.go
+++ b/internal/state/key_test.go
@@ -2,7 +2,6 @@ package state_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/spxrogers/agentsync/internal/state"
@@ -106,20 +105,22 @@ func TestKey_RoundTripsAdversarialFields(t *testing.T) {
 //	claude:project:${HOME}/work/app:${HOME}/work/app/.mcp.json
 //	claude:project:${HOME}/work/app:staging:${HOME}/work/app:staging/.mcp.json
 //
-// and the second STRING-PREFIX-matched the first project's key prefix
-// ("claude:project:${HOME}/work/app:"), so an apply of the first project deleted
-// the second project's ownership.
+// and the second STRING-PREFIX-matched the PRUNE PREFIX an apply of the first
+// project scoped its state sweep with ("claude:project:${HOME}/work/app:"), so
+// applying the first project deleted the second project's ownership.
+//
+// The v2 counterpart of that prune prefix is InTree — no consumer builds a key
+// prefix any more — so InTree is what the assertions below pin. (Asserting the
+// two v2 ENCODINGS do not prefix one another would be decorative: length
+// prefixes make the encoding injective for any bytes, and the encodings of
+// these two keys happen not to prefix each other under v1 either. What went
+// wrong was the prune prefix, not the key-to-key relation.)
 func TestKey_HistoricalCollisionIsGone(t *testing.T) {
 	p1 := state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/work/app", Path: "${HOME}/work/app/.mcp.json"}
 	p2 := state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/work/app:staging", Path: "${HOME}/work/app:staging/.mcp.json"}
 
 	if p1.String() == p2.String() {
 		t.Fatal("distinct destinations must not share an encoding")
-	}
-	// The v1 bug was a PREFIX match, so pin that too: neither encoding may be a
-	// prefix of the other.
-	if strings.HasPrefix(p2.String(), p1.String()) || strings.HasPrefix(p1.String(), p2.String()) {
-		t.Fatalf("one encoding prefixes the other:\n  %q\n  %q", p1.String(), p2.String())
 	}
 	if !p1.InTree("claude", "project", "${HOME}/work/app") {
 		t.Fatal("p1 must be in its own tree")
@@ -137,6 +138,12 @@ func TestKey_ParseRejectsMalformed(t *testing.T) {
 		{"empty", ""},
 		{"a v1 legacy key", "claude:user::${HOME}/.claude.json"},
 		{"wrong marker", "as2|6:claude|4:user|0:|1:x|0:"},
+		// The marker itself, not just its bytes: every other row here also trips
+		// the '|' / length-prefix checks, so none of them discriminates the
+		// marker. This one is perfectly framed and differs ONLY by the missing
+		// "as1" — swapping ParseKey's strings.CutPrefix for strings.TrimPrefix
+		// leaves the rest of the suite green but fails this row.
+		{"well-framed but marker-less", "|6:claude|4:user|0:|1:x|0:"},
 		{"missing separator", "as16:claude|4:user|0:|1:x|0:"},
 		{"missing length prefix", "as1|claude|4:user|0:|1:x|0:"},
 		{"non-canonical length", "as1|06:claude|4:user|0:|1:x|0:"},

--- a/internal/state/key_test.go
+++ b/internal/state/key_test.go
@@ -1,0 +1,184 @@
+package state_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestKey_EncodingIsExact pins the WIRE FORMAT byte-for-byte. targets.json is an
+// on-disk artifact: asserting only that the struct round-trips would let the
+// encoding change silently and orphan every existing state file.
+func TestKey_EncodingIsExact(t *testing.T) {
+	tests := []struct {
+		name string
+		key  state.Key
+		want string
+	}{
+		{
+			name: "user-scope whole file",
+			key:  state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude/settings.json"},
+			want: "as1|6:claude|4:user|0:|29:${HOME}/.claude/settings.json|0:",
+		},
+		{
+			name: "project-scope whole file",
+			key: state.Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/work/app", Path: "${HOME}/work/app/.mcp.json",
+			},
+			want: "as1|6:claude|7:project|16:${HOME}/work/app|26:${HOME}/work/app/.mcp.json|0:",
+		},
+		{
+			name: "colon-bearing project root, with a pointer",
+			key: state.Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/work/app:staging",
+				Path:    "${HOME}/work/app:staging/.mcp.json",
+				Pointer: "/mcpServers/github",
+			},
+			want: "as1|6:claude|7:project|24:${HOME}/work/app:staging|34:${HOME}/work/app:staging/.mcp.json|18:/mcpServers/github",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.key.String(); got != tc.want {
+				t.Fatalf("String() =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKey_RoundTripsAdversarialFields proves ParseKey is a left inverse of
+// String for ANY byte content — which is what makes String injective. The v1
+// ':'-joined format failed exactly here.
+func TestKey_RoundTripsAdversarialFields(t *testing.T) {
+	tests := []struct {
+		name string
+		key  state.Key
+	}{
+		{"zero value", state.Key{}},
+		{"colons everywhere", state.Key{Agent: "a:b", Scope: "user:x", Project: "p:q", Path: "x:y", Pointer: "/p:q"}},
+		{"separator byte in fields", state.Key{Agent: "a|b", Project: "|", Path: "p|q|", Pointer: "|"}},
+		{"pointer-lookalike inside a path", state.Key{Path: "a:/b", Pointer: "/c"}},
+		{"field that looks like its own prefix", state.Key{Agent: "12:abc", Path: "0:"}},
+		{"NUL and invalid utf-8", state.Key{Agent: "a\x00b", Path: "\xff\xfe"}},
+		{"portable home path", state.Key{Agent: "codex", Scope: "user", Path: "${HOME}/.codex/config.toml", Pointer: "/mcp_servers/gh"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := state.ParseKey(tc.key.String())
+			if err != nil {
+				t.Fatalf("ParseKey(%q): %v", tc.key.String(), err)
+			}
+			if got != tc.key {
+				t.Fatalf("round-trip lost data: got %+v, want %+v", got, tc.key)
+			}
+		})
+	}
+}
+
+// TestKey_HistoricalCollisionIsGone is the regression for issue #227. Under the
+// v1 format these two keys were
+//
+//	claude:project:${HOME}/work/app:${HOME}/work/app/.mcp.json
+//	claude:project:${HOME}/work/app:staging:${HOME}/work/app:staging/.mcp.json
+//
+// and the second STRING-PREFIX-matched the first project's key prefix
+// ("claude:project:${HOME}/work/app:"), so an apply of the first project deleted
+// the second project's ownership.
+func TestKey_HistoricalCollisionIsGone(t *testing.T) {
+	p1 := state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/work/app", Path: "${HOME}/work/app/.mcp.json"}
+	p2 := state.Key{Agent: "claude", Scope: "project", Project: "${HOME}/work/app:staging", Path: "${HOME}/work/app:staging/.mcp.json"}
+
+	if p1.String() == p2.String() {
+		t.Fatal("distinct destinations must not share an encoding")
+	}
+	// The v1 bug was a PREFIX match, so pin that too: neither encoding may be a
+	// prefix of the other.
+	if strings.HasPrefix(p2.String(), p1.String()) || strings.HasPrefix(p1.String(), p2.String()) {
+		t.Fatalf("one encoding prefixes the other:\n  %q\n  %q", p1.String(), p2.String())
+	}
+	if !p1.InTree("claude", "project", "${HOME}/work/app") {
+		t.Fatal("p1 must be in its own tree")
+	}
+	if p2.InTree("claude", "project", "${HOME}/work/app") {
+		t.Fatal("p2 must NOT be in the sibling project's tree — this is the bug")
+	}
+}
+
+func TestKey_ParseRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"a v1 legacy key", "claude:user::${HOME}/.claude.json"},
+		{"wrong marker", "as2|6:claude|4:user|0:|1:x|0:"},
+		{"missing separator", "as16:claude|4:user|0:|1:x|0:"},
+		{"missing length prefix", "as1|claude|4:user|0:|1:x|0:"},
+		{"non-canonical length", "as1|06:claude|4:user|0:|1:x|0:"},
+		{"negative length", "as1|-1:claude|4:user|0:|1:x|0:"},
+		{"truncated payload", "as1|6:clau"},
+		{"too few fields", "as1|6:claude|4:user|0:|1:x"},
+		{"trailing bytes", "as1|6:claude|4:user|0:|1:x|0:junk"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := state.ParseKey(tc.in); err == nil {
+				t.Fatalf("ParseKey(%q) should fail; got %+v", tc.in, got)
+			}
+		})
+	}
+}
+
+// TestKey_ConstructorsPortabilize pins that the constructors — the ONLY place
+// paths.HomeRelative is called for a state key — produce the portable form, and
+// that AbsPath is its inverse.
+func TestKey_ConstructorsPortabilize(t *testing.T) {
+	const userHome = "/home/alice"
+	k := state.NewFileKey(userHome, "claude", "user", "", "/home/alice/.claude.json")
+	want := state.Key{Agent: "claude", Scope: "user", Project: "", Path: "${HOME}/.claude.json"}
+	if k != want {
+		t.Fatalf("NewFileKey = %+v, want %+v", k, want)
+	}
+	if got := k.AbsPath(userHome); got != "/home/alice/.claude.json" {
+		t.Fatalf("AbsPath = %q, want %q", got, "/home/alice/.claude.json")
+	}
+	// A path OUTSIDE the user's home stays absolute (paths.HomeRelative's contract).
+	out := state.NewPointerKey(userHome, "claude", "project", "/srv/repo", "/srv/repo/.mcp.json", "/mcpServers/gh")
+	wantOut := state.Key{
+		Agent: "claude", Scope: "project", Project: "/srv/repo",
+		Path: "/srv/repo/.mcp.json", Pointer: "/mcpServers/gh",
+	}
+	if out != wantOut {
+		t.Fatalf("NewPointerKey = %+v, want %+v", out, wantOut)
+	}
+}
+
+// TestKey_IsAJSONObjectKey pins that a map[Key]V marshals to an ordinary
+// string-keyed JSON object and unmarshals back — the property that lets
+// targets.json keep its shape while the Go type gets stricter.
+func TestKey_IsAJSONObjectKey(t *testing.T) {
+	k := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json"}
+	in := map[state.Key]string{k: "v"}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if want := `{"` + k.String() + `":"v"}`; string(data) != want {
+		t.Fatalf("Marshal = %s, want %s", data, want)
+	}
+	var out map[state.Key]string
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out[k] != "v" {
+		t.Fatalf("round-trip lost the entry: %+v", out)
+	}
+	// A legacy key must FAIL the unmarshal rather than decode to something wrong.
+	if err := json.Unmarshal([]byte(`{"claude:user::x":"v"}`), &out); err == nil {
+		t.Fatal("a v1 key must not unmarshal into a map[Key]V")
+	}
+}

--- a/internal/state/key_test.go
+++ b/internal/state/key_test.go
@@ -40,6 +40,19 @@ func TestKey_EncodingIsExact(t *testing.T) {
 			},
 			want: "as1|6:claude|7:project|24:${HOME}/work/app:staging|34:${HOME}/work/app:staging/.mcp.json|18:/mcpServers/github",
 		},
+		{
+			// The length prefix is a BYTE count, and only a multibyte field can
+			// say so: every other row here is ASCII, where len and rune count
+			// agree, so a utf8.RuneCountInString implementation would satisfy
+			// them all. "héllo.md" is 8 runes but 9 bytes, and "日本" is 2 runes
+			// but 6 — the wanted prefixes below are the byte counts.
+			name: "multibyte fields are length-prefixed in BYTES, not runes",
+			key: state.Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/日本", Path: "${HOME}/日本/héllo.md", Pointer: "/mcpServers/héllo",
+			},
+			want: "as1|6:claude|7:project|14:${HOME}/日本|24:${HOME}/日本/héllo.md|18:/mcpServers/héllo",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -65,6 +78,14 @@ func TestKey_RoundTripsAdversarialFields(t *testing.T) {
 		{"field that looks like its own prefix", state.Key{Agent: "12:abc", Path: "0:"}},
 		{"NUL and invalid utf-8", state.Key{Agent: "a\x00b", Path: "\xff\xfe"}},
 		{"portable home path", state.Key{Agent: "codex", Scope: "user", Path: "${HOME}/.codex/config.toml", Pointer: "/mcp_servers/gh"}},
+		// Valid multibyte UTF-8, where len(f) and utf8.RuneCountInString(f)
+		// DIVERGE. Every other row is ASCII or invalid UTF-8 ("\xff\xfe" has
+		// rune count 2 as well as length 2), so without this one a rune-counting
+		// String would round-trip the whole table.
+		{"valid multibyte utf-8", state.Key{Agent: "héllo", Scope: "user", Project: "日本", Path: "${HOME}/héllo/日本.md", Pointer: "/mcpServers/héllo"}},
+		// A field whose CONTENT is itself a well-formed encoded key: the decoder
+		// must consume it as opaque bytes, never re-enter the grammar.
+		{"field holding a valid encoded key", state.Key{Agent: "as1|1:a|1:b|0:|0:|0:", Path: "as1|1:a|1:b|0:|0:|0:"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -3,7 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 )
 
@@ -49,11 +48,13 @@ func parseLegacyPointerKey(s string) (Key, error) { return parseLegacyKey(s, tru
 //  6. Exactly one candidate reading: take it.
 //  7. Several: prefer the readings whose path lies WITHIN the project root.
 //     Every adapter's project-scope ResolvePaths joins its destinations onto the
-//     project root, so this holds for every key agentsync has ever written —
-//     provided containment is tested with the separator that key actually uses,
-//     which is why withinProject normalizes '\' as well as '/'. It is used only
-//     as a tie-breaker, never as a filter — a lone candidate is accepted at step
-//     6 whether or not it is contained.
+//     project root, so the reading agentsync ACTUALLY WROTE is always contained
+//     — withinProject is normalized so that stays true for any bytes, separator
+//     or dot segment. A false reading can therefore only ADD to the contained
+//     set, never displace the true one: at worst it pushes the count to two and
+//     turns an acceptance into the refusal at step 8. Containment is only ever
+//     a tie-break, never a filter — a lone candidate is accepted at step 6
+//     whether or not it is contained.
 //  8. Still several, or none: errAmbiguousLegacyKey / a parse error.
 func parseLegacyKey(s string, pointered bool) (Key, error) {
 	agent, rest, ok := strings.Cut(s, ":")
@@ -129,38 +130,83 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 
 // withinProject reports whether destination path p lies inside the project root.
 //
-// The two arguments are NOT necessarily slash-form. paths.HomeRelative stores a
-// path under $HOME as "${HOME}/..." with forward slashes, but returns a path
-// OUTSIDE $HOME verbatim — so on Windows an ordinary project root outside
-// %USERPROFILE% arrives here as `C:\dev\repo` with a drive colon and
-// backslashes. That drive colon makes the v1 key ambiguous (three candidate
-// project/tail splits), and a slash-only containment test finds ZERO contained
-// readings, so the tie-break below could never fire and the whole state file was
-// refused on the first run after upgrade. toSlashAny is what makes it fire.
+// This is parseLegacyKey's step-7 tie-break, and the property it must have is
+// not "be accurate" but "never lose the reading agentsync actually wrote". If
+// the true reading always survives the filter, a false reading can at most make
+// the survivor count two and turn the acceptance into a REFUSAL — it can never
+// take the acceptance for itself. That is what makes the tie-break safe, and it
+// follows from how containmentParts normalizes:
 //
-// After normalization path.Clean is the right normalizer — it also collapses the
-// "${HOME}/." form paths.HomeRelative produces when the project root IS the
-// user's $HOME.
+//	agentsync writes a project-scope destination as the project root plus a
+//	relative tail, so the true reading's p is byte-for-byte root + separator +
+//	tail. containmentParts is a per-component FILTER — it drops only empty and
+//	"." components and never rewrites, reorders or removes anything else — so
+//	p's components are exactly the root's components followed by the tail's, and
+//	the true reading is ALWAYS contained.
+//
+// The previous implementation (path.Clean over a slash-substituted string) did
+// NOT have that property. Clean collapses "..", so a root or destination
+// carrying a ".." component lost components the other did not; the true reading
+// could drop out of the contained set and leave a FALSE reading alone in it,
+// which then won — a silent wrong-project acceptance, exactly the bug class the
+// typed key exists to remove (e.g. `claude:project:H/\..:H/\../..:` decoded
+// under project `H/\..:H/\../..` instead of `H/\..`, with no error). Hence
+// containmentParts leaves ".." alone: in a state key a component is a stored
+// string, not a path to resolve.
 func withinProject(project, p string) bool {
+	// A key with no project field roots nothing: "" is not a directory, so it
+	// must not be reported as containing anything. The guard is load-bearing,
+	// not belt-and-braces: "" normalizes to the EMPTY component list, which is a
+	// prefix of every relative path, so without it a candidate whose project
+	// field is empty would vacuously contain any non-rooted destination and
+	// silently settle a tie ("claude:project::a:b/x" in legacy_test.go).
 	if project == "" {
 		return false
 	}
-	root, dest := path.Clean(toSlashAny(project)), path.Clean(toSlashAny(p))
-	return dest == root || strings.HasPrefix(dest, root+"/")
+	rootAbs, root := containmentParts(project)
+	destAbs, dest := containmentParts(p)
+	if rootAbs != destAbs || len(dest) < len(root) {
+		return false
+	}
+	for i := range root {
+		if dest[i] != root[i] {
+			return false
+		}
+	}
+	return true
 }
 
-// toSlashAny rewrites every '\' to '/' UNCONDITIONALLY — deliberately not
-// filepath.ToSlash, which is compiled against the HOST separator and is a no-op
-// on POSIX. targets.json is a portable artifact (the ${HOME}-relative encoding
-// exists so it can be synced between machines), and parseLegacyKey is pure
-// string work, so a Windows-written key must decode identically wherever it is
-// read — including in the Linux container this package's tests run in.
+// containmentParts splits s into the components withinProject compares: rooted
+// reports a leading separator, and parts are the separator-delimited fields with
+// the empty ("a//b") and "." fields dropped. Dropping "." is what handles the
+// "${HOME}/." form paths.HomeRelative produces when the project root IS the
+// user's $HOME.
 //
-// A POSIX filename may legally contain '\', so this can only make containment
-// MORE permissive there (byte-substitution preserves the prefix relation, it
-// never breaks one). That is safe by construction: containment is only ever a
-// TIE-BREAK among readings already enumerated, never a filter, so the extra
-// permissiveness can turn a refusal into an acceptance (the Windows fix) or a
-// lone acceptance into a refusal (still fail-closed) — it can never silently
-// swap the winning reading for a different one.
-func toSlashAny(s string) string { return strings.ReplaceAll(s, `\`, "/") }
+// Both '\' and '/' are separators, UNCONDITIONALLY — deliberately not
+// filepath.Separator, which is compiled against the HOST and would make this a
+// slash-only test on POSIX. targets.json is a portable artifact (the
+// ${HOME}-relative encoding exists so it can be synced between machines) and
+// parseLegacyKey is pure string work, so a Windows-written key must decode
+// identically wherever it is read — including in the Linux container this
+// package's tests run in. paths.HomeRelative stores a path under $HOME as
+// "${HOME}/..." with forward slashes but returns a path OUTSIDE $HOME verbatim,
+// so on Windows an ordinary project root outside %USERPROFILE% arrives here as
+// `C:\dev\repo`. That drive colon makes the v1 key ambiguous (three candidate
+// project/tail splits), and a slash-only containment test finds ZERO contained
+// readings, so the tie-break could never fire and the whole state file was
+// refused on the first run after upgrade. Treating '\' as a separator is what
+// makes it fire.
+//
+// ".." is deliberately NOT collapsed; see withinProject for why that is
+// load-bearing.
+func containmentParts(s string) (rooted bool, parts []string) {
+	s = strings.ReplaceAll(s, `\`, "/")
+	rooted = strings.HasPrefix(s, "/")
+	for _, c := range strings.Split(s, "/") {
+		if c == "" || c == "." {
+			continue
+		}
+		parts = append(parts, c)
+	}
+	return rooted, parts
+}

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -17,7 +17,32 @@ import (
 // the wrong project — reproducing the very over-disown bug the typed key exists
 // to remove — so migrate refuses instead. See migrate for the user-facing
 // remedy.
+//
+// It also marks a key refused for exceeding maxLegacyReadings: that key too has
+// more readings than agentsync will settle, and the remedy is identical.
 var errAmbiguousLegacyKey = errors.New("legacy state key has more than one possible reading")
+
+// maxLegacyReadings bounds how many candidate readings parseLegacyKey will
+// enumerate for one v1 key before refusing it outright.
+//
+// The enumeration is a PRODUCT, and the tie-break walks its result: at project
+// scope every ':' in the remainder is a candidate project/tail boundary, and in
+// a pointer key every ":/" in each of those tails is a candidate path/pointer
+// boundary — so a key holding n ":/" pairs yields O(n²) readings, each costing
+// a containment test linear in the key. That is O(n³) byte work driven by a
+// hand-editable file that `status`, `apply`, `diff` and `doctor` all read.
+// Unbounded it is a denial of service from a few KB of targets.json: measured
+// on `"claude:project:" + strings.Repeat(":/", n)`, a 215-byte key cost 15 ms
+// and 20 MiB, an 815-byte key 0.9 s and 1.3 GiB, and a 1615-byte key 4.7 s and
+// 10 GiB — enough to OOM-kill the process a little above 4 KB.
+//
+// The cap is a deliberate, documented narrowing, not a free win: a key with
+// more than 64 candidate readings that containment WOULD have settled is now
+// refused instead of recovered. Nothing agentsync writes can reach it — a key
+// needs 64 ':' bytes (or about a dozen ":/" pairs) spread across its project
+// and path fields — and the refusal is the same fail-closed answer an ambiguous
+// key already gets, with the same cheap remedy (see migrate).
+const maxLegacyReadings = 64
 
 // parseLegacyFileKey decodes a v1 Targets.Files key,
 // "<agent>:<scope>:<project>:<path>".
@@ -45,16 +70,20 @@ func parseLegacyPointerKey(s string) (Key, error) { return parseLegacyKey(s, tru
 //     boundary.
 //  5. For a pointer key every ":/" in the tail is a candidate path/pointer
 //     boundary — a JSON pointer always begins with '/' (render.CollectPointers).
+//     Steps 4 and 5 multiply, so both are capped at maxLegacyReadings: a key
+//     past the cap is refused without enumerating the rest.
 //  6. Exactly one candidate reading: take it.
 //  7. Several: prefer the readings whose path lies WITHIN the project root.
 //     Every adapter's project-scope ResolvePaths joins its destinations onto the
 //     project root, so the reading agentsync ACTUALLY WROTE is always contained
-//     — withinProject is normalized so that stays true for any bytes, separator
-//     or dot segment. A false reading can therefore only ADD to the contained
-//     set, never displace the true one: at worst it pushes the count to two and
-//     turns an acceptance into the refusal at step 8. Containment is only ever
-//     a tie-break, never a filter — a lone candidate is accepted at step 6
-//     whether or not it is contained.
+//     — projectRoot.contains is normalized so that stays true for any bytes,
+//     separator or dot segment. A false reading can therefore only ADD to the
+//     contained set, never displace the true one: at worst it pushes the count
+//     to two and turns an acceptance into the refusal at step 8. Containment is
+//     only ever a tie-break, never a filter — a lone candidate is accepted at
+//     step 6 whether or not it is contained.
+//     TestLegacyContainmentProperties pins that invariant over a generated
+//     corpus; it is prose everywhere else.
 //  8. Still several, or none: errAmbiguousLegacyKey / a parse error.
 func parseLegacyKey(s string, pointered bool) (Key, error) {
 	agent, rest, ok := strings.Cut(s, ":")
@@ -76,20 +105,36 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 		splits = append(splits, split{project: "", tail: tail})
 	} else {
 		for i := 0; i < len(remainder); i++ {
-			if remainder[i] == ':' {
-				splits = append(splits, split{project: remainder[:i], tail: remainder[i+1:]})
+			if remainder[i] != ':' {
+				continue
 			}
+			if len(splits) == maxLegacyReadings {
+				return Key{}, fmt.Errorf("%w: %q has more than %d candidate project/path splits",
+					errAmbiguousLegacyKey, s, maxLegacyReadings)
+			}
+			splits = append(splits, split{project: remainder[:i], tail: remainder[i+1:]})
 		}
 	}
 
-	var all []Key
+	var all, contained []Key
 	for _, sp := range splits {
+		// The candidate root is parsed ONCE per project/tail split rather than
+		// once per reading — every reading this split produces shares its project
+		// field. With the cap above that keeps a key's containment work
+		// proportional to its LENGTH instead of to the square of its ':' count.
+		root := newProjectRoot(sp.project)
+		start := len(all)
 		if !pointered {
 			all = append(all, Key{Agent: agent, Scope: scope, Project: sp.project, Path: sp.tail})
-			continue
-		}
-		for i := 0; i+1 < len(sp.tail); i++ {
-			if sp.tail[i] == ':' && sp.tail[i+1] == '/' {
+		} else {
+			for i := 0; i+1 < len(sp.tail); i++ {
+				if sp.tail[i] != ':' || sp.tail[i+1] != '/' {
+					continue
+				}
+				if len(all) == maxLegacyReadings {
+					return Key{}, fmt.Errorf("%w: %q has more than %d possible readings",
+						errAmbiguousLegacyKey, s, maxLegacyReadings)
+				}
 				all = append(all, Key{
 					Agent:   agent,
 					Scope:   scope,
@@ -99,6 +144,11 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 				})
 			}
 		}
+		for _, k := range all[start:] {
+			if root.contains(k.Path) {
+				contained = append(contained, k)
+			}
+		}
 	}
 
 	switch len(all) {
@@ -106,12 +156,6 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 		return Key{}, fmt.Errorf("legacy state key %q: no valid reading", s)
 	case 1:
 		return all[0], nil
-	}
-	var contained []Key
-	for _, k := range all {
-		if withinProject(k.Project, k.Path) {
-			contained = append(contained, k)
-		}
 	}
 	if len(contained) == 1 {
 		return contained[0], nil
@@ -125,10 +169,43 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 	if len(contained) >= 2 {
 		n = len(contained)
 	}
-	return Key{}, fmt.Errorf("%w: %q has %d readings", errAmbiguousLegacyKey, s, n)
+	return Key{}, fmt.Errorf("%w: %q (%d readings)", errAmbiguousLegacyKey, s, n)
 }
 
-// withinProject reports whether destination path p lies inside the project root.
+// projectRoot is one candidate reading's project field, parsed into the
+// component form contains compares destination paths against. parseLegacyKey
+// builds ONE per project/tail split and reuses it for every reading that split
+// produces.
+type projectRoot struct {
+	// roots reports whether the field names a directory at all; when false,
+	// contains is always false. See newProjectRoot.
+	roots  bool
+	rooted bool
+	parts  []string
+}
+
+// newProjectRoot parses a candidate reading's project field.
+//
+// A key with no project field roots nothing: "" is not a directory, so it must
+// not be reported as containing anything. The guard is load-bearing, not
+// belt-and-braces: "" normalizes to the EMPTY component list, which is a prefix
+// of every relative path, so without it a candidate whose project field is empty
+// would vacuously contain any non-rooted destination and silently settle a tie
+// ("claude:project::a:b/x" in legacy_test.go).
+//
+// "" is the only field treated this way — deliberately. Other fields also
+// normalize to zero components ("/", "\", ".", "./."), and those DO vacuously
+// contain every path of matching rootedness; contains documents why excluding
+// them would be a regression rather than a fix.
+func newProjectRoot(project string) projectRoot {
+	if project == "" {
+		return projectRoot{}
+	}
+	rooted, parts := containmentParts(project)
+	return projectRoot{roots: true, rooted: rooted, parts: parts}
+}
+
+// contains reports whether destination path p lies inside r.
 //
 // This is parseLegacyKey's step-7 tie-break, and the property it must have is
 // not "be accurate" but "never lose the reading agentsync actually wrote". If
@@ -144,6 +221,10 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 //	p's components are exactly the root's components followed by the tail's, and
 //	the true reading is ALWAYS contained.
 //
+// TestLegacyContainmentProperties enforces that over a generated corpus of
+// (root, tail) pairs, end to end through parseLegacyKey: no generated key ever
+// decodes under a project other than the one it was built from.
+//
 // The previous implementation (path.Clean over a slash-substituted string) did
 // NOT have that property. Clean collapses "..", so a root or destination
 // carrying a ".." component lost components the other did not; the true reading
@@ -153,34 +234,50 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 // under project `H/\..:H/\../..` instead of `H/\..`, with no error). Hence
 // containmentParts leaves ".." alone: in a state key a component is a stored
 // string, not a path to resolve.
-func withinProject(project, p string) bool {
-	// A key with no project field roots nothing: "" is not a directory, so it
-	// must not be reported as containing anything. The guard is load-bearing,
-	// not belt-and-braces: "" normalizes to the EMPTY component list, which is a
-	// prefix of every relative path, so without it a candidate whose project
-	// field is empty would vacuously contain any non-rooted destination and
-	// silently settle a tie ("claude:project::a:b/x" in legacy_test.go).
-	if project == "" {
+//
+// # Zero-component roots are deliberately still contained
+//
+// "/" normalizes to the empty component list (so do "\", "." and "./.", which a
+// stored project field cannot actually hold — paths.HomeRelative emits
+// "${HOME}/." for $HOME itself, one component, and an absolute root verbatim).
+// An empty component list is a prefix of everything, so such a root vacuously
+// contains every path of matching rootedness and can never discriminate.
+//
+// Excluding it looks like a pure win: a FALSE split of "/" then stops padding
+// the contained set, and keys whose true root merely starts with "/:" are
+// recovered instead of refused. It is not a win, because "/" is also a legal
+// TRUE project root, and excluding it drops that true reading out of the
+// contained set — leaving a false reading alone in it, which then wins silently
+// under the wrong project. A sweep of 79,632 generated project-scope keys found
+// zero misrecoveries as written and 24 with the exclusion, e.g.
+// `claude:project:/://:/:` (true root "/", path "//:/:"), which decodes
+// correctly today and under project "/://" with it. Over-refusing a key whose
+// root begins "/:" is the cheap failure; misrecovering one rooted at "/" is the
+// expensive one, so the vacuous containment stays.
+func (r projectRoot) contains(p string) bool {
+	if !r.roots {
 		return false
 	}
-	rootAbs, root := containmentParts(project)
 	destAbs, dest := containmentParts(p)
-	if rootAbs != destAbs || len(dest) < len(root) {
+	if r.rooted != destAbs || len(dest) < len(r.parts) {
 		return false
 	}
-	for i := range root {
-		if dest[i] != root[i] {
+	for i := range r.parts {
+		if dest[i] != r.parts[i] {
 			return false
 		}
 	}
 	return true
 }
 
-// containmentParts splits s into the components withinProject compares: rooted
-// reports a leading separator, and parts are the separator-delimited fields with
-// the empty ("a//b") and "." fields dropped. Dropping "." is what handles the
-// "${HOME}/." form paths.HomeRelative produces when the project root IS the
-// user's $HOME.
+// containmentParts splits s into the components projectRoot.contains compares:
+// rooted reports a leading separator, and parts are the separator-delimited
+// fields with the empty ("a//b") and "." fields dropped. Dropping "." is what
+// handles the "${HOME}/." form paths.HomeRelative produces when the project root
+// IS the user's $HOME (paths.HomeRelative calls filepath.Rel(home, home), which
+// returns "."). TestParseLegacyKey pins that with a "${HOME}/." row; without the
+// "." drop the root's components are ["${HOME}", "."] and no destination under
+// it is contained.
 //
 // Both '\' and '/' are separators, UNCONDITIONALLY — deliberately not
 // filepath.Separator, which is compiled against the HOST and would make this a
@@ -197,7 +294,7 @@ func withinProject(project, p string) bool {
 // refused on the first run after upgrade. Treating '\' as a separator is what
 // makes it fire.
 //
-// ".." is deliberately NOT collapsed; see withinProject for why that is
+// ".." is deliberately NOT collapsed; see projectRoot.contains for why that is
 // load-bearing.
 func containmentParts(s string) (rooted bool, parts []string) {
 	s = strings.ReplaceAll(s, `\`, "/")

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -1,0 +1,129 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// errAmbiguousLegacyKey marks a v1 (schema_version <= 1) state key with more
+// than one possible reading. The v1 format joined fields with ':' and both the
+// project root and the destination path may legally contain one, so
+//
+//	claude:project:${HOME}/a:${HOME}/b:${HOME}/c
+//
+// could name project "${HOME}/a" at path "${HOME}/b:${HOME}/c", or project
+// "${HOME}/a:${HOME}/b" at path "${HOME}/c". Guessing would write a Key under
+// the wrong project — reproducing the very over-disown bug the typed key exists
+// to remove — so migrate refuses instead. See migrate for the user-facing
+// remedy.
+var errAmbiguousLegacyKey = errors.New("legacy state key has more than one possible reading")
+
+// parseLegacyFileKey decodes a v1 Targets.Files key,
+// "<agent>:<scope>:<project>:<path>".
+func parseLegacyFileKey(s string) (Key, error) { return parseLegacyKey(s, false) }
+
+// parseLegacyPointerKey decodes a v1 Targets.Keys key,
+// "<agent>:<scope>:<project>:<path>:<pointer>".
+func parseLegacyPointerKey(s string) (Key, error) { return parseLegacyKey(s, true) }
+
+// parseLegacyKey is the shared body. It NEVER guesses: it enumerates every
+// syntactically possible reading and accepts one only when the choice is forced.
+//
+//  1. Agent is the bytes before the first ':' — agent names come from a fixed
+//     registry and never contain one.
+//  2. Scope is the next field and must be exactly "user" or "project", the only
+//     two values adapter.Scope.String() produces.
+//  3. At user scope the project field is always empty, so the remainder must
+//     start with ':' and the project/tail split is FORCED — one candidate, no
+//     choice to make. That retires the project-boundary ambiguity for the
+//     overwhelming majority of every real targets.json. It does NOT make
+//     user-scope keys ambiguity-free: a pointer key still splits path from
+//     pointer at step 5, so e.g. "claude:user::a:/b:/c" has two readings and is
+//     refused at step 8.
+//  4. At project scope every ':' in the remainder is a candidate project/tail
+//     boundary.
+//  5. For a pointer key every ":/" in the tail is a candidate path/pointer
+//     boundary — a JSON pointer always begins with '/' (render.CollectPointers).
+//  6. Exactly one candidate reading: take it.
+//  7. Several: prefer the readings whose path lies WITHIN the project root.
+//     Every adapter's project-scope ResolvePaths joins its destinations onto the
+//     project root, so this holds for every key agentsync has ever written. It
+//     is used only as a tie-breaker, never as a filter — a lone candidate is
+//     accepted at step 6 whether or not it is contained.
+//  8. Still several, or none: errAmbiguousLegacyKey / a parse error.
+func parseLegacyKey(s string, pointered bool) (Key, error) {
+	agent, rest, ok := strings.Cut(s, ":")
+	if !ok || agent == "" {
+		return Key{}, fmt.Errorf("legacy state key %q: no agent field", s)
+	}
+	scope, remainder, ok := strings.Cut(rest, ":")
+	if !ok || (scope != "user" && scope != "project") {
+		return Key{}, fmt.Errorf("legacy state key %q: second field is %q, want \"user\" or \"project\"", s, scope)
+	}
+
+	type split struct{ project, tail string }
+	var splits []split
+	if scope == "user" {
+		tail, ok := strings.CutPrefix(remainder, ":")
+		if !ok {
+			return Key{}, fmt.Errorf("legacy state key %q: user scope with a non-empty project field", s)
+		}
+		splits = append(splits, split{project: "", tail: tail})
+	} else {
+		for i := 0; i < len(remainder); i++ {
+			if remainder[i] == ':' {
+				splits = append(splits, split{project: remainder[:i], tail: remainder[i+1:]})
+			}
+		}
+	}
+
+	var all []Key
+	for _, sp := range splits {
+		if !pointered {
+			all = append(all, Key{Agent: agent, Scope: scope, Project: sp.project, Path: sp.tail})
+			continue
+		}
+		for i := 0; i+1 < len(sp.tail); i++ {
+			if sp.tail[i] == ':' && sp.tail[i+1] == '/' {
+				all = append(all, Key{
+					Agent:   agent,
+					Scope:   scope,
+					Project: sp.project,
+					Path:    sp.tail[:i],
+					Pointer: sp.tail[i+1:],
+				})
+			}
+		}
+	}
+
+	switch len(all) {
+	case 0:
+		return Key{}, fmt.Errorf("legacy state key %q: no valid reading", s)
+	case 1:
+		return all[0], nil
+	}
+	var contained []Key
+	for _, k := range all {
+		if withinProject(k.Project, k.Path) {
+			contained = append(contained, k)
+		}
+	}
+	if len(contained) == 1 {
+		return contained[0], nil
+	}
+	return Key{}, fmt.Errorf("%w: %q has %d readings", errAmbiguousLegacyKey, s, len(all))
+}
+
+// withinProject reports whether destination path p lies inside the project root.
+// Both are slash-form (${HOME}-relative or POSIX absolute), so path.Clean is the
+// right normalizer — it also collapses the "${HOME}/." form paths.HomeRelative
+// produces when the project root IS the user's $HOME.
+func withinProject(project, p string) bool {
+	if project == "" {
+		return false
+	}
+	root, dest := path.Clean(project), path.Clean(p)
+	return dest == root || strings.HasPrefix(dest, root+"/")
+}

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -49,9 +49,11 @@ func parseLegacyPointerKey(s string) (Key, error) { return parseLegacyKey(s, tru
 //  6. Exactly one candidate reading: take it.
 //  7. Several: prefer the readings whose path lies WITHIN the project root.
 //     Every adapter's project-scope ResolvePaths joins its destinations onto the
-//     project root, so this holds for every key agentsync has ever written. It
-//     is used only as a tie-breaker, never as a filter — a lone candidate is
-//     accepted at step 6 whether or not it is contained.
+//     project root, so this holds for every key agentsync has ever written —
+//     provided containment is tested with the separator that key actually uses,
+//     which is why withinProject normalizes '\' as well as '/'. It is used only
+//     as a tie-breaker, never as a filter — a lone candidate is accepted at step
+//     6 whether or not it is contained.
 //  8. Still several, or none: errAmbiguousLegacyKey / a parse error.
 func parseLegacyKey(s string, pointered bool) (Key, error) {
 	agent, rest, ok := strings.Cut(s, ":")
@@ -117,13 +119,39 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 }
 
 // withinProject reports whether destination path p lies inside the project root.
-// Both are slash-form (${HOME}-relative or POSIX absolute), so path.Clean is the
-// right normalizer — it also collapses the "${HOME}/." form paths.HomeRelative
-// produces when the project root IS the user's $HOME.
+//
+// The two arguments are NOT necessarily slash-form. paths.HomeRelative stores a
+// path under $HOME as "${HOME}/..." with forward slashes, but returns a path
+// OUTSIDE $HOME verbatim — so on Windows an ordinary project root outside
+// %USERPROFILE% arrives here as `C:\dev\repo` with a drive colon and
+// backslashes. That drive colon makes the v1 key ambiguous (three candidate
+// project/tail splits), and a slash-only containment test finds ZERO contained
+// readings, so the tie-break below could never fire and the whole state file was
+// refused on the first run after upgrade. toSlashAny is what makes it fire.
+//
+// After normalization path.Clean is the right normalizer — it also collapses the
+// "${HOME}/." form paths.HomeRelative produces when the project root IS the
+// user's $HOME.
 func withinProject(project, p string) bool {
 	if project == "" {
 		return false
 	}
-	root, dest := path.Clean(project), path.Clean(p)
+	root, dest := path.Clean(toSlashAny(project)), path.Clean(toSlashAny(p))
 	return dest == root || strings.HasPrefix(dest, root+"/")
 }
+
+// toSlashAny rewrites every '\' to '/' UNCONDITIONALLY — deliberately not
+// filepath.ToSlash, which is compiled against the HOST separator and is a no-op
+// on POSIX. targets.json is a portable artifact (the ${HOME}-relative encoding
+// exists so it can be synced between machines), and parseLegacyKey is pure
+// string work, so a Windows-written key must decode identically wherever it is
+// read — including in the Linux container this package's tests run in.
+//
+// A POSIX filename may legally contain '\', so this can only make containment
+// MORE permissive there (byte-substitution preserves the prefix relation, it
+// never breaks one). That is safe by construction: containment is only ever a
+// TIE-BREAK among readings already enumerated, never a filter, so the extra
+// permissiveness can turn a refusal into an acceptance (the Windows fix) or a
+// lone acceptance into a refusal (still fail-closed) — it can never silently
+// swap the winning reading for a different one.
+func toSlashAny(s string) string { return strings.ReplaceAll(s, `\`, "/") }

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -115,7 +115,16 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 	if len(contained) == 1 {
 		return contained[0], nil
 	}
-	return Key{}, fmt.Errorf("%w: %q has %d readings", errAmbiguousLegacyKey, s, len(all))
+	// Report the number of readings the user must actually disambiguate. When
+	// containment narrowed the field but did not settle it, the surviving tie is
+	// among the CONTAINED readings — quoting the raw candidate count there would
+	// overstate it and send the reader looking for splits agentsync has already
+	// ruled out.
+	n := len(all)
+	if len(contained) >= 2 {
+		n = len(contained)
+	}
+	return Key{}, fmt.Errorf("%w: %q has %d readings", errAmbiguousLegacyKey, s, n)
 }
 
 // withinProject reports whether destination path p lies inside the project root.

--- a/internal/state/legacy.go
+++ b/internal/state/legacy.go
@@ -18,12 +18,35 @@ import (
 // to remove — so migrate refuses instead. See migrate for the user-facing
 // remedy.
 //
-// It also marks a key refused for exceeding maxLegacyReadings: that key too has
-// more readings than agentsync will settle, and the remedy is identical.
+// A key refused by the enumeration cap is NOT this error — see
+// errLegacyEnumerationCapped, which makes no claim about how many readings its
+// key has.
 var errAmbiguousLegacyKey = errors.New("legacy state key has more than one possible reading")
 
-// maxLegacyReadings bounds how many candidate readings parseLegacyKey will
-// enumerate for one v1 key before refusing it outright.
+// errLegacyEnumerationCapped marks a v1 key refused for reaching
+// maxLegacyReadings while its candidates were still being ENUMERATED.
+//
+// It is a separate sentinel from errAmbiguousLegacyKey deliberately, because it
+// is not an ambiguity verdict. The cap fires mid-count — before the reading set
+// is complete and before containment has scored any of it — so a key refused
+// this way may have had several readings, exactly ONE, or NONE at all.
+// parseLegacyKey never finds out, which is the whole point of stopping. Two
+// examples, both refused here and both pinned by
+// TestParseLegacyKey_CapIsNotAnAmbiguityVerdict, which certifies each reading
+// count by parsing the same key shape just UNDER the cap:
+//
+//	"claude:project:a:b:/c" + strings.Repeat(":", 63) // 84 bytes, ONE reading
+//	"claude:project:" + strings.Repeat("a:", 70)      // 155 bytes, NO reading
+//
+// Reporting either as ambiguous would hand the user the wrong remedy: migrate's
+// ambiguity paragraph explains why agentsync will not pick BETWEEN readings,
+// which is not what happened. migrate branches on the two sentinels separately
+// and prints a paragraph for each. The fix is the same (delete the entry; the
+// next apply re-adopts the destination); the explanation is not.
+var errLegacyEnumerationCapped = errors.New("legacy state key has too many candidate readings to enumerate")
+
+// maxLegacyReadings bounds how many candidates parseLegacyKey will enumerate
+// for one v1 key before refusing it outright.
 //
 // The enumeration is a PRODUCT, and the tie-break walks its result: at project
 // scope every ':' in the remainder is a candidate project/tail boundary, and in
@@ -36,12 +59,18 @@ var errAmbiguousLegacyKey = errors.New("legacy state key has more than one possi
 // and 20 MiB, an 815-byte key 0.9 s and 1.3 GiB, and a 1615-byte key 4.7 s and
 // 10 GiB — enough to OOM-kill the process a little above 4 KB.
 //
-// The cap is a deliberate, documented narrowing, not a free win: a key with
-// more than 64 candidate readings that containment WOULD have settled is now
-// refused instead of recovered. Nothing agentsync writes can reach it — a key
-// needs 64 ':' bytes (or about a dozen ":/" pairs) spread across its project
-// and path fields — and the refusal is the same fail-closed answer an ambiguous
-// key already gets, with the same cheap remedy (see migrate).
+// The cap is a deliberate, documented narrowing, and its cost is WIDER than
+// "keys that were ambiguous anyway": it bounds ENUMERATION, not ambiguity.
+// Counting stops the moment the cap is reached, so a key past it is refused
+// whether it would have had many readings, exactly one, or none at all — see
+// errLegacyEnumerationCapped, which is the sentinel both sites wrap and which
+// carries a measured example of each. What it takes to get there: at project
+// scope, a 65th ':' anywhere in the remainder — project, path and, in a pointer
+// key, pointer all contribute; or, in a pointer key at either scope, a 65th
+// candidate reading, which a ":/"-dense key reaches on FEWER colons than that
+// (see the fourth row of the cap test). The refusal is the same
+// fail-closed answer an ambiguous key already gets, with the same cheap remedy
+// (see migrate), and TestParseLegacyKey_ReadingCapBoundsWork pins both sites.
 const maxLegacyReadings = 64
 
 // parseLegacyFileKey decodes a v1 Targets.Files key,
@@ -71,7 +100,8 @@ func parseLegacyPointerKey(s string) (Key, error) { return parseLegacyKey(s, tru
 //  5. For a pointer key every ":/" in the tail is a candidate path/pointer
 //     boundary — a JSON pointer always begins with '/' (render.CollectPointers).
 //     Steps 4 and 5 multiply, so both are capped at maxLegacyReadings: a key
-//     past the cap is refused without enumerating the rest.
+//     past the cap is refused (errLegacyEnumerationCapped) without enumerating
+//     the rest — and therefore without ever learning how many readings it had.
 //  6. Exactly one candidate reading: take it.
 //  7. Several: prefer the readings whose path lies WITHIN the project root.
 //     Every adapter's project-scope ResolvePaths joins its destinations onto the
@@ -110,7 +140,7 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 			}
 			if len(splits) == maxLegacyReadings {
 				return Key{}, fmt.Errorf("%w: %q has more than %d candidate project/path splits",
-					errAmbiguousLegacyKey, s, maxLegacyReadings)
+					errLegacyEnumerationCapped, s, maxLegacyReadings)
 			}
 			splits = append(splits, split{project: remainder[:i], tail: remainder[i+1:]})
 		}
@@ -133,7 +163,7 @@ func parseLegacyKey(s string, pointered bool) (Key, error) {
 				}
 				if len(all) == maxLegacyReadings {
 					return Key{}, fmt.Errorf("%w: %q has more than %d possible readings",
-						errAmbiguousLegacyKey, s, maxLegacyReadings)
+						errLegacyEnumerationCapped, s, maxLegacyReadings)
 				}
 				all = append(all, Key{
 					Agent:   agent,

--- a/internal/state/legacy_test.go
+++ b/internal/state/legacy_test.go
@@ -1,0 +1,145 @@
+package state
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestParseLegacyKey covers every v1 key shape that appears in this repo's own
+// test corpus plus the adversarial ones. The v1 format joined fields with ':'
+// and both the project root and the destination path may legally contain one,
+// so the parser enumerates readings and accepts one only when the choice is
+// forced.
+func TestParseLegacyKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		pointered bool
+		want      Key
+		wantErr   bool
+		ambiguous bool
+	}{
+		{
+			name: "user scope, whole file",
+			in:   "claude:user::${HOME}/CLAUDE.md",
+			want: Key{Agent: "claude", Scope: "user", Path: "${HOME}/CLAUDE.md"},
+		},
+		{
+			name: "user scope, empty path",
+			in:   "claude:user::",
+			want: Key{Agent: "claude", Scope: "user"},
+		},
+		{
+			name: "user scope, colon-bearing path in a file key is unambiguous",
+			in:   "claude:user::a:b:c",
+			want: Key{Agent: "claude", Scope: "user", Path: "a:b:c"},
+		},
+		{
+			name: "agent name is bound exactly",
+			in:   "claude2:user::${HOME}/.claude.json",
+			want: Key{Agent: "claude2", Scope: "user", Path: "${HOME}/.claude.json"},
+		},
+		{
+			name: "project scope, plain",
+			in:   "claude:project:${HOME}/proj:${HOME}/proj/.mcp.json",
+			want: Key{Agent: "claude", Scope: "project", Project: "${HOME}/proj", Path: "${HOME}/proj/.mcp.json"},
+		},
+		{
+			name: "project scope, colon-bearing root resolves by containment",
+			in:   "claude:project:/mnt/we:ird/proj:/mnt/we:ird/proj/.mcp.json",
+			want: Key{Agent: "claude", Scope: "project", Project: "/mnt/we:ird/proj", Path: "/mnt/we:ird/proj/.mcp.json"},
+		},
+		{
+			name: "project scope, the #227 sibling-collision root",
+			in:   "claude:project:${HOME}/work/app:staging:${HOME}/work/app:staging/.mcp.json",
+			want: Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/work/app:staging", Path: "${HOME}/work/app:staging/.mcp.json",
+			},
+		},
+		{
+			name: "project scope, single candidate wins even without containment",
+			in:   "claude:project:${HOME}/proj:${HOME}/other/x.md",
+			want: Key{Agent: "claude", Scope: "project", Project: "${HOME}/proj", Path: "${HOME}/other/x.md"},
+		},
+		{
+			name:      "pointer key, user scope",
+			in:        "claude:user::${HOME}/.claude.json:/mcpServers/github",
+			pointered: true,
+			want:      Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/github"},
+		},
+		{
+			name:      "pointer key, colon-bearing path anchors on \":/\"",
+			in:        "claude:user::a:b:/realptr",
+			pointered: true,
+			want:      Key{Agent: "claude", Scope: "user", Path: "a:b", Pointer: "/realptr"},
+		},
+		{
+			name:      "pointer key, project scope",
+			in:        "claude:project:${HOME}/proj:${HOME}/proj/.claude/settings.json:/hooks/PreToolUse",
+			pointered: true,
+			want: Key{
+				Agent: "claude", Scope: "project", Project: "${HOME}/proj",
+				Path: "${HOME}/proj/.claude/settings.json", Pointer: "/hooks/PreToolUse",
+			},
+		},
+		{
+			name:    "no scope field",
+			in:      "opencode:user",
+			wantErr: true,
+		},
+		{
+			name:    "second field is not a scope",
+			in:      "claude:nope::x",
+			wantErr: true,
+		},
+		{
+			name:    "no agent field",
+			in:      ":user::x",
+			wantErr: true,
+		},
+		{
+			name:      "pointer key with no pointer",
+			in:        "claude:user::${HOME}/.claude.json",
+			pointered: true,
+			wantErr:   true,
+		},
+		{
+			name:      "ambiguous project split",
+			in:        "claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
+			wantErr:   true,
+			ambiguous: true,
+		},
+		{
+			name:      "ambiguous pointer split",
+			in:        "claude:user::a:/b:/c",
+			pointered: true,
+			wantErr:   true,
+			ambiguous: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parse := parseLegacyFileKey
+			if tc.pointered {
+				parse = parseLegacyPointerKey
+			}
+			got, err := parse(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parse(%q) should fail; got %+v", tc.in, got)
+				}
+				if tc.ambiguous && !errors.Is(err, errAmbiguousLegacyKey) {
+					t.Fatalf("parse(%q) error should be errAmbiguousLegacyKey; got %v", tc.in, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parse(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/state/legacy_test.go
+++ b/internal/state/legacy_test.go
@@ -135,6 +135,49 @@ func TestParseLegacyKey(t *testing.T) {
 			wantErr:   true,
 			ambiguous: true,
 		},
+		// Dot-segment forgery. The containment tie-break used to normalize with
+		// path.Clean, which COLLAPSES ".." — so a root or destination carrying a
+		// ".." component lost components the other did not, the TRUE reading fell
+		// out of the contained set, and a false reading was left alone in it and
+		// won silently under the WRONG project. containmentParts leaves ".."
+		// alone, so the true reading is always contained and the worst a false
+		// one can do is force a refusal. The last two rows show the enabler is
+		// the ".." collapse itself, not the '\' substitution: the family occurs
+		// with backslashes, with only backslashes, and with none at all.
+		{
+			name: "dot segments do not forge a wrong-project reading",
+			in:   `claude:project:H/\..:H/\../..:`,
+			want: Key{Agent: "claude", Scope: "project", Project: `H/\..`, Path: `H/\../..:`},
+		},
+		{
+			name: "dot segments with backslash separators only",
+			in:   `claude:project:H\..:H\..\..:`,
+			want: Key{Agent: "claude", Scope: "project", Project: `H\..`, Path: `H\..\..:`},
+		},
+		{
+			name: "dot segments forge with no backslash at all",
+			in:   "claude:project:H/..:H/../..:",
+			want: Key{Agent: "claude", Scope: "project", Project: "H/..", Path: "H/../..:"},
+		},
+		{
+			// Same family in a pointer key, where the forged reading swapped the
+			// path/pointer split rather than the project. Two readings are now
+			// genuinely contained, so it refuses instead of guessing.
+			name:      "dot segments in a pointer key refuse rather than guess",
+			in:        "claude:project:H:H/..:/a:/b",
+			pointered: true,
+			wantErr:   true,
+			ambiguous: true,
+		},
+		{
+			// Pins withinProject's empty-project guard: without it the "" root
+			// vacuously contains every relative path, so this tie would be
+			// settled silently by the reading whose project field is empty.
+			name:      "project scope, empty project field with a tie is refused",
+			in:        "claude:project::a:b/x",
+			wantErr:   true,
+			ambiguous: true,
+		},
 		{
 			name:    "user scope with a non-empty project field",
 			in:      "claude:user:proj:${HOME}/x.md",

--- a/internal/state/legacy_test.go
+++ b/internal/state/legacy_test.go
@@ -309,6 +309,16 @@ func TestParseLegacyKey(t *testing.T) {
 // The assertion is on ALLOCATED BYTES, not a timeout: it is a real bound the
 // uncapped implementation misses by roughly five orders of magnitude, and it
 // does not turn a slow CI machine into a flake.
+//
+// The cap is enforced at TWO multiplying sites — the project/tail split loop and
+// the path/pointer reading loop — and the rows below cover both ON PURPOSE. The
+// first three carry well over 64 ':' in the remainder, so the SPLIT site fires
+// and the reading site is never reached; deleting the reading-site guard left
+// this test (and the whole package) green. The last row is shaped the other way
+// round — 60 colons, under the split cap, but ":/"-dense enough that the
+// readings accumulate past 64 across those splits — so it is the only row that
+// exercises the second site. Measured: 2,677,240 bytes uncapped against 18,520
+// capped, 34x over this test's own bound for a 195-byte key.
 func TestParseLegacyKey_ReadingCapBoundsWork(t *testing.T) {
 	tests := []struct {
 		name string
@@ -317,6 +327,7 @@ func TestParseLegacyKey_ReadingCapBoundsWork(t *testing.T) {
 		{"pathological pointer key", "claude:project:" + strings.Repeat(":/", 800)},
 		{"pathological pointer key, 40x larger", "claude:project:" + strings.Repeat(":/", 20000)},
 		{"pathological file key", "claude:project:" + strings.Repeat(":", 1600)},
+		{"pointer key under the split cap that still floods the reading cap", "claude:project:" + strings.Repeat(":/a", 60)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -333,14 +344,91 @@ func TestParseLegacyKey_ReadingCapBoundsWork(t *testing.T) {
 			_, err := parseLegacyPointerKey(tc.key)
 			runtime.ReadMemStats(&m1)
 
-			if !errors.Is(err, errAmbiguousLegacyKey) {
-				t.Fatalf("a key past the cap must refuse as ambiguous; got %v", err)
+			if !errors.Is(err, errLegacyEnumerationCapped) {
+				t.Fatalf("a key past the cap must refuse with errLegacyEnumerationCapped; got %v", err)
 			}
 			if !strings.Contains(err.Error(), "more than 64") {
 				t.Errorf("the refusal must name the cap that fired; got %v", err)
 			}
 			if got := m1.TotalAlloc - m0.TotalAlloc; got > want {
 				t.Fatalf("parsing a %d-byte key allocated %d bytes, want <= %d", len(tc.key), got, want)
+			}
+		})
+	}
+}
+
+// TestParseLegacyKey_CapIsNotAnAmbiguityVerdict pins what the enumeration cap
+// does and does NOT claim.
+//
+// maxLegacyReadings bounds enumeration, not ambiguity: it fires while counting,
+// so it refuses a key without ever learning how many readings that key had. The
+// refusal must therefore report itself as the cap (errLegacyEnumerationCapped)
+// and never as errAmbiguousLegacyKey — migrate branches on the two to pick a
+// remedy paragraph, and telling a user "agentsync refuses to guess between the
+// readings" about a key with exactly one reading is the wrong remedy.
+//
+// The test certifies the reading count itself rather than asserting it: each row
+// parses the SAME key shape trimmed to just under the cap, where the parser runs
+// to completion, and pins what it finds there — one reading in the first row,
+// none in the second. Without that half the rows would only be restating the
+// comment.
+func TestParseLegacyKey_CapIsNotAnAmbiguityVerdict(t *testing.T) {
+	tests := []struct {
+		name string
+		// under is the same shape with few enough ':' to stay under the cap, so
+		// the parser finishes and the row can prove its own premise.
+		under, over string
+		// wantUnder is what `under` must decode to. Its zero value means `under`
+		// has NO valid reading and must fail — with neither sentinel, since a
+		// zero-reading key is not ambiguous either.
+		wantUnder Key
+	}{
+		{
+			// 84 bytes over, 83 under. Only one ":/" exists in the whole key, so
+			// exactly one reading survives however the project/tail boundary
+			// moves — yet 65 colons is enough to stop the split loop first.
+			name:  "a key with exactly one reading is still refused past the cap",
+			under: "claude:project:a:b:/c" + strings.Repeat(":", 62),
+			over:  "claude:project:a:b:/c" + strings.Repeat(":", 63),
+			wantUnder: Key{
+				Agent: "claude", Scope: "project", Project: "a", Path: "b",
+				Pointer: "/c" + strings.Repeat(":", 62),
+			},
+		},
+		{
+			// No ":/" anywhere, so a pointer key has nowhere to split path from
+			// pointer and there is no reading at all — the colons alone trip the
+			// cap.
+			name:  "a key with no valid reading at all is still refused past the cap",
+			under: "claude:project:" + strings.Repeat("a:", 32),
+			over:  "claude:project:" + strings.Repeat("a:", 70),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLegacyPointerKey(tc.under)
+			if tc.wantUnder == (Key{}) {
+				if err == nil {
+					t.Fatalf("premise: %q must have no valid reading; got %+v", tc.under, got)
+				}
+				if errors.Is(err, errAmbiguousLegacyKey) || errors.Is(err, errLegacyEnumerationCapped) {
+					t.Fatalf("premise: %q must fail for having no reading, not as ambiguous or capped; got %v", tc.under, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("premise: %q must decode uniquely under the cap; got %v", tc.under, err)
+				}
+				if got != tc.wantUnder {
+					t.Fatalf("premise: %q = %+v, want %+v", tc.under, got, tc.wantUnder)
+				}
+			}
+
+			_, err = parseLegacyPointerKey(tc.over)
+			if !errors.Is(err, errLegacyEnumerationCapped) {
+				t.Fatalf("parse(%q) must refuse with errLegacyEnumerationCapped; got %v", tc.over, err)
+			}
+			if errors.Is(err, errAmbiguousLegacyKey) {
+				t.Fatalf("parse(%q) must NOT claim ambiguity — the cap never counted its readings; got %v", tc.over, err)
 			}
 		})
 	}
@@ -495,9 +583,10 @@ func TestLegacyContainmentProperties(t *testing.T) {
 			}
 		}
 		// Refusing everything would satisfy the property VACUOUSLY, so pin a
-		// floor. 70.7% of this deliberately adversarial corpus decodes today;
-		// half is well clear of that, and still fails loudly if a change turns
-		// the tie-break into a blanket refusal.
+		// floor. 29,140 of the 41,256 keys this corpus generates — 70.6% of a
+		// deliberately adversarial set — decode today; half is well clear of
+		// that, and still fails loudly if a change turns the tie-break into a
+		// blanket refusal.
 		total := 2 * len(corpus)
 		if accepted < total/2 {
 			t.Fatalf("only %d of %d generated keys decoded; the property is near-vacuous", accepted, total)

--- a/internal/state/legacy_test.go
+++ b/internal/state/legacy_test.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"errors"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -87,7 +89,7 @@ func TestParseLegacyKey(t *testing.T) {
 		// "${HOME}/..." with forward slashes, but returns a path OUTSIDE it
 		// VERBATIM — on Windows that keeps the drive colon and the backslashes.
 		// Such a root therefore has several candidate ':' splits and only the
-		// containment tie-break can settle them, so withinProject must treat '\'
+		// containment tie-break can settle them, so containmentParts must treat '\'
 		// as a separator too. parseLegacyKey is pure string work, so these rows
 		// exercise the Windows encoding from the Linux container.
 		{
@@ -170,11 +172,50 @@ func TestParseLegacyKey(t *testing.T) {
 			ambiguous: true,
 		},
 		{
-			// Pins withinProject's empty-project guard: without it the "" root
+			// Pins newProjectRoot's empty-project guard: without it the "" root
 			// vacuously contains every relative path, so this tie would be
 			// settled silently by the reading whose project field is empty.
 			name:      "project scope, empty project field with a tie is refused",
 			in:        "claude:project::a:b/x",
+			wantErr:   true,
+			ambiguous: true,
+		},
+		{
+			// paths.HomeRelative stores the project root as "${HOME}/." when the
+			// root IS $HOME (filepath.Rel(h, h) == "."), while every destination
+			// under it is stored "${HOME}/<rel>". The two only share a component
+			// prefix because containmentParts DROPS ".", so this row is what makes
+			// that drop load-bearing: with `c == ""` alone the root normalizes to
+			// ["${HOME}", "."], nothing under it is contained, and the tie below
+			// is refused instead of settled.
+			name: "project root of ${HOME} is stored ${HOME}/. and still contains its tree",
+			in:   "claude:project:${HOME}/.:${HOME}/we:ird.mcp.json",
+			want: Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/.", Path: "${HOME}/we:ird.mcp.json",
+			},
+		},
+		{
+			// A zero-component root ("/", and the "\", "." and "./." forms a
+			// stored key cannot actually hold) contains every path of matching
+			// rootedness, so a FALSE split of "/" pads the contained set and costs
+			// an acceptance here. That over-refusal is DELIBERATE: excluding such
+			// roots would recover this key but silently misdecode a key whose true
+			// root is "/" — see projectRoot.contains. The row exists so the cost
+			// is visible and the cure cannot be applied without breaking a test.
+			name:      "a false zero-component root pads the tie and costs an acceptance",
+			in:        "claude:project:/:/a:/:/a/AGENTS.md",
+			wantErr:   true,
+			ambiguous: true,
+		},
+		{
+			// The same shape with the roles swapped: here "/" is the TRUE root and
+			// "/://" is the false split that containment also accepts. Refusing is
+			// right; decoding it under "/://" (which is what excluding
+			// zero-component roots does) is the wrong-project bug this format
+			// change exists to remove.
+			name:      "a true zero-component root is never traded for a false discriminating one",
+			in:        "claude:project:/://:/:",
 			wantErr:   true,
 			ambiguous: true,
 		},
@@ -252,4 +293,214 @@ func TestParseLegacyKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseLegacyKey_ReadingCapBoundsWork pins maxLegacyReadings.
+//
+// parseLegacyKey's enumeration is a PRODUCT — every ':' in the remainder is a
+// candidate project/tail boundary and every ":/" in each of those tails is a
+// candidate path/pointer boundary — and the containment tie-break then walks the
+// result, so the work is cubic in the key's ":/" count. targets.json is
+// hand-editable (migrate's own remedy invites it) and is read by status, apply,
+// diff and doctor, so an uncapped key was a denial of service: measured before
+// the cap, a 215-byte key cost 15 ms / 20 MiB, an 815-byte key 0.9 s / 1.3 GiB
+// and a 1615-byte key 4.7 s / 10 GiB — an OOM kill a little above 4 KB.
+//
+// The assertion is on ALLOCATED BYTES, not a timeout: it is a real bound the
+// uncapped implementation misses by roughly five orders of magnitude, and it
+// does not turn a slow CI machine into a flake.
+func TestParseLegacyKey_ReadingCapBoundsWork(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"pathological pointer key", "claude:project:" + strings.Repeat(":/", 800)},
+		{"pathological pointer key, 40x larger", "claude:project:" + strings.Repeat(":/", 20000)},
+		{"pathological file key", "claude:project:" + strings.Repeat(":", 1600)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Bound: 64 bytes per key byte plus 64 KiB of slack. Generous — the
+			// capped parser measured ~3-7x the key length — but still four to five
+			// orders of magnitude under what the uncapped parser allocated on the
+			// same inputs.
+			const perByte, slack = 64, 64 << 10
+			want := uint64(perByte*len(tc.key) + slack)
+
+			var m0, m1 runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&m0)
+			_, err := parseLegacyPointerKey(tc.key)
+			runtime.ReadMemStats(&m1)
+
+			if !errors.Is(err, errAmbiguousLegacyKey) {
+				t.Fatalf("a key past the cap must refuse as ambiguous; got %v", err)
+			}
+			if !strings.Contains(err.Error(), "more than 64") {
+				t.Errorf("the refusal must name the cap that fired; got %v", err)
+			}
+			if got := m1.TotalAlloc - m0.TotalAlloc; got > want {
+				t.Fatalf("parsing a %d-byte key allocated %d bytes, want <= %d", len(tc.key), got, want)
+			}
+		})
+	}
+}
+
+// legacyContainmentCorpus generates the (project root, destination) pairs
+// TestLegacyContainmentProperties quantifies over: every destination is its root
+// plus a separator plus a relative tail, which is exactly the shape an adapter's
+// project-scope ResolvePaths produces.
+//
+// The alphabet is chosen for what it stresses, not for realism: an ordinary
+// name, a bare ':' (the byte that makes the v1 encoding ambiguous at all), the
+// '.' and '..' dot segments containmentParts respectively drops and deliberately
+// does not collapse, a name embedding a ':', and ":/" (the pointer anchor). The
+// prefixes cover a POSIX root, the "${HOME}/" form paths.HomeRelative emits, the
+// `C:\` drive-letter form it passes through verbatim on Windows, and — as roots
+// in their own right — the zero-component "/" and "${HOME}/." spellings.
+func legacyContainmentCorpus(t *testing.T) [][2]string {
+	t.Helper()
+	comps := []string{"a", ":", ".", "..", "b:c", ":/"}
+	prefixes := []string{"/", "${HOME}/", `C:\`}
+	seps := []string{"/", `\`}
+
+	seen := map[string]bool{}
+	var roots []string
+	addRoot := func(r string) {
+		if !seen[r] {
+			seen[r] = true
+			roots = append(roots, r)
+		}
+	}
+	for _, p := range prefixes {
+		addRoot(p)
+		for _, sep := range seps {
+			for _, c1 := range comps {
+				addRoot(p + c1)
+				for _, c2 := range comps {
+					addRoot(p + c1 + sep + c2)
+				}
+			}
+		}
+	}
+	var tails []string
+	for _, c1 := range comps {
+		tails = append(tails, c1)
+		for _, c2 := range comps {
+			tails = append(tails, c1+"/"+c2)
+		}
+	}
+
+	pairSeen := map[[2]string]bool{}
+	var out [][2]string
+	add := func(root, dest string) {
+		pair := [2]string{root, dest}
+		if !pairSeen[pair] {
+			pairSeen[pair] = true
+			out = append(out, pair)
+		}
+	}
+	for _, root := range roots {
+		for _, tail := range tails {
+			for _, sep := range seps {
+				add(root, root+sep+tail)
+				// The one real shape where the destination is NOT byte-for-byte
+				// root + separator + tail: when the project root IS $HOME,
+				// paths.HomeRelative stores it as "${HOME}/." (filepath.Rel(h, h)
+				// == ".") while the destination under it goes through
+				// filepath.Join, which CLEANS the "." away — so the stored pair is
+				// ("${HOME}/.", "${HOME}/<tail>"). Only containmentParts dropping
+				// "." keeps the true reading contained here.
+				if trimmed, ok := strings.CutSuffix(root, "/."); ok {
+					add(root, trimmed+"/"+tail)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// TestLegacyContainmentProperties pins the invariant parseLegacyKey's step 7
+// rests on, which lived only as prose.
+//
+// Every adapter writes a project-scope destination as the project root plus a
+// relative tail, so the reading agentsync ACTUALLY WROTE is always contained.
+// That is what makes containment safe as a tie-break: a false reading can only
+// ADD to the contained set, so at worst it forces a refusal — it can never take
+// the acceptance for itself. The property is universally quantified over key
+// bytes, so it is checked over a generated corpus rather than tabulated; the
+// rows in TestParseLegacyKey each pin one instance of it.
+//
+// Three sub-properties, in increasing strength. The third is the one that
+// matters operationally: over-refusing a v1 key costs a documented, cheap
+// re-adopt, but decoding one under the wrong project is issue #227 all over
+// again.
+func TestLegacyContainmentProperties(t *testing.T) {
+	corpus := legacyContainmentCorpus(t)
+	if len(corpus) < 1000 {
+		t.Fatalf("corpus is too small to quantify over: %d pairs", len(corpus))
+	}
+
+	t.Run("the true reading is always contained", func(t *testing.T) {
+		for _, pair := range corpus {
+			root, dest := pair[0], pair[1]
+			if !newProjectRoot(root).contains(dest) {
+				t.Fatalf("root %q must contain the destination %q it was joined onto", root, dest)
+			}
+		}
+	})
+
+	// No true reading can exercise the rootedness arm — root and destination
+	// always agree on it — so only a negative case pins it. Re-rooting the
+	// destination leaves its component list untouched, so this arm is the only
+	// thing that can reject it.
+	t.Run("a destination of the other rootedness is never contained", func(t *testing.T) {
+		for _, pair := range corpus {
+			root, dest := pair[0], pair[1]
+			r := newProjectRoot(root)
+			flipped := "/" + dest
+			if r.rooted {
+				flipped = strings.TrimLeft(dest, `/\`)
+			}
+			if r.contains(flipped) {
+				t.Fatalf("root %q (rooted=%v) must not contain %q", root, r.rooted, flipped)
+			}
+		}
+	})
+
+	t.Run("a decoded key never names a project other than the true root", func(t *testing.T) {
+		const pointer = "/mcpServers/gh"
+		var accepted int
+		for _, pair := range corpus {
+			root, dest := pair[0], pair[1]
+
+			fileKey := "claude:project:" + root + ":" + dest
+			got, err := parseLegacyFileKey(fileKey)
+			if err == nil {
+				accepted++
+				if got.Project != root || got.Path != dest {
+					t.Fatalf("%q decoded as project %q path %q, want %q / %q",
+						fileKey, got.Project, got.Path, root, dest)
+				}
+			}
+
+			ptrKey := fileKey + ":" + pointer
+			got, err = parseLegacyPointerKey(ptrKey)
+			if err == nil {
+				accepted++
+				if got.Project != root || got.Path != dest || got.Pointer != pointer {
+					t.Fatalf("%q decoded as project %q path %q pointer %q, want %q / %q / %q",
+						ptrKey, got.Project, got.Path, got.Pointer, root, dest, pointer)
+				}
+			}
+		}
+		// Refusing everything would satisfy the property VACUOUSLY, so pin a
+		// floor. 70.7% of this deliberately adversarial corpus decodes today;
+		// half is well clear of that, and still fails loudly if a change turns
+		// the tie-break into a blanket refusal.
+		total := 2 * len(corpus)
+		if accepted < total/2 {
+			t.Fatalf("only %d of %d generated keys decoded; the property is near-vacuous", accepted, total)
+		}
+	})
 }

--- a/internal/state/legacy_test.go
+++ b/internal/state/legacy_test.go
@@ -83,6 +83,73 @@ func TestParseLegacyKey(t *testing.T) {
 				Path: "${HOME}/proj/.claude/settings.json", Pointer: "/hooks/PreToolUse",
 			},
 		},
+		// Windows shapes. paths.HomeRelative stores a path INSIDE $HOME as
+		// "${HOME}/..." with forward slashes, but returns a path OUTSIDE it
+		// VERBATIM — on Windows that keeps the drive colon and the backslashes.
+		// Such a root therefore has several candidate ':' splits and only the
+		// containment tie-break can settle them, so withinProject must treat '\'
+		// as a separator too. parseLegacyKey is pure string work, so these rows
+		// exercise the Windows encoding from the Linux container.
+		{
+			name: "windows drive-letter project root outside %USERPROFILE%",
+			in:   `claude:project:C:\dev\repo:C:\dev\repo\.mcp.json`,
+			want: Key{
+				Agent: "claude", Scope: "project",
+				Project: `C:\dev\repo`, Path: `C:\dev\repo\.mcp.json`,
+			},
+		},
+		{
+			name: "windows project root on another drive",
+			in:   `claude:project:D:\work\repo:D:\work\repo\.mcp.json`,
+			want: Key{
+				Agent: "claude", Scope: "project",
+				Project: `D:\work\repo`, Path: `D:\work\repo\.mcp.json`,
+			},
+		},
+		{
+			name:      "windows drive-letter root, pointer key",
+			in:        `claude:project:C:\dev\repo:C:\dev\repo\.claude\settings.json:/hooks/PreToolUse`,
+			pointered: true,
+			want: Key{
+				Agent: "claude", Scope: "project", Project: `C:\dev\repo`,
+				Path: `C:\dev\repo\.claude\settings.json`, Pointer: "/hooks/PreToolUse",
+			},
+		},
+		{
+			// A Windows project root INSIDE %USERPROFILE% is stored ${HOME}-relative
+			// with forward slashes and no drive colon, so it was never affected —
+			// pinned so the claim above is checked rather than asserted.
+			name: "windows project root inside %USERPROFILE% is slash-form",
+			in:   "claude:project:${HOME}/dev/repo:${HOME}/dev/repo/.mcp.json",
+			want: Key{
+				Agent: "claude", Scope: "project",
+				Project: "${HOME}/dev/repo", Path: "${HOME}/dev/repo/.mcp.json",
+			},
+		},
+		{
+			// The separator fix is a TIE-BREAK, not a guess: a drive-letter root
+			// whose destination is not under it still has no unique reading and is
+			// still refused.
+			name:      "windows drive-letter root with a dest outside it stays ambiguous",
+			in:        `claude:project:C:\dev\repo:C:\other\x.md`,
+			wantErr:   true,
+			ambiguous: true,
+		},
+		{
+			name:    "user scope with a non-empty project field",
+			in:      "claude:user:proj:${HOME}/x.md",
+			wantErr: true,
+		},
+		{
+			name:    "project scope with no ':' in the remainder",
+			in:      "claude:project:onlyproject",
+			wantErr: true,
+		},
+		{
+			name: "project scope with an empty project field",
+			in:   "claude:project::${HOME}/x.md",
+			want: Key{Agent: "claude", Scope: "project", Path: "${HOME}/x.md"},
+		},
 		{
 			name:    "no scope field",
 			in:      "opencode:user",

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -1,37 +1,102 @@
 package state
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
 
-// migrate brings a loaded Targets up to SchemaVersion. Today the only
-// recognized states are:
-//   - schema_version == 0 (legacy implicit-v1 file, written before the
-//     field was stamped): upgrade in place to current.
-//   - schema_version == SchemaVersion: nothing to do.
+// migrate converts a decoded targets.json (rawTargets, string-keyed) into the
+// current typed Targets, upgrading the key encoding on the way:
 //
-// A higher schema_version means a newer agentsync binary wrote this
-// file and the current binary cannot safely interpret it. We refuse
-// rather than silently treat unknown future fields as missing.
+//   - schema_version 0 (legacy implicit v1, written before the field was
+//     stamped) or 1: every files/keys key is read with the v1 parser
+//     (legacy.go) and re-keyed as a state.Key. The version is stamped to
+//     SchemaVersion; the next Save commits the upgrade.
+//   - schema_version == SchemaVersion: keys must already be state.Key
+//     encodings; each is parsed, so a hand-edited or corrupted file fails loudly
+//     instead of silently disowning a destination.
+//   - A higher schema_version means a newer agentsync binary wrote this file and
+//     the current binary cannot safely interpret it. We refuse rather than
+//     silently treat unknown future fields as missing.
 //
-// When v2 ships, add a case here that walks v1 fields into the v2
-// shape. The Save() side stamps SchemaVersion = current, so post-
-// migration writes commit the upgrade.
-func migrate(t *Targets) error {
-	switch t.SchemaVersion {
-	case 0:
-		t.SchemaVersion = SchemaVersion
-	case SchemaVersion:
-		// no-op
-	default:
-		if t.SchemaVersion > SchemaVersion {
-			return fmt.Errorf("state schema_version=%d is newer than this binary supports (%d); "+
-				"upgrade agentsync or remove ~/.agentsync/.state/targets.json to start fresh",
-				t.SchemaVersion, SchemaVersion)
-		}
-		// Older but non-zero — no migrator registered yet. Bail loud so
-		// the user can decide rather than silently treating it as
-		// current.
-		return fmt.Errorf("no migrator registered for state schema_version=%d (current=%d)",
-			t.SchemaVersion, SchemaVersion)
+// A v1 key with more than one possible reading is REFUSED, never guessed: a
+// wrong project/path split records the entry under the wrong project, which is
+// exactly the over-disown bug the typed key exists to remove. targets.json holds
+// no configuration, so the remedy is cheap and the message says so — this is the
+// user-facing remedy errAmbiguousLegacyKey's doc comment points at, and an
+// ambiguous reading gets its own paragraph explaining why nothing is guessed.
+//
+// Marketplaces and Plugins keys are marketplace names and "owner/plugin" ids —
+// a different namespace — and are carried across verbatim.
+//
+// When v3 ships, add a case here.
+func migrate(raw *rawTargets) (*Targets, error) {
+	out := &Targets{
+		SchemaVersion: SchemaVersion,
+		Files:         make(map[Key]FileEntry, len(raw.Files)),
+		Keys:          make(map[Key]KeyEntry, len(raw.Keys)),
+		Marketplaces:  raw.Marketplaces,
+		Plugins:       raw.Plugins,
 	}
-	return nil
+
+	var parseFile, parsePointer func(string) (Key, error)
+	switch raw.SchemaVersion {
+	case 0, 1:
+		parseFile, parsePointer = parseLegacyFileKey, parseLegacyPointerKey
+	case SchemaVersion:
+		parseFile, parsePointer = ParseKey, ParseKey
+	default:
+		if raw.SchemaVersion > SchemaVersion {
+			return nil, fmt.Errorf("state schema_version=%d is newer than this binary supports (%d); "+
+				"upgrade agentsync or remove ~/.agentsync/.state/targets.json to start fresh",
+				raw.SchemaVersion, SchemaVersion)
+		}
+		return nil, fmt.Errorf("no migrator registered for state schema_version=%d (current=%d)",
+			raw.SchemaVersion, SchemaVersion)
+	}
+
+	var bad []string
+	ambiguous := false
+	note := func(s string, err error) {
+		if errors.Is(err, errAmbiguousLegacyKey) {
+			ambiguous = true
+		}
+		bad = append(bad, fmt.Sprintf("%s — %v", s, err))
+	}
+	for s, entry := range raw.Files {
+		k, err := parseFile(s)
+		if err != nil {
+			note(s, err)
+			continue
+		}
+		out.Files[k] = entry
+	}
+	for s, entry := range raw.Keys {
+		k, err := parsePointer(s)
+		if err != nil {
+			note(s, err)
+			continue
+		}
+		out.Keys[k] = entry
+	}
+	if len(bad) > 0 {
+		sort.Strings(bad)
+		remedy := "targets.json is bookkeeping only; no configuration lives here. Delete those entries " +
+			"(or the whole file) and re-run — the next `agentsync apply` re-adopts each destination, " +
+			"backing up any pre-existing content to .state/backups/ first, so nothing is lost"
+		if ambiguous {
+			// Only the ambiguous case has a second thing to say: the entry is
+			// readable, just not UNIQUELY, and agentsync will not pick one.
+			remedy += ".\nAn entry reported as having several readings is one the v1 ':'-joined encoding " +
+				"left genuinely ambiguous — only possible when a project root or a destination path " +
+				"contains ':'. agentsync refuses to guess the project/path split because recording the " +
+				"entry under the wrong project is exactly the over-disown bug this format change removes; " +
+				"deleting it costs only the re-adopt above"
+		}
+		return nil, fmt.Errorf("%d state key(s) could not be read at schema_version=%d:\n  %s\n%s",
+			len(bad), raw.SchemaVersion, strings.Join(bad, "\n  "), remedy)
+	}
+	return out, nil
 }

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -15,8 +15,9 @@ import (
 //     (legacy.go) and re-keyed as a state.Key. The version is stamped to
 //     SchemaVersion; the next Save commits the upgrade.
 //   - schema_version == SchemaVersion: keys must already be state.Key
-//     encodings; each is parsed, so a hand-edited or corrupted file fails loudly
-//     instead of silently disowning a destination.
+//     encodings; each is parsed AND role-checked (parseCurrentKey), so a
+//     hand-edited or corrupted file fails loudly instead of silently disowning a
+//     destination.
 //   - A higher schema_version means a newer agentsync binary wrote this file and
 //     the current binary cannot safely interpret it. We refuse rather than
 //     silently treat unknown future fields as missing.
@@ -46,7 +47,8 @@ func migrate(raw *rawTargets) (*Targets, error) {
 	case 0, 1:
 		parseFile, parsePointer = parseLegacyFileKey, parseLegacyPointerKey
 	case SchemaVersion:
-		parseFile, parsePointer = ParseKey, ParseKey
+		parseFile = func(s string) (Key, error) { return parseCurrentKey(s, false) }
+		parsePointer = func(s string) (Key, error) { return parseCurrentKey(s, true) }
 	default:
 		if raw.SchemaVersion > SchemaVersion {
 			return nil, fmt.Errorf("state schema_version=%d is newer than this binary supports (%d); "+
@@ -99,4 +101,32 @@ func migrate(raw *rawTargets) (*Targets, error) {
 			len(bad), raw.SchemaVersion, strings.Join(bad, "\n  "), remedy)
 	}
 	return out, nil
+}
+
+// parseCurrentKey decodes a current-encoding key and enforces its ROLE: a
+// Targets.Files key names a whole file and must carry NO pointer; a Targets.Keys
+// key names one JSON-pointer-addressable key inside a shared file and must carry
+// one.
+//
+// The v1 parser enforces that structurally — parseLegacyPointerKey only produces
+// readings that contain a ":/" boundary, and parseLegacyFileKey never splits one
+// off — so without this check the CURRENT schema would be LAXER than the one it
+// replaced: a hand-edited v2 file could file a pointered key under "files" (its
+// whole-file entry would then own a path it does not write) or an empty-Pointer
+// key under "keys" (which reaches jsonkeys.MergeKeys as the pointer "", where
+// pointerExists is vacuously true and the entry is never pruned). Both load
+// silently today. Refusing costs the user only the cheap re-adopt every other
+// refusal in migrate offers.
+func parseCurrentKey(s string, pointered bool) (Key, error) {
+	k, err := ParseKey(s)
+	if err != nil {
+		return Key{}, err
+	}
+	if pointered && k.Pointer == "" {
+		return Key{}, fmt.Errorf("state key %q: a keys entry must name a JSON pointer, but its pointer field is empty", s)
+	}
+	if !pointered && k.Pointer != "" {
+		return Key{}, fmt.Errorf("state key %q: a files entry names a whole file and must not carry a JSON pointer (has %q)", s, k.Pointer)
+	}
+	return k, nil
 }

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -61,11 +61,21 @@ func migrate(raw *rawTargets) (*Targets, error) {
 
 	var bad []string
 	ambiguous := false
+	// The key is quoted with %q, never interpolated raw. Map keys here come
+	// VERBATIM from targets.json, which is a hand-editable file: an unsanitized
+	// key carrying ESC or CR would reach the terminal through whichever sink
+	// prints this error (ui.WarnWriter passes lines 2..n of a multi-line message
+	// through untouched, and this refusal is ALWAYS multi-line), and a key
+	// carrying a newline could forge whole extra output lines even through a
+	// SANITIZING sink, since sanitization preserves newlines. %q escapes all
+	// three, needs no import, and matches what every inner error in legacy.go /
+	// key.go already does — so the escaping lives at this single source rather
+	// than in each present and future sink.
 	note := func(s string, err error) {
 		if errors.Is(err, errAmbiguousLegacyKey) {
 			ambiguous = true
 		}
-		bad = append(bad, fmt.Sprintf("%s — %v", s, err))
+		bad = append(bad, fmt.Sprintf("%q — %v", s, err))
 	}
 	for s, entry := range raw.Files {
 		k, err := parseFile(s)

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -61,26 +61,28 @@ func migrate(raw *rawTargets) (*Targets, error) {
 
 	var bad []string
 	ambiguous := false
-	// The key is quoted with %q, never interpolated raw. Map keys here come
-	// VERBATIM from targets.json, which is a hand-editable file: an unsanitized
-	// key carrying ESC or CR would reach the terminal through whichever sink
-	// prints this error (ui.WarnWriter passes lines 2..n of a multi-line message
-	// through untouched, and this refusal is ALWAYS multi-line), and a key
-	// carrying a newline could forge whole extra output lines even through a
-	// SANITIZING sink, since sanitization preserves newlines. %q escapes all
-	// three, needs no import, and matches what every inner error in legacy.go /
-	// key.go already does — so the escaping lives at this single source rather
-	// than in each present and future sink.
-	note := func(s string, err error) {
+	// The line is the error alone: EVERY error parseFile/parsePointer can return
+	// already names the offending key, quoted with %q (legacy.go, key.go,
+	// parseCurrentKey) — so prefixing the key again here printed it twice per
+	// line, three times when the message also quotes the field that failed.
+	// That %q is a CONTRACT, not a coincidence, and a new error constructor in
+	// those files must keep it. Map keys come VERBATIM from targets.json, which
+	// is a hand-editable file: an unsanitized key carrying ESC or CR would reach
+	// the terminal through whichever sink prints this error (ui.WarnWriter
+	// passes lines 2..n of a multi-line message through untouched, and this
+	// refusal is ALWAYS multi-line), and a key carrying a newline could forge
+	// whole extra output lines even through a SANITIZING sink, since
+	// sanitization preserves newlines. %q escapes all three and needs no import.
+	note := func(err error) {
 		if errors.Is(err, errAmbiguousLegacyKey) {
 			ambiguous = true
 		}
-		bad = append(bad, fmt.Sprintf("%q — %v", s, err))
+		bad = append(bad, err.Error())
 	}
 	for s, entry := range raw.Files {
 		k, err := parseFile(s)
 		if err != nil {
-			note(s, err)
+			note(err)
 			continue
 		}
 		out.Files[k] = entry
@@ -88,14 +90,16 @@ func migrate(raw *rawTargets) (*Targets, error) {
 	for s, entry := range raw.Keys {
 		k, err := parsePointer(s)
 		if err != nil {
-			note(s, err)
+			note(err)
 			continue
 		}
 		out.Keys[k] = entry
 	}
 	if len(bad) > 0 {
 		sort.Strings(bad)
-		remedy := "targets.json is bookkeeping only; no configuration lives here. Delete those entries " +
+		remedy := "each key above is shown Go-quoted, so a backslash appears doubled and a control byte " +
+			"as an escape — unquote it before searching targets.json.\n" +
+			"targets.json is bookkeeping only; no configuration lives here. Delete those entries " +
 			"(or the whole file) and re-run — the next `agentsync apply` re-adopts each destination, " +
 			"backing up any pre-existing content to .state/backups/ first, so nothing is lost"
 		if ambiguous {

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -29,6 +29,13 @@ import (
 // user-facing remedy errAmbiguousLegacyKey's doc comment points at, and an
 // ambiguous reading gets its own paragraph explaining why nothing is guessed.
 //
+// A key that reached maxLegacyReadings is refused too, but it gets a DIFFERENT
+// paragraph. The cap fires mid-enumeration, so agentsync never learns how many
+// readings that key had — calling it ambiguous would tell the user agentsync
+// declined to choose between readings when in fact it declined to finish
+// counting them, and the key may well have had exactly one (or none). See
+// errLegacyEnumerationCapped.
+//
 // Marketplaces and Plugins keys are marketplace names and "owner/plugin" ids —
 // a different namespace — and are carried across verbatim.
 //
@@ -60,7 +67,7 @@ func migrate(raw *rawTargets) (*Targets, error) {
 	}
 
 	var bad []string
-	ambiguous := false
+	ambiguous, capped := false, false
 	// The line is the error alone: EVERY error parseFile/parsePointer can return
 	// already names the offending key, quoted with %q (legacy.go, key.go,
 	// parseCurrentKey) — so prefixing the key again here printed it twice per
@@ -74,8 +81,14 @@ func migrate(raw *rawTargets) (*Targets, error) {
 	// whole extra output lines even through a SANITIZING sink, since
 	// sanitization preserves newlines. %q escapes all three and needs no import.
 	note := func(err error) {
+		// Two sentinels, two paragraphs — never folded into one. errors.Is on
+		// each rather than a switch on the first match, so a file holding both
+		// kinds of bad key gets both explanations.
 		if errors.Is(err, errAmbiguousLegacyKey) {
 			ambiguous = true
+		}
+		if errors.Is(err, errLegacyEnumerationCapped) {
+			capped = true
 		}
 		bad = append(bad, err.Error())
 	}
@@ -110,6 +123,19 @@ func migrate(raw *rawTargets) (*Targets, error) {
 				"contains ':'. agentsync refuses to guess the project/path split because recording the " +
 				"entry under the wrong project is exactly the over-disown bug this format change removes; " +
 				"deleting it costs only the re-adopt above"
+		}
+		if capped {
+			// Deliberately NOT the ambiguity paragraph. An entry refused by the
+			// cap was never read to the end, so "agentsync refuses to guess
+			// between the readings" would be a claim about a reading set that
+			// was never built — and for a key with one reading (or none) it is
+			// simply false. Say what actually happened instead.
+			remedy += ".\nAn entry reported as having too many candidates is one whose v1 encoding packs " +
+				"enough ':' bytes into a single key that listing its possible readings is superlinear " +
+				"work; unbounded, a hand-edited targets.json of a few KB could exhaust memory in every " +
+				"command that loads state. agentsync stops counting at the cap named on that line, so it " +
+				"does not know whether the key had one reading, several or none — it is refused unread, " +
+				"and deleting it costs only the re-adopt above"
 		}
 		return nil, fmt.Errorf("%d state key(s) could not be read at schema_version=%d:\n  %s\n%s",
 			len(bad), raw.SchemaVersion, strings.Join(bad, "\n  "), remedy)

--- a/internal/state/migrate_fidelity_test.go
+++ b/internal/state/migrate_fidelity_test.go
@@ -1,0 +1,143 @@
+package state_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// v1Fixture is a spec-complete schema_version-1 targets.json: all four maps
+// populated, files and keys entries with every field set, a user-scope key, a
+// project-scope key, a colon-bearing project root (the issue #227 shape), and a
+// pointer key.
+const v1Fixture = `{
+  "schema_version": 1,
+  "files": {
+    "claude:user::${HOME}/.claude/settings.json": {
+      "sha256": "aaa",
+      "mode": 420,
+      "applied_at": "2026-05-04T10:00:00Z",
+      "source_id": "memory/AGENTS.md"
+    },
+    "claude:project:${HOME}/work/app:staging:${HOME}/work/app:staging/.mcp.json": {
+      "sha256": "bbb",
+      "mode": 420,
+      "applied_at": "2026-05-04T10:00:01Z",
+      "source_id": "mcp/github.toml"
+    }
+  },
+  "keys": {
+    "claude:user::${HOME}/.claude.json:/mcpServers/github": {
+      "sha256": "ccc",
+      "applied_at": "2026-05-04T10:00:02Z",
+      "source_id": "mcp/* (multiple)"
+    }
+  },
+  "marketplaces": {
+    "anthropic": {"url": "https://example/x.git", "ref": "main", "head_sha": "deadbeef", "fetched_at": "2026-05-04T09:00:00Z"}
+  },
+  "plugins": {
+    "anthropic/atlassian": {"version": "1.2.3", "manifest_sha": "tree:v1:abc", "enabled": true}
+  }
+}`
+
+// TestMigrate_V1FixtureUpgradesOnDisk drives Load → Save over a real v1 file and
+// asserts against the BYTES that come back, not the struct: schema_version is
+// stamped 2, every key is re-encoded as a state.Key, every entry payload
+// survives unchanged, and a second Load is a fixpoint.
+func TestMigrate_V1FixtureUpgradesOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "targets.json")
+	if err := os.WriteFile(p, []byte(v1Fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := state.Load(p)
+	if err != nil {
+		t.Fatalf("Load v1 fixture: %v", err)
+	}
+	if loaded.SchemaVersion != state.SchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d", loaded.SchemaVersion, state.SchemaVersion)
+	}
+
+	wantFiles := map[state.Key]string{
+		{Agent: "claude", Scope: "user", Path: "${HOME}/.claude/settings.json"}: "aaa",
+		{
+			Agent: "claude", Scope: "project",
+			Project: "${HOME}/work/app:staging",
+			Path:    "${HOME}/work/app:staging/.mcp.json",
+		}: "bbb",
+	}
+	if len(loaded.Files) != len(wantFiles) {
+		t.Fatalf("Files has %d entries, want %d: %+v", len(loaded.Files), len(wantFiles), loaded.Files)
+	}
+	for k, sha := range wantFiles {
+		got, ok := loaded.Files[k]
+		if !ok {
+			t.Fatalf("migrated Files is missing %+v; have %+v", k, loaded.Files)
+		}
+		if got.SHA256 != sha || got.Mode != 0o644 || got.SourceID == "" || got.AppliedAt.IsZero() {
+			t.Fatalf("entry payload changed for %+v: %+v", k, got)
+		}
+	}
+	ptrKey := state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/.claude.json", Pointer: "/mcpServers/github"}
+	if got, ok := loaded.Keys[ptrKey]; !ok || got.SHA256 != "ccc" || got.SourceID != "mcp/* (multiple)" {
+		t.Fatalf("migrated Keys lost the pointer entry: ok=%v got=%+v have=%+v", ok, got, loaded.Keys)
+	}
+	if m, ok := loaded.Marketplaces["anthropic"]; !ok || m.HeadSHA != "deadbeef" {
+		t.Fatalf("marketplaces must survive verbatim: %+v", loaded.Marketplaces)
+	}
+	if pl, ok := loaded.Plugins["anthropic/atlassian"]; !ok || pl.Version != "1.2.3" || !pl.Enabled {
+		t.Fatalf("plugins must survive verbatim: %+v", loaded.Plugins)
+	}
+
+	// Now the artifact assertion: save and re-read the FILE.
+	if err := state.Save(p, loaded); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onDisk struct {
+		SchemaVersion int                        `json:"schema_version"`
+		Files         map[string]json.RawMessage `json:"files"`
+		Keys          map[string]json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("saved file is not valid JSON: %v\n%s", err, raw)
+	}
+	if onDisk.SchemaVersion != 2 {
+		t.Fatalf("on-disk schema_version = %d, want 2\n%s", onDisk.SchemaVersion, raw)
+	}
+	if len(onDisk.Files) != 2 || len(onDisk.Keys) != 1 {
+		t.Fatalf("on-disk entry counts changed: files=%d keys=%d\n%s", len(onDisk.Files), len(onDisk.Keys), raw)
+	}
+	for s := range onDisk.Files {
+		if _, err := state.ParseKey(s); err != nil {
+			t.Fatalf("on-disk files key %q is not a state.Key: %v", s, err)
+		}
+	}
+	for s := range onDisk.Keys {
+		if _, err := state.ParseKey(s); err != nil {
+			t.Fatalf("on-disk keys key %q is not a state.Key: %v", s, err)
+		}
+	}
+
+	// Reloading the saved file is a fixpoint — the migration is idempotent.
+	again, err := state.Load(p)
+	if err != nil {
+		t.Fatalf("reload migrated file: %v", err)
+	}
+	if len(again.Files) != len(loaded.Files) || len(again.Keys) != len(loaded.Keys) {
+		t.Fatalf("reload is not a fixpoint: %+v vs %+v", again, loaded)
+	}
+	for k, v := range loaded.Files {
+		if again.Files[k] != v {
+			t.Fatalf("reload changed %+v: %+v vs %+v", k, again.Files[k], v)
+		}
+	}
+}

--- a/internal/state/migrate_refusal_test.go
+++ b/internal/state/migrate_refusal_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,5 +69,61 @@ func TestLoad_RefusesUnreadableKeys(t *testing.T) {
 					got, tc.wantAmbiguity, err)
 			}
 		})
+	}
+}
+
+// TestLoad_RefusalEscapesUntrustedKeyBytes pins that a state key — read
+// VERBATIM from the hand-editable targets.json — cannot carry terminal control
+// bytes into the refusal message.
+//
+// The refusal is always MULTI-LINE, and ui.WarnWriter passes lines 2..n through
+// unsanitized, so a raw ESC/CR in a key reaches the terminal as a control
+// sequence at several sinks (opencode ingest's warn, import's warnf, doctor).
+// A raw newline is worse than a control byte even at a SANITIZING sink:
+// sanitization preserves newlines, so the key could forge whole extra output
+// lines. migrate therefore quotes the key at the SOURCE (%q), which escapes all
+// three, rather than relying on every present and future sink to do it.
+func TestLoad_RefusalEscapesUntrustedKeyBytes(t *testing.T) {
+	const hostile = "\x1b[2KSPOOFED\r\nevil"
+	// Same shape, no control bytes: the structural newline count of the refusal
+	// must not depend on the key's content.
+	const benign = "x[2KSPOOFEDxxevil"
+
+	load := func(t *testing.T, key string) error {
+		t.Helper()
+		enc, err := json.Marshal(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc := `{"schema_version":2,"files":{` + string(enc) + `:{"sha256":"x"}}}`
+		p := filepath.Join(t.TempDir(), "targets.json")
+		if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		lerr := func() error { _, e := state.Load(p); return e }()
+		if lerr == nil {
+			t.Fatalf("Load must refuse the unreadable key %q", key)
+		}
+		return lerr
+	}
+
+	got := load(t, hostile).Error()
+	for _, raw := range []struct{ name, b string }{
+		{"ESC", "\x1b"},
+		{"CR", "\r"},
+	} {
+		if strings.Contains(got, raw.b) {
+			t.Fatalf("refusal leaked a raw %s byte from the state key: %q", raw.name, got)
+		}
+	}
+	for _, want := range []string{`\x1b`, `\r`, `\n`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("refusal must escape the key (missing %s); got %q", want, got)
+		}
+	}
+	// The key must not be able to forge output lines: the refusal for a hostile
+	// key has exactly as many real newlines as the refusal for a benign one.
+	if h, b := strings.Count(got, "\n"), strings.Count(load(t, benign).Error(), "\n"); h != b {
+		t.Fatalf("state key forged %d extra output line(s): hostile=%d newlines, benign=%d\n%q", h-b, h, b, got)
 	}
 }

--- a/internal/state/migrate_refusal_test.go
+++ b/internal/state/migrate_refusal_test.go
@@ -1,0 +1,60 @@
+package state_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestLoad_RefusesUnreadableKeys pins the fail-closed half of the schema-2
+// migration. A v1 key with more than one possible reading must NOT be guessed:
+// a wrong project/path split records the entry under the wrong project, which
+// is the over-disown bug the typed key exists to remove. A malformed key in a
+// file that already claims schema_version 2 means a hand-edit or corruption and
+// is refused for the same reason.
+func TestLoad_RefusesUnreadableKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantInError string
+	}{
+		{
+			name: "ambiguous legacy files key",
+			content: `{"schema_version":1,"files":{` +
+				`"claude:project:${HOME}/a:${HOME}/b:${HOME}/c":{"sha256":"x"}}}`,
+			wantInError: "claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
+		},
+		{
+			name: "ambiguous legacy keys key",
+			content: `{"schema_version":1,"keys":{` +
+				`"claude:user::a:/b:/c":{"sha256":"x"}}}`,
+			wantInError: "claude:user::a:/b:/c",
+		},
+		{
+			name:        "malformed key in a schema-2 file",
+			content:     `{"schema_version":2,"files":{"claude:user::x":{"sha256":"x"}}}`,
+			wantInError: "claude:user::x",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "targets.json")
+			if err := os.WriteFile(p, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := state.Load(p)
+			if err == nil {
+				t.Fatal("Load must refuse a key it cannot read unambiguously")
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Fatalf("error must name the offending key %q; got %q", tc.wantInError, err)
+			}
+			if !strings.Contains(err.Error(), "bookkeeping only") {
+				t.Fatalf("error must state the remedy; got %q", err)
+			}
+		})
+	}
+}

--- a/internal/state/migrate_refusal_test.go
+++ b/internal/state/migrate_refusal_test.go
@@ -16,22 +16,30 @@ import (
 // file that already claims schema_version 2 means a hand-edit or corruption and
 // is refused for the same reason.
 func TestLoad_RefusesUnreadableKeys(t *testing.T) {
+	// The ambiguity-specific half of the remedy. Asserting only the key name and
+	// the shared "bookkeeping only" line would pass for ANY refusal, so this file
+	// — the one named for the refusals — could not tell an ambiguous key from a
+	// plainly unparseable one. Each row pins which of the two it is.
+	const ambiguityNote = "refuses to guess the project/path split"
 	tests := []struct {
-		name        string
-		content     string
-		wantInError string
+		name          string
+		content       string
+		wantInError   string
+		wantAmbiguity bool
 	}{
 		{
 			name: "ambiguous legacy files key",
 			content: `{"schema_version":1,"files":{` +
 				`"claude:project:${HOME}/a:${HOME}/b:${HOME}/c":{"sha256":"x"}}}`,
-			wantInError: "claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
+			wantInError:   "claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
+			wantAmbiguity: true,
 		},
 		{
 			name: "ambiguous legacy keys key",
 			content: `{"schema_version":1,"keys":{` +
 				`"claude:user::a:/b:/c":{"sha256":"x"}}}`,
-			wantInError: "claude:user::a:/b:/c",
+			wantInError:   "claude:user::a:/b:/c",
+			wantAmbiguity: true,
 		},
 		{
 			name:        "malformed key in a schema-2 file",
@@ -54,6 +62,10 @@ func TestLoad_RefusesUnreadableKeys(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "bookkeeping only") {
 				t.Fatalf("error must state the remedy; got %q", err)
+			}
+			if got := strings.Contains(err.Error(), ambiguityNote); got != tc.wantAmbiguity {
+				t.Fatalf("ambiguity-specific remedy present = %v, want %v; got %q",
+					got, tc.wantAmbiguity, err)
 			}
 		})
 	}

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -67,6 +67,11 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 		raw           *rawTargets
 		wantSubstrs   []string
 		wantAmbiguity bool
+		// wantKeyOnce, when set, must appear EXACTLY once in the refusal. Every
+		// error the key parsers return already names the key with %q, so the
+		// message used to print it twice (three times when the error also quoted
+		// the offending field). See migrate's note closure.
+		wantKeyOnce string
 	}{
 		{
 			name: "unparseable v1 key refuses with the base remedy only",
@@ -80,6 +85,7 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 				"targets.json is bookkeeping only",
 				"re-adopts each destination",
 			},
+			wantKeyOnce: "no-scope-field",
 		},
 		{
 			name: "ambiguous v1 key also explains why nothing is guessed",
@@ -89,10 +95,11 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 			},
 			wantSubstrs: []string{
 				"claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
-				"has 2 readings",
+				"(2 readings)",
 				"targets.json is bookkeeping only",
 			},
 			wantAmbiguity: true,
+			wantKeyOnce:   "claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
 		},
 		{
 			// Containment narrowed three candidate splits to two but could not
@@ -106,7 +113,40 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 			},
 			wantSubstrs: []string{
 				"claude:project:/a:/a/p:/a:/a/p/q",
-				"has 2 readings",
+				"(2 readings)",
+			},
+			wantAmbiguity: true,
+		},
+		{
+			// The key is printed Go-quoted, which DOUBLES a backslash — a
+			// Windows-shaped key pasted straight from this message into an editor
+			// search of targets.json finds nothing. Say so rather than leave the
+			// reader to work it out.
+			name: "a backslash-bearing key is quoted and the remedy says so",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files:         map[string]FileEntry{`claude:project:C:\dev\repo:C:\other\x.md`: {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				`C:\\dev\\repo`, // %q doubled the separators
+				"shown Go-quoted",
+				"unquote it before searching targets.json",
+			},
+			wantAmbiguity: true,
+		},
+		{
+			// A key whose candidate readings exceed maxLegacyReadings is refused
+			// without enumerating them; parseLegacyKey's enumeration is a product
+			// and the containment tie-break walks its result, so an uncapped key
+			// of a few KB could OOM-kill the process (see maxLegacyReadings).
+			name: "a key past the reading cap is refused as ambiguous",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files:         map[string]FileEntry{"claude:project:" + strings.Repeat(":/", 200): {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				"more than 64 candidate project/path splits",
+				"targets.json is bookkeeping only",
 			},
 			wantAmbiguity: true,
 		},
@@ -166,6 +206,11 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 			}
 			if hasNote := strings.Contains(err.Error(), ambiguityNote); hasNote != tc.wantAmbiguity {
 				t.Errorf("ambiguity remedy present = %v, want %v; got %q", hasNote, tc.wantAmbiguity, err)
+			}
+			if tc.wantKeyOnce != "" {
+				if n := strings.Count(err.Error(), tc.wantKeyOnce); n != 1 {
+					t.Errorf("refusal names %q %d times, want exactly 1; got %q", tc.wantKeyOnce, n, err)
+				}
 			}
 		})
 	}

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -24,15 +24,22 @@ func TestMigrate_LegacyZeroBecomesCurrent(t *testing.T) {
 
 func TestMigrate_CurrentIsNoop(t *testing.T) {
 	k := Key{Agent: "claude", Scope: "user", Path: "x"}
+	ptr := Key{Agent: "claude", Scope: "user", Path: "y", Pointer: "/mcpServers/gh"}
 	got, err := migrate(&rawTargets{
 		SchemaVersion: SchemaVersion,
 		Files:         map[string]FileEntry{k.String(): {SHA256: "a"}},
+		Keys:          map[string]KeyEntry{ptr.String(): {SHA256: "b"}},
 	})
 	if err != nil {
 		t.Fatalf("current schema should be no-op: %v", err)
 	}
 	if entry, ok := got.Files[k]; !ok || entry.SHA256 != "a" {
 		t.Errorf("current-schema key was not preserved: have %+v", got.Files)
+	}
+	// The role check parseCurrentKey adds must not reject a correctly-filed
+	// pointer entry — pin the accepting half beside the two refusals below.
+	if entry, ok := got.Keys[ptr]; !ok || entry.SHA256 != "b" {
+		t.Errorf("current-schema pointer key was not preserved: have %+v", got.Keys)
 	}
 }
 
@@ -86,6 +93,53 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 				"targets.json is bookkeeping only",
 			},
 			wantAmbiguity: true,
+		},
+		{
+			// Containment narrowed three candidate splits to two but could not
+			// settle them. The count must name what the reader still has to
+			// disambiguate, not the raw candidate count — otherwise it sends them
+			// looking for a split agentsync has already ruled out.
+			name: "an ambiguity narrowed by containment reports the narrowed count",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files:         map[string]FileEntry{"claude:project:/a:/a/p:/a:/a/p/q": {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				"claude:project:/a:/a/p:/a:/a/p/q",
+				"has 2 readings",
+			},
+			wantAmbiguity: true,
+		},
+		{
+			// v1 distinguishes the two maps structurally, so v2 must too: without
+			// the role check a hand-edited file could put a whole-file key in
+			// "keys" (it would reach jsonkeys.MergeKeys as the pointer "") or a
+			// pointered key in "files", and load silently.
+			name: "a v2 pointered key filed under files is refused",
+			raw: &rawTargets{
+				SchemaVersion: SchemaVersion,
+				Files: map[string]FileEntry{
+					Key{Agent: "claude", Scope: "user", Path: "x", Pointer: "/mcpServers/gh"}.String(): {SHA256: "a"},
+				},
+			},
+			wantSubstrs: []string{
+				"must not carry a JSON pointer",
+				`"/mcpServers/gh"`,
+				"targets.json is bookkeeping only",
+			},
+		},
+		{
+			name: "a v2 whole-file key filed under keys is refused",
+			raw: &rawTargets{
+				SchemaVersion: SchemaVersion,
+				Keys: map[string]KeyEntry{
+					Key{Agent: "claude", Scope: "user", Path: "x"}.String(): {SHA256: "a"},
+				},
+			},
+			wantSubstrs: []string{
+				"must name a JSON pointer",
+				"targets.json is bookkeeping only",
+			},
 		},
 		{
 			name: "a v2 key that does not decode refuses the same way",

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -55,18 +55,29 @@ func TestMigrate_FutureRejected(t *testing.T) {
 
 // TestMigrate_UnreadableKeysRefuseWithRemedy pins the refusal legacy.go's
 // errAmbiguousLegacyKey doc comment points at ("See migrate for the user-facing
-// remedy"). Both kinds of unreadable v1 key stop the load and carry the cheap
-// delete-and-re-adopt remedy; only a genuinely AMBIGUOUS one — several valid
-// readings, possible solely when a project root or dest path contains ':' —
-// additionally explains why agentsync will not pick one, since that is the only
-// case where guessing was even an option.
+// remedy"). Every kind of unreadable v1 key stops the load and carries the cheap
+// delete-and-re-adopt remedy; two of them add a paragraph, and the paragraphs
+// are NOT interchangeable:
+//
+//   - A genuinely AMBIGUOUS key — several valid readings, possible solely when a
+//     project root or dest path contains ':' — explains why agentsync will not
+//     pick one, since that is the only case where guessing was an option at all.
+//   - A key past maxLegacyReadings explains that enumeration was ABANDONED. It
+//     must not get the ambiguity paragraph: the cap fires while counting, so such
+//     a key may have had one reading or none (see
+//     TestParseLegacyKey_CapIsNotAnAmbiguityVerdict, which certifies both), and
+//     "agentsync refuses to guess between the readings" would then be false.
 func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
-	const ambiguityNote = "refuses to guess the project/path split"
+	const (
+		ambiguityNote = "refuses to guess the project/path split"
+		cappedNote    = "agentsync stops counting at the cap"
+	)
 	tests := []struct {
 		name          string
 		raw           *rawTargets
 		wantSubstrs   []string
 		wantAmbiguity bool
+		wantCapped    bool
 		// wantKeyOnce, when set, must appear EXACTLY once in the refusal. Every
 		// error the key parsers return already names the key with %q, so the
 		// message used to print it twice (three times when the error also quoted
@@ -135,11 +146,13 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 			wantAmbiguity: true,
 		},
 		{
-			// A key whose candidate readings exceed maxLegacyReadings is refused
-			// without enumerating them; parseLegacyKey's enumeration is a product
-			// and the containment tie-break walks its result, so an uncapped key
-			// of a few KB could OOM-kill the process (see maxLegacyReadings).
-			name: "a key past the reading cap is refused as ambiguous",
+			// A key whose candidates exceed maxLegacyReadings is refused without
+			// enumerating them; parseLegacyKey's enumeration is a product and the
+			// containment tie-break walks its result, so an uncapped key of a few
+			// KB could OOM-kill the process (see maxLegacyReadings). It gets the
+			// cap paragraph and NOT the ambiguity one — nothing counted its
+			// readings, so nothing may claim there was more than one.
+			name: "a key past the reading cap is refused as capped, not as ambiguous",
 			raw: &rawTargets{
 				SchemaVersion: 1,
 				Files:         map[string]FileEntry{"claude:project:" + strings.Repeat(":/", 200): {SHA256: "a"}},
@@ -148,7 +161,42 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 				"more than 64 candidate project/path splits",
 				"targets.json is bookkeeping only",
 			},
+			wantCapped: true,
+		},
+		{
+			// The sharp case for keeping the two paragraphs apart: uncapped, this
+			// key has EXACTLY ONE reading (TestParseLegacyKey_CapIsNotAnAmbiguity
+			// Verdict pins that by parsing it one colon shorter). Telling this
+			// user agentsync "refuses to guess the project/path split" would be
+			// describing a choice that was never available.
+			name: "a capped key that has only one reading still avoids the ambiguity paragraph",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Keys: map[string]KeyEntry{
+					"claude:project:a:b:/c" + strings.Repeat(":", 63): {SHA256: "a"},
+				},
+			},
+			wantSubstrs: []string{
+				"more than 64 candidate project/path splits",
+				"refused unread",
+			},
+			wantCapped: true,
+		},
+		{
+			// Both kinds in one file must produce BOTH paragraphs: a user whose
+			// targets.json holds an ambiguous key and a capped one needs the
+			// explanation for each, not whichever the loop happened to see last.
+			name: "a file holding both kinds of bad key gets both paragraphs",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files: map[string]FileEntry{
+					"claude:project:${HOME}/a:${HOME}/b:${HOME}/c": {SHA256: "a"},
+					"claude:project:" + strings.Repeat(":/", 200):  {SHA256: "b"},
+				},
+			},
+			wantSubstrs:   []string{"2 state key(s) could not be read"},
 			wantAmbiguity: true,
+			wantCapped:    true,
 		},
 		{
 			// v1 distinguishes the two maps structurally, so v2 must too: without
@@ -206,6 +254,9 @@ func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
 			}
 			if hasNote := strings.Contains(err.Error(), ambiguityNote); hasNote != tc.wantAmbiguity {
 				t.Errorf("ambiguity remedy present = %v, want %v; got %q", hasNote, tc.wantAmbiguity, err)
+			}
+			if hasNote := strings.Contains(err.Error(), cappedNote); hasNote != tc.wantCapped {
+				t.Errorf("enumeration-cap remedy present = %v, want %v; got %q", hasNote, tc.wantCapped, err)
 			}
 			if tc.wantKeyOnce != "" {
 				if n := strings.Count(err.Error(), tc.wantKeyOnce); n != 1 {

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -6,29 +6,113 @@ import (
 )
 
 func TestMigrate_LegacyZeroBecomesCurrent(t *testing.T) {
-	tt := &Targets{SchemaVersion: 0}
-	if err := migrate(tt); err != nil {
+	got, err := migrate(&rawTargets{
+		SchemaVersion: 0,
+		Files:         map[string]FileEntry{"claude:user::x": {SHA256: "a"}},
+	})
+	if err != nil {
 		t.Fatalf("legacy zero should migrate cleanly: %v", err)
 	}
-	if tt.SchemaVersion != SchemaVersion {
-		t.Errorf("schema not stamped: got %d want %d", tt.SchemaVersion, SchemaVersion)
+	if got.SchemaVersion != SchemaVersion {
+		t.Errorf("schema not stamped: got %d want %d", got.SchemaVersion, SchemaVersion)
+	}
+	want := Key{Agent: "claude", Scope: "user", Path: "x"}
+	if entry, ok := got.Files[want]; !ok || entry.SHA256 != "a" {
+		t.Errorf("legacy key not re-keyed: have %+v", got.Files)
 	}
 }
 
 func TestMigrate_CurrentIsNoop(t *testing.T) {
-	tt := &Targets{SchemaVersion: SchemaVersion}
-	if err := migrate(tt); err != nil {
+	k := Key{Agent: "claude", Scope: "user", Path: "x"}
+	got, err := migrate(&rawTargets{
+		SchemaVersion: SchemaVersion,
+		Files:         map[string]FileEntry{k.String(): {SHA256: "a"}},
+	})
+	if err != nil {
 		t.Fatalf("current schema should be no-op: %v", err)
+	}
+	if entry, ok := got.Files[k]; !ok || entry.SHA256 != "a" {
+		t.Errorf("current-schema key was not preserved: have %+v", got.Files)
 	}
 }
 
 func TestMigrate_FutureRejected(t *testing.T) {
-	tt := &Targets{SchemaVersion: SchemaVersion + 1}
-	err := migrate(tt)
+	_, err := migrate(&rawTargets{SchemaVersion: SchemaVersion + 1})
 	if err == nil {
 		t.Fatal("future schema should be rejected")
 	}
 	if !strings.Contains(err.Error(), "newer than this binary supports") {
 		t.Errorf("error should explain upgrade path; got %q", err)
+	}
+}
+
+// TestMigrate_UnreadableKeysRefuseWithRemedy pins the refusal legacy.go's
+// errAmbiguousLegacyKey doc comment points at ("See migrate for the user-facing
+// remedy"). Both kinds of unreadable v1 key stop the load and carry the cheap
+// delete-and-re-adopt remedy; only a genuinely AMBIGUOUS one — several valid
+// readings, possible solely when a project root or dest path contains ':' —
+// additionally explains why agentsync will not pick one, since that is the only
+// case where guessing was even an option.
+func TestMigrate_UnreadableKeysRefuseWithRemedy(t *testing.T) {
+	const ambiguityNote = "refuses to guess the project/path split"
+	tests := []struct {
+		name          string
+		raw           *rawTargets
+		wantSubstrs   []string
+		wantAmbiguity bool
+	}{
+		{
+			name: "unparseable v1 key refuses with the base remedy only",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files:         map[string]FileEntry{"no-scope-field": {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				"1 state key(s) could not be read at schema_version=1",
+				"no-scope-field",
+				"targets.json is bookkeeping only",
+				"re-adopts each destination",
+			},
+		},
+		{
+			name: "ambiguous v1 key also explains why nothing is guessed",
+			raw: &rawTargets{
+				SchemaVersion: 1,
+				Files:         map[string]FileEntry{"claude:project:${HOME}/a:${HOME}/b:${HOME}/c": {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				"claude:project:${HOME}/a:${HOME}/b:${HOME}/c",
+				"has 2 readings",
+				"targets.json is bookkeeping only",
+			},
+			wantAmbiguity: true,
+		},
+		{
+			name: "a v2 key that does not decode refuses the same way",
+			raw: &rawTargets{
+				SchemaVersion: SchemaVersion,
+				Keys:          map[string]KeyEntry{"as1|6:claude|4:user": {SHA256: "a"}},
+			},
+			wantSubstrs: []string{
+				"could not be read at schema_version=2",
+				"targets.json is bookkeeping only",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := migrate(tc.raw)
+			if err == nil {
+				t.Fatalf("an unreadable key must refuse the whole load; got %+v", got)
+			}
+			for _, want := range tc.wantSubstrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("refusal must mention %q; got %q", want, err)
+				}
+			}
+			if hasNote := strings.Contains(err.Error(), ambiguityNote); hasNote != tc.wantAmbiguity {
+				t.Errorf("ambiguity remedy present = %v, want %v; got %q", hasNote, tc.wantAmbiguity, err)
+			}
+		})
 	}
 }

--- a/internal/state/save_guard_test.go
+++ b/internal/state/save_guard_test.go
@@ -1,0 +1,103 @@
+package state_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/state"
+)
+
+// TestSave_RefusesNonUTF8Keys pins the JSON-boundary guard. state.Key's own
+// encoding is byte-safe — ParseKey(k.String()) == k for ANY bytes — but
+// targets.json is JSON, and encoding/json rewrites an invalid UTF-8 byte in a
+// string to U+FFFD. Persisting such a key would write a length prefix that no
+// longer matches its payload, so the next Load would refuse the whole file — and
+// the remedy that error suggests would not converge, because the next apply
+// rebuilds and re-writes the same mangled key. Save refuses at creation time
+// instead, and names the DESTINATION PATH, which is the thing the user can
+// actually change: Linux paths are byte strings, so $HOME, a project root or a
+// filename may legally contain a raw 0xFF.
+func TestSave_RefusesNonUTF8Keys(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*state.Targets)
+		wantPath string
+	}{
+		{
+			name: "invalid byte in a files key path",
+			mutate: func(tg *state.Targets) {
+				tg.Files[state.Key{Agent: "claude", Scope: "user", Path: "${HOME}/bad\xffdir/CLAUDE.md"}] = state.FileEntry{SHA256: "a"}
+			},
+			wantPath: `${HOME}/bad\xffdir/CLAUDE.md`,
+		},
+		{
+			name: "invalid byte in a project root",
+			mutate: func(tg *state.Targets) {
+				tg.Files[state.Key{
+					Agent: "claude", Scope: "project",
+					Project: "${HOME}/we\xffird", Path: "${HOME}/we\xffird/.mcp.json",
+				}] = state.FileEntry{SHA256: "b"}
+			},
+			wantPath: `${HOME}/we\xffird/.mcp.json`,
+		},
+		{
+			name: "invalid byte in a keys entry pointer",
+			mutate: func(tg *state.Targets) {
+				tg.Keys[state.Key{
+					Agent: "claude", Scope: "user",
+					Path: "${HOME}/.claude.json", Pointer: "/mcpServers/b\xffd",
+				}] = state.KeyEntry{SHA256: "c"}
+			},
+			wantPath: "${HOME}/.claude.json",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "targets.json")
+			tg := state.New()
+			tc.mutate(tg)
+			err := state.Save(p, tg)
+			if err == nil {
+				t.Fatal("Save must refuse a key the JSON container cannot carry losslessly")
+			}
+			if !errors.Is(err, state.ErrNonUTF8Key) {
+				t.Fatalf("error must match state.ErrNonUTF8Key; got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Fatalf("error must name the offending path %q; got %q", tc.wantPath, err)
+			}
+			if _, statErr := os.Stat(p); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("Save must refuse BEFORE writing; stat(%s) = %v", p, statErr)
+			}
+		})
+	}
+}
+
+// TestSave_AcceptsColonAndPipeKeys is the negative control: the guard rejects
+// only invalid UTF-8, never the ':' and '|' bytes the length-prefixed encoding
+// exists to carry.
+func TestSave_AcceptsColonAndPipeKeys(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "targets.json")
+	tg := state.New()
+	tg.Files[state.Key{
+		Agent: "claude", Scope: "project",
+		Project: "${HOME}/work/app:staging", Path: "${HOME}/work/app:staging/.mcp|json",
+	}] = state.FileEntry{SHA256: "a"}
+	tg.Keys[state.Key{
+		Agent: "claude", Scope: "user",
+		Path: "${HOME}/.claude.json", Pointer: "/mcpServers/gh",
+	}] = state.KeyEntry{SHA256: "b"}
+	if err := state.Save(p, tg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	back, err := state.Load(p)
+	if err != nil {
+		t.Fatalf("Load of the saved file: %v", err)
+	}
+	if len(back.Files) != 1 || len(back.Keys) != 1 {
+		t.Fatalf("round-trip lost entries: %+v", back)
+	}
+}

--- a/internal/state/save_guard_test.go
+++ b/internal/state/save_guard_test.go
@@ -69,6 +69,12 @@ func TestSave_RefusesNonUTF8Keys(t *testing.T) {
 			if !strings.Contains(err.Error(), tc.wantPath) {
 				t.Fatalf("error must name the offending path %q; got %q", tc.wantPath, err)
 			}
+			// Save runs after the caller has already written its destinations, so
+			// the message must say the run's writes landed — otherwise "rename it
+			// and re-run" reads as if nothing happened.
+			if !strings.Contains(err.Error(), "anything this run wrote is on disk and correct") {
+				t.Fatalf("error must say the run's writes already landed; got %q", err)
+			}
 			if _, statErr := os.Stat(p); !errors.Is(statErr, os.ErrNotExist) {
 				t.Fatalf("Save must refuse BEFORE writing; stat(%s) = %v", p, statErr)
 			}

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -17,10 +17,13 @@ const SchemaVersion = 2
 
 // Targets is the root state document.
 //
-// Files and Keys are keyed by the typed Key, so a state key can only be built
-// through NewFileKey/NewPointerKey — a hand-rolled fmt.Sprintf is a compile
-// error. Marketplaces and Plugins keep string keys: those are marketplace names
-// and "owner/plugin" ids, a different namespace with no ambiguity problem.
+// Files and Keys are keyed by the typed Key, so a hand-rolled fmt.Sprintf key is
+// a compile error rather than a convention. That is the guarantee — NOT that
+// NewFileKey/NewPointerKey are the only way in: a Key{…} composite literal
+// compiles anywhere (it just skips their paths.HomeRelative, which is how tests
+// plant a key in a specific portable spelling), and ParseKey is exported.
+// Marketplaces and Plugins keep string keys: those are marketplace names and
+// "owner/plugin" ids, a different namespace with no ambiguity problem.
 type Targets struct {
 	SchemaVersion int                    `json:"schema_version"`
 	Files         map[Key]FileEntry      `json:"files,omitempty"`

--- a/internal/state/schema.go
+++ b/internal/state/schema.go
@@ -5,19 +5,32 @@ package state
 
 import "time"
 
-const SchemaVersion = 1
+// SchemaVersion is the on-disk format version of targets.json.
+//
+//	1 — files/keys were string maps keyed "agent:scope:project:path[:pointer]",
+//	    a ':'-joined encoding that is NOT injective: ':' is legal in a POSIX
+//	    path, so a project root containing one produced keys that string-prefixed
+//	    a sibling project's (issue #227).
+//	2 — files/keys are keyed by the typed, length-prefixed state.Key (key.go).
+//	    Load migrates 0/1 -> 2 in place; the next Save commits the upgrade.
+const SchemaVersion = 2
 
 // Targets is the root state document.
+//
+// Files and Keys are keyed by the typed Key, so a state key can only be built
+// through NewFileKey/NewPointerKey — a hand-rolled fmt.Sprintf is a compile
+// error. Marketplaces and Plugins keep string keys: those are marketplace names
+// and "owner/plugin" ids, a different namespace with no ambiguity problem.
 type Targets struct {
 	SchemaVersion int                    `json:"schema_version"`
-	Files         map[string]FileEntry   `json:"files,omitempty"`
-	Keys          map[string]KeyEntry    `json:"keys,omitempty"`
+	Files         map[Key]FileEntry      `json:"files,omitempty"`
+	Keys          map[Key]KeyEntry       `json:"keys,omitempty"`
 	Marketplaces  map[string]Marketplace `json:"marketplaces,omitempty"`
 	Plugins       map[string]PluginEntry `json:"plugins,omitempty"`
 }
 
-// FileEntry tracks one fully-managed destination file.
-// Key format: "<agent>:<scope>:<project>:<dest_path>"
+// FileEntry tracks one fully-managed destination file, under a Key whose
+// Pointer is empty.
 type FileEntry struct {
 	SHA256    string    `json:"sha256"`
 	Mode      uint32    `json:"mode"`
@@ -26,8 +39,7 @@ type FileEntry struct {
 }
 
 // KeyEntry tracks one managed JSON-pointer-addressable key inside a shared
-// destination file.
-// Key format: "<agent>:<scope>:<project>:<file>:<json_pointer>"
+// destination file, under a Key whose Pointer is that JSON pointer.
 type KeyEntry struct {
 	SHA256    string    `json:"sha256"`
 	AppliedAt time.Time `json:"applied_at"`
@@ -51,8 +63,8 @@ type PluginEntry struct {
 func New() *Targets {
 	return &Targets{
 		SchemaVersion: SchemaVersion,
-		Files:         map[string]FileEntry{},
-		Keys:          map[string]KeyEntry{},
+		Files:         map[Key]FileEntry{},
+		Keys:          map[Key]KeyEntry{},
 		Marketplaces:  map[string]Marketplace{},
 		Plugins:       map[string]PluginEntry{},
 	}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -54,12 +54,9 @@ func Load(path string) (*Targets, error) {
 	if err != nil {
 		return nil, fmt.Errorf("migrate %s: %w", path, err)
 	}
-	if t.Files == nil {
-		t.Files = map[Key]FileEntry{}
-	}
-	if t.Keys == nil {
-		t.Keys = map[Key]KeyEntry{}
-	}
+	// Files and Keys are always allocated by migrate; Marketplaces and Plugins
+	// are copied straight from the decoded document and are nil when the file
+	// omits them, so only those two need a guard.
 	if t.Marketplaces == nil {
 		t.Marketplaces = map[string]Marketplace{}
 	}
@@ -81,6 +78,12 @@ func Load(path string) (*Targets, error) {
 // that does not converge, because the next apply rebuilds and re-writes the same
 // mangled key. Save therefore fails closed at the moment the key is created,
 // naming the destination path so the user can rename it.
+//
+// It fires from Save, which every caller reaches AFTER doing its work (apply has
+// already written every destination), so the message also says so: the files
+// landed, only the ownership record did not. Validating at plan time instead was
+// considered and declined — it would reshape the apply pipeline for a failure
+// mode that already self-heals on the next run.
 var ErrNonUTF8Key = errors.New("state key field is not valid UTF-8")
 
 // checkKeysEncodable rejects every key in t whose fields are not all valid
@@ -114,8 +117,16 @@ func checkKeysEncodable(t *Targets) error {
 		return nil
 	}
 	sort.Strings(bad)
+	// Say where in the run this lands. checkKeysEncodable fires from Save, which
+	// every caller reaches AFTER doing its work, so a user hitting this has a
+	// half-recorded machine and no way to tell from "rename it and re-run"
+	// whether their destinations were written. They were.
 	return fmt.Errorf("%w:\n  %s\nagentsync cannot record a destination whose path is not valid UTF-8; "+
-		"rename it (or drop it from this agent's config) and re-run",
+		"rename it (or drop it from this agent's config) and re-run.\n"+
+		"This check runs when state is SAVED, which is after the run has already done its work: "+
+		"anything this run wrote is on disk and correct — only the ownership record was not updated. "+
+		"Re-running after the rename converges (a destination agentsync does not own is backed up to "+
+		".state/backups/ and re-adopted), but until then every attempt adds another backup",
 		ErrNonUTF8Key, strings.Join(bad, "\n  "))
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -5,12 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/spxrogers/agentsync/internal/iox"
 )
 
+// rawTargets is the wire shape of targets.json with UNTYPED map keys. Load
+// decodes into it first because a v1 document's keys ("claude:user::x") cannot
+// unmarshal into map[Key]…; migrate converts them.
+type rawTargets struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Files         map[string]FileEntry   `json:"files,omitempty"`
+	Keys          map[string]KeyEntry    `json:"keys,omitempty"`
+	Marketplaces  map[string]Marketplace `json:"marketplaces,omitempty"`
+	Plugins       map[string]PluginEntry `json:"plugins,omitempty"`
+}
+
 // Load reads targets.json from path. If the file is missing, returns a fresh
-// state at the current SchemaVersion.
+// state at the current SchemaVersion. Keys are upgraded to the current encoding
+// on the way in (see migrate).
 func Load(path string) (*Targets, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -19,8 +34,8 @@ func Load(path string) (*Targets, error) {
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	var t Targets
-	if err := json.Unmarshal(data, &t); err != nil {
+	var raw rawTargets
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	// A file that is valid JSON but empty-shaped (`null`, `{}`, or any doc
@@ -30,19 +45,20 @@ func Load(path string) (*Targets, error) {
 	// pristine empty state would make the next apply treat every managed
 	// destination as unowned and back them all up as foreign collisions.
 	// A legacy v0 file with real entries is still accepted (migrate handles it).
-	if t.SchemaVersion == 0 && len(t.Files) == 0 && len(t.Keys) == 0 &&
-		len(t.Marketplaces) == 0 && len(t.Plugins) == 0 {
+	if raw.SchemaVersion == 0 && len(raw.Files) == 0 && len(raw.Keys) == 0 &&
+		len(raw.Marketplaces) == 0 && len(raw.Plugins) == 0 {
 		return nil, fmt.Errorf("state file %s is empty or corrupt (no schema_version and no entries); "+
 			"remove it to reinitialize (agentsync will re-adopt destinations on the next apply)", path)
 	}
-	if err := migrate(&t); err != nil {
+	t, err := migrate(&raw)
+	if err != nil {
 		return nil, fmt.Errorf("migrate %s: %w", path, err)
 	}
 	if t.Files == nil {
-		t.Files = map[string]FileEntry{}
+		t.Files = map[Key]FileEntry{}
 	}
 	if t.Keys == nil {
-		t.Keys = map[string]KeyEntry{}
+		t.Keys = map[Key]KeyEntry{}
 	}
 	if t.Marketplaces == nil {
 		t.Marketplaces = map[string]Marketplace{}
@@ -50,13 +66,68 @@ func Load(path string) (*Targets, error) {
 	if t.Plugins == nil {
 		t.Plugins = map[string]PluginEntry{}
 	}
-	return &t, nil
+	return t, nil
+}
+
+// ErrNonUTF8Key marks a state key that cannot be persisted because one of its
+// fields is not valid UTF-8.
+//
+// The key ENCODING is byte-safe — ParseKey(k.String()) == k for any bytes at all
+// — but the container is narrower: targets.json is JSON, and encoding/json
+// rewrites every invalid byte in a string to U+FFFD. A key holding a raw 0xFF
+// (Linux paths are byte strings, so $HOME, a project root or a filename may
+// legally contain one) would be written with a length prefix that no longer
+// matches its payload, and the next Load would refuse the WHOLE file — a state
+// that does not converge, because the next apply rebuilds and re-writes the same
+// mangled key. Save therefore fails closed at the moment the key is created,
+// naming the destination path so the user can rename it.
+var ErrNonUTF8Key = errors.New("state key field is not valid UTF-8")
+
+// checkKeysEncodable rejects every key in t whose fields are not all valid
+// UTF-8, BEFORE json.Marshal can silently rewrite them (see ErrNonUTF8Key).
+// Offenders are reported sorted, each naming the destination path and the
+// offending field, so the message is actionable rather than just diagnostic.
+func checkKeysEncodable(t *Targets) error {
+	var bad []string
+	check := func(kind string, k Key) {
+		for _, f := range [5]struct{ name, value string }{
+			{"agent", k.Agent},
+			{"scope", k.Scope},
+			{"project", k.Project},
+			{"path", k.Path},
+			{"pointer", k.Pointer},
+		} {
+			if !utf8.ValidString(f.value) {
+				bad = append(bad, fmt.Sprintf("%s entry for destination path %q: field %s = %q",
+					kind, k.Path, f.name, f.value))
+				return
+			}
+		}
+	}
+	for k := range t.Files {
+		check("files", k)
+	}
+	for k := range t.Keys {
+		check("keys", k)
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	sort.Strings(bad)
+	return fmt.Errorf("%w:\n  %s\nagentsync cannot record a destination whose path is not valid UTF-8; "+
+		"rename it (or drop it from this agent's config) and re-run",
+		ErrNonUTF8Key, strings.Join(bad, "\n  "))
 }
 
 // Save serializes t to path atomically (iox.AtomicWrite).
 func Save(path string, t *Targets) error {
 	if t == nil {
 		return fmt.Errorf("save nil targets")
+	}
+	// Fail closed BEFORE writing anything: json.Marshal would rewrite an invalid
+	// UTF-8 byte in a key to U+FFFD and produce a file the next Load refuses.
+	if err := checkKeysEncodable(t); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
 	}
 	data, err := json.MarshalIndent(t, "", "  ")
 	if err != nil {

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -42,7 +42,8 @@ func TestStore_RoundTrip(t *testing.T) {
 	p := filepath.Join(dir, "targets.json")
 
 	in := state.New()
-	in.Files["claude:user::~/.claude/settings.json"] = state.FileEntry{
+	settingsKey := state.Key{Agent: "claude", Scope: "user", Path: "~/.claude/settings.json"}
+	in.Files[settingsKey] = state.FileEntry{
 		SHA256:    "abc",
 		Mode:      0o644,
 		AppliedAt: time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC),
@@ -56,7 +57,7 @@ func TestStore_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	got := out.Files["claude:user::~/.claude/settings.json"]
+	got := out.Files[settingsKey]
 	if got.SHA256 != "abc" || got.SourceID != "mcp/github.toml" {
 		t.Fatalf("entry round-trip lost data: %+v", got)
 	}


### PR DESCRIPTION
## Summary

Closes #227.

`targets.json` keyed entries by a stringly format — `"agent:scope:project:path[:ptr]"` — that lived only in comments, was built by hand-rolled `fmt.Sprintf` at nine sites across three packages (`internal/render`, `internal/cli`, `internal/adapter/opencode`), and was hand-parsed at ~six more. Several call sites carried "accepted residual" comments acknowledging that the encoding is **non-injective**: a project root containing `:` can prefix-match a sibling project's keys, producing over-disowns and mangled purge extraction.

This replaces it with a typed `state.Key` owned by `internal/state`, using a marker plus five byte-length-prefixed fields (`as1|6:claude|4:user|0:|29:${HOME}/.claude/settings.json|0:`). Parsing slices declared byte counts and never inspects field content, so `ParseKey` accepts exactly the image of `String()` — injective for any byte content, including fields holding `|`, `:`, or a complete encoded key. The state maps become `map[state.Key]…`, so **a hand-rolled `fmt.Sprintf` key is a compile error rather than a convention**. (That is the guarantee — not that `NewFileKey`/`NewPointerKey` are the only way in: a `Key{…}` composite literal compiles anywhere, which is how tests plant a key in a specific portable spelling, and `ParseKey` is exported. No non-test code builds one by hand.)

`schema_version` goes 1 → 2. The migration recovers every unambiguous v1 key and **refuses fail-closed** on one that isn't, naming the offending key and the remedy — guessing would file the entry under the wrong project, which is the bug being fixed.

## Commits

| Commit | What |
| --- | --- |
| `f241651` | `feat(state)` — the typed key: `String()`/`ParseKey`, `MarshalText`/`UnmarshalText`, `AbsPath`, `InTree` |
| `7c38313` | `feat(state)` — the one-way v1 parser used only by the migration |
| `f16e8cc` | `refactor(state)` — the cutover: `map[Key]`, schema 2, migration, every call site, 37 test literals, docs |
| `2a353c6` | `test(state)` — pins the migration refusals and the fixed bug class |
| `6020ed5` | `fix(state)` — Windows v1 keys decode instead of refusing the file |
| `d702819` | `fix(state)` — v2 role check, refusal-message precision, key-test hardening |
| `1212525` | `fix(state)` — stop dot-segment forgery and raw key bytes in refusals |
| `a540553` | `fix(cli)` — keep an unreadable `targets.json` instead of replacing it with an empty one |
| `d26ea1d` | `test(cli)` — make the key's project, path, scope and pointer legs load-bearing |
| `7433f9b` | `fix(state)` — bound legacy key enumeration; close round-2 review findings |
| `8fb39ca` | `fix(state)` — separate the enumeration cap from ambiguity; pin the claims |

## What reviewers should look at

**A Windows upgrade-blocker.** `withinProject` — the containment tie-break that resolves an ambiguous legacy key — normalized slash-only, but `paths.HomeRelative` returns paths outside `$HOME` verbatim. On Windows an ordinary project root arrives as `C:\dev\repo`, giving three candidate splits and **zero** contained readings, so the tie-break never fired and `state.Load` refused the entire file — every state-loading command failing on the first run after upgrade. Nothing caught it because `internal/state` is gated behind `testenv.MustRunInContainer()` and `test-fast`, the lane that runs on `windows-latest`, excludes it. The new `legacy_test.go` rows are pure-string and platform-independent, so they run in the Linux container.

**Silent wrong-project recovery.** Containment used `path.Clean`, whose `..` collapse let a crafted key be *accepted under the wrong project with no error* — fail-open, the exact bug class this PR exists to kill. Replaced by `containmentParts`, a per-component comparison that never collapses `..`, so a destination written as `root+sep+tail` is always contained and a false reading can only force a refusal.

A proposed follow-on guard (excluding zero-component roots, to recover some over-refusals) was **deliberately declined**: `/` is a legal *true* project root, and excluding it drops the true reading out of the contained set, letting a false one win silently. Over-refusal is the cheap failure; misrecovery is the expensive one. The reasoning is documented on `projectRoot.contains`.

**Bounded enumeration.** `parseLegacyKey` enumerated O(colons × `:/`) candidates; a ~4 KB hand-edited v1 key OOM-killed the process on the `status`/`apply`/`doctor`/`diff` path. Now capped at both multiplying sites, with the root parsed once per split. The cap has **its own sentinel**, separate from `errAmbiguousLegacyKey`, because a key can exceed the cap while having exactly one reading — calling that "ambiguous" would hand the user the wrong remedy.

**`Save` refuses non-UTF-8 key fields** (`ErrNonUTF8Key`), naming the offending destination path. Such a key survives `String()`/`ParseKey` but not the JSON layer: `json.Marshal` coerces the bytes to U+FFFD, breaking the declared length so the next `Load` refuses the file — and the remedy doesn't converge, because the next apply rewrites the same mangled key.

## Downgrade is NOT safe — read before rolling back

`CHANGELOG.md` and `docs/architecture.md` §7.8 previously claimed an older binary *refuses* an upgraded file. It refuses at the `migrate` layer, but pre-schema-2 `addMarketplaceSource` discards that error and overwrites `targets.json` with an empty state — destroying all ownership entries and every marketplace record, which then makes the next apply back up every managed destination as a foreign collision.

This branch fixes that in the current binary, but **older binaries cannot be patched**, so both docs now say plainly that rolling back is unsafe and to back up `~/.agentsync/.state/targets.json` first. `agentsync marketplace add` and `import` are the destroyers; the other commands return the error.

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [x] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

Full `-race -count=1` suite green across all packages, plus the `e2e` and `bdd` tagged suites; `golangci-lint` 0 issues. A real v1→v2 upgrade was smoke-tested through the built binary.

Beyond the suite, the load-bearing properties were established by measurement rather than assertion:

- **Containment**: 12.8M realizable `(project, path[, pointer])` tuples, built as `project + sep + tail` the way adapters actually write them — 0 wrong-project acceptances, 0 refusals of colon-free keys.
- **The cap**: differential-tested against the pre-cap parser over 87,696 keys × 2 modes — 0 value differences, 0 fail-opens; every narrowing fail-closed. Scaling is linear (200 KB key → 1.2 ms).
- **Concurrency**: every `state.Save` path is under `withGlobalLock`; no lost-update window found.
- **The downgrade claim** was verified command-by-command against the merge base.

New tests, each verified to fail against the behavior it pins:

- `TestKey_EncodingIsExact` pins the on-disk wire format byte-for-byte, and `migrate_fidelity_test.go` uses re-read file bytes as its oracle — per CLAUDE.md, a round-trip whose oracle is the parsed model proves nothing.
- `TestKey_HistoricalCollisionIsGone` and `TestPruneStaleState_SiblingColonProjectRootSurvives` pin the actual **prefix-collision** property, not mere key inequality. The latter is the only `TestPruneStaleState` case that fails when `InTree` reverts to v1 prefix semantics.
- `TestLegacyContainmentProperties` anchors the invariant the tie-break rests on — *the true reading is always contained* — over a generated corpus.
- `TestCommandsRefuseUnreadableState` pins that a refusing state file is not clobbered, closing a gap where the `marketplace add` bug could be reintroduced in `status`/`apply` with nothing to catch it.
- `TestParseLegacyKey_CapIsNotAnAmbiguityVerdict` pins that the enumeration cap is reported as itself, not as ambiguity.
- `TestSave_RefusesNonUTF8Keys` proves no file is written on refusal; `TestSave_AcceptsColonAndPipeKeys` is the negative control.

- [ ] `just test-release` is green (the release bar) — **not run**: `just` is not installable in this environment (the proxy blocks `just.systems`), so the recipes were run directly. The hermetic-container release gate has not been exercised; CI is the check here.
- [x] `just lint` is clean — run as its underlying recipe with the `GOTOOLCHAIN=go1.26.2` pin CLAUDE.md documents.

## Checklist

- [x] Conventional commit messages with a scope.
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any `source.Write*` path, I've re-read the secret-handling invariants in `CLAUDE.md` / `SECURITY.md` and not weakened them. — State keys embed file paths, so this was checked explicitly: no resolved secret is routed into the canonical source and nothing bypasses `capture.Capture`. Those packages are untouched.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/architecture.md` (§6 + a new §7 safety primitive), `docs/components.md`, `docs/concepts.md`, a superseded-by note on the v1.0 design spec, and `CHANGELOG.md`. The website and capability matrix owe nothing; the CLI surface is unchanged.

## Known follow-ups (not this branch)

- **Back up the v1 state during the 1→2 upgrade.** Snapshotting the pre-migration bytes into `.state/backups/` would turn the downgrade warning above from "back it up yourself" into "already done". Happens once per machine. Deliberately out of scope here as new runtime behavior late in the branch.
- **A Windows-safe test lane.** The pure-string parser tests are platform-independent but sit behind the container-only `TestMain`, so the platform this migration must survive never exercises them. CI-structure work, not state-key work.
- **`InTree` also matches on agent**, which the name hides. Renaming was considered and declined: the three sites that open-code a Scope+Project-only predicate could not call it under any name, so a rename buys nothing here.