### PR TITLE
refactor(cli): reconcileRun becomes a reconcileSession (#232)

### DIFF
--- a/.agentsync/memory/AGENTS.md
+++ b/.agentsync/memory/AGENTS.md
@@ -230,10 +230,10 @@ deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
 and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
 stale-hook retirement. Both are safe without Capture because a pure deletion
 carries no content to re-reference — there is no secret material to persist —
-and both are guarded (the reconcile path runs only for that chosen write-back
-and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
-native-supplied event id before touching a path). Anything that *writes
-content* dest→source still MUST go through `capture.Capture`.
+and both are guarded (the reconcile path is `withinDir`-bounded to
+`~/.agentsync`; RemoveHooks validates the native-supplied event id before
+touching a path). Anything that *writes content* dest→source still MUST go
+through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/.agentsync/memory/AGENTS.md
+++ b/.agentsync/memory/AGENTS.md
@@ -225,14 +225,15 @@ Capture **refuses the whole write** rather than persist cleartext. It errs towar
 refusing; the user updates the vault or edits the canonical source directly.
 Two narrow **deletion-only** exceptions sit outside the funnel: `reconcile`'s
 `removeDroppedSource` (`internal/cli/reconcile.go`) unlinks a canonical
-`mcp/<id>.toml` when the user explicitly chooses `[w]rite-back` for a
-destination-side server deletion, and `source.RemoveHooks` deletes a stale
-`hooks/<event>.toml` during import's stale-hook retirement. Both are safe
-without Capture because a pure deletion carries no content to re-reference —
-there is no secret material to persist — and both are guarded (the reconcile
-path is keystroke-gated and `withinDir`-bounded to `~/.agentsync`; RemoveHooks
-validates the native-supplied event id before touching a path). Anything that
-*writes content* dest→source still MUST go through `capture.Capture`.
+`mcp/<id>.toml` when the user chooses write-back for a destination-side server
+deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
+and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
+stale-hook retirement. Both are safe without Capture because a pure deletion
+carries no content to re-reference — there is no secret material to persist —
+and both are guarded (the reconcile path runs only for that chosen write-back
+and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
+native-supplied event id before touching a path). Anything that *writes
+content* dest→source still MUST go through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,10 +237,10 @@ deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
 and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
 stale-hook retirement. Both are safe without Capture because a pure deletion
 carries no content to re-reference — there is no secret material to persist —
-and both are guarded (the reconcile path runs only for that chosen write-back
-and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
-native-supplied event id before touching a path). Anything that *writes
-content* dest→source still MUST go through `capture.Capture`.
+and both are guarded (the reconcile path is `withinDir`-bounded to
+`~/.agentsync`; RemoveHooks validates the native-supplied event id before
+touching a path). Anything that *writes content* dest→source still MUST go
+through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,14 +232,15 @@ Capture **refuses the whole write** rather than persist cleartext. It errs towar
 refusing; the user updates the vault or edits the canonical source directly.
 Two narrow **deletion-only** exceptions sit outside the funnel: `reconcile`'s
 `removeDroppedSource` (`internal/cli/reconcile.go`) unlinks a canonical
-`mcp/<id>.toml` when the user explicitly chooses `[w]rite-back` for a
-destination-side server deletion, and `source.RemoveHooks` deletes a stale
-`hooks/<event>.toml` during import's stale-hook retirement. Both are safe
-without Capture because a pure deletion carries no content to re-reference —
-there is no secret material to persist — and both are guarded (the reconcile
-path is keystroke-gated and `withinDir`-bounded to `~/.agentsync`; RemoveHooks
-validates the native-supplied event id before touching a path). Anything that
-*writes content* dest→source still MUST go through `capture.Capture`.
+`mcp/<id>.toml` when the user chooses write-back for a destination-side server
+deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
+and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
+stale-hook retirement. Both are safe without Capture because a pure deletion
+carries no content to re-reference — there is no secret material to persist —
+and both are guarded (the reconcile path runs only for that chosen write-back
+and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
+native-supplied event id before touching a path). Anything that *writes
+content* dest→source still MUST go through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,23 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `Adapter` interface and is deferred to
   [#250](https://github.com/spxrogers/agentsync/issues/250).
 
+- **Internal: `reconcile`'s interactive pass is a session type**
+  ([#232](https://github.com/spxrogers/agentsync/issues/232)). `reconcileRun`
+  was 375 lines with five `goto done`s, two labeled loops and six pieces of
+  run-scoped state travelling as loose locals; it is now a 28-line entry point
+  over a `reconcileSession` whose methods are the two prompts, the `--auto-*`
+  dispatch, the action switch and the run's tail. Every `goto` is a plain
+  return, and the tail runs from exactly one call site — deliberately not a
+  `defer`, since it re-applies the queued `[o]verride` ops and saves state. The
+  bulk-action state machine is a typed enum instead of a `byte` with `ch | 0x20`
+  case folding, which also writes down the two keystrokes the prompt
+  deliberately does **not** fold (`I` is not a bulk ignore; `D` is not a
+  diff). No user-visible behaviour changes: 39 scripted-stdin scenarios —
+  every prompt, bulk confirmation, EOF, `[q]uit` (including a quit with a
+  queued override), `--auto-*` mode, project-scope override, exit code, masked
+  secret value and resulting source/state tree — are byte-identical to the
+  pre-change binary (`main` at `309fde0`).
+
 - **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
   and requires nothing: every command reads the old keys, and the first command
   that WRITES state (`apply`, `import`, `reconcile`, `migrate`, `agent disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,7 +304,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   every prompt, bulk confirmation, EOF, `[q]uit` (including a quit with a
   queued override), `--auto-*` mode, project-scope override, exit code, masked
   secret value and resulting source/state tree — are byte-identical to the
-  pre-change binary (`main` at `309fde0`).
+  pre-change binary (`main` at `309fde0`). Two per-item rebuilds went with it:
+  `printItemDiff` was a pure alias of `renderItemValues`, and inverting a hook
+  pointer's native event spelling now uses the registry the caller already
+  holds instead of rebuilding all 31 adapters (~10 µs) on every resolution.
 
 - **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
   and requires nothing: every command reads the old keys, and the first command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `printItemDiff` was a pure alias of `renderItemValues`, and inverting a hook
   pointer's native event spelling now uses the registry the caller already
   holds instead of rebuilding all 31 adapters (~10 µs) on every resolution.
+  The docs' description of `removeDroppedSource`'s gate (SECURITY.md,
+  architecture §5, the project memory file) now names the three write-back
+  routes that reach it — a per-item `[w]`, a confirmed bulk `[W]`, or
+  `--auto-writeback` — instead of calling it "keystroke-gated", which
+  `--auto-writeback` never was.
 
 - **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
   and requires nothing: every command reads the old keys, and the first command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,8 +291,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 - **Internal: `reconcile`'s interactive pass is a session type**
   ([#232](https://github.com/spxrogers/agentsync/issues/232)). `reconcileRun`
-  was 375 lines with five `goto done`s, two labeled loops and six pieces of
-  run-scoped state travelling as loose locals; it is now a 28-line entry point
+  was 375 lines with five `goto done`s, two labeled loops and seven pieces of
+  run-scoped state travelling as loose locals; it is now a 22-line entry point
   over a `reconcileSession` whose methods are the two prompts, the `--auto-*`
   dispatch, the action switch and the run's tail. Every `goto` is a plain
   return, and the tail runs from exactly one call site — deliberately not a
@@ -304,7 +304,7 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   every prompt, bulk confirmation, EOF, `[q]uit` (including a quit with a
   queued override), `--auto-*` mode, project-scope override, exit code, masked
   secret value and resulting source/state tree — are byte-identical to the
-  pre-change binary (`main` at `309fde0`). Two per-item rebuilds went with it:
+  pre-change binary (`main` at `309fde0`). Two smaller things went with it:
   `printItemDiff` was a pure alias of `renderItemValues`, and inverting a hook
   pointer's native event spelling now uses the registry the caller already
   holds instead of rebuilding all 31 adapters (~10 µs) on every resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,11 +308,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `printItemDiff` was a pure alias of `renderItemValues`, and inverting a hook
   pointer's native event spelling now uses the registry the caller already
   holds instead of rebuilding all 31 adapters (~10 µs) on every resolution.
-  The docs' description of `removeDroppedSource`'s gate (SECURITY.md,
-  architecture §5, the project memory file) now names the three write-back
-  routes that reach it — a per-item `[w]`, a confirmed bulk `[W]`, or
-  `--auto-writeback` — instead of calling it "keystroke-gated", which
-  `--auto-writeback` never was.
+  The docs no longer call `removeDroppedSource`'s gate "keystroke-gated"
+  (`--auto-writeback` never was one): SECURITY.md, architecture §5 and the
+  project memory name the three write-back routes that reach it.
 
 - **`.state/targets.json` is now `schema_version: 2`.** The upgrade is automatic
   and requires nothing: every command reads the old keys, and the first command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,10 +237,10 @@ deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
 and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
 stale-hook retirement. Both are safe without Capture because a pure deletion
 carries no content to re-reference — there is no secret material to persist —
-and both are guarded (the reconcile path runs only for that chosen write-back
-and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
-native-supplied event id before touching a path). Anything that *writes
-content* dest→source still MUST go through `capture.Capture`.
+and both are guarded (the reconcile path is `withinDir`-bounded to
+`~/.agentsync`; RemoveHooks validates the native-supplied event id before
+touching a path). Anything that *writes content* dest→source still MUST go
+through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,14 +232,15 @@ Capture **refuses the whole write** rather than persist cleartext. It errs towar
 refusing; the user updates the vault or edits the canonical source directly.
 Two narrow **deletion-only** exceptions sit outside the funnel: `reconcile`'s
 `removeDroppedSource` (`internal/cli/reconcile.go`) unlinks a canonical
-`mcp/<id>.toml` when the user explicitly chooses `[w]rite-back` for a
-destination-side server deletion, and `source.RemoveHooks` deletes a stale
-`hooks/<event>.toml` during import's stale-hook retirement. Both are safe
-without Capture because a pure deletion carries no content to re-reference —
-there is no secret material to persist — and both are guarded (the reconcile
-path is keystroke-gated and `withinDir`-bounded to `~/.agentsync`; RemoveHooks
-validates the native-supplied event id before touching a path). Anything that
-*writes content* dest→source still MUST go through `capture.Capture`.
+`mcp/<id>.toml` when the user chooses write-back for a destination-side server
+deletion — a per-item `[w]`, a confirmed bulk `[W]`, or `--auto-writeback` —
+and `source.RemoveHooks` deletes a stale `hooks/<event>.toml` during import's
+stale-hook retirement. Both are safe without Capture because a pure deletion
+carries no content to re-reference — there is no secret material to persist —
+and both are guarded (the reconcile path runs only for that chosen write-back
+and is `withinDir`-bounded to `~/.agentsync`; RemoveHooks validates the
+native-supplied event id before touching a path). Anything that *writes
+content* dest→source still MUST go through `capture.Capture`.
 
 **3. Resolved vs templated types.** `secrets.SubstituteCanonical` returns
 `secrets.Resolved` (a wrapper, NOT assignable to `source.Canonical`); it is the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,8 +29,10 @@ can resolve secrets into native config files. Areas of particular interest:
   cannot verify the source's `${secret:…}` refs (the leak check would be blind),
   so a locked vault never silently degrades into persisting a credential. The
   only write-backs outside this path are two guarded pure *deletions* of
-  canonical files (reconcile's dest-dropped MCP-server removal, keystroke-gated
-  and path-bounded to `~/.agentsync`; import's stale-hook retirement) — a
+  canonical files (reconcile's dest-dropped MCP-server removal, which runs only
+  for a chosen write-back — per-item `[w]`, confirmed bulk `[W]`, or
+  `--auto-writeback` — and is path-bounded to `~/.agentsync`; import's
+  stale-hook retirement) — a
   deletion carries no secret content to persist, and anything that writes
   content back still goes through `capture.Capture`.
   The alternative `backend = "env"` stores nothing: `${secret:…}` resolves from

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,8 @@ can resolve secrets into native config files. Areas of particular interest:
   canonical files (reconcile's dest-dropped MCP-server removal, which runs only
   for a chosen write-back — per-item `[w]`, confirmed bulk `[W]`, or
   `--auto-writeback` — and is path-bounded to `~/.agentsync`; import's
-  stale-hook retirement) — a
-  deletion carries no secret content to persist, and anything that writes
-  content back still goes through `capture.Capture`.
+  stale-hook retirement) — a deletion carries no secret content to persist,
+  and anything that writes content back still goes through `capture.Capture`.
   The alternative `backend = "env"` stores nothing: `${secret:…}` resolves from
   the process environment at apply time, so there is no vault, no identity file
   and no decryption — the credential's protection is whatever protects the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -716,7 +716,8 @@ to `int64`/`float64` before writing. No other
 code path writes destination data back into the source. (Two guarded code paths
 *delete* canonical files without going through Capture: `reconcile`'s
 `removeDroppedSource` unlinks `mcp/<id>.toml` when the user writes back a
-destination-side server deletion — keystroke-gated, `withinDir`-bounded to
+destination-side server deletion — gated on that chosen write-back (a per-item
+`[w]`, a confirmed bulk `[W]`, or `--auto-writeback`), `withinDir`-bounded to
 `~/.agentsync` — and import's stale-hook retirement calls `source.RemoveHooks`
 on `hooks/<event>.toml`. A pure deletion carries no content to re-reference, so
 the funnel's secret guarantees are not in play; anything that writes *content*

--- a/docs/components.md
+++ b/docs/components.md
@@ -58,7 +58,7 @@ is the only package that depends on nearly all the others.
   `agentsync reconcile` pass (printer, scripted input, registry, loaded state,
   redaction map) plus its run-scoped bookkeeping, so the two prompts, the
   `--auto-*` dispatch, the action switch and the run's tail (`finish`) are
-  separately testable methods rather than five `goto`s over six loose locals
+  separately testable methods rather than five `goto`s over seven loose locals
   (#232); `finish` has exactly one call site and is never deferred, because it
   writes and it returns the run's error; `destReadPath` / `readDestText`
   (`destread.go`) — the whole-file destination readers that carry the symlink

--- a/docs/components.md
+++ b/docs/components.md
@@ -54,7 +54,13 @@ is the only package that depends on nearly all the others.
   behind `status`, `diff`, `reconcile` and `explain` (`planwalk.go`); its
   `planItem` is deliberately unexported field-for-field so it can never become
   a `--json` surface, because a plan built from `secrets.SubstituteCanonical`
-  carries resolved cleartext in `op.Content`; `destReadPath` / `readDestText`
+  carries resolved cleartext in `op.Content`; `reconcileSession` — one
+  `agentsync reconcile` pass (printer, scripted input, registry, loaded state,
+  redaction map) plus its run-scoped bookkeeping, so the two prompts, the
+  `--auto-*` dispatch, the action switch and the run's tail (`finish`) are
+  separately testable methods rather than five `goto`s over six loose locals
+  (#232); `finish` has exactly one call site and is never deferred, because it
+  writes and it returns the run's error; `destReadPath` / `readDestText`
   (`destread.go`) — the whole-file destination readers that carry the symlink
   policy (`AGENTSYNC_ALLOW_SYMLINK_DEST`), mirroring `iox.AtomicWrite`'s.
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,

--- a/internal/cli/apply_state_order_internal_test.go
+++ b/internal/cli/apply_state_order_internal_test.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -42,7 +39,7 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 	// The two halves are independent contracts; separate subtests so a Fatal
 	// in one never hides a failure in the other.
 	t.Run("pipeline loads state after the source reload", func(t *testing.T) {
-		applySrc := pkgSource(t, "apply.go")
+		applySrc := readFileForGuard(t, repoRootFromCaller(t), "internal/cli/apply.go")
 		body := funcBody(applySrc, "func runApplyPipeline(")
 		if body == "" {
 			t.Fatal("runApplyPipeline not found in apply.go — update this guard")
@@ -88,7 +85,7 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 		// The plugin re-apply must BE the pipeline, not a copy of it. The
 		// positive check and the four negatives are Errorf, not Fatal, so a
 		// hand-rolled re-apply reports every way it diverged in one run.
-		reapply := funcBody(pkgSource(t, "plugin_poll.go"), "func reapplyAfterPluginChange(")
+		reapply := funcBody(readFileForGuard(t, repoRootFromCaller(t), "internal/cli/plugin_poll.go"), "func reapplyAfterPluginChange(")
 		if reapply == "" {
 			t.Fatal("reapplyAfterPluginChange not found in plugin_poll.go — update this guard")
 		}
@@ -109,23 +106,6 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 
 // funcBody returns the source text of the function whose declaration starts
 // with decl, from the opening brace to the first line that is exactly "}".
-// pkgSource returns the text of a production source file in this package,
-// located from this test file's own path so the neutral cwd TestMain switches
-// to does not matter. The source-text guards read the code they pin through
-// it.
-func pkgSource(t *testing.T, name string) string {
-	t.Helper()
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), name))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(src)
-}
-
 func funcBody(src, decl string) string {
 	i := strings.Index(src, decl)
 	if i < 0 {

--- a/internal/cli/apply_state_order_internal_test.go
+++ b/internal/cli/apply_state_order_internal_test.go
@@ -39,20 +39,11 @@ import (
 // If this ever gains a genuine observable (a component the re-apply does not
 // re-record), replace half A with a test of that.
 func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(thisFile)
-
 	// The two halves are independent contracts; separate subtests so a Fatal
 	// in one never hides a failure in the other.
 	t.Run("pipeline loads state after the source reload", func(t *testing.T) {
-		applySrc, err := os.ReadFile(filepath.Join(dir, "apply.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		body := funcBody(string(applySrc), "func runApplyPipeline(")
+		applySrc := pkgSource(t, "apply.go")
+		body := funcBody(applySrc, "func runApplyPipeline(")
 		if body == "" {
 			t.Fatal("runApplyPipeline not found in apply.go — update this guard")
 		}
@@ -86,7 +77,7 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 		// The signature must not accept state either: a caller-supplied
 		// *state.Targets is read before this function runs, which has the same
 		// defect and is how the bug originally shipped.
-		sig := funcSignature(string(applySrc), "func runApplyPipeline(")
+		sig := funcSignature(applySrc, "func runApplyPipeline(")
 		if strings.Contains(sig, "*state.Targets") {
 			t.Errorf("runApplyPipeline takes a *state.Targets again: %s\n"+
 				"A caller reads it before the source reload that can rewrite it. Load it inside, after the reload.", sig)
@@ -97,11 +88,7 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 		// The plugin re-apply must BE the pipeline, not a copy of it. The
 		// positive check and the four negatives are Errorf, not Fatal, so a
 		// hand-rolled re-apply reports every way it diverged in one run.
-		pollSrc, err := os.ReadFile(filepath.Join(dir, "plugin_poll.go"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		reapply := funcBody(string(pollSrc), "func reapplyAfterPluginChange(")
+		reapply := funcBody(pkgSource(t, "plugin_poll.go"), "func reapplyAfterPluginChange(")
 		if reapply == "" {
 			t.Fatal("reapplyAfterPluginChange not found in plugin_poll.go — update this guard")
 		}
@@ -122,6 +109,23 @@ func TestApplyPipelineLoadsStateAfterSourceReload(t *testing.T) {
 
 // funcBody returns the source text of the function whose declaration starts
 // with decl, from the opening brace to the first line that is exactly "}".
+// pkgSource returns the text of a production source file in this package,
+// located from this test file's own path so the neutral cwd TestMain switches
+// to does not matter. The source-text guards read the code they pin through
+// it.
+func pkgSource(t *testing.T, name string) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(src)
+}
+
 func funcBody(src, decl string) string {
 	i := strings.Index(src, decl)
 	if i < 0 {

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -252,6 +252,7 @@ func explainRun(cmd *cobra.Command, rawPath, ptr string, jsonOut bool) error {
 		target:        target,
 		pointer:       ptr,
 		plan:          plan,
+		reg:           reg,
 		agents:        reg.Names(),
 		canonical:     c,
 		state:         s,

--- a/internal/cli/explain_model.go
+++ b/internal/cli/explain_model.go
@@ -18,10 +18,13 @@ import (
 // explainInputs bundles everything buildExplainModel needs, so the builder stays
 // a pure-ish function the tests can drive without a cobra command.
 type explainInputs struct {
-	fs            afero.Fs
-	target        string
-	pointer       string
-	plan          render.RenderPlan
+	fs      afero.Fs
+	target  string
+	pointer string
+	plan    render.RenderPlan
+	// reg is the registry the plan was rendered with; it resolves a renaming
+	// adapter's native hook-event spelling back to the canonical one.
+	reg           *adapter.Registry
 	agents        []string // registry order, for stable owner ordering
 	canonical     source.Canonical
 	state         *state.Targets
@@ -173,7 +176,7 @@ func fileItem(in explainInputs, it planItem, skips []adapter.Skip,
 func keyItem(in explainInputs, it planItem, skips []adapter.Skip, origins map[string]explainPluginOrigin,
 	secretRefs map[secrets.RefLocation][]string, hookEvents []string,
 ) explainItem {
-	kind, name := componentFromPointer(it.agent, it.ptr, hookEvents)
+	kind, name := componentFromPointer(in.reg, it.agent, it.ptr, hookEvents)
 
 	item := explainItem{
 		Pointer:    it.ptr,
@@ -245,7 +248,7 @@ func sourceOf(in explainInputs, srcID, kind string) *explainSource {
 // pointer shape (the mcp/lsp/hooks container families), falling back to the
 // op-level SourceID when the pointer names no single source.
 func pointerSource(in explainInputs, agent, ptr, opSourceID string, hookEvents []string) *explainSource {
-	abs := pointerSourceFile(in.srcHome, agent, ptr, hookEvents)
+	abs := pointerSourceFile(in.reg, in.srcHome, agent, ptr, hookEvents)
 	if abs == "" {
 		if opSourceID == "" {
 			return nil
@@ -297,7 +300,7 @@ func componentFromSourceID(srcID string) (kind, name string) {
 
 // componentFromPointer maps a NATIVE key-merge pointer to (kind, name), routing
 // hooks through the same canonical-event inversion reconcile's write-back uses.
-func componentFromPointer(agent, ptr string, hookEvents []string) (kind, name string) {
+func componentFromPointer(reg *adapter.Registry, agent, ptr string, hookEvents []string) (kind, name string) {
 	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
 	if len(parts) < 2 || parts[1] == "" {
 		return "", ""
@@ -308,7 +311,7 @@ func componentFromPointer(agent, ptr string, hookEvents []string) (kind, name st
 	case "lspServers", "lsp":
 		return "lsp", parts[1]
 	case "hooks":
-		if event, ok := canonicalHookEvent(agent, parts[1], hookEvents); ok {
+		if event, ok := canonicalHookEvent(reg, agent, parts[1], hookEvents); ok {
 			return "hook", event
 		}
 		return "hook", ""

--- a/internal/cli/planwalk_characterization_test.go
+++ b/internal/cli/planwalk_characterization_test.go
@@ -1090,6 +1090,7 @@ func TestPlanWalkCharacterization(t *testing.T) {
 				target:        tc.target(userHome),
 				pointer:       tc.pointer,
 				plan:          plan,
+				reg:           reg,
 				agents:        reg.Names(),
 				state:         s,
 				userHome:      userHome,

--- a/internal/cli/planwalk_internal_test.go
+++ b/internal/cli/planwalk_internal_test.go
@@ -623,6 +623,7 @@ func TestPathFilterFlagsSurviveAZeroItemOp(t *testing.T) {
 		fs:          afero.NewMemMapFs(),
 		target:      d,
 		plan:        plan,
+		reg:         registryFactory(),
 		agents:      names,
 		state:       state.New(),
 		userHome:    userHome,

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -98,6 +98,200 @@ first time. Rule of thumb: import adopts, reconcile resolves.`,
 	return cmd
 }
 
+// reconcileAction is the resolved outcome for one non-orphan item: what the
+// interactive prompt, a confirmed bulk choice, or an --auto-* mode decided to
+// do with it.
+//
+// Unlike adapter.Action, whose zero value is the valid common case (a write),
+// the zero value here is deliberately NOT an action — the adapter.SkipKind
+// convention, whose zero is likewise invalid. actionNone is the "nothing
+// decided yet" state both the unset bulk choice and "no --auto-* mode claimed
+// this item" need, so an unresolved item can never be mistaken for a resolved
+// one.
+// It replaces the byte the loop used to carry ('w'/'o'/'s'/'i'/'q', with a
+// `ch | 0x20` case fold open-coded at three sites); parseItemKey is now the one
+// place a keystroke becomes an action.
+type reconcileAction int
+
+const (
+	// actionNone is the zero value: no action chosen. It never reaches
+	// applyAction.
+	actionNone reconcileAction = iota
+	// actionWriteBack persists the destination value into the canonical source.
+	actionWriteBack
+	// actionOverride queues a re-apply of this item's op over the destination.
+	actionOverride
+	// actionSkip leaves the item alone.
+	actionSkip
+	// actionIgnore appends the item's label to ignore.toml.
+	actionIgnore
+	// actionQuit ends the pass; finish still runs.
+	actionQuit
+)
+
+// key is the lowercase hotkey that chooses the action. The bulk-confirm prompt
+// prints it ("apply 'w' to all N remaining items?"), so its spelling is
+// user-visible; 0 for actionNone, which is never printed.
+func (a reconcileAction) key() byte {
+	switch a {
+	case actionWriteBack:
+		return 'w'
+	case actionOverride:
+		return 'o'
+	case actionSkip:
+		return 's'
+	case actionIgnore:
+		return 'i'
+	case actionQuit:
+		return 'q'
+	}
+	return 0
+}
+
+// String is the Stringer form, kept for %v in test failure messages the way
+// adapter.Action's is; nothing in production prints an action's name (the
+// prompt prints key()).
+func (a reconcileAction) String() string {
+	switch a {
+	case actionNone:
+		return "none"
+	case actionWriteBack:
+		return "write-back"
+	case actionOverride:
+		return "override"
+	case actionSkip:
+		return "skip"
+	case actionIgnore:
+		return "ignore"
+	case actionQuit:
+		return "quit"
+	default:
+		return fmt.Sprintf("reconcileAction(%d)", int(a))
+	}
+}
+
+// parseItemKey maps one keystroke at the per-item prompt to what it means:
+// the action it chooses, whether it is the CAPITAL "apply to all remaining"
+// spelling, and whether it is [d]iff (which chooses no action and re-prompts).
+// ok is false for every other byte, which the prompt ignores and re-reads.
+//
+// The folding is deliberately NOT uniform, and that asymmetry is exactly what
+// the old `case 'w', 'W', 'o', 'O', 's', 'S', 'i', 'q', 'Q'` switch encoded by
+// omission: there is no bulk [i]gnore and no capital [D]iff, so 'I' and 'D' are
+// unknown keys. Case-folding every byte would silently add two accepted
+// keystrokes — one of them a bulk-ignore that has no confirmation path.
+func parseItemKey(ch byte) (act reconcileAction, bulk, diff, ok bool) {
+	switch ch {
+	case 'w':
+		return actionWriteBack, false, false, true
+	case 'W':
+		return actionWriteBack, true, false, true
+	case 'o':
+		return actionOverride, false, false, true
+	case 'O':
+		return actionOverride, true, false, true
+	case 's':
+		return actionSkip, false, false, true
+	case 'S':
+		return actionSkip, true, false, true
+	case 'i':
+		return actionIgnore, false, false, true
+	case 'q', 'Q':
+		return actionQuit, false, false, true
+	case 'd':
+		return actionNone, false, true, true
+	}
+	return actionNone, false, false, false
+}
+
+// reconcileAuto is the --auto-* mode for the run. At most one field is ever
+// set: reconcileRun rejects more than one before a session exists.
+type reconcileAuto struct {
+	writeBack bool // --auto-writeback
+	override  bool // --auto-override
+	safe      bool // --auto-safe
+}
+
+// active reports whether any auto mode is set, i.e. the run is not interactive.
+func (a reconcileAuto) active() bool { return a.writeBack || a.override || a.safe }
+
+// overrideOp is one item the user chose to [o]verride. finish re-applies ONLY
+// these ops, never the full plan — pressing [o] on one drifted item must not
+// silently re-apply every other item in the plan as a side effect.
+type overrideOp struct {
+	agentName string
+	op        adapter.FileOp
+}
+
+// reconcileSession is one `agentsync reconcile` pass: the wiring it was built
+// with (printer, input, registry, loaded state, scope, redaction map) and the
+// run-scoped bookkeeping the walk accumulates (the queued overrides, the bulk
+// choice, the three counters, the per-source write ledger).
+//
+// It exists because that bookkeeping used to travel as six loose locals inside
+// a 375-line reconcileRun whose only exits were five `goto done`s and two
+// labeled loops (issue #232). With the state on a receiver each phase — the two
+// prompts, the --auto-* dispatch, the action switch and the finish block — is a
+// method a test can drive directly, and every `goto done` is a plain return out
+// of walk with exactly one finish call site.
+//
+// It changes no dest→source write: [w]rite-back still runs through
+// writeBackItem → capture.Capture, and the one deletion-only exception
+// (removeDroppedSource) keeps its keystroke gate and its withinDir bound.
+type reconcileSession struct {
+	// --- wiring, fixed for the run ---
+	cmd *cobra.Command
+	p   *ui.Printer
+	// w is p.Out: the transcript every prompt, echo and result line writes to.
+	w  io.Writer
+	br *bufio.Reader
+	// reg is the adapter registry the plan was rendered with; finish looks up
+	// each override's adapter in it.
+	reg         *adapter.Registry
+	home        string // ~/.agentsync (canonical source root)
+	userHome    string
+	statePath   string
+	scope       adapter.Scope
+	projectRoot string
+	st          *state.Targets
+	auto        reconcileAuto
+	// hookEvents is the canonical hook-event vocabulary of the loaded model,
+	// computed once: it is the candidate set every hook pointer is inverted
+	// against, and the model cannot change mid-run.
+	hookEvents []string
+	// redact/canMask drive the prompt's masked value display: redact maps each
+	// resolved secret value back to its ${secret:…} placeholder, and canMask is
+	// false when some reference could not be resolved now — in which case the
+	// display falls back to SHA prefixes rather than risk printing a credential.
+	redact  map[string]string
+	canMask bool
+
+	// --- run-scoped bookkeeping ---
+	// bulk is the confirmed W/O/S choice applied to every remaining item;
+	// actionNone until the user confirms one.
+	bulk reconcileAction
+	// stateDirty tracks orphan removals so finish persists the pruned state.
+	stateDirty bool
+	// autoSkipped counts items an --auto-* mode left unresolved, so the run
+	// ends with a summary instead of silently doing nothing.
+	autoSkipped int
+	// writeBackFailed counts [w]rite-back attempts that errored. A failed
+	// write-back did NOT persist the user's dest edit, so the run must exit
+	// non-zero rather than report success (a scripted `reconcile --auto-writeback
+	// && deploy` must not proceed, and the next apply would clobber the edit).
+	writeBackFailed int
+	// writtenSources records, per canonical source file written this run, the
+	// bytes that landed — so a SECOND write-back to the same file (a server/skill
+	// that fanned out to multiple agents, each drifted differently) is detected
+	// instead of silently last-writer-wins clobbering the first.
+	writtenSources map[string][]byte
+	// overrideOps is the queue finish re-applies; dedupOverride keeps us from
+	// re-applying the same path twice when the user picks [o] for two pointers
+	// inside the same merge file.
+	overrideOps   []overrideOp
+	dedupOverride map[string]bool
+}
+
 func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool, agentsCSV string) error {
 	// The three auto modes are mutually exclusive — writeback (dest→source)
 	// and override (source→dest) are exact opposites, and silently accepting
@@ -105,18 +299,49 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	if n := b2i(autoWB) + b2i(autoOR) + b2i(autoSafe); n > 1 {
 		return fmt.Errorf("--auto-writeback, --auto-override, and --auto-safe are mutually exclusive; pass at most one")
 	}
+	s, items, err := newReconcileSession(cmd, in, reconcileAuto{writeBack: autoWB, override: autoOR, safe: autoSafe}, agentsCSV)
+	if err != nil {
+		return err
+	}
+	// No actionable items?
+	if !anyRequiresAction(items) {
+		fmt.Fprintln(s.w, "nothing to reconcile")
+		return nil
+	}
+	// walk returns no error: every way out of the loop — the last item, an EOF
+	// at either prompt, an EOF mid bulk-confirm, and [q]uit at either prompt —
+	// is a plain return that lands here, so finish has exactly ONE call site and
+	// still runs on every path that used to `goto done`.
+	//
+	// finish is deliberately NOT deferred. It WRITES (the override re-apply and
+	// the state save) and it returns the run's error: a defer would run those
+	// writes while a panic unwound, and would have to clobber or swallow the
+	// error of any future early return added above it.
+	s.walk(items)
+	return s.finish()
+}
+
+// newReconcileSession loads everything one reconcile pass works from and
+// returns the session plus the classified items (drift items first, then
+// orphans).
+//
+// The load order is preserved from the inline setup this replaced — source
+// before the printer, state before the registry, plan before the item
+// collection — because it is observable: which step fails decides which error
+// the user sees, and the printer does not exist yet when the source load fails.
+func newReconcileSession(cmd *cobra.Command, in io.Reader, auto reconcileAuto, agentsCSV string) (*reconcileSession, []reconcileItem, error) {
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	// Project plugins like apply does so drift classification covers
 	// plugin-managed components instead of reporting them as untracked.
 	c, sc, projectRoot, err := loadProjectedForScope(cmd, afero.NewOsFs(), home, false)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	p, err := newPrinter(cmd)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// Redaction map for the prompt/[d]iff value display. The destination content
@@ -132,9 +357,9 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	canMask := len(secrets.UnresolvedSecretRefs(&c, secBackend, envBackend)) == 0
 
 	statePath := filepath.Join(home, ".state", "targets.json")
-	s, err := state.Load(statePath)
+	st, err := state.Load(statePath)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	reg := registryFactory()
 	var agents []string
@@ -149,15 +374,15 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	if len(agents) > 0 {
 		sel, aerr := selectAgents(cmd, agents, enabled, agentsCSV)
 		if aerr != nil {
-			return aerr
+			return nil, nil, aerr
 		}
 		agents = sel
 	}
 	// reconcile hashes the rendered TEMPLATED source for drift; wrap as a
 	// render-only Resolved without substituting (no backend needed).
-	plan, err := render.Plan(secrets.ForRender(c), reg, agents, sc, projectRoot, s, userHome)
+	plan, err := render.Plan(secrets.ForRender(c), reg, agents, sc, projectRoot, st, userHome)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// Collect all items in order, then append orphaned whole-file dests
@@ -170,56 +395,47 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 	if sc == adapter.ScopeProject && c.Project != nil {
 		ownerSrc = *c.Project
 	}
-	items, orphans := collectReconcileItems(plan, reg, s, sc, projectRoot, userHome, pluginProvidedSourceIDs(ownerSrc))
+	items, orphans := collectReconcileItems(plan, reg, st, sc, projectRoot, userHome, pluginProvidedSourceIDs(ownerSrc))
 	items = append(items, orphans...)
 
-	w := p.Out
-	// stateDirty tracks orphan removals so we persist the pruned state at the end.
-	stateDirty := false
+	return &reconcileSession{
+		cmd:            cmd,
+		p:              p,
+		w:              p.Out,
+		br:             bufio.NewReader(in),
+		reg:            reg,
+		home:           home,
+		userHome:       userHome,
+		statePath:      statePath,
+		scope:          sc,
+		projectRoot:    projectRoot,
+		st:             st,
+		auto:           auto,
+		hookEvents:     canonicalHookEvents(c),
+		redact:         redact,
+		canMask:        canMask,
+		writtenSources: map[string][]byte{},
+		dedupOverride:  map[string]bool{},
+	}, items, nil
+}
 
-	// No actionable items?
-	needsPrompt := 0
+// anyRequiresAction reports whether the pass has anything to ask about: an item
+// whose class requires action, or an orphan (which has its own remove/keep
+// prompt). When it is false the run prints "nothing to reconcile" and stops
+// before the session's walk — nothing is queued, so there is nothing to finish.
+func anyRequiresAction(items []reconcileItem) bool {
 	for _, it := range items {
 		if requiresAction(it.cls) || it.orphan {
-			needsPrompt++
+			return true
 		}
 	}
-	if needsPrompt == 0 {
-		fmt.Fprintln(w, "nothing to reconcile")
-		return nil
-	}
+	return false
+}
 
-	// Track ops the user explicitly chose to override (re-apply source on
-	// top of dest). We re-apply ONLY these ops at the end, never the full
-	// plan — pressing [o] on one drifted item must not silently re-apply
-	// every other item in the plan as a side effect.
-	type overrideOp struct {
-		agentName string
-		op        adapter.FileOp
-	}
-	var overrideOps []overrideOp
-	// dedupOverride keeps us from re-applying the same path twice when the
-	// user picks [o] for two pointers inside the same merge file.
-	dedupOverride := map[string]bool{}
-
-	// bulkAction is set when user presses W/O/S to apply to all remaining items.
-	bulkAction := byte(0)
-	// autoSkipped counts items an --auto-* mode left unresolved, so the run
-	// ends with a summary instead of silently doing nothing.
-	autoSkipped := 0
-	// writeBackFailed counts [w]rite-back attempts that errored. A failed
-	// write-back did NOT persist the user's dest edit, so the run must exit
-	// non-zero rather than report success (a scripted `reconcile --auto-writeback
-	// && deploy` must not proceed, and the next apply would clobber the edit).
-	writeBackFailed := 0
-	// writtenSources records, per canonical source file written this run, the
-	// bytes that landed — so a SECOND write-back to the same file (a server/skill
-	// that fanned out to multiple agents, each drifted differently) is detected
-	// instead of silently last-writer-wins clobbering the first.
-	writtenSources := map[string][]byte{}
-
-	br := bufio.NewReader(in)
-
+// walk runs the pass over items, resolving each one through the bulk choice,
+// the --auto-* dispatch, or the interactive prompt. It returns as soon as the
+// user quits or the input ends; the caller then calls finish exactly once.
+func (s *reconcileSession) walk(items []reconcileItem) {
 	for idx := range items {
 		it := items[idx]
 		if !requiresAction(it.cls) && !it.orphan {
@@ -229,247 +445,296 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 		// Orphans get a dedicated delete/keep prompt — deletion is never done
 		// in an auto mode (too destructive to do non-interactively).
 		if it.orphan {
-			if autoWB || autoOR || autoSafe {
-				fmt.Fprintf(w, "orphan left in place (run `agentsync reconcile` interactively to remove): %s\n", ui.Sanitize(it.op.Path))
-				autoSkipped++
+			if s.auto.active() {
+				fmt.Fprintf(s.w, "orphan left in place (run `agentsync reconcile` interactively to remove): %s\n", ui.Sanitize(it.op.Path))
+				s.autoSkipped++
 				continue
 			}
-			fmt.Fprintf(w, "\n%s  (orphan — source no longer produces this file)\n", ui.Sanitize(it.op.Path))
-			// [k]eep is honest only for the kinds `apply` does NOT auto-reclaim.
-			// Skills, subagents, and commands are reclaimed on the next apply, so
-			// "keep" there means "keep until then" — say so rather than imply it
-			// is permanent.
-			//
-			// This asks the KIND question (OrphanIsReclaimable), not the
-			// readability one (OrphanDeleteWillProceed): a reclaimable orphan that
-			// happens to be unreadable right now is retried on every subsequent
-			// apply, so "until the next apply reclaims it" is still the truth for
-			// it. Using the readability predicate here would print the permanent
-			// wording for exactly the file apply keeps coming back to.
-			if render.OrphanIsReclaimable(it.op.SourceID) {
-				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep (until the next apply reclaims it)  [q]uit\n  > ")
-			} else {
-				fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep  [q]uit\n  > ")
-			}
-		orphanPrompt:
-			for {
-				ch, readErr := readChar(br)
-				if readErr != nil {
-					goto done // EOF → finish (persist any pruned state)
-				}
-				switch ch {
-				case 'r', 'R':
-					fmt.Fprintf(w, "%c\n", ch)
-					bk, berr := render.BackupFile(home, it.op.Path)
-					if berr != nil {
-						p.Fdiagf(w, ui.LevelError, "backup failed, NOT removing: %s", ui.Sanitize(berr.Error()))
-						break orphanPrompt
-					}
-					if bk != "" {
-						fmt.Fprintf(w, "  backup: %s\n", ui.Sanitize(bk))
-					}
-					if rmErr := os.Remove(it.op.Path); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:forbidigo // the one NATIVE-destination delete outside DestWriter: interactive orphan removal, safe only because render.BackupFile succeeded just above
-						p.Fdiagf(w, ui.LevelError, "remove failed: %s", ui.Sanitize(rmErr.Error()))
-						break orphanPrompt
-					}
-					pruneStateFilesForPath(s, userHome, it.op.Path)
-					stateDirty = true
-					fmt.Fprintf(w, "  removed: %s\n", ui.Sanitize(it.op.Path))
-					break orphanPrompt
-				case 'k', 'K':
-					fmt.Fprintf(w, "%c\n", ch)
-					fmt.Fprintf(w, "  kept: %s\n", ui.Sanitize(it.op.Path))
-					break orphanPrompt
-				case 'q', 'Q':
-					fmt.Fprintln(w, "quit")
-					goto done
-				default:
-					// ignore unknown key, re-read
-				}
+			if s.promptOrphan(it) {
+				return
 			}
 			continue
 		}
 
-		// Apply bulk action if set.
-		action := bulkAction
-		if action == 0 {
-			switch {
-			case autoWB:
-				// ForeignCollision is a never-applied pre-existing native
-				// file. Writing it back would overwrite the curated source
-				// with foreign content — the worst data-loss path. Refuse to
-				// do that non-interactively; leave it for an explicit choice.
-				switch {
-				case it.cls == drift.ForeignCollision:
-					fmt.Fprintf(w, "skipped (foreign-collision, would overwrite source): %s — resolve interactively\n", itemLabelDisp(it))
-					autoSkipped++
-					action = 's'
-				case it.pluginOwner != "":
-					// A plugin-provided component cannot be written back at all —
-					// it has no canonical file of its own. That refusal is
-					// STRUCTURAL and permanent, not a transient failure, so
-					// letting it count as a write-back FAILURE would make
-					// `reconcile --auto-writeback` exit non-zero on every run
-					// forever, breaking any `reconcile && deploy` until the user
-					// disables the plugin. Skip it like a foreign collision — the
-					// same "cannot be resolved non-interactively" shape.
-					fmt.Fprintf(w, "skipped (provided by plugin %q, no canonical file to write into): %s — use [o]verride, or change it upstream\n",
-						ui.Sanitize(it.pluginOwner), itemLabelDisp(it))
-					autoSkipped++
-					action = 's'
-				default:
-					action = 'w'
-				}
-			case autoOR:
-				action = 'o'
-			case autoSafe:
-				// auto-safe resolves nothing: everything that reaches this loop
-				// needs a human.
-				fmt.Fprintf(w, "skipped (needs manual review): %s (%s)\n", itemLabelDisp(it), it.cls)
-				autoSkipped++
-				action = 's'
+		// A confirmed bulk choice wins; otherwise an --auto-* mode may claim the
+		// item; otherwise ask.
+		action := s.bulk
+		if action == actionNone {
+			action = s.resolveAuto(it)
+		}
+		if action == actionNone {
+			var stop bool
+			action, stop = s.promptItem(it, items[idx:])
+			if stop {
+				return
 			}
 		}
-
-		if action == 0 {
-			// Interactive prompt.
-			label := itemLabelDisp(it)
-			fmt.Fprintf(w, "\n%s  (%s)\n", label, it.cls)
-			renderItemValues(w, p, it, redact, canMask)
-			fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
-
-		prompt:
-			for {
-				ch, readErr := readChar(br)
-				if readErr != nil {
-					// EOF → finish gracefully, but reach `done:` so any queued
-					// [o]verride ops are applied and pruned/dirty state is flushed
-					// (a bare `return nil` here dropped both — issue #171).
-					goto done
-				}
-				switch ch {
-				case 'w', 'W', 'o', 'O', 's', 'S', 'i', 'q', 'Q':
-					if ch == 'W' || ch == 'O' || ch == 'S' {
-						// Capital letter = "apply this choice to all
-						// remaining items." Confirm before locking it
-						// in — a stray shift-W on a hooks item used to
-						// silently no-op data away across the whole
-						// queue. Show the count and require an
-						// explicit y/N. Default is N.
-						//
-						// The count is the TRUE blast radius of this bulk action:
-						// the items from HERE forward it will actually act on —
-						// remaining actionable, non-orphan items (orphans have their
-						// own r/k prompt and are never swept by a bulk choice). The
-						// prior count walked the WHOLE queue including items already
-						// handled, overstating the reach.
-						remaining := 0
-						for j := idx; j < len(items); j++ {
-							if requiresAction(items[j].cls) && !items[j].orphan {
-								remaining++
-							}
-						}
-						lower := ch | 0x20
-						fmt.Fprintf(w, "%c\n", ch)
-						fmt.Fprintf(w, "  apply '%c' to all %d remaining items? [y/N] ", lower, remaining)
-						confirm, readErr := readChar(br)
-						if readErr != nil {
-							goto done // EOF mid-confirm → flush queued overrides + state (issue #171)
-						}
-						fmt.Fprintf(w, "%c\n", confirm)
-						if confirm != 'y' && confirm != 'Y' {
-							fmt.Fprintln(w, "  cancelled; choose a per-item action")
-							continue
-						}
-						bulkAction = lower
-						action = lower
-						break prompt
-					}
-					action = ch | 0x20
-					fmt.Fprintf(w, "%c\n", ch)
-					break prompt
-				case 'd':
-					printItemDiff(w, p, it, redact, canMask)
-					fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
-				default:
-					// ignore unknown key
-				}
-			}
-		}
-
-		switch action {
-		case 'w':
-			// write-back: persist destination value into the canonical source.
-			if attemptWriteBack(cmd, p, w, home, it, canonicalHookEvents(c), writtenSources) {
-				writeBackFailed++
-			}
-		case 'o':
-			// override: queue a re-apply of this item's op.
-			dedupKey := it.agentName + "\x00" + it.op.Path
-			if !dedupOverride[dedupKey] {
-				dedupOverride[dedupKey] = true
-				overrideOps = append(overrideOps, overrideOp{it.agentName, it.op})
-			}
-		case 's':
-			// skip: do nothing.
-		case 'i':
-			// ignore: append to ignore.toml (best-effort).
-			_ = appendIgnore(home, itemLabel(it))
-			fmt.Fprintf(w, "  ignored: %s\n", itemLabelDisp(it))
-		case 'q':
-			fmt.Fprintln(w, "quit")
-			goto done
+		if s.applyAction(it, action) {
+			return
 		}
 	}
+}
 
-done:
+// promptOrphan runs the remove/keep prompt for one orphaned destination and
+// reports whether the whole run must stop — the user pressed [q]uit, or the
+// input ended. Both land on the same finish the walk's other exits do, so a
+// removal already made this run is still persisted (issue #171).
+func (s *reconcileSession) promptOrphan(it reconcileItem) bool {
+	w := s.w
+	fmt.Fprintf(w, "\n%s  (orphan — source no longer produces this file)\n", ui.Sanitize(it.op.Path))
+	// [k]eep is honest only for the kinds `apply` does NOT auto-reclaim.
+	// Skills, subagents, and commands are reclaimed on the next apply, so
+	// "keep" there means "keep until then" — say so rather than imply it
+	// is permanent.
+	//
+	// This asks the KIND question (OrphanIsReclaimable), not the
+	// readability one (OrphanDeleteWillProceed): a reclaimable orphan that
+	// happens to be unreadable right now is retried on every subsequent
+	// apply, so "until the next apply reclaims it" is still the truth for
+	// it. Using the readability predicate here would print the permanent
+	// wording for exactly the file apply keeps coming back to.
+	if render.OrphanIsReclaimable(it.op.SourceID) {
+		fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep (until the next apply reclaims it)  [q]uit\n  > ")
+	} else {
+		fmt.Fprintf(w, "  [r]emove (backs up first)  [k]eep  [q]uit\n  > ")
+	}
+	for {
+		ch, readErr := readChar(s.br)
+		if readErr != nil {
+			return true // EOF → finish (persist any pruned state)
+		}
+		switch ch {
+		case 'r', 'R':
+			fmt.Fprintf(w, "%c\n", ch)
+			bk, berr := render.BackupFile(s.home, it.op.Path)
+			if berr != nil {
+				s.p.Fdiagf(w, ui.LevelError, "backup failed, NOT removing: %s", ui.Sanitize(berr.Error()))
+				return false
+			}
+			if bk != "" {
+				fmt.Fprintf(w, "  backup: %s\n", ui.Sanitize(bk))
+			}
+			if rmErr := os.Remove(it.op.Path); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:forbidigo // the one NATIVE-destination delete outside DestWriter: interactive orphan removal, safe only because render.BackupFile succeeded just above
+				s.p.Fdiagf(w, ui.LevelError, "remove failed: %s", ui.Sanitize(rmErr.Error()))
+				return false
+			}
+			pruneStateFilesForPath(s.st, s.userHome, it.op.Path)
+			s.stateDirty = true
+			fmt.Fprintf(w, "  removed: %s\n", ui.Sanitize(it.op.Path))
+			return false
+		case 'k', 'K':
+			fmt.Fprintf(w, "%c\n", ch)
+			fmt.Fprintf(w, "  kept: %s\n", ui.Sanitize(it.op.Path))
+			return false
+		case 'q', 'Q':
+			fmt.Fprintln(w, "quit")
+			return true
+		default:
+			// ignore unknown key, re-read
+		}
+	}
+}
+
+// resolveAuto is the --auto-* dispatch for one non-orphan item: the action the
+// mode chose, or actionNone when no mode is set and the item needs the
+// interactive prompt. The two refusals print their own line and count the skip,
+// because a refusal IS the mode's answer for that item.
+func (s *reconcileSession) resolveAuto(it reconcileItem) reconcileAction {
+	switch {
+	case s.auto.writeBack:
+		switch {
+		case it.cls == drift.ForeignCollision:
+			// ForeignCollision is a never-applied pre-existing native
+			// file. Writing it back would overwrite the curated source
+			// with foreign content — the worst data-loss path. Refuse to
+			// do that non-interactively; leave it for an explicit choice.
+			fmt.Fprintf(s.w, "skipped (foreign-collision, would overwrite source): %s — resolve interactively\n", itemLabelDisp(it))
+			s.autoSkipped++
+			return actionSkip
+		case it.pluginOwner != "":
+			// A plugin-provided component cannot be written back at all —
+			// it has no canonical file of its own. That refusal is
+			// STRUCTURAL and permanent, not a transient failure, so
+			// letting it count as a write-back FAILURE would make
+			// `reconcile --auto-writeback` exit non-zero on every run
+			// forever, breaking any `reconcile && deploy` until the user
+			// disables the plugin. Skip it like a foreign collision — the
+			// same "cannot be resolved non-interactively" shape.
+			fmt.Fprintf(s.w, "skipped (provided by plugin %q, no canonical file to write into): %s — use [o]verride, or change it upstream\n",
+				ui.Sanitize(it.pluginOwner), itemLabelDisp(it))
+			s.autoSkipped++
+			return actionSkip
+		default:
+			return actionWriteBack
+		}
+	case s.auto.override:
+		return actionOverride
+	case s.auto.safe:
+		// auto-safe resolves nothing: everything that reaches this loop
+		// needs a human.
+		fmt.Fprintf(s.w, "skipped (needs manual review): %s (%s)\n", itemLabelDisp(it), it.cls)
+		s.autoSkipped++
+		return actionSkip
+	}
+	return actionNone
+}
+
+// promptItem runs the per-item prompt and returns the action the user chose.
+// stop is true when the run must end without acting on this item: the input
+// ended at the prompt, or ended mid bulk-confirm — both reach finish so queued
+// [o]verride ops are applied and pruned state is flushed (issue #171).
+//
+// rest is the queue from this item forward; the bulk-confirm count is measured
+// over it. A confirmed bulk choice is recorded on the session, so every later
+// item skips this prompt entirely.
+func (s *reconcileSession) promptItem(it reconcileItem, rest []reconcileItem) (reconcileAction, bool) {
+	w := s.w
+	label := itemLabelDisp(it)
+	fmt.Fprintf(w, "\n%s  (%s)\n", label, it.cls)
+	renderItemValues(w, s.p, it, s.redact, s.canMask)
+	fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
+
+	for {
+		ch, readErr := readChar(s.br)
+		if readErr != nil {
+			return actionNone, true
+		}
+		act, bulk, diff, ok := parseItemKey(ch)
+		switch {
+		case !ok:
+			// ignore unknown key
+		case diff:
+			printItemDiff(w, s.p, it, s.redact, s.canMask)
+			fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
+		case bulk:
+			// Capital letter = "apply this choice to all
+			// remaining items." Confirm before locking it
+			// in — a stray shift-W on a hooks item used to
+			// silently no-op data away across the whole
+			// queue. Show the count and require an
+			// explicit y/N. Default is N.
+			remaining := bulkTargets(rest)
+			fmt.Fprintf(w, "%c\n", ch)
+			fmt.Fprintf(w, "  apply '%c' to all %d remaining items? [y/N] ", act.key(), remaining)
+			confirm, readErr := readChar(s.br)
+			if readErr != nil {
+				return actionNone, true
+			}
+			fmt.Fprintf(w, "%c\n", confirm)
+			if confirm != 'y' && confirm != 'Y' {
+				fmt.Fprintln(w, "  cancelled; choose a per-item action")
+				continue
+			}
+			s.bulk = act
+			return act, false
+		default:
+			fmt.Fprintf(w, "%c\n", ch)
+			return act, false
+		}
+	}
+}
+
+// bulkTargets is the TRUE blast radius of a bulk action chosen at the head of
+// rest: the items from HERE forward it will actually act on — remaining
+// actionable, non-orphan items, including the current one. Orphans have their
+// own r/k prompt and are never swept by a bulk choice. An earlier count walked
+// the WHOLE queue including items already handled, overstating the reach.
+func bulkTargets(rest []reconcileItem) int {
+	n := 0
+	for _, it := range rest {
+		if requiresAction(it.cls) && !it.orphan {
+			n++
+		}
+	}
+	return n
+}
+
+// applyAction performs the resolved action for one item and reports whether the
+// run must stop ([q]uit). It is the single place an action's meaning lives, so
+// the bulk, --auto-* and interactive paths cannot drift apart on what one does.
+func (s *reconcileSession) applyAction(it reconcileItem, action reconcileAction) bool {
+	switch action {
+	case actionWriteBack:
+		// write-back: persist destination value into the canonical source.
+		if s.attemptWriteBack(it) {
+			s.writeBackFailed++
+		}
+	case actionOverride:
+		// override: queue a re-apply of this item's op.
+		dedupKey := it.agentName + "\x00" + it.op.Path
+		if !s.dedupOverride[dedupKey] {
+			s.dedupOverride[dedupKey] = true
+			s.overrideOps = append(s.overrideOps, overrideOp{it.agentName, it.op})
+		}
+	case actionSkip:
+		// skip: do nothing.
+	case actionIgnore:
+		// ignore: append to ignore.toml (best-effort).
+		_ = appendIgnore(s.home, itemLabel(it))
+		fmt.Fprintf(s.w, "  ignored: %s\n", itemLabelDisp(it))
+	case actionQuit:
+		fmt.Fprintln(s.w, "quit")
+		return true
+	}
+	return false
+}
+
+// finish is the tail of every reconcile pass — the `done:` block the five
+// `goto done`s used to jump to. It re-applies the queued [o]verride ops,
+// persists state when an orphan removal pruned it, prints the unresolved
+// summary and decides the exit code.
+//
+// It has exactly one caller (reconcileRun, after walk returns) and is never
+// deferred: it writes and it returns the run's error.
+func (s *reconcileSession) finish() error {
+	w := s.w
 	// Execute override re-applies — ONLY for the ops the user opted into,
 	// grouped by adapter so each adapter sees its own ops. The previous
 	// implementation re-ran Apply for the entire plan, which silently
 	// re-applied every other agent's ops as a side effect.
-	if len(overrideOps) > 0 {
+	if len(s.overrideOps) > 0 {
 		byAgent := map[string][]adapter.FileOp{}
-		for _, oo := range overrideOps {
+		for _, oo := range s.overrideOps {
 			byAgent[oo.agentName] = append(byAgent[oo.agentName], oo.op)
 		}
 		for name, ops := range byAgent {
-			a := reg.Lookup(name)
+			a := s.reg.Lookup(name)
 			if a == nil {
 				return fmt.Errorf("reconcile override: adapter %q not registered", name)
 			}
-			rw := render.NewWriter(s, home, userHome, sc, projectRoot, name)
+			rw := render.NewWriter(s.st, s.home, s.userHome, s.scope, s.projectRoot, name)
 			if err := a.Apply(ops, rw); err != nil {
 				return fmt.Errorf("reconcile override apply %s: %w", name, err)
 			}
 			for _, r := range rw.Reports() {
 				fmt.Fprintf(w, "  backup: %s\n", r.String())
 			}
-			if err := render.RecordOpsState(s, userHome, name, sc, projectRoot, ops); err != nil {
+			if err := render.RecordOpsState(s.st, s.userHome, name, s.scope, s.projectRoot, ops); err != nil {
 				return err
 			}
 		}
-		if err := state.Save(statePath, s); err != nil {
+		if err := state.Save(s.statePath, s.st); err != nil {
 			return err
 		}
-		stateDirty = false // override save already persisted the pruned state
-		fmt.Fprintf(w, "override: applied %d item(s)\n", len(overrideOps))
+		s.stateDirty = false // override save already persisted the pruned state
+		fmt.Fprintf(w, "override: applied %d item(s)\n", len(s.overrideOps))
 	}
 
 	// Persist state if orphan removals pruned ownership and the override block
 	// above didn't already save.
-	if stateDirty {
-		if err := state.Save(statePath, s); err != nil {
+	if s.stateDirty {
+		if err := state.Save(s.statePath, s.st); err != nil {
 			return err
 		}
 	}
 
-	if autoSkipped > 0 {
-		fmt.Fprintf(w, "%d item(s) left unresolved; run `agentsync reconcile` interactively to handle them\n", autoSkipped)
+	if s.autoSkipped > 0 {
+		fmt.Fprintf(w, "%d item(s) left unresolved; run `agentsync reconcile` interactively to handle them\n", s.autoSkipped)
 	}
 	// A write-back that errored did NOT persist the edit; surface it as a
 	// non-zero exit so callers (and scripts) don't treat the sync as complete.
-	if writeBackFailed > 0 {
-		return fmt.Errorf("reconcile: %d item(s) failed to write back", writeBackFailed)
+	if s.writeBackFailed > 0 {
+		return fmt.Errorf("reconcile: %d item(s) failed to write back", s.writeBackFailed)
 	}
 	return nil
 }
@@ -796,36 +1061,37 @@ func readChar(r *bufio.Reader) (byte, error) {
 // file and this write changes it, revert to the first write and report a
 // conflict (counted as a failure → non-zero exit) for the user to resolve.
 // Returns true on failure/conflict.
-func attemptWriteBack(cmd *cobra.Command, p *ui.Printer, w io.Writer, home string, it reconcileItem, hookEvents []string, writtenSources map[string][]byte) bool {
-	srcFile := itemSourceFile(home, it, hookEvents)
+func (s *reconcileSession) attemptWriteBack(it reconcileItem) bool {
+	w := s.w
+	srcFile := s.itemSourceFile(it)
 	var prior []byte
 	priorWritten := false
 	if srcFile != "" {
-		prior, priorWritten = writtenSources[srcFile]
+		prior, priorWritten = s.writtenSources[srcFile]
 	}
-	werr := writeBackItem(cmd, home, it)
+	werr := writeBackItem(s.cmd, s.home, it)
 	if errors.Is(werr, errDestDroppedServer) {
 		// Tombstone: the user deleted this MCP server from the native config, and
 		// chose [w]rite-back to persist that. A pure deletion carries no secret, so
 		// remove the canonical mcp/<id>.toml directly (the same os.Remove primitive
 		// `mcp remove` uses) rather than routing an empty spec through capture.
-		return removeDroppedSource(p, w, home, it, srcFile, prior, priorWritten, writtenSources)
+		return s.removeDroppedSource(it, srcFile, prior, priorWritten)
 	}
 	if werr != nil {
-		p.Fdiagf(w, ui.LevelError, "write-back: %s", ui.Sanitize(werr.Error()))
+		s.p.Fdiagf(w, ui.LevelError, "write-back: %s", ui.Sanitize(werr.Error()))
 		return true
 	}
 	if srcFile != "" {
 		if after, rerr := os.ReadFile(srcFile); rerr == nil {
 			if priorWritten && string(prior) != string(after) {
 				revertSource(srcFile, prior) // undo this write; keep the first
-				rel, _ := filepath.Rel(home, srcFile)
+				rel, _ := filepath.Rel(s.home, srcFile)
 				fmt.Fprintf(w, "  conflict: %s — another agent drifted the same source (%s) to a different "+
 					"value this run; kept the first write and skipped this one. Make the agents agree, or "+
 					"reconcile one at a time, then re-run.\n", itemLabelDisp(it), ui.Sanitize(rel))
 				return true
 			}
-			writtenSources[srcFile] = after
+			s.writtenSources[srcFile] = after
 		}
 	}
 	fmt.Fprintf(w, "  write-back: %s\n", itemLabelDisp(it))
@@ -841,30 +1107,31 @@ func attemptWriteBack(cmd *cobra.Command, p *ui.Printer, w io.Writer, home strin
 // (nil bytes) in writtenSources so a LATER content write-back to the same file
 // this run is likewise flagged rather than silently resurrecting it. Returns true
 // on failure/conflict.
-func removeDroppedSource(p *ui.Printer, w io.Writer, home string, it reconcileItem, srcFile string, prior []byte, priorWritten bool, writtenSources map[string][]byte) bool {
+func (s *reconcileSession) removeDroppedSource(it reconcileItem, srcFile string, prior []byte, priorWritten bool) bool {
+	w := s.w
 	if srcFile == "" {
-		p.Fdiagf(w, ui.LevelError, "write-back: %s — cannot locate the canonical source file to delete", itemLabelDisp(it))
+		s.p.Fdiagf(w, ui.LevelError, "write-back: %s — cannot locate the canonical source file to delete", itemLabelDisp(it))
 		return true
 	}
 	// Defense-in-depth: srcFile derives from a native-config-supplied server id;
 	// never let a traversal segment escape ~/.agentsync into an arbitrary unlink.
-	if !withinDir(home, srcFile) {
-		p.Fdiagf(w, ui.LevelError, "write-back: %s — refusing to delete outside the source tree", itemLabelDisp(it))
+	if !withinDir(s.home, srcFile) {
+		s.p.Fdiagf(w, ui.LevelError, "write-back: %s — refusing to delete outside the source tree", itemLabelDisp(it))
 		return true
 	}
 	if priorWritten && len(prior) > 0 {
-		rel, _ := filepath.Rel(home, srcFile)
-		p.Fdiagf(w, ui.LevelError, "conflict: %s — another agent wrote this source (%s) this run, so it is still in use; "+
+		rel, _ := filepath.Rel(s.home, srcFile)
+		s.p.Fdiagf(w, ui.LevelError, "conflict: %s — another agent wrote this source (%s) this run, so it is still in use; "+
 			"not deleting it. Make the agents agree (remove it from every native config), then re-run.",
 			itemLabelDisp(it), ui.Sanitize(rel))
 		return true
 	}
 	if rmErr := os.Remove(srcFile); rmErr != nil && !os.IsNotExist(rmErr) { //nolint:forbidigo // removes a canonical source file under ~/.agentsync (withinDir-guarded above), not a native destination
-		p.Fdiagf(w, ui.LevelError, "write-back: remove %s: %s", itemLabelDisp(it), ui.Sanitize(rmErr.Error()))
+		s.p.Fdiagf(w, ui.LevelError, "write-back: remove %s: %s", itemLabelDisp(it), ui.Sanitize(rmErr.Error()))
 		return true
 	}
-	writtenSources[srcFile] = nil // deletion sentinel for a later same-file write
-	rel, _ := filepath.Rel(home, srcFile)
+	s.writtenSources[srcFile] = nil // deletion sentinel for a later same-file write
+	rel, _ := filepath.Rel(s.home, srcFile)
 	fmt.Fprintf(w, "  write-back: removed source %s (destination dropped %s)\n", ui.Sanitize(rel), itemLabelDisp(it))
 	return false
 }
@@ -884,14 +1151,14 @@ func revertSource(srcFile string, prior []byte) {
 // targets, so two agents writing the same component can be detected. Both the
 // claude (/mcpServers/<id>) and opencode (/mcp/<id>) pointers map to the SAME
 // mcp/<id>.toml. Returns "" for items with no single source-of-record.
-func itemSourceFile(home string, it reconcileItem, hookEvents []string) string {
+func (s *reconcileSession) itemSourceFile(it reconcileItem) string {
 	if it.ptr == "" {
 		if it.op.SourceID == "" || strings.HasSuffix(it.op.SourceID, "(multiple)") {
 			return ""
 		}
-		return filepath.Join(home, it.op.SourceID)
+		return filepath.Join(s.home, it.op.SourceID)
 	}
-	return pointerSourceFile(home, it.agentName, it.ptr, hookEvents)
+	return pointerSourceFile(s.home, it.agentName, it.ptr, s.hookEvents)
 }
 
 // pointerSourceFile maps a NATIVE key-merge JSON pointer back to the canonical

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -110,7 +110,7 @@ first time. Rule of thumb: import adopts, reconcile resolves.`,
 // this item" need, so an unresolved item can never be mistaken for a resolved
 // one.
 // It replaces the byte the loop used to carry ('w'/'o'/'s'/'i'/'q', with a
-// `ch | 0x20` case fold open-coded at three sites); parseItemKey is now the one
+// `ch | 0x20` case fold open-coded at two sites); parseItemKey is now the one
 // place a keystroke becomes an action.
 type reconcileAction int
 
@@ -1059,9 +1059,6 @@ func readChar(r *bufio.Reader) (byte, error) {
 	}
 }
 
-// writeBackItem persists the current destination value for item it back into
-// the canonical source (~/.agentsync/). Only MCP-server items are fully
-// supported in v1; other item types fall back to a raw file copy.
 // attemptWriteBack writes one item back and guards against silent
 // last-writer-wins when a single reconcile run writes the SAME canonical source
 // file from more than one agent. A server/skill that fans out to claude AND
@@ -1274,6 +1271,9 @@ func canonicalHookEvents(c source.Canonical) []string {
 	return out
 }
 
+// writeBackItem persists the current destination value for item it back into
+// the canonical source (~/.agentsync/). Only MCP-server items are fully
+// supported in v1; other item types fall back to a raw file copy.
 func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 	// A plugin-provided component has no canonical file of its own: it is
 	// re-derived from the plugin cache on every load. Writing the destination
@@ -1337,7 +1337,8 @@ func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
 		specRaw, ok := mcpServers[serverID]
 		if !ok {
 			// Server removed from dest: the user deleted it from the native
-			// config and chose [w]rite-back to persist that. Signal a tombstone;
+			// config and chose write-back (per-item [w], confirmed bulk [W], or
+			// --auto-writeback) to persist that. Signal a tombstone;
 			// attemptWriteBack deletes the canonical mcp/<id>.toml through the
 			// approved os.Remove funnel (a pure deletion carries no secret), with
 			// the multi-agent fan-out guard.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -588,8 +588,9 @@ func (s *reconcileSession) resolveAuto(it reconcileItem) reconcileAction {
 	return actionNone
 }
 
-// itemMenu is the per-item prompt's menu line. promptItem prints it before the
-// first read and again after [d]iff; one spelling keeps the two sites in step.
+// itemMenu is the per-item menu line and the "> " prompt that follows it.
+// promptItem prints it before the first read and again after [d]iff; one
+// spelling keeps the two sites in step.
 const itemMenu = "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > "
 
 // promptItem runs the per-item prompt and returns the action the user chose.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -246,7 +246,8 @@ type reconcileSession struct {
 	w  io.Writer
 	br *bufio.Reader
 	// reg is the adapter registry the plan was rendered with; finish looks up
-	// each override's adapter in it.
+	// each override's adapter in it, and it resolves a hook pointer's native
+	// event spelling on write-back, so no per-item registry rebuild is needed.
 	reg         *adapter.Registry
 	home        string // ~/.agentsync (canonical source root)
 	userHome    string
@@ -1154,7 +1155,7 @@ func (s *reconcileSession) itemSourceFile(it reconcileItem) string {
 		}
 		return filepath.Join(s.home, it.op.SourceID)
 	}
-	return pointerSourceFile(s.home, it.agentName, it.ptr, s.hookEvents)
+	return pointerSourceFile(s.reg, s.home, it.agentName, it.ptr, s.hookEvents)
 }
 
 // pointerSourceFile maps a NATIVE key-merge JSON pointer back to the canonical
@@ -1174,8 +1175,11 @@ func (s *reconcileSession) itemSourceFile(it reconcileItem) string {
 // comes from one of them, so scanning that set is both sufficient and free of a
 // second, drift-prone enumeration of the event vocabulary.
 //
+// reg is the caller's own registry — reconcile's session, explain's — so the
+// inversion costs a map lookup instead of rebuilding all 31 adapters per call.
+//
 // Returns "" when the pointer names no single canonical source-of-record.
-func pointerSourceFile(home, agent, ptr string, canonicalEvents []string) string {
+func pointerSourceFile(reg *adapter.Registry, home, agent, ptr string, canonicalEvents []string) string {
 	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
 	if len(parts) < 2 || parts[1] == "" {
 		return ""
@@ -1186,7 +1190,7 @@ func pointerSourceFile(home, agent, ptr string, canonicalEvents []string) string
 	case "lspServers", "lsp":
 		return filepath.Join(home, "lsp", parts[1]+".toml")
 	case "hooks":
-		event, ok := canonicalHookEvent(agent, parts[1], canonicalEvents)
+		event, ok := canonicalHookEvent(reg, agent, parts[1], canonicalEvents)
 		if !ok {
 			return ""
 		}
@@ -1200,8 +1204,24 @@ func pointerSourceFile(home, agent, ptr string, canonicalEvents []string) string
 // codex — no HookEventNamer) passes the segment through. A renaming adapter is
 // inverted by asking it for the native spelling of each candidate canonical
 // event; ok is false when nothing matches.
-func canonicalHookEvent(agent, native string, canonicalEvents []string) (string, bool) {
-	namer, ok := registryFactory().Lookup(agent).(adapter.HookEventNamer)
+//
+// reg is the CALLER's registry (reconcile's session, explain's), not a fresh
+// registryFactory() per call: that spelling rebuilt all 31 adapters every time
+// a hook pointer was resolved (measured: ~10µs per call, building 31
+// adapters). Registry.Lookup returns a nil adapter.Adapter for an unregistered
+// name, and a comma-ok type assertion on a nil interface yields (nil, false)
+// rather than panicking, so an unknown agent is treated as non-renaming and
+// passes the segment through — unchanged from the registryFactory() spelling,
+// which had exactly the same contents.
+//
+// The precondition is a non-nil reg — every production caller holds one — but
+// Registry.Lookup dereferences its receiver, so a nil *Registry is guarded here
+// and treated exactly like an unregistered agent: the non-renaming passthrough.
+func canonicalHookEvent(reg *adapter.Registry, agent, native string, canonicalEvents []string) (string, bool) {
+	if reg == nil {
+		return native, true
+	}
+	namer, ok := reg.Lookup(agent).(adapter.HookEventNamer)
 	if !ok {
 		return native, true
 	}

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -588,6 +588,10 @@ func (s *reconcileSession) resolveAuto(it reconcileItem) reconcileAction {
 	return actionNone
 }
 
+// itemMenu is the per-item prompt's menu line. promptItem prints it before the
+// first read and again after [d]iff; one spelling keeps the two sites in step.
+const itemMenu = "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > "
+
 // promptItem runs the per-item prompt and returns the action the user chose.
 // stop is true when the run must end without acting on this item: the input
 // ended at the prompt, or ended mid bulk-confirm — both reach finish so queued
@@ -601,7 +605,7 @@ func (s *reconcileSession) promptItem(it reconcileItem, rest []reconcileItem) (r
 	label := itemLabelDisp(it)
 	fmt.Fprintf(w, "\n%s  (%s)\n", label, it.cls)
 	renderItemValues(w, s.p, it, s.redact, s.canMask)
-	fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
+	fmt.Fprint(w, itemMenu)
 
 	for {
 		ch, readErr := readChar(s.br)
@@ -614,7 +618,7 @@ func (s *reconcileSession) promptItem(it reconcileItem, rest []reconcileItem) (r
 			// ignore unknown key
 		case diff:
 			renderItemValues(w, s.p, it, s.redact, s.canMask)
-			fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
+			fmt.Fprint(w, itemMenu)
 		case bulk:
 			// Capital letter = "apply this choice to all
 			// remaining items." Confirm before locking it

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -240,9 +240,9 @@ type overrideOp struct {
 //
 // It changes no dest→source write: [w]rite-back still runs through
 // writeBackItem → capture.Capture, and the one deletion-only exception
-// (removeDroppedSource) keeps its gate — it runs only for a chosen write-back,
-// interactive [w] or --auto-writeback, whose destination dropped the server —
-// and its withinDir bound.
+// (removeDroppedSource) keeps its gate — it runs only for a chosen write-back
+// (a per-item [w], a confirmed bulk [W], or --auto-writeback) whose destination
+// dropped the server — and its withinDir bound.
 type reconcileSession struct {
 	// --- wiring, fixed for the run ---
 	cmd *cobra.Command

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -604,7 +604,7 @@ func (s *reconcileSession) promptItem(it reconcileItem, rest []reconcileItem) (r
 		case !ok:
 			// ignore unknown key
 		case diff:
-			printItemDiff(w, s.p, it, s.redact, s.canMask)
+			renderItemValues(w, s.p, it, s.redact, s.canMask)
 			fmt.Fprintf(w, "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > ")
 		case bulk:
 			// Capital letter = "apply this choice to all
@@ -1029,10 +1029,6 @@ func renderItemValues(w io.Writer, p *ui.Printer, it reconcileItem, redact map[s
 	for _, line := range strings.Split(renderDiffText(p, diffs), "\n") {
 		fmt.Fprintf(w, "  %s\n", line)
 	}
-}
-
-func printItemDiff(w io.Writer, p *ui.Printer, it reconcileItem, redact map[string]string, canMask bool) {
-	renderItemValues(w, p, it, redact, canMask)
 }
 
 // readChar reads a single non-whitespace character from r.

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -206,7 +206,9 @@ func parseItemKey(ch byte) (act reconcileAction, bulk, diff, ok bool) {
 
 // reconcileAuto is the --auto-* mode for the run. At most one field is ever
 // set: newReconcileSession rejects more than one as its first step, before it
-// loads anything, so no session with two modes can exist.
+// loads anything, so no session it builds can carry two modes. (A struct
+// literal bypasses that check; the session tests build one and set at most one
+// mode.)
 type reconcileAuto struct {
 	writeBack bool // --auto-writeback
 	override  bool // --auto-override

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -61,7 +61,8 @@ type reconcileItem struct {
 // native config. attemptWriteBack turns it into a guarded deletion of the
 // canonical mcp/<id>.toml: a pure deletion carries no secret to re-reference, so
 // os.Remove (the same primitive `mcp remove` uses) is the approved funnel, and it
-// runs only when the user explicitly chose [w]rite-back for that item.
+// runs only for a chosen write-back on that item — a per-item [w], a confirmed
+// bulk [W], or --auto-writeback.
 var errDestDroppedServer = errors.New("destination dropped server")
 
 func newReconcileCmd() *cobra.Command {
@@ -1082,7 +1083,8 @@ func (s *reconcileSession) attemptWriteBack(it reconcileItem) bool {
 	werr := writeBackItem(s.cmd, s.home, it)
 	if errors.Is(werr, errDestDroppedServer) {
 		// Tombstone: the user deleted this MCP server from the native config, and
-		// chose [w]rite-back to persist that. A pure deletion carries no secret, so
+		// chose write-back (per-item [w], confirmed bulk [W], or --auto-writeback)
+		// to persist that. A pure deletion carries no secret, so
 		// remove the canonical mcp/<id>.toml directly (the same os.Remove primitive
 		// `mcp remove` uses) rather than routing an empty spec through capture.
 		return s.removeDroppedSource(it, srcFile, prior, priorWritten)

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -205,7 +205,8 @@ func parseItemKey(ch byte) (act reconcileAction, bulk, diff, ok bool) {
 }
 
 // reconcileAuto is the --auto-* mode for the run. At most one field is ever
-// set: reconcileRun rejects more than one before a session exists.
+// set: newReconcileSession rejects more than one as its first step, before it
+// loads anything, so no session with two modes can exist.
 type reconcileAuto struct {
 	writeBack bool // --auto-writeback
 	override  bool // --auto-override
@@ -228,7 +229,7 @@ type overrideOp struct {
 // run-scoped bookkeeping the walk accumulates (the queued overrides, the bulk
 // choice, the three counters, the per-source write ledger).
 //
-// It exists because that bookkeeping used to travel as six loose locals inside
+// It exists because that bookkeeping used to travel as seven loose locals inside
 // a 375-line reconcileRun whose only exits were five `goto done`s and two
 // labeled loops (issue #232). With the state on a receiver each phase — the two
 // prompts, the --auto-* dispatch, the action switch and the finish block — is a
@@ -237,7 +238,9 @@ type overrideOp struct {
 //
 // It changes no dest→source write: [w]rite-back still runs through
 // writeBackItem → capture.Capture, and the one deletion-only exception
-// (removeDroppedSource) keeps its keystroke gate and its withinDir bound.
+// (removeDroppedSource) keeps its gate — it runs only for a chosen write-back,
+// interactive [w] or --auto-writeback, whose destination dropped the server —
+// and its withinDir bound.
 type reconcileSession struct {
 	// --- wiring, fixed for the run ---
 	cmd *cobra.Command
@@ -294,12 +297,6 @@ type reconcileSession struct {
 }
 
 func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe bool, agentsCSV string) error {
-	// The three auto modes are mutually exclusive — writeback (dest→source)
-	// and override (source→dest) are exact opposites, and silently accepting
-	// both (writeback won) was a data-loss footgun.
-	if n := b2i(autoWB) + b2i(autoOR) + b2i(autoSafe); n > 1 {
-		return fmt.Errorf("--auto-writeback, --auto-override, and --auto-safe are mutually exclusive; pass at most one")
-	}
 	s, items, err := newReconcileSession(cmd, in, reconcileAuto{writeBack: autoWB, override: autoOR, safe: autoSafe}, agentsCSV)
 	if err != nil {
 		return err
@@ -331,6 +328,15 @@ func reconcileRun(cmd *cobra.Command, in io.Reader, autoWB, autoOR, autoSafe boo
 // collection — because it is observable: which step fails decides which error
 // the user sees, and the printer does not exist yet when the source load fails.
 func newReconcileSession(cmd *cobra.Command, in io.Reader, auto reconcileAuto, agentsCSV string) (*reconcileSession, []reconcileItem, error) {
+	// The three auto modes are mutually exclusive — writeback (dest→source)
+	// and override (source→dest) are exact opposites, and silently accepting
+	// both (writeback won) was a data-loss footgun. The check is the
+	// constructor's, not the caller's, so the invariant reconcileAuto's doc
+	// states is enforced where a session is built: resolveAuto's switch would
+	// otherwise let writeBack win again for a hand-built session.
+	if n := b2i(auto.writeBack) + b2i(auto.override) + b2i(auto.safe); n > 1 {
+		return nil, nil, fmt.Errorf("--auto-writeback, --auto-override, and --auto-safe are mutually exclusive; pass at most one")
+	}
 	home := paths.AgentsyncHome(paths.OSEnv{})
 	userHome := paths.HomeDir(paths.OSEnv{})
 	// Project plugins like apply does so drift classification covers
@@ -1215,11 +1221,15 @@ func pointerSourceFile(reg *adapter.Registry, home, agent, ptr string, canonical
 // which had exactly the same contents.
 //
 // The precondition is a non-nil reg — every production caller holds one — but
-// Registry.Lookup dereferences its receiver, so a nil *Registry is guarded here
-// and treated exactly like an unregistered agent: the non-renaming passthrough.
+// Registry.Lookup dereferences its receiver, so a nil *Registry is guarded here.
+// It resolves NOTHING (ok is false) rather than passing the segment through: a
+// caller that forgot its registry would otherwise get a plausible wrong answer
+// (gemini's /hooks/BeforeTool as hooks/BeforeTool.toml) that no test could tell
+// from a right one, whereas "no source" is visibly incomplete in explain and
+// leaves reconcile's write-back no file to touch.
 func canonicalHookEvent(reg *adapter.Registry, agent, native string, canonicalEvents []string) (string, bool) {
 	if reg == nil {
-		return native, true
+		return "", false
 	}
 	namer, ok := reg.Lookup(agent).(adapter.HookEventNamer)
 	if !ok {

--- a/internal/cli/reconcile_hookevent_internal_test.go
+++ b/internal/cli/reconcile_hookevent_internal_test.go
@@ -19,8 +19,9 @@ import (
 //     nil-safe only by Go's assertion semantics, never by an explicit guard, and
 //     nothing asserted it.
 //   - a NIL registry is guarded explicitly (Registry.Lookup dereferences its
-//     receiver) and takes that same passthrough; the precondition is a non-nil
-//     registry, and the guard is what a caller that forgot to set one gets.
+//     receiver) and resolves nothing: the precondition is a non-nil registry,
+//     and a caller that forgot to set one gets "no source" rather than the
+//     plausible wrong path a passthrough would hand it.
 //
 // The renaming rows are the ones that must keep working: a gemini
 // `/hooks/BeforeTool` pointer has to resolve to hooks/PreToolUse.toml, or
@@ -45,7 +46,7 @@ func TestCanonicalHookEvent(t *testing.T) {
 		{name: "renaming agent, unknown native spelling", agent: "gemini", native: "NoSuchEvent"},
 		{name: "unregistered agent passes through", agent: "no-such-agent", native: "PreToolUse", want: "PreToolUse", wantOK: true},
 		{name: "empty agent passes through", agent: "", native: "PreToolUse", want: "PreToolUse", wantOK: true},
-		{name: "nil registry passes through", nilReg: true, agent: "gemini", native: "BeforeTool", want: "BeforeTool", wantOK: true},
+		{name: "nil registry resolves nothing", nilReg: true, agent: "gemini", native: "BeforeTool"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/reconcile_hookevent_internal_test.go
+++ b/internal/cli/reconcile_hookevent_internal_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+// TestCanonicalHookEvent pins the inversion contract at the moment it stopped
+// building its own registry (#232). Passing the caller's registry cannot change
+// the answer — it is the same registryFactory() product either way — but the
+// old spelling made two facts implicit that the table below makes explicit:
+//
+//   - a NON-renaming adapter (claude, codex: no HookEventNamer) passes the
+//     native segment straight through, because the comma-ok assertion fails; and
+//   - an UNREGISTERED agent takes exactly the same branch, because
+//     Registry.Lookup returns a nil adapter.Adapter and a comma-ok assertion on
+//     a nil interface yields (nil, false) rather than panicking. That was
+//     nil-safe only by Go's assertion semantics, never by an explicit guard, and
+//     nothing asserted it.
+//   - a NIL registry is guarded explicitly (Registry.Lookup dereferences its
+//     receiver) and takes that same passthrough; the precondition is a non-nil
+//     registry, and the guard is what a caller that forgot to set one gets.
+//
+// The renaming rows are the ones that must keep working: a gemini
+// `/hooks/BeforeTool` pointer has to resolve to hooks/PreToolUse.toml, or
+// reconcile's write-back and `explain <path>#<pointer>` name a file that does
+// not exist.
+func TestCanonicalHookEvent(t *testing.T) {
+	reg := registryFactory()
+	events := []string{"PreToolUse", "PostToolUse"}
+
+	tests := []struct {
+		name   string
+		nilReg bool // pass a nil *Registry instead of reg
+		agent  string
+		native string
+		want   string
+		wantOK bool
+	}{
+		{name: "claude does not rename", agent: "claude", native: "PreToolUse", want: "PreToolUse", wantOK: true},
+		{name: "codex does not rename", agent: "codex", native: "PostToolUse", want: "PostToolUse", wantOK: true},
+		{name: "gemini renames", agent: "gemini", native: "BeforeTool", want: "PreToolUse", wantOK: true},
+		{name: "cursor renames", agent: "cursor", native: "preToolUse", want: "PreToolUse", wantOK: true},
+		{name: "renaming agent, unknown native spelling", agent: "gemini", native: "NoSuchEvent"},
+		{name: "unregistered agent passes through", agent: "no-such-agent", native: "PreToolUse", want: "PreToolUse", wantOK: true},
+		{name: "empty agent passes through", agent: "", native: "PreToolUse", want: "PreToolUse", wantOK: true},
+		{name: "nil registry passes through", nilReg: true, agent: "gemini", native: "BeforeTool", want: "BeforeTool", wantOK: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := reg
+			if tc.nilReg {
+				r = nil
+			}
+			got, ok := canonicalHookEvent(r, tc.agent, tc.native, events)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("canonicalHookEvent(%q, %q) = (%q, %v), want (%q, %v)",
+					tc.agent, tc.native, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestCanonicalHookEvent_UnregisteredLookupIsNil is the half of the above the
+// table cannot show: WHY an unregistered agent is safe. If Lookup ever returned
+// a non-nil zero adapter, the comma-ok assertion could start succeeding and the
+// passthrough row above would silently change meaning.
+func TestCanonicalHookEvent_UnregisteredLookupIsNil(t *testing.T) {
+	a := registryFactory().Lookup("no-such-agent")
+	if a != nil {
+		t.Fatalf("Registry.Lookup of an unregistered name = %T, want a nil adapter.Adapter: "+
+			"canonicalHookEvent's passthrough depends on the comma-ok assertion failing", a)
+	}
+	if _, ok := a.(adapter.HookEventNamer); ok {
+		t.Fatal("the comma-ok assertion on Lookup's nil result reported ok=true")
+	}
+}

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -2,8 +2,12 @@ package cli
 
 import (
 	"bufio"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/drift"
@@ -27,10 +31,15 @@ import (
 // transcript. Only the fields the prompt/walk path reads are set; home, st and
 // reg are deliberately left zero, which bounds what these tests may drive: the
 // actions exercised below are [s]kip (a no-op), [o]verride (appends to
-// overrideOps and marks dedupOverride) and [q]uit (prints). [w]rite-back and
-// [i]gnore need a real ~/.agentsync and
-// are covered end to end in reconcile_test.go instead — driving them from here
-// would write relative to the test's working directory.
+// overrideOps and marks dedupOverride), [q]uit (prints) and, with home pointed
+// at a temp dir, [i]gnore (appends to ignore.toml under it). [w]rite-back needs
+// a real ~/.agentsync, a plan and a destination and is covered end to end in
+// reconcile_test.go instead. Two more arms would PANIC on this session rather
+// than misbehave, which is what bounds the orphan and override tests: the
+// orphan [r]emove arm (pruneStateFilesForPath on a nil st) and finish with a
+// queued override (Registry.Lookup on a nil reg) — so the orphan tests press
+// only [k], [q] or EOF, and nothing here calls finish;
+// TestReconcile_FinishRunsExactlyOnce covers it end to end.
 //
 // The reader is NOT a fake: it is the same *bufio.Reader production wraps stdin
 // in, over a strings.Reader, so readChar sees production's exact EOF behaviour.
@@ -285,8 +294,13 @@ func TestApplyAction_OnlyQuitStopsThePass(t *testing.T) {
 			if got := s.applyAction(it, tc.action); got != tc.wantStop {
 				t.Errorf("applyAction(%v) = %v, want %v", tc.action, got, tc.wantStop)
 			}
-			if tc.action == actionOverride && len(s.overrideOps) != 1 {
-				t.Fatalf("after one [o]: %d queued override ops, want 1", len(s.overrideOps))
+			if tc.action == actionOverride {
+				if len(s.overrideOps) != 1 {
+					t.Fatalf("after one [o]: %d queued override ops, want 1", len(s.overrideOps))
+				}
+				if oo := s.overrideOps[0]; oo.agentName != "claude" || oo.op.Path != "/dest/a" {
+					t.Errorf("queued override = %+v, want claude's op for /dest/a", oo)
+				}
 			}
 			// The same item a second time: nothing new may be queued, and
 			// stop must not change.
@@ -296,6 +310,154 @@ func TestApplyAction_OnlyQuitStopsThePass(t *testing.T) {
 			if len(s.overrideOps) != tc.wantQueue {
 				t.Errorf("after applying %v twice: %d queued override ops, want %d", tc.action, len(s.overrideOps), tc.wantQueue)
 			}
+			if tc.action == actionOverride {
+				// The dedup key is agent AND path: another agent's item at the
+				// same path is a different re-apply and must queue.
+				other := it
+				other.agentName = "opencode"
+				s.applyAction(other, actionOverride)
+				if len(s.overrideOps) != 2 {
+					t.Errorf("after a second agent's [o] on the same path: %d queued, want 2", len(s.overrideOps))
+				}
+			}
 		})
+	}
+}
+
+// itemMenu is the per-item prompt's menu line, pinned here so the tests below
+// can count how many times the user was (re)prompted.
+const itemMenu = "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > "
+
+// TestPromptItem_DiffReprintsValuesAndMenu pins the [d]iff arm: it re-renders
+// the item's values and the menu, echoes nothing, chooses no action, and the
+// next key still decides the item. Measured on the pre-#232 tree and on commit
+// 1: deleting the re-render failed zero tests — the arm was pinned only by the
+// scripted-stdin harness.
+func TestPromptItem_DiffReprintsValuesAndMenu(t *testing.T) {
+	s, out := newTestSession(t, "ds")
+	it := driftItem("/dest/a")
+	act, stop := s.promptItem(it, []reconcileItem{it})
+	if stop || act != actionSkip {
+		t.Fatalf("promptItem = (%v, stop=%v), want (%v, false): [d] must not choose, the [s] after it must", act, stop, actionSkip)
+	}
+	got := out.String()
+	if n := strings.Count(got, itemMenu); n != 2 {
+		t.Errorf("menu printed %d time(s), want 2 (once before [d], once after); transcript:\n%s", n, got)
+	}
+	if n := strings.Count(got, "  destination: "); n != 2 {
+		t.Errorf("values rendered %d time(s), want 2; transcript:\n%s", n, got)
+	}
+	if !strings.HasSuffix(got, "  > s\n") {
+		t.Errorf("[d] is not echoed and only the deciding key is; the transcript must end at the echoed s, got:\n%q", got)
+	}
+}
+
+// TestPromptItem_DeclinedBulkDoesNotReprintMenu pins the cancel path of the
+// bulk confirmation: [N] prints "cancelled; choose a per-item action", records
+// no bulk choice, and reads the next key WITHOUT re-printing the menu — the
+// user is still at the same prompt, not a new one.
+func TestPromptItem_DeclinedBulkDoesNotReprintMenu(t *testing.T) {
+	s, out := newTestSession(t, "Wns")
+	it := driftItem("/dest/a")
+	act, stop := s.promptItem(it, []reconcileItem{it, driftItem("/dest/b")})
+	if stop || act != actionSkip {
+		t.Fatalf("promptItem = (%v, stop=%v), want (%v, false)", act, stop, actionSkip)
+	}
+	if s.bulk != actionNone {
+		t.Errorf("a declined bulk choice must not be recorded; s.bulk = %v", s.bulk)
+	}
+	got := out.String()
+	want := "apply 'w' to all 2 remaining items? [y/N] n\n  cancelled; choose a per-item action\ns\n"
+	if !strings.HasSuffix(got, want) {
+		t.Errorf("after declining, the next key is read at the same prompt with no menu re-print; transcript must end %q, got:\n%q", want, got)
+	}
+	if n := strings.Count(got, itemMenu); n != 1 {
+		t.Errorf("menu printed %d time(s), want exactly 1; transcript:\n%s", n, got)
+	}
+}
+
+// TestPromptItem_UnknownKeyIsIgnored pins what the prompt does with a byte
+// parseItemKey rejects: nothing — no echo, no re-prompt, just the next read. The
+// byte is a capital I, so this also pins that "not a bulk ignore" means ignored
+// as a keystroke, not accepted as something else.
+func TestPromptItem_UnknownKeyIsIgnored(t *testing.T) {
+	s, out := newTestSession(t, "Is")
+	it := driftItem("/dest/a")
+	act, stop := s.promptItem(it, []reconcileItem{it})
+	if stop || act != actionSkip {
+		t.Fatalf("promptItem = (%v, stop=%v), want (%v, false)", act, stop, actionSkip)
+	}
+	if got := out.String(); !strings.HasSuffix(got, itemMenu+"s\n") {
+		t.Errorf("an unknown key must leave the transcript untouched until a known one arrives; want it to end with the menu then the echoed s, got:\n%q", got)
+	}
+}
+
+// TestWalk_BulkNeverSweepsOrphans pins that a confirmed bulk choice acts on
+// the remaining actionable items only: an orphan in the queue still gets its
+// own remove/keep prompt, and the confirmation's count excludes it.
+func TestWalk_BulkNeverSweepsOrphans(t *testing.T) {
+	s, out := newTestSession(t, "Syk")
+	orphan := driftItem("/dest/b")
+	orphan.orphan = true
+	s.walk([]reconcileItem{driftItem("/dest/a"), orphan, driftItem("/dest/c")})
+	got := out.String()
+	if s.bulk != actionSkip {
+		t.Fatalf("s.bulk = %v, want %v", s.bulk, actionSkip)
+	}
+	if !strings.Contains(got, "apply 's' to all 2 remaining items? [y/N] y\n") {
+		t.Errorf("the blast radius must count the two drift items and not the orphan; transcript:\n%s", got)
+	}
+	if n := strings.Count(got, itemMenu); n != 1 {
+		t.Errorf("item menu printed %d time(s), want 1 — the bulk choice answers /dest/c; transcript:\n%s", n, got)
+	}
+	if !strings.Contains(got, "  kept: /dest/b\n") {
+		t.Errorf("the orphan must still be prompted and [k]ept; transcript:\n%s", got)
+	}
+}
+
+// TestApplyAction_IgnoreAppendsToIgnoreFile pins the [i]gnore arm: the item's
+// RAW label lands in ignore.toml under home and the transcript says so.
+// Measured on commit 1: deleting the append and the print failed zero tests.
+// home is the one piece of wiring this test sets, because appendIgnore writes
+// under it; nothing else here needs a filesystem.
+func TestApplyAction_IgnoreAppendsToIgnoreFile(t *testing.T) {
+	s, out := newTestSession(t, "")
+	s.home = t.TempDir()
+	it := driftItem("/dest/.claude.json")
+	it.ptr = "/mcpServers/demo"
+	if stop := s.applyAction(it, actionIgnore); stop {
+		t.Fatal("applyAction(actionIgnore) = stop, want the pass to continue")
+	}
+	data, err := os.ReadFile(filepath.Join(s.home, "ignore.toml"))
+	if err != nil {
+		t.Fatalf("ignore.toml not written: %v", err)
+	}
+	if want := "ignore = \"/dest/.claude.json#/mcpServers/demo\"\n"; string(data) != want {
+		t.Errorf("ignore.toml = %q, want %q", data, want)
+	}
+	if got, want := out.String(), "  ignored: /dest/.claude.json#/mcpServers/demo\n"; got != want {
+		t.Errorf("transcript = %q, want %q", got, want)
+	}
+}
+
+// TestNewReconcileSession_RejectsMultipleAutoModes pins that the constructor,
+// not its caller, enforces reconcileAuto's "at most one mode" invariant — and
+// does so before loading anything, so the check costs no I/O and no session
+// with two modes can be built (resolveAuto's switch would otherwise let
+// writeBack win silently, the data-loss shape the check exists to prevent).
+func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
+	for _, auto := range []reconcileAuto{
+		{writeBack: true, override: true},
+		{writeBack: true, safe: true},
+		{override: true, safe: true},
+		{writeBack: true, override: true, safe: true},
+	} {
+		s, items, err := newReconcileSession(&cobra.Command{}, strings.NewReader(""), auto, "")
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("newReconcileSession(%+v) error = %v, want the mutually-exclusive error", auto, err)
+		}
+		if s != nil || items != nil {
+			t.Errorf("newReconcileSession(%+v) returned a session or items alongside the error", auto)
+		}
 	}
 }

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -23,23 +24,21 @@ import (
 // pinned by nothing. Measured on the pre-#232 tree: mutating any of those five
 // exits failed zero tests.
 //
-// None of these tests touches the filesystem: every item carries hasText=false,
-// so the prompt renders the SHA-prefix fallback, and every action they exercise
-// (skip, quit) is a no-op or a print.
+// Every item carries hasText=false, so the prompt renders the SHA-prefix
+// fallback and no destination is read. The one test that writes,
+// TestApplyAction_IgnoreAppendsToIgnoreFile, points the session's home at a
+// temp dir first; everything else here is a no-op, a print or an in-memory
+// queue.
 
 // newTestSession builds a session wired to a scripted stdin and an in-memory
 // transcript. Only the fields the prompt/walk path reads are set; home, st and
-// reg are deliberately left zero, which bounds what these tests may drive: the
-// actions exercised below are [s]kip (a no-op), [o]verride (appends to
-// overrideOps and marks dedupOverride), [q]uit (prints) and, with home pointed
-// at a temp dir, [i]gnore (appends to ignore.toml under it). [w]rite-back needs
-// a real ~/.agentsync, a plan and a destination and is covered end to end in
-// reconcile_test.go instead. Two more arms would PANIC on this session rather
-// than misbehave, which is what bounds the orphan and override tests: the
-// orphan [r]emove arm (pruneStateFilesForPath on a nil st) and finish with a
-// queued override (Registry.Lookup on a nil reg) — so the orphan tests press
-// only [k], [q] or EOF, and nothing here calls finish;
-// TestReconcile_FinishRunsExactlyOnce covers it end to end.
+// reg are deliberately left zero, and that bounds what a test may drive. Two
+// arms PANIC on this session rather than misbehave — the orphan [r]emove arm
+// (pruneStateFilesForPath on a nil st) and finish with a queued override
+// (Registry.Lookup on a nil reg) — so the orphan tests press only [k], [q] or
+// EOF, nothing here calls finish (TestReconcile_FinishRunsExactlyOnce covers it
+// end to end), and [w]rite-back, which needs a real ~/.agentsync, a plan and a
+// destination, stays in reconcile_test.go. A test that needs home sets it.
 //
 // The reader is NOT a fake: it is the same *bufio.Reader production wraps stdin
 // in, over a strings.Reader, so readChar sees production's exact EOF behaviour.
@@ -294,13 +293,8 @@ func TestApplyAction_OnlyQuitStopsThePass(t *testing.T) {
 			if got := s.applyAction(it, tc.action); got != tc.wantStop {
 				t.Errorf("applyAction(%v) = %v, want %v", tc.action, got, tc.wantStop)
 			}
-			if tc.action == actionOverride {
-				if len(s.overrideOps) != 1 {
-					t.Fatalf("after one [o]: %d queued override ops, want 1", len(s.overrideOps))
-				}
-				if oo := s.overrideOps[0]; oo.agentName != "claude" || oo.op.Path != "/dest/a" {
-					t.Errorf("queued override = %+v, want claude's op for /dest/a", oo)
-				}
+			if tc.action == actionOverride && len(s.overrideOps) != 1 {
+				t.Fatalf("after one [o]: %d queued override ops, want 1", len(s.overrideOps))
 			}
 			// The same item a second time: nothing new may be queued, and
 			// stop must not change.
@@ -310,23 +304,37 @@ func TestApplyAction_OnlyQuitStopsThePass(t *testing.T) {
 			if len(s.overrideOps) != tc.wantQueue {
 				t.Errorf("after applying %v twice: %d queued override ops, want %d", tc.action, len(s.overrideOps), tc.wantQueue)
 			}
-			if tc.action == actionOverride {
-				// The dedup key is agent AND path: another agent's item at the
-				// same path is a different re-apply and must queue.
-				other := it
-				other.agentName = "opencode"
-				s.applyAction(other, actionOverride)
-				if len(s.overrideOps) != 2 {
-					t.Errorf("after a second agent's [o] on the same path: %d queued, want 2", len(s.overrideOps))
-				}
-			}
 		})
 	}
 }
 
-// itemMenu is the per-item prompt's menu line, pinned here so the tests below
-// can count how many times the user was (re)prompted.
-const itemMenu = "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > "
+// TestApplyAction_OverrideDedupsByAgentAndPath pins the dedup key: [o] twice
+// on the same agent's item queues one re-apply of that path, but another
+// agent's item at the same path is a different re-apply and must queue too.
+func TestApplyAction_OverrideDedupsByAgentAndPath(t *testing.T) {
+	s, _ := newTestSession(t, "")
+	it := driftItem("/dest/a")
+	s.applyAction(it, actionOverride)
+	s.applyAction(it, actionOverride)
+	if len(s.overrideOps) != 1 {
+		t.Fatalf("after [o] twice on one item: %d queued, want 1", len(s.overrideOps))
+	}
+	if oo := s.overrideOps[0]; oo.agentName != "claude" || oo.op.Path != "/dest/a" {
+		t.Errorf("queued override = %+v, want claude's op for /dest/a", oo)
+	}
+	other := it
+	other.agentName = "opencode"
+	s.applyAction(other, actionOverride)
+	if len(s.overrideOps) != 2 {
+		t.Errorf("after a second agent's [o] on the same path: %d queued, want 2", len(s.overrideOps))
+	}
+}
+
+// wantItemMenu is deliberately a COPY of the production itemMenu, not a
+// reference to it: the tests below count it to see how many times the user was
+// (re)prompted, and a change to the menu's wording should fail here rather
+// than be absorbed by a constant both sides share.
+const wantItemMenu = "  [w]rite-back  [o]verride  [s]kip  [i]gnore  [d]iff  [q]uit\n  > "
 
 // TestPromptItem_DiffReprintsValuesAndMenu pins the [d]iff arm: it re-renders
 // the item's values and the menu, echoes nothing, chooses no action, and the
@@ -341,7 +349,7 @@ func TestPromptItem_DiffReprintsValuesAndMenu(t *testing.T) {
 		t.Fatalf("promptItem = (%v, stop=%v), want (%v, false): [d] must not choose, the [s] after it must", act, stop, actionSkip)
 	}
 	got := out.String()
-	if n := strings.Count(got, itemMenu); n != 2 {
+	if n := strings.Count(got, wantItemMenu); n != 2 {
 		t.Errorf("menu printed %d time(s), want 2 (once before [d], once after); transcript:\n%s", n, got)
 	}
 	if n := strings.Count(got, "  destination: "); n != 2 {
@@ -371,7 +379,7 @@ func TestPromptItem_DeclinedBulkDoesNotReprintMenu(t *testing.T) {
 	if !strings.HasSuffix(got, want) {
 		t.Errorf("after declining, the next key is read at the same prompt with no menu re-print; transcript must end %q, got:\n%q", want, got)
 	}
-	if n := strings.Count(got, itemMenu); n != 1 {
+	if n := strings.Count(got, wantItemMenu); n != 1 {
 		t.Errorf("menu printed %d time(s), want exactly 1; transcript:\n%s", n, got)
 	}
 }
@@ -387,7 +395,7 @@ func TestPromptItem_UnknownKeyIsIgnored(t *testing.T) {
 	if stop || act != actionSkip {
 		t.Fatalf("promptItem = (%v, stop=%v), want (%v, false)", act, stop, actionSkip)
 	}
-	if got := out.String(); !strings.HasSuffix(got, itemMenu+"s\n") {
+	if got := out.String(); !strings.HasSuffix(got, wantItemMenu+"s\n") {
 		t.Errorf("an unknown key must leave the transcript untouched until a known one arrives; want it to end with the menu then the echoed s, got:\n%q", got)
 	}
 }
@@ -407,7 +415,7 @@ func TestWalk_BulkNeverSweepsOrphans(t *testing.T) {
 	if !strings.Contains(got, "apply 's' to all 2 remaining items? [y/N] y\n") {
 		t.Errorf("the blast radius must count the two drift items and not the orphan; transcript:\n%s", got)
 	}
-	if n := strings.Count(got, itemMenu); n != 1 {
+	if n := strings.Count(got, wantItemMenu); n != 1 {
 		t.Errorf("item menu printed %d time(s), want 1 — the bulk choice answers /dest/c; transcript:\n%s", n, got)
 	}
 	if !strings.Contains(got, "  kept: /dest/b\n") {
@@ -446,6 +454,12 @@ func TestApplyAction_IgnoreAppendsToIgnoreFile(t *testing.T) {
 // with two modes can be built (resolveAuto's switch would otherwise let
 // writeBack win silently, the data-loss shape the check exists to prevent).
 func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
+	// A constructor that regressed to loading BEFORE checking would read the
+	// ambient ~/.agentsync; point both home lookups at an empty temp dir so
+	// that regression fails against nothing real.
+	root := t.TempDir()
+	t.Setenv("AGENTSYNC_TARGET_ROOT", root)
+	t.Setenv("AGENTSYNC_HOME", filepath.Join(root, ".agentsync"))
 	for _, auto := range []reconcileAuto{
 		{writeBack: true, override: true},
 		{writeBack: true, safe: true},
@@ -458,6 +472,53 @@ func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
 		}
 		if s != nil || items != nil {
 			t.Errorf("newReconcileSession(%+v) returned a session or items alongside the error", auto)
+		}
+	}
+}
+
+// TestNewReconcileSession_ChecksModesBeforeLoading is the source-text guard for
+// the constructor doc's "as its first step, before it loads anything": the
+// mutual-exclusion check must precede every load in newReconcileSession, so a
+// bad flag combination costs no I/O and is the FIRST error the user sees even
+// when the source itself is unloadable. Measured before this guard existed:
+// moving the check below loadProjectedForScope left
+// TestNewReconcileSession_RejectsMultipleAutoModes passing — the ordering is
+// behaviour that nothing else pins. Same shape as the apply pipeline's
+// TestApplyPipelineLoadsStateAfterSourceReload.
+func TestNewReconcileSession_ChecksModesBeforeLoading(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "reconcile.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := funcBody(string(src), "func newReconcileSession(")
+	if body == "" {
+		t.Fatal("newReconcileSession not found in reconcile.go")
+	}
+	// The capture must end at the constructor's top-level return of the
+	// session literal; anything else means funcBody was cut short above the
+	// calls this guard orders.
+	if !strings.HasSuffix(body, "\t}, items, nil") {
+		t.Fatalf("funcBody captured a truncated newReconcileSession (the body does not end at the "+
+			"`}, items, nil` return); tail: %q", body[len(body)-min(80, len(body)):])
+	}
+	check := strings.Index(body, "b2i(auto.writeBack)")
+	if check < 0 {
+		t.Fatal("newReconcileSession no longer checks the auto modes with b2i(auto.writeBack); update this guard")
+	}
+	for _, load := range []string{
+		"loadProjectedForScope(", "newPrinter(", "state.Load(", "registryFactory()", "selectAgents(", "render.Plan(",
+	} {
+		at := strings.Index(body, load)
+		if at < 0 {
+			t.Errorf("newReconcileSession no longer calls %s; update this guard", load)
+			continue
+		}
+		if at < check {
+			t.Errorf("%s runs before the --auto-* mutual-exclusion check; the check must be the constructor's first step", load)
 		}
 	}
 }

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -449,10 +448,14 @@ func TestApplyAction_IgnoreAppendsToIgnoreFile(t *testing.T) {
 }
 
 // TestNewReconcileSession_RejectsMultipleAutoModes pins that the constructor,
-// not its caller, enforces reconcileAuto's "at most one mode" invariant — and
-// does so before loading anything, so the check costs no I/O and no session
-// with two modes can be built (resolveAuto's switch would otherwise let
-// writeBack win silently, the data-loss shape the check exists to prevent).
+// not its caller, enforces reconcileAuto's "at most one mode" invariant, so no
+// session with two modes can be built (resolveAuto's switch would otherwise
+// let writeBack win silently, the data-loss shape the check exists to
+// prevent). That the check runs BEFORE anything loads is
+// TestNewReconcileSession_ChecksModesBeforeLoading's job: measured, a check
+// moved below the loads still passes this test against the empty temp home
+// set up here, which only keeps a regressed constructor away from the real
+// ~/.agentsync.
 func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
 	// A constructor that regressed to loading BEFORE checking would read the
 	// ambient ~/.agentsync; point both home lookups at an empty temp dir so
@@ -486,15 +489,7 @@ func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
 // behaviour that nothing else pins. Same shape as the apply pipeline's
 // TestApplyPipelineLoadsStateAfterSourceReload.
 func TestNewReconcileSession_ChecksModesBeforeLoading(t *testing.T) {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "reconcile.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	body := funcBody(string(src), "func newReconcileSession(")
+	body := funcBody(pkgSource(t, "reconcile.go"), "func newReconcileSession(")
 	if body == "" {
 		t.Fatal("newReconcileSession not found in reconcile.go")
 	}

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -489,7 +489,7 @@ func TestNewReconcileSession_RejectsMultipleAutoModes(t *testing.T) {
 // behaviour that nothing else pins. Same shape as the apply pipeline's
 // TestApplyPipelineLoadsStateAfterSourceReload.
 func TestNewReconcileSession_ChecksModesBeforeLoading(t *testing.T) {
-	body := funcBody(pkgSource(t, "reconcile.go"), "func newReconcileSession(")
+	body := funcBody(readFileForGuard(t, repoRootFromCaller(t), "internal/cli/reconcile.go"), "func newReconcileSession(")
 	if body == "" {
 		t.Fatal("newReconcileSession not found in reconcile.go")
 	}

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -1,0 +1,301 @@
+package cli
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/drift"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// The tests below drive reconcileSession's methods directly. That is the point
+// of the type (#232): before it existed, the prompt loops, the bulk-confirm
+// state machine and the run's exit paths were reachable only by running the
+// whole 375-line reconcileRun against a real ~/.agentsync tree, a real plan and
+// a real destination — so the paths that decide when a pass STOPS (an EOF at
+// either prompt, an EOF mid bulk-confirm, [q]uit with items still queued) were
+// pinned by nothing. Measured on the pre-#232 tree: mutating any of those five
+// exits failed zero tests.
+//
+// None of these tests touches the filesystem: every item carries hasText=false,
+// so the prompt renders the SHA-prefix fallback, and every action they exercise
+// (skip, quit) is a no-op or a print.
+
+// newTestSession builds a session wired to a scripted stdin and an in-memory
+// transcript. Only the fields the prompt/walk path reads are set; home, st and
+// reg are deliberately left zero, which bounds what these tests may drive: the
+// actions exercised below are [s]kip (a no-op), [o]verride (appends to
+// overrideOps and marks dedupOverride) and [q]uit (prints). [w]rite-back and
+// [i]gnore need a real ~/.agentsync and
+// are covered end to end in reconcile_test.go instead — driving them from here
+// would write relative to the test's working directory.
+//
+// The reader is NOT a fake: it is the same *bufio.Reader production wraps stdin
+// in, over a strings.Reader, so readChar sees production's exact EOF behaviour.
+func newTestSession(t *testing.T, stdin string) (*reconcileSession, *strings.Builder) {
+	t.Helper()
+	var out strings.Builder
+	p := ui.New(&out, &out, ui.ColorNever)
+	return &reconcileSession{
+		p:              p,
+		w:              p.Out,
+		br:             bufio.NewReader(strings.NewReader(stdin)),
+		writtenSources: map[string][]byte{},
+		dedupOverride:  map[string]bool{},
+	}, &out
+}
+
+// driftItem is a minimal actionable, non-orphan item: drift class, a distinct
+// path, and no text (so the prompt shows the hash fallback and reads nothing).
+func driftItem(path string) reconcileItem {
+	return reconcileItem{
+		agentName: "claude",
+		op:        adapter.FileOp{Path: path},
+		cls:       drift.Drift,
+		hsrc:      "aaaa", hdest: "bbbb",
+	}
+}
+
+// TestParseItemKey pins the per-item hotkey table, including the two case
+// foldings the prompt deliberately does NOT do.
+//
+// The old loop matched `case 'w','W','o','O','s','S','i','q','Q'` and only then
+// folded with `ch | 0x20`, so 'I' and 'D' fell to the ignore-and-re-read
+// default by OMISSION. Folding every byte uniformly would silently add two
+// accepted keystrokes — one of them a bulk [I]gnore that has no confirmation
+// step at all, which is exactly the "stray capital wipes the queue" failure the
+// bulk confirmation (#155) exists to prevent. The asymmetry is behaviour; this
+// table is where it is written down.
+func TestParseItemKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		ch       byte
+		wantAct  reconcileAction
+		wantBulk bool
+		wantDiff bool
+		wantOK   bool
+	}{
+		{name: "w write-back", ch: 'w', wantAct: actionWriteBack, wantOK: true},
+		{name: "W bulk write-back", ch: 'W', wantAct: actionWriteBack, wantBulk: true, wantOK: true},
+		{name: "o override", ch: 'o', wantAct: actionOverride, wantOK: true},
+		{name: "O bulk override", ch: 'O', wantAct: actionOverride, wantBulk: true, wantOK: true},
+		{name: "s skip", ch: 's', wantAct: actionSkip, wantOK: true},
+		{name: "S bulk skip", ch: 'S', wantAct: actionSkip, wantBulk: true, wantOK: true},
+		{name: "i ignore", ch: 'i', wantAct: actionIgnore, wantOK: true},
+		{name: "q quit", ch: 'q', wantAct: actionQuit, wantOK: true},
+		{name: "Q quit folds", ch: 'Q', wantAct: actionQuit, wantOK: true},
+		{name: "d diff", ch: 'd', wantAct: actionNone, wantDiff: true, wantOK: true},
+		// The two deliberate non-foldings, and the reason this table exists.
+		{name: "I is NOT a bulk ignore", ch: 'I'},
+		{name: "D is NOT a diff", ch: 'D'},
+		{name: "unknown letter", ch: 'x'},
+		{name: "digit", ch: '7'},
+		{name: "NUL", ch: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			act, bulk, diff, ok := parseItemKey(tc.ch)
+			if act != tc.wantAct || bulk != tc.wantBulk || diff != tc.wantDiff || ok != tc.wantOK {
+				t.Errorf("parseItemKey(%q) = (%v, bulk=%v, diff=%v, ok=%v), want (%v, bulk=%v, diff=%v, ok=%v)",
+					tc.ch, act, bulk, diff, ok, tc.wantAct, tc.wantBulk, tc.wantDiff, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestBulkTargets pins the bulk-confirm count as the TRUE blast radius (#155):
+// the items from the current one forward that a bulk choice would act on. Items
+// already answered are behind the slice; a non-actionable item is not swept; and
+// an orphan is never swept, because it has its own r/k prompt.
+//
+// A count of len(rest) passes the pre-existing end-to-end coverage (three
+// drifted servers, all actionable, none orphaned — measured), so the mixed rows
+// below are the ones that make the assertion mean anything.
+func TestBulkTargets(t *testing.T) {
+	orphan := driftItem("/o")
+	orphan.orphan = true
+	clean := driftItem("/c")
+	clean.cls = drift.Clean
+
+	tests := []struct {
+		name string
+		rest []reconcileItem
+		want int
+	}{
+		{name: "empty queue", rest: nil, want: 0},
+		{name: "all actionable", rest: []reconcileItem{driftItem("/a"), driftItem("/b")}, want: 2},
+		{name: "orphans are never swept", rest: []reconcileItem{driftItem("/a"), orphan}, want: 1},
+		{name: "non-actionable classes do not count", rest: []reconcileItem{driftItem("/a"), clean}, want: 1},
+		{name: "only orphans", rest: []reconcileItem{orphan}, want: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bulkTargets(tc.rest); got != tc.want {
+				t.Errorf("bulkTargets = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPromptItem_EOFStopsThePass pins the first of the three EOF exits: the
+// input ends while the per-item prompt is waiting. The pass must STOP (so the
+// caller reaches finish and flushes queued overrides + pruned state — #171)
+// rather than treat the item as answered.
+func TestPromptItem_EOFStopsThePass(t *testing.T) {
+	s, out := newTestSession(t, "")
+	it := driftItem("/dest/a")
+	act, stop := s.promptItem(it, []reconcileItem{it})
+	if !stop {
+		t.Errorf("promptItem at EOF: stop = false, want true — the pass must end, not fall through to the next item")
+	}
+	if act != actionNone {
+		t.Errorf("promptItem at EOF: action = %v, want %v — an unanswered item must not resolve to anything", act, actionNone)
+	}
+	if !strings.Contains(out.String(), "[w]rite-back") {
+		t.Errorf("the prompt itself should still have been printed; got:\n%s", out.String())
+	}
+}
+
+// TestPromptItem_EOFMidBulkConfirmStopsThePass pins the exit the issue calls out
+// as unreachable from a test before the session existed: the input ends AFTER a
+// capital W/O/S has printed the confirmation prompt but BEFORE the y/N answer.
+//
+// Two things are asserted, and the second is the subtle one: the transcript must
+// end at "[y/N] " with no echoed character, because the echo is written only
+// after the read succeeds. Treating an EOF as a declined confirmation would
+// print a stray NUL and keep going.
+func TestPromptItem_EOFMidBulkConfirmStopsThePass(t *testing.T) {
+	s, out := newTestSession(t, "W")
+	it := driftItem("/dest/a")
+	act, stop := s.promptItem(it, []reconcileItem{it, driftItem("/dest/b")})
+	if !stop {
+		t.Errorf("promptItem at EOF mid-confirm: stop = false, want true")
+	}
+	if act != actionNone {
+		t.Errorf("promptItem at EOF mid-confirm: action = %v, want %v", act, actionNone)
+	}
+	if s.bulk != actionNone {
+		t.Errorf("an unconfirmed bulk choice must not be recorded; s.bulk = %v", s.bulk)
+	}
+	got := out.String()
+	if !strings.Contains(got, "apply 'w' to all 2 remaining items? [y/N] ") {
+		t.Errorf("the confirmation prompt should name the action and the blast radius; got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "[y/N] ") {
+		t.Errorf("the transcript must end at the unanswered confirmation — nothing is echoed for a read that failed; got:\n%q", got)
+	}
+}
+
+// TestPromptOrphan_EOFStopsThePass pins the third EOF exit, on the orphan
+// remove/keep prompt. Same contract as the item prompt: stop the pass so finish
+// still persists a removal made earlier in the same run.
+func TestPromptOrphan_EOFStopsThePass(t *testing.T) {
+	s, out := newTestSession(t, "")
+	it := driftItem("/dest/skills/demo/SKILL.md")
+	it.orphan = true
+	if stop := s.promptOrphan(it); !stop {
+		t.Error("promptOrphan at EOF: stop = false, want true")
+	}
+	if s.stateDirty {
+		t.Error("an unanswered orphan prompt must not mark state dirty")
+	}
+	if !strings.Contains(out.String(), "[r]emove") {
+		t.Errorf("the orphan prompt should still have been printed; got:\n%s", out.String())
+	}
+}
+
+// TestPromptOrphan_QuitStopsThePass is the orphan prompt's [q]uit exit, the
+// second of the two quits. It prints "quit" (the EOF exit does not) and stops.
+func TestPromptOrphan_QuitStopsThePass(t *testing.T) {
+	s, out := newTestSession(t, "q")
+	it := driftItem("/dest/skills/demo/SKILL.md")
+	it.orphan = true
+	if stop := s.promptOrphan(it); !stop {
+		t.Error("promptOrphan on [q]: stop = false, want true")
+	}
+	if !strings.Contains(out.String(), "quit") {
+		t.Errorf("[q] at the orphan prompt should print quit; got:\n%s", out.String())
+	}
+}
+
+// TestWalk_QuitLeavesRemainingItemsUnprompted pins that [q]uit ENDS the pass.
+// The observable is the transcript: the third item is never printed at all.
+//
+// The pre-existing end-to-end quit tests each have a single drifted item, so
+// "quit" appearing in the output is true whether or not the walk stops —
+// measured: making applyAction's quit arm return false failed zero tests.
+func TestWalk_QuitLeavesRemainingItemsUnprompted(t *testing.T) {
+	s, out := newTestSession(t, "sq")
+	s.walk([]reconcileItem{driftItem("/dest/a"), driftItem("/dest/b"), driftItem("/dest/c")})
+	got := out.String()
+	if n := strings.Count(got, "[w]rite-back"); n != 2 {
+		t.Errorf("after [s] then [q] the walk must stop: %d item prompts, want 2\n%s", n, got)
+	}
+	if strings.Contains(got, "/dest/c") {
+		t.Errorf("the item after [q]uit must never be prompted; got:\n%s", got)
+	}
+}
+
+// TestWalk_ConfirmedBulkSkipsLaterPrompts pins the other half of the bulk state
+// machine: once confirmed, the choice is recorded ON THE SESSION and every later
+// item is resolved without a prompt.
+//
+// [S]kip is used deliberately: applying it touches nothing, so the assertion is
+// purely about the prompt count. Dropping the `s.bulk = act` assignment — the
+// bug this pins — leaves the confirmation working for the current item only and
+// re-prompts the rest; measured against the pre-existing suite, it failed zero
+// tests.
+func TestWalk_ConfirmedBulkSkipsLaterPrompts(t *testing.T) {
+	s, out := newTestSession(t, "Sy")
+	s.walk([]reconcileItem{driftItem("/dest/a"), driftItem("/dest/b"), driftItem("/dest/c")})
+	got := out.String()
+	if n := strings.Count(got, "[w]rite-back"); n != 1 {
+		t.Errorf("a confirmed bulk choice must prompt exactly once: %d prompts\n%s", n, got)
+	}
+	if s.bulk != actionSkip {
+		t.Errorf("s.bulk = %v, want %v — the confirmed choice must persist for the rest of the queue", s.bulk, actionSkip)
+	}
+	if !strings.Contains(got, "apply 's' to all 3 remaining items?") {
+		t.Errorf("the confirmation should name the action and the full remaining count; got:\n%s", got)
+	}
+}
+
+// TestApplyAction_OnlyQuitStopsThePass pins the applyAction contract each walk
+// exit depends on: quit stops, and nothing else does. The override row also
+// asserts what "queues" means — one overrideOp per distinct agent+path, so a
+// second [o] on the same item (two pointers inside one merge file) does not
+// re-apply the file twice (dedupOverride).
+func TestApplyAction_OnlyQuitStopsThePass(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    reconcileAction
+		wantStop  bool
+		wantQueue int // overrideOps after applying the action twice to the same item
+	}{
+		{name: "skip", action: actionSkip},
+		{name: "override queues", action: actionOverride, wantQueue: 1},
+		{name: "quit", action: actionQuit, wantStop: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestSession(t, "")
+			it := driftItem("/dest/a")
+			if got := s.applyAction(it, tc.action); got != tc.wantStop {
+				t.Errorf("applyAction(%v) = %v, want %v", tc.action, got, tc.wantStop)
+			}
+			if tc.action == actionOverride && len(s.overrideOps) != 1 {
+				t.Fatalf("after one [o]: %d queued override ops, want 1", len(s.overrideOps))
+			}
+			// The same item a second time: nothing new may be queued, and
+			// stop must not change.
+			if got := s.applyAction(it, tc.action); got != tc.wantStop {
+				t.Errorf("second applyAction(%v) = %v, want %v", tc.action, got, tc.wantStop)
+			}
+			if len(s.overrideOps) != tc.wantQueue {
+				t.Errorf("after applying %v twice: %d queued override ops, want %d", tc.action, len(s.overrideOps), tc.wantQueue)
+			}
+		})
+	}
+}

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spxrogers/agentsync/internal/paths"
+	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
 
@@ -37,12 +39,37 @@ func TestReconcile_OrphanFile(t *testing.T) {
 
 	t.Run("remove backs up and deletes", func(t *testing.T) {
 		env, dest := setup(t)
+		// apply recorded the dest in state.Files; [r] must prune that entry AND
+		// the run must persist the prune, or the next apply still believes it
+		// owns a file that is gone (issue #171). Measured before this assertion
+		// existed: dropping the prune's stateDirty flag failed zero tests.
+		root := env["AGENTSYNC_TARGET_ROOT"]
+		stateOwnsDest := func() bool {
+			t.Helper()
+			st, err := state.Load(filepath.Join(root, ".agentsync", ".state", "targets.json"))
+			if err != nil {
+				t.Fatalf("load state: %v", err)
+			}
+			portable := paths.HomeRelative(root, dest)
+			for key := range st.Files {
+				if key.Path == portable {
+					return true
+				}
+			}
+			return false
+		}
+		if !stateOwnsDest() {
+			t.Fatal("precondition: apply should have recorded the dest skill in state.Files")
+		}
 		out, err := runCLIWithStdin(t, env, "r", "reconcile")
 		if err != nil {
 			t.Fatalf("reconcile: %v\n%s", err, out)
 		}
 		if _, err := os.Stat(dest); !os.IsNotExist(err) {
 			t.Fatalf("orphan dest should have been removed; stat err=%v\n%s", err, out)
+		}
+		if stateOwnsDest() {
+			t.Fatalf("state still owns the removed orphan: the prune was not persisted\n%s", out)
 		}
 		// A backup of the removed file must exist.
 		backups := filepath.Join(env["AGENTSYNC_TARGET_ROOT"], ".agentsync", ".state", "backups")

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -24,10 +24,10 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		env = map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 		mustRun(t, env, "init")
 		mustRun(t, env, "agent", "add", "claude")
-		// Two skills: demo becomes the orphan; keep stays in sync, so its
+		// Two skills: demo becomes the orphan; insync stays in sync, so its
 		// state entry must survive the orphan's prune — a wiped state file
 		// would pass a "demo is gone" check for the wrong reason.
-		for _, name := range []string{"demo", "keep"} {
+		for _, name := range []string{"demo", "insync"} {
 			skill := filepath.Join(tmp, ".agentsync", "skills", name, "SKILL.md")
 			_ = os.MkdirAll(filepath.Dir(skill), 0o755)
 			_ = os.WriteFile(skill, []byte("---\nname: "+name+"\ndescription: d\n---\nbody\n"), 0o644)
@@ -49,7 +49,7 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		// owns a file that is gone (issue #171). Measured before this assertion
 		// existed: dropping the prune's stateDirty flag failed zero tests.
 		root := env["AGENTSYNC_TARGET_ROOT"]
-		keep := filepath.Join(root, ".claude", "skills", "keep", "SKILL.md")
+		insync := filepath.Join(root, ".claude", "skills", "insync", "SKILL.md")
 		stateOwns := func(p string) bool {
 			t.Helper()
 			st, err := state.Load(filepath.Join(root, ".agentsync", ".state", "targets.json"))
@@ -64,7 +64,7 @@ func TestReconcile_OrphanFile(t *testing.T) {
 			}
 			return false
 		}
-		if !stateOwns(dest) || !stateOwns(keep) {
+		if !stateOwns(dest) || !stateOwns(insync) {
 			t.Fatal("precondition: apply should have recorded both skills in state.Files")
 		}
 		out, err := runCLIWithStdin(t, env, "r", "reconcile")
@@ -77,7 +77,7 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		if stateOwns(dest) {
 			t.Fatalf("state still owns the removed orphan: the prune was not persisted\n%s", out)
 		}
-		if !stateOwns(keep) {
+		if !stateOwns(insync) {
 			t.Fatalf("the prune must be exact: the in-sync sibling's state entry is gone too\n%s", out)
 		}
 		// A backup of the removed file must exist.
@@ -813,11 +813,18 @@ func TestReconcile_DroppedServer_WriteBackRemovesSource(t *testing.T) {
 		name  string
 		stdin string
 		args  []string
-		want  string // a transcript line unique to the route
+		// want is a transcript line only this route prints; noPrompt is the
+		// pin for the route that prints nothing route-specific — an auto mode
+		// never asks, so the prompt marker must be absent.
+		want     string
+		noPrompt bool
 	}{
 		{name: "per-item [w]", stdin: "ww", want: "  > w\n"},
 		{name: "confirmed bulk [W]", stdin: "Wy", want: "apply 'w' to all 2 remaining items? [y/N] y\n"},
-		{name: "--auto-writeback", stdin: "", args: []string{"--auto-writeback"}, want: "write-back: "},
+		// The [q] on stdin must never be read: a flag that regressed into the
+		// interactive pass would quit at the first prompt and fail the shared
+		// assertions below, instead of blocking on a terminal's stdin.
+		{name: "--auto-writeback", stdin: "q", args: []string{"--auto-writeback"}, noPrompt: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -826,8 +833,11 @@ func TestReconcile_DroppedServer_WriteBackRemovesSource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("reconcile: %v\n%s", err, out)
 			}
-			if !strings.Contains(out, tc.want) {
+			if tc.want != "" && !strings.Contains(out, tc.want) {
 				t.Fatalf("transcript should show the %s route; want %q in:\n%s", tc.name, tc.want, out)
+			}
+			if tc.noPrompt && strings.Contains(out, "  > ") {
+				t.Fatalf("%s must not prompt; transcript:\n%s", tc.name, out)
 			}
 			if !strings.Contains(out, "write-back: removed source mcp/dropped.toml (destination dropped ") {
 				t.Errorf("the dropped server's source removal must be reported; transcript:\n%s", out)

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -24,9 +24,14 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		env = map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 		mustRun(t, env, "init")
 		mustRun(t, env, "agent", "add", "claude")
-		skill := filepath.Join(tmp, ".agentsync", "skills", "demo", "SKILL.md")
-		_ = os.MkdirAll(filepath.Dir(skill), 0o755)
-		_ = os.WriteFile(skill, []byte("---\nname: demo\ndescription: d\n---\nbody\n"), 0o644)
+		// Two skills: demo becomes the orphan; keep stays in sync, so its
+		// state entry must survive the orphan's prune — a wiped state file
+		// would pass a "demo is gone" check for the wrong reason.
+		for _, name := range []string{"demo", "keep"} {
+			skill := filepath.Join(tmp, ".agentsync", "skills", name, "SKILL.md")
+			_ = os.MkdirAll(filepath.Dir(skill), 0o755)
+			_ = os.WriteFile(skill, []byte("---\nname: "+name+"\ndescription: d\n---\nbody\n"), 0o644)
+		}
 		mustRun(t, env, "apply")
 		dest = filepath.Join(tmp, ".claude", "skills", "demo", "SKILL.md")
 		if _, err := os.Stat(dest); err != nil {
@@ -44,13 +49,14 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		// owns a file that is gone (issue #171). Measured before this assertion
 		// existed: dropping the prune's stateDirty flag failed zero tests.
 		root := env["AGENTSYNC_TARGET_ROOT"]
-		stateOwnsDest := func() bool {
+		keep := filepath.Join(root, ".claude", "skills", "keep", "SKILL.md")
+		stateOwns := func(p string) bool {
 			t.Helper()
 			st, err := state.Load(filepath.Join(root, ".agentsync", ".state", "targets.json"))
 			if err != nil {
 				t.Fatalf("load state: %v", err)
 			}
-			portable := paths.HomeRelative(root, dest)
+			portable := paths.HomeRelative(root, p)
 			for key := range st.Files {
 				if key.Path == portable {
 					return true
@@ -58,8 +64,8 @@ func TestReconcile_OrphanFile(t *testing.T) {
 			}
 			return false
 		}
-		if !stateOwnsDest() {
-			t.Fatal("precondition: apply should have recorded the dest skill in state.Files")
+		if !stateOwns(dest) || !stateOwns(keep) {
+			t.Fatal("precondition: apply should have recorded both skills in state.Files")
 		}
 		out, err := runCLIWithStdin(t, env, "r", "reconcile")
 		if err != nil {
@@ -68,8 +74,11 @@ func TestReconcile_OrphanFile(t *testing.T) {
 		if _, err := os.Stat(dest); !os.IsNotExist(err) {
 			t.Fatalf("orphan dest should have been removed; stat err=%v\n%s", err, out)
 		}
-		if stateOwnsDest() {
+		if stateOwns(dest) {
 			t.Fatalf("state still owns the removed orphan: the prune was not persisted\n%s", out)
+		}
+		if !stateOwns(keep) {
+			t.Fatalf("the prune must be exact: the in-sync sibling's state entry is gone too\n%s", out)
 		}
 		// A backup of the removed file must exist.
 		backups := filepath.Join(env["AGENTSYNC_TARGET_ROOT"], ".agentsync", ".state", "backups")
@@ -751,5 +760,88 @@ func TestReconcile_ProjectScope_OverrideRecordsProjectState(t *testing.T) {
 	// reads clean at project scope afterwards.
 	if out, err := runCLI(t, env, "status", "--project", projectDir, "--exit-code"); err != nil {
 		t.Fatalf("status --project after override should be clean: %v\n%s", err, out)
+	}
+}
+
+// TestReconcile_DroppedServer_WriteBackRemovesSource pins the deletion-only
+// exception to the capture funnel, removeDroppedSource, on each of the three
+// routes the secret-handling docs name for it: a per-item [w], a confirmed
+// bulk [W], and --auto-writeback. Each must unlink the canonical mcp/<id>.toml
+// of the server the destination dropped, while the drifted sibling is written
+// back normally. Before this test the function had no in-repo coverage at all;
+// only the out-of-tree scripted-stdin harness reached it.
+func TestReconcile_DroppedServer_WriteBackRemovesSource(t *testing.T) {
+	setup := func(t *testing.T) (env map[string]string, srcDir string) {
+		t.Helper()
+		tmp := t.TempDir()
+		env = map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		mustRun(t, env, "agent", "add", "claude")
+		srcDir = filepath.Join(tmp, ".agentsync", "mcp")
+		_ = os.MkdirAll(srcDir, 0o755)
+		for _, name := range []string{"dropped", "kept"} {
+			_ = os.WriteFile(filepath.Join(srcDir, name+".toml"), []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+		}
+		mustRun(t, env, "apply")
+		// The destination drops one server outright and drifts the other.
+		dst := filepath.Join(tmp, ".claude.json")
+		body, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(body, &doc); err != nil {
+			t.Fatalf("parse %s: %v\n%s", dst, err, body)
+		}
+		servers, _ := doc["mcpServers"].(map[string]any)
+		if servers == nil || servers["dropped"] == nil || servers["kept"] == nil {
+			t.Fatalf("apply did not render both servers into %s:\n%s", dst, body)
+		}
+		delete(servers, "dropped")
+		servers["kept"].(map[string]any)["command"] = "npm"
+		out, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, out, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return env, srcDir
+	}
+
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string // a transcript line unique to the route
+	}{
+		{name: "per-item [w]", stdin: "ww", want: "  > w\n"},
+		{name: "confirmed bulk [W]", stdin: "Wy", want: "apply 'w' to all 2 remaining items? [y/N] y\n"},
+		{name: "--auto-writeback", stdin: "", args: []string{"--auto-writeback"}, want: "write-back: "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, srcDir := setup(t)
+			out, err := runCLIWithStdin(t, env, tc.stdin, append([]string{"reconcile"}, tc.args...)...)
+			if err != nil {
+				t.Fatalf("reconcile: %v\n%s", err, out)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("transcript should show the %s route; want %q in:\n%s", tc.name, tc.want, out)
+			}
+			if !strings.Contains(out, "write-back: removed source mcp/dropped.toml (destination dropped ") {
+				t.Errorf("the dropped server's source removal must be reported; transcript:\n%s", out)
+			}
+			if _, err := os.Stat(filepath.Join(srcDir, "dropped.toml")); !os.IsNotExist(err) {
+				t.Errorf("mcp/dropped.toml should have been unlinked; stat err = %v\n%s", err, out)
+			}
+			kept, err := os.ReadFile(filepath.Join(srcDir, "kept.toml"))
+			if err != nil {
+				t.Fatalf("mcp/kept.toml must survive: %v", err)
+			}
+			if !strings.Contains(string(kept), "npm") {
+				t.Errorf("the drifted sibling should have been written back to npm; kept.toml:\n%s", kept)
+			}
+		})
 	}
 }

--- a/internal/cli/reconcile_test.go
+++ b/internal/cli/reconcile_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -563,5 +564,165 @@ func TestReconcile_EOFFlushesOverrides(t *testing.T) {
 	final, _ := os.ReadFile(dst)
 	if !strings.Contains(string(final), `"npx"`) {
 		t.Fatalf("EOF after [o]verride dropped the queued override (source value not restored):\n%s", final)
+	}
+}
+
+// TestReconcile_FinishRunsExactlyOnce is the behavioural half of the #232
+// decision that the run's tail (finish) has exactly ONE call site and is never
+// deferred. finish prints one summary line per run — "N item(s) left
+// unresolved" in an auto mode, "override: applied N item(s)" after an
+// [o]verride — so the observable trace of a finish that ran twice (a defer plus
+// the explicit call, or a second call added later) is exactly a duplicated line.
+//
+// Three exits are covered: the natural end of an --auto-safe pass, an EOF after
+// [o]verride, and [q]uit after [o]verride. The last one also pins that quitting
+// still APPLIES the queued override: both quits reach finish exactly as the
+// EOFs do (TestReconcile_EOFFlushesOverrides), but no test or scripted scenario
+// ever queued an override and then quit, so a quit that dropped the queue
+// failed nothing.
+func TestReconcile_FinishRunsExactlyOnce(t *testing.T) {
+	setup := func(t *testing.T) (env map[string]string, dst string) {
+		t.Helper()
+		tmp := t.TempDir()
+		env = map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+		mustRun(t, env, "init")
+		mustRun(t, env, "agent", "add", "claude")
+		for _, name := range []string{"aaa", "bbb"} {
+			mcp := filepath.Join(tmp, ".agentsync", "mcp", name+".toml")
+			_ = os.MkdirAll(filepath.Dir(mcp), 0o755)
+			_ = os.WriteFile(mcp, []byte("[server]\ntype=\"stdio\"\ncommand=\"npx\"\n"), 0o644)
+		}
+		mustRun(t, env, "apply")
+		// Drift BOTH servers in the destination (npx -> npm).
+		dst = filepath.Join(tmp, ".claude.json")
+		body, _ := os.ReadFile(dst)
+		if err := os.WriteFile(dst, []byte(strings.ReplaceAll(string(body), `"npx"`, `"npm"`)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return env, dst
+	}
+	// commandOf reads mcpServers.<id>.command from the claude destination.
+	commandOf := func(t *testing.T, dst, id string) string {
+		t.Helper()
+		var doc struct {
+			MCPServers map[string]struct {
+				Command string `json:"command"`
+			} `json:"mcpServers"`
+		}
+		body, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			t.Fatalf("parse %s: %v\n%s", dst, err, body)
+		}
+		return doc.MCPServers[id].Command
+	}
+
+	t.Run("auto-safe prints the unresolved summary once", func(t *testing.T) {
+		env, _ := setup(t)
+		out, err := runCLI(t, env, "reconcile", "--auto-safe")
+		if err != nil {
+			t.Fatalf("reconcile --auto-safe: %v\n%s", err, out)
+		}
+		if n := strings.Count(out, "item(s) left unresolved"); n != 1 {
+			t.Fatalf("the unresolved summary must be printed exactly once (finish ran %d times):\n%s", n, out)
+		}
+		if !strings.Contains(out, "2 item(s) left unresolved") {
+			t.Fatalf("both drifted servers should be counted; got:\n%s", out)
+		}
+	})
+
+	t.Run("EOF after override applies the queue once", func(t *testing.T) {
+		env, dst := setup(t)
+		out, err := runCLIWithStdin(t, env, "o", "reconcile")
+		if err != nil {
+			t.Fatalf("reconcile: %v\n%s", err, out)
+		}
+		if n := strings.Count(out, "override: applied"); n != 1 {
+			t.Fatalf("the override summary must be printed exactly once (finish ran %d times):\n%s", n, out)
+		}
+		if got := commandOf(t, dst, "aaa"); got != "npx" {
+			t.Fatalf("the queued override was not applied at EOF: aaa.command = %q, want npx", got)
+		}
+	})
+
+	t.Run("quit after override still applies the queue once", func(t *testing.T) {
+		env, dst := setup(t)
+		out, err := runCLIWithStdin(t, env, "oq", "reconcile")
+		if err != nil {
+			t.Fatalf("reconcile: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "quit") {
+			t.Fatalf("expected the [q]uit echo; got:\n%s", out)
+		}
+		if n := strings.Count(out, "override: applied 1 item(s)"); n != 1 {
+			t.Fatalf("[q]uit must still apply the ONE queued override, exactly once (got %d summary lines):\n%s", n, out)
+		}
+		// Only the first server is asserted: the queued op is the whole merge
+		// file's op (which is why dedupOverride keys by path), so the re-apply
+		// restores every owned key in .claude.json, not just aaa.
+		if got := commandOf(t, dst, "aaa"); got != "npx" {
+			t.Fatalf("[q]uit dropped the queued override: aaa.command = %q, want npx (restored from source)", got)
+		}
+	})
+}
+
+// TestReconcile_ProjectScope_OverrideRecordsProjectState pins the scope and
+// project root that finish hands to render.NewWriter and RecordOpsState. Every
+// other reconcile test runs at user scope, where a transposition to
+// ScopeUser/"" is invisible; at project scope it makes the writer look the
+// destination up under the wrong state key, treat the project's own .mcp.json
+// as a never-applied foreign file, back it up and print a "backup:" line, and
+// record the re-apply against the wrong scope.
+func TestReconcile_ProjectScope_OverrideRecordsProjectState(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmpHome}
+	mustRun(t, env, "init")
+	mustRun(t, env, "agent", "add", "claude")
+	mustRun(t, env, "init", "--scope", "project", "--project", projectDir)
+	declareProjectAgent(t, env, projectDir, "claude")
+	scaffoldProjectMCP(t, projectDir, "github", "npx")
+	mustRun(t, env, "apply", "--project", projectDir)
+
+	mcpPath := filepath.Join(projectDir, ".mcp.json")
+	body, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("read project .mcp.json: %v", err)
+	}
+	drifted := strings.ReplaceAll(string(body), `"npx"`, `"npm"`)
+	if drifted == string(body) {
+		t.Fatalf("fixture did not contain the expected command to drift:\n%s", body)
+	}
+	if err := os.WriteFile(mcpPath, []byte(drifted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLIWithStdin(t, env, "o", "reconcile", "--project", projectDir)
+	if err != nil {
+		t.Fatalf("reconcile --project: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "override: applied 1 item(s)") {
+		t.Fatalf("expected the override to be applied; got:\n%s", out)
+	}
+	if strings.Contains(out, "backup:") {
+		t.Fatalf("the project's own destination was treated as a foreign collision (wrong scope in finish):\n%s", out)
+	}
+	if final, _ := os.ReadFile(mcpPath); !strings.Contains(string(final), `"npx"`) {
+		t.Fatalf("override did not restore the project source value:\n%s", final)
+	}
+	for _, backups := range []string{
+		filepath.Join(tmpHome, ".agentsync", ".state", "backups"),
+		filepath.Join(projectDir, ".agentsync", ".state", "backups"),
+	} {
+		if _, err := os.Stat(backups); !os.IsNotExist(err) {
+			t.Fatalf("no backup may be taken for an owned project destination; found %s (stat err=%v)", backups, err)
+		}
+	}
+	// The re-apply must be recorded against the project's state, so the tree
+	// reads clean at project scope afterwards.
+	if out, err := runCLI(t, env, "status", "--project", projectDir, "--exit-code"); err != nil {
+		t.Fatalf("status --project after override should be clean: %v\n%s", err, out)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #232. Sixth PR in the #226 code-quality series (after #240, #244, #247, #249, #252). A behaviour-preserving restructure of `reconcile`'s interactive pass, plus the two per-item rebuilds the issue asked about. No user-visible change, and that claim is measured rather than argued (below).

**1. `reconcileRun` becomes a `reconcileSession`** (commit 1, `34bbf3c`, `internal/cli/reconcile.go` + docs). The old body was 375 lines with five `goto done`s, two labeled loops and seven pieces of run-scoped state travelling as loose locals. It is now a 22-line entry point over a `reconcileSession` struct: the wiring the run was built with (printer, buffered input, registry, loaded state, scope, redaction map, the hoisted canonical hook-event vocabulary) and the run-scoped bookkeeping (queued overrides + dedup map, the confirmed bulk choice, `stateDirty`, `autoSkipped`, `writeBackFailed`, the per-source write ledger). Each phase is a method a test can drive directly: `promptOrphan`, `resolveAuto`, `promptItem`, `applyAction`, `finish`; `attemptWriteBack`, `removeDroppedSource` and `itemSourceFile` become methods too. Every `goto done` is a plain return out of `walk`, which returns no error, and `finish` has exactly **one** call site. It is deliberately **not** deferred: it writes (the override re-apply, the state save) and returns the run's error, and a `defer` would run those writes while a panic unwound.

The bulk-action byte (`'w'`/`'o'`/`'s'`/`'i'`/`'q'` with `ch | 0x20` open-coded at two sites) is a typed `reconcileAction` whose zero value is invalid (the `adapter.SkipKind` convention, not `adapter.Action`'s). `parseItemKey` is now the one place a keystroke becomes an action, and it writes down the asymmetry the old `case 'w', 'W', 'o', 'O', 's', 'S', 'i', 'q', 'Q'` switch encoded by omission: `I` is **not** a bulk ignore and `D` is **not** a diff; folding uniformly would have silently added an unconfirmed bulk-ignore keystroke. `bulkTargets` is the blast-radius count as a function; the per-item menu and its prompt are one `itemMenu` const printed at both prompt sites. The at-most-one `--auto-*` check is the constructor's first statement, so the invariant `reconcileAuto`'s doc states is enforced where a session is built, before anything loads.

The dest→source surface is unchanged. `[w]rite-back` still runs through `writeBackItem` → `capture.Capture`; the deletion-only exception `removeDroppedSource` keeps its gate (it runs only for a chosen write-back, a per-item `[w]`, a confirmed bulk `[W]` or `--auto-writeback`, whose destination dropped the server) and its `withinDir` bound. The secret-invariants docs used to call that gate "keystroke-gated", which `--auto-writeback` never was; the canonical project memory (`.agentsync/memory/AGENTS.md`), its renders `CLAUDE.md`/`AGENTS.md` (re-rendered with `agentsync apply --scope project`), `SECURITY.md`, `docs/architecture.md` §5 and every in-code comment now name the three routes (`eabe6d8`, `75d0e1a`, `93ff469`), and each route is pinned by a test (round 3).

**Why one file.** The session stays in `reconcile.go` rather than a new `reconcile_session.go`. A split would not move any fenced site (both `iox.AtomicWrite` calls stay put, and the three `os.Remove` sites carry line-scoped `//nolint`), but it would falsify the prose of `.golangci.yml`'s fence entry, which names "reconcile.go's interactive orphan removal". A behaviour-preserving refactor does not touch `.golangci.yml`, not even its prose.

**2. Tests** (commit 2, `7eea03b`, extended in review rounds 1–4). Seventeen session-level unit tests (`reconcile_session_internal_test.go`) drive the methods on a scripted `bufio.Reader`: `TestParseItemKey` (15 rows, including the two non-folded capitals), `TestBulkTargets`, the four exits (`TestPromptItem_EOFStopsThePass`, `TestPromptItem_EOFMidBulkConfirmStopsThePass` whose transcript must end at `[y/N] `, `TestPromptOrphan_EOFStopsThePass`, `TestPromptOrphan_QuitStopsThePass`), `TestWalk_QuitLeavesRemainingItemsUnprompted`, `TestWalk_ConfirmedBulkSkipsLaterPrompts`, `TestApplyAction_OnlyQuitStopsThePass`, and from the review rounds: the `[d]iff` arm, the declined bulk confirm (no menu re-print), an unknown key, a bulk choice that must not sweep an orphan, the `[i]gnore` arm, the override dedup key (agent **and** path), the constructor's `--auto-*` rejection (against an empty temp home), and a source-text guard that the check precedes every load (reading source through the package's `readFileForGuard`/`funcBody` guard convention). End-to-end in `reconcile_test.go`: `TestReconcile_FinishRunsExactlyOnce` (three subtests: the auto-safe summary prints once; EOF after an `[o]` applies the queue once; `[q]` after an `[o]` still applies the queue once), `TestReconcile_ProjectScope_OverrideRecordsProjectState` (a project-scope `[o]` records project state and takes no backup), `TestReconcile_OrphanFile`'s remove subtest asserts the removed orphan's state entry is pruned **and** an in-sync sibling's survives (a wipe of state passed the whole package before), and `TestReconcile_DroppedServer_WriteBackRemovesSource` pins `removeDroppedSource` on each of its three routes (per-item `[w]`, confirmed bulk `[W]`, and `--auto-writeback`, the last pinned by the absence of any prompt with a never-read `[q]` on stdin): the dropped server's `mcp/<id>.toml` is unlinked and the drifted sibling written back. That function had no in-repo coverage before.

**3. `printItemDiff` dropped** (commit 3, `fab41c2`): it was a pure alias of `renderItemValues`; the `[d]iff` arm calls the real thing.

**4. `canonicalHookEvent` uses the caller's registry** (commit 4, `18c4f42`). Inverting a hook pointer's native event spelling rebuilt all 31 adapters via `registryFactory()` on every resolution (~10 µs measured). It now takes the registry the caller already holds: the session's in `reconcile`, and `explainInputs.reg` threaded through `explain.go` / `explain_model.go` for `explain`. The comma-ok assertion already meant it could not panic on a non-renaming adapter (the issue's question); a `reg == nil` guard exists because `Registry.Lookup` dereferences its receiver, and it resolves nothing (ok false) rather than passing the native spelling through, so a caller that forgot its registry gets "no source" instead of a plausible wrong path. `registryFactory()` call sites in the file: 2 → 1.

**Review provenance.** The plan and execution spec were reviewed by a fresh reviewer who replicated all four commits and the fixture from the artifacts and found five issues before execution: quit-with-a-queued-override was unpinned (added as two scenarios and a subtest), `finish`'s hoisted scope/projectRoot was unpinned (added as a project-scope scenario and test), the CHANGELOG compared against the wrong binary, the one-file reason was wrong (corrected above), and commit 4's registry could be nil from two test literals (guard + row). All fixed before execution.

**Review loop (five rounds, the full budget; every finding from every round fixed).** Round 1 (four lenses on `18c4f42`; closed by `97682da` + `20bf626`): the constructor now enforces the at-most-one `--auto-*` invariant its own doc states; the nil-registry guard resolves nothing rather than passing through; "six loose locals" was seven; six session-level tests pin the arms that were covered only by the uncommitted harness. Round 2 (on `20bf626`; closed by `eabe6d8` + `58201c5`): the docs' "keystroke-gated" claim corrected at its canonical source and every copy (a confirmed bulk `[W]` was a third route nobody had named); the production `itemMenu` const with the tests keeping a deliberate copy; the orphan-remove state-prune assertion; the load-order source-text guard and a hermetic constructor test; the dedup pin in its own test. Round 3 (on `58201c5`; correctness and API design CLEAN, adversarial and test rigor ship-it; closed by `4f1f492`): the three-route test for `removeDroppedSource`, the exact-prune sibling assertion, prose tightening; the adversarial lens's pre-existing finding, that a confirmed bulk `[W]` writes back ForeignCollision items `--auto-writeback` refuses, is filed as #255. Round 4 (on `4f1f492`; three lenses ship-it; closed by `75d0e1a`): the guards read source through the package's existing `readFileForGuard`/`repoRootFromCaller` convention instead of a round-3 helper that had also displaced `funcBody`'s doc; the `--auto-writeback` route is pinned by the absence of any prompt, with a never-read `[q]` on stdin so a regressed flag fails instead of blocking on a terminal; test rigor's pre-existing finding, that the per-item diff labels `--- source / +++ dest` but renders the sides the other way round, is filed as #256. Round 5 (on `75d0e1a`; API design, correctness and test rigor CLEAN, adversarial ship-it; closed by `93ff469`): three comment-only residuals (a miscount of the old case-fold sites, the last per-item-keystroke framing of the deletion gate, and a doc paragraph that had sat on the wrong function). Byte-identity re-measured after every round that touched production code: 39 scenarios, `diff -r` empty; round 4's correctness lens independently re-ran 11 dropped-server scenarios against the base binary, and round 5's proved the sorted string-literal sets of base and head differ only by the deduplicated menu. Declined with reason: pinning the orphan `[r]` backup/remove-failure arms and `finish`'s two error returns (each needs a failing backup dir or a failing adapter Apply); folding `--auto-*` into a single mode enum (it would only relocate the same check to the flag boundary; a follow-up candidate); turning the nil-registry guard into a panic (house style is a documented guard, and every production call site is verified non-nil). One reviewer's closing reflection, recorded rather than acted on: the load-order source-text guard is the one test they would cut as mild over-pinning; two other lenses had validated it as complementary to the behavioural test.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

**Byte-identity oracle.** Two binaries, `main` at `309fde0` and each of commit 1, the round-0 head, the round-1 tree and the round-2 tree (rounds 3–5 changed only comments in production), were run through 39 scripted-stdin scenarios covering every prompt, bulk confirmation (confirmed and cancelled), EOF at both prompts and mid-confirm, `[q]uit` at both prompts (including a quit with a queued override), every `--auto-*` mode and the mutually-exclusive error, a project-scope override, the write-back conflict and dropped-server paths, exit codes, and a masked secret value. Per scenario the harness captures stdout, stderr, exit status and the normalized source/state tree (195 files per arm). Determinism was proved first (base-vs-base `diff -r` empty), then each arm against base: all **empty**. Run from a working directory with no `.agentsync/` ancestor.

**Break-verifies** (literal `--- FAIL` sets, each mutation asserted to land exactly once):
- On the commit-1 tree with only the pre-existing suite, 9 of 11 control-flow mutations (EOF/quit exits returning "continue", `bulkTargets` → `len(rest)`, folding `I`/`D`, dropping the bulk latch, dropping the `stateDirty` reset, calling `finish` twice) failed **zero** tests. That is the gap commit 2 closes.
- On the commit-2 tree each of those fails exactly its named test: BV-1 → `TestPromptItem_EOFStopsThePass`; BV-2 → `TestPromptItem_EOFMidBulkConfirmStopsThePass`; BV-3 → `TestApplyAction_OnlyQuitStopsThePass` + `TestWalk_QuitLeavesRemainingItemsUnprompted`; BV-4 → `TestPromptOrphan_EOFStopsThePass`; BV-5 → three `TestBulkTargets` rows; BV-6 → the two `TestParseItemKey` capital rows; BV-7 → `TestWalk_ConfirmedBulkSkipsLaterPrompts`; BV-11 (`finish` twice) → `TestReconcile_FinishRunsExactlyOnce` and all three subtests. Discarding the queue on `[q]` → exactly the `quit_after_override` subtest. Hard-coding user scope in `finish` → exactly `TestReconcile_ProjectScope_OverrideRecordsProjectState`.
- BV-10 (dropping `s.stateDirty = false` after the override save) fails **0** tests on both trees and the fixture is identical: it is an equivalent mutation (a second byte-identical `state.Save`). Reported, no test added.
- On the commit-4 tree: a fresh empty registry → the three renaming `TestCanonicalHookEvent` rows **and** `TestExplainPath_RenamedHookEventResolves`; a single-value type assertion → the `claude_does_not_rename` row with the `missing method NativeHookEvent` panic the issue asked about; removing the nil guard → the `nil_registry` row with a nil-pointer dereference inside `Registry.Lookup`.
- Round 1: moving the `--auto-*` check back to the caller → `TestNewReconcileSession_RejectsMultipleAutoModes` + `TestReconcile_AutoFlagsMutuallyExclusive`; nil guard passing through → the `nil_registry_resolves_nothing` row; deleting the `[d]iff` re-render, re-printing the menu after a declined confirm, echoing an unknown key, letting a bulk choice sweep an orphan, dropping the `appendIgnore` call, keying the dedup on path only → each exactly its new test.
- Round 2: dropping the orphan prune's `stateDirty = true`, or the `pruneStateFilesForPath` call → exactly `TestReconcile_OrphanFile/remove_backs_up_and_deletes`; moving the `--auto-*` check below `loadProjectedForScope` → exactly `TestNewReconcileSession_ChecksModesBeforeLoading`; a column-0 brace inside the constructor → the guard's truncation check; changing the production menu wording → the four count/suffix tests, each printing the transcript; dedup on path only → exactly `TestApplyAction_OverrideDedupsByAgentAndPath`.
- Round 3: skipping the `errDestDroppedServer` branch → all three `TestReconcile_DroppedServer_WriteBackRemovesSource` subtests; `--auto-writeback` resolving to skip → exactly its `--auto-writeback` subtest; not latching the confirmed bulk choice → exactly its `confirmed_bulk_[W]` subtest (+ `TestWalk_ConfirmedBulkSkipsLaterPrompts`); replacing the orphan prune with a wipe of `state.Files` → exactly the orphan remove subtest, on the sibling assertion.
- Round 4: `--auto-writeback` falling through to the interactive prompt → exactly its subtest (`must not prompt`); the ordering check moved below the loads → exactly the guard, through the `readFileForGuard` read path.

**Accepted fixture coverage holes**: no #247 refused-symlink/shape item (covered by `dest_fifo_e2e_unix_test.go`); no `Q`/`Y` capitals; no `--auto-override` with an orphan; no interactive `w` on a ForeignCollision.

**Post-conditions** on `internal/cli/reconcile.go`: `goto` 5 → 0; labels 3 → 0; `reconcileRun` 375 → 22 lines; `registryFactory()` 2 → 1; `capture.Capture(` 1 → 1; `source.Write*(` 1 → 1; `iox.AtomicWrite(` 2 → 2; `os.Remove(` 3 → 3; `//nolint:` 4 → 4; `.Canonical()` in non-test `internal/cli` 0 → 0; `.golangci.yml` absent from the diff.

Gates, each commit independently and again on the head: `go build`, `go vet`, `gofmt -l` empty, gofumpt + `go mod tidy` no rewrites, `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` (29 packages ok), `go test -race ./internal/cli/...`, `go test -tags=e2e ./test/e2e/...`, `go test -tags=bdd ./test/bdd/...`, `GOTOOLCHAIN=go1.26.2 golangci-lint@v2.12.2 run ./...` → 0 issues.

- [ ] `just test-release` is green (the release bar) — `just` is not installable in this session; every layer the recipe orchestrates (vet → build → race → e2e → bdd) was run directly as listed above, and CI's hermetic `test-release` job runs on the PR.
- [x] `just lint` is clean — run directly with the pinned toolchain; `go.mod`/`go.sum` untouched.

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any
      `source.Write*` path, I've re-read the secret-handling invariants in
      `CLAUDE.md` / `SECURITY.md` and not weakened them. — Neither package is touched. `reconcile.go`'s one `capture.Capture` call and one `source.Write*` call are unmoved (counts above); `removeDroppedSource` keeps its gate and `withinDir` bound as a method, and each of its three routes is now pinned by a test; no `.Canonical()` unwrap is added; the redaction map reaches both `renderItemValues` sites. The invariants' own wording was made accurate (the gate is a chosen write-back, not a keystroke), not weakened.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/components.md` (a `reconcileSession` entry in the `internal/cli` key list), `CHANGELOG.md` (Internal bullet under Changed, incl. the gate-wording note), `.agentsync/memory/AGENTS.md` + rendered `CLAUDE.md`/`AGENTS.md`, `SECURITY.md`, `docs/architecture.md` §5. No CLI surface or capability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4VNyoCuGXx7pYxNfLVbFG