### PR TITLE
refactor(cli): plugins/<id>.toml has one struct and a struct-level preserve (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,22 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **A plugin's `plugins/<id>.toml` now has one schema and one preserve rule**
+  ([#234](https://github.com/spxrogers/agentsync/issues/234)). The file was
+  described by two identical structs — the canonical `source.PluginSpec` and a
+  private copy inside the CLI — and a re-install merged the existing file into
+  the new one field by field, naming `agents`, `native_agents`, `update` and
+  `disabled` one at a time. A key added to the schema but forgotten in that
+  merge would have been silently reset to its default on every re-install and
+  re-import, the same class of loss as
+  [#140](https://github.com/spxrogers/agentsync/issues/140). The CLI now reads
+  and writes the canonical struct, and a re-install starts from the whole
+  existing entry and overwrites only the three fields it re-fetches (`id`,
+  `version`, `manifest_sha`) — so every other key is preserved by default
+  rather than dropped by default, and a test fails if a new key is neither
+  classified as re-fetched nor as preserved. The on-disk bytes are unchanged: a
+  first install still writes `agents = ['*']` and `update = 'track'` with no
+  `disabled` key, and `plugin add` and `import` still produce identical files.
 - **`status --json`, `diff` and `reconcile` now list a shared file's merged keys
   in a stable, sorted order.** The three walked `render.CollectPointers`' output
   directly, which ranges a Go map, so with five MCP servers in one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,9 +275,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   [#140](https://github.com/spxrogers/agentsync/issues/140). The CLI now reads
   and writes the canonical struct, and a re-install starts from the whole
   existing entry and overwrites only the three fields it re-fetches (`id`,
-  `version`, `manifest_sha`), backfilling just the default an omitted key means
-  — so every other modelled field is preserved by default rather than dropped
-  by default, and a test fails if a new field is
+  `version`, `manifest_sha`) — so every other modelled field is preserved by
+  default rather than dropped by default, and a test fails if a new field is
   neither classified as re-fetched nor as preserved. The on-disk bytes are
   unchanged: a first install still writes `agents = ['*']` and
   `update = 'track'` with no `disabled` key, whether it comes from `plugin add`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,8 +275,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   [#140](https://github.com/spxrogers/agentsync/issues/140). The CLI now reads
   and writes the canonical struct, and a re-install starts from the whole
   existing entry and overwrites only the three fields it re-fetches (`id`,
-  `version`, `manifest_sha`) — so every other modelled field is preserved by
-  default rather than dropped by default, and a test fails if a new field is
+  `version`, `manifest_sha`), backfilling just the default an omitted key means
+  — so every other modelled field is preserved by default rather than dropped
+  by default, and a test fails if a new field is
   neither classified as re-fetched nor as preserved. The on-disk bytes are
   unchanged: a first install still writes `agents = ['*']` and
   `update = 'track'` with no `disabled` key, whether it comes from `plugin add`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,8 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
-- **A plugin's `plugins/<id>.toml` now has one schema and one preserve rule**
+- **Internal: a plugin's `plugins/<id>.toml` has one schema and one preserve
+  rule**
   ([#234](https://github.com/spxrogers/agentsync/issues/234)). The file was
   described by two identical structs — the canonical `source.PluginSpec` and a
   private copy inside the CLI — and a re-install merged the existing file into
@@ -274,11 +275,13 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   [#140](https://github.com/spxrogers/agentsync/issues/140). The CLI now reads
   and writes the canonical struct, and a re-install starts from the whole
   existing entry and overwrites only the three fields it re-fetches (`id`,
-  `version`, `manifest_sha`) — so every other key is preserved by default
-  rather than dropped by default, and a test fails if a new key is neither
-  classified as re-fetched nor as preserved. The on-disk bytes are unchanged: a
-  first install still writes `agents = ['*']` and `update = 'track'` with no
-  `disabled` key, and `plugin add` and `import` still produce identical files.
+  `version`, `manifest_sha`) — so every other modelled field is preserved by
+  default rather than dropped by default, and a test fails if a new field is
+  neither classified as re-fetched nor as preserved. The on-disk bytes are
+  unchanged: a first install still writes `agents = ['*']` and
+  `update = 'track'` with no `disabled` key, whether it comes from `plugin add`
+  or `import`.
+
 - **`status --json`, `diff` and `reconcile` now list a shared file's merged keys
   in a stable, sorted order.** The three walked `render.CollectPointers`' output
   directly, which ranges a Go map, so with five MCP servers in one

--- a/docs/components.md
+++ b/docs/components.md
@@ -62,7 +62,14 @@ is the only package that depends on nearly all the others.
   (#232); `finish` has exactly one call site and is never deferred, because it
   writes and it returns the run's error; `destReadPath` / `readDestText`
   (`destread.go`) — the whole-file destination readers that carry the symlink
-  policy (`AGENTSYNC_ALLOW_SYMLINK_DEST`), mirroring `iox.AtomicWrite`'s.
+  policy (`AGENTSYNC_ALLOW_SYMLINK_DEST`), mirroring `iox.AtomicWrite`'s;
+  `readPluginTOML` + `pluginLifecycleBase` / `pluginInstallRefresh`
+  (`plugin.go`) — `plugins/<id>.toml` has ONE shape, the canonical
+  `source.Plugin`, and a re-install carries the whole existing entry forward and
+  overwrites only the re-fetched `ID`/`Version`/`ManifestSHA`, so a field added
+  to `source.PluginSpec` is preserved by default rather than dropped by default
+  (#234; the CLI's private duplicate of the struct, and the field-by-field merge
+  that went with it, are gone).
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
   `revert`, `status`, `diff`, `reconcile`, `import`, `doctor`, `check`,
   `mcp {add,remove,list,enable,disable}`,

--- a/docs/components.md
+++ b/docs/components.md
@@ -67,8 +67,8 @@ is the only package that depends on nearly all the others.
   (`plugin.go`) — `plugins/<id>.toml` has ONE shape, the canonical
   `source.Plugin`, and a re-install carries the whole existing entry forward and
   overwrites only the re-fetched `ID`/`Version`/`ManifestSHA` (backfilling just
-  the default an omitted or empty key means), so a field added
-  to `source.PluginSpec` is preserved by default rather than dropped by default
+  the default an omitted or empty key means), so a field added to
+  `source.PluginSpec` is preserved by default rather than dropped by default
   (#234; the CLI's private duplicate of the struct, and the field-by-field merge
   that went with it, are gone).
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,

--- a/docs/components.md
+++ b/docs/components.md
@@ -66,7 +66,8 @@ is the only package that depends on nearly all the others.
   `readPluginTOML` + `pluginLifecycleBase` / `pluginInstallRefresh`
   (`plugin.go`) — `plugins/<id>.toml` has ONE shape, the canonical
   `source.Plugin`, and a re-install carries the whole existing entry forward and
-  overwrites only the re-fetched `ID`/`Version`/`ManifestSHA`, so a field added
+  overwrites only the re-fetched `ID`/`Version`/`ManifestSHA` (backfilling just
+  the default an omitted or empty key means), so a field added
   to `source.PluginSpec` is preserved by default rather than dropped by default
   (#234; the CLI's private duplicate of the struct, and the field-by-field merge
   that went with it, are gone).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,15 +643,15 @@ config is touched either way — the deferral lives entirely in your canonical
 source, which is what keeps `apply` reproducible from a dotfiles repo alone
 rather than dependent on whatever the machine happens to have installed.
 
-Both keys — and every other field in `plugins/<id>.toml` beyond the three a
-re-install re-fetches (`id`, `version`, `manifest_sha`) — survive re-installs
-and re-imports untouched (issues #140, #234), so a narrowed allowlist or an
-adopted plugin is never silently reset. A re-install carries every other
-modelled field forward from the file you have; a key you omitted, or an
-`agents` or `update` you left empty, is written with its default
-(`agents = ['*']`, `update = 'track'`). The file is rewritten in canonical
-form, not patched: comments and keys agentsync does not model are not kept,
-and `disabled = false` is written as no key at all.
+Both keys — and every other field agentsync models in `plugins/<id>.toml`
+beyond the three a re-install re-fetches (`id`, `version`, `manifest_sha`) —
+survive re-installs and re-imports (issues #140, #234), so a narrowed allowlist
+or an adopted plugin is never silently reset. A re-install carries every other
+field forward from the file you have; a key you omitted, or an `agents` or
+`update` you left empty, is written with its default (`agents = ['*']`,
+`update = 'track'`). The file is rewritten, not patched: comments and keys
+agentsync does not model are not kept, `disabled = false` is written as no key
+at all, and keys come out in agentsync's order.
 
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,14 +643,15 @@ config is touched either way — the deferral lives entirely in your canonical
 source, which is what keeps `apply` reproducible from a dotfiles repo alone
 rather than dependent on whatever the machine happens to have installed.
 
-Both keys — and every other field agentsync models in `plugins/<id>.toml` —
-survive re-installs and re-imports untouched (issues #140, #234), so a
-narrowed allowlist or an adopted plugin is never silently reset. A re-install
-rewrites only the three fields it re-fetches (`id`, `version`,
-`manifest_sha`) and carries every other modelled field forward from the file
-you have; a key you omitted (or an `agents` you left empty) is written with its
-default (`agents = ['*']`, `update = 'track'`). The file is rewritten, not
-patched, so comments and keys agentsync does not model are not kept.
+Both keys — and every other field in `plugins/<id>.toml` beyond the three a
+re-install re-fetches (`id`, `version`, `manifest_sha`) — survive re-installs
+and re-imports untouched (issues #140, #234), so a narrowed allowlist or an
+adopted plugin is never silently reset. A re-install carries every other
+modelled field forward from the file you have; a key you omitted, or an
+`agents` or `update` you left empty, is written with its default
+(`agents = ['*']`, `update = 'track'`). The file is rewritten in canonical
+form, not patched: comments and keys agentsync does not model are not kept,
+and `disabled = false` is written as no key at all.
 
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,12 +643,14 @@ config is touched either way — the deferral lives entirely in your canonical
 source, which is what keeps `apply` reproducible from a dotfiles repo alone
 rather than dependent on whatever the machine happens to have installed.
 
-Both keys — and every other key in `plugins/<id>.toml` — survive re-installs
-and re-imports untouched (issues #140, #234), so a narrowed allowlist or an
-adopted plugin is never silently reset. A re-install rewrites only the three
-fields it re-fetches (`id`, `version`, `manifest_sha`); every other key is
-carried forward from the file you have, and a key you omitted is written with
-its default (`agents = ['*']`, `update = 'track'`).
+Both keys — and every other field agentsync models in `plugins/<id>.toml` —
+survive re-installs and re-imports untouched (issues #140, #234), so a
+narrowed allowlist or an adopted plugin is never silently reset. A re-install
+rewrites only the three fields it re-fetches (`id`, `version`,
+`manifest_sha`) and carries every other modelled field forward from the file
+you have; a key you omitted (or an `agents` you left empty) is written with its
+default (`agents = ['*']`, `update = 'track'`). The file is rewritten, not
+patched, so comments and keys agentsync does not model are not kept.
 
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -643,8 +643,12 @@ config is touched either way — the deferral lives entirely in your canonical
 source, which is what keeps `apply` reproducible from a dotfiles repo alone
 rather than dependent on whatever the machine happens to have installed.
 
-Both keys survive re-installs and re-imports untouched (issue #140), so a
-narrowed allowlist or an adopted plugin is never silently reset.
+Both keys — and every other key in `plugins/<id>.toml` — survive re-installs
+and re-imports untouched (issues #140, #234), so a narrowed allowlist or an
+adopted plugin is never silently reset. A re-install rewrites only the three
+fields it re-fetches (`id`, `version`, `manifest_sha`); every other key is
+carried forward from the file you have, and a key you omitted is written with
+its default (`agents = ['*']`, `update = 'track'`).
 
 Because apply's plan never reads the destination, agentsync cannot notice a
 plugin you install natively AFTER declaring it. `status` and `doctor` do read

--- a/internal/cli/import_native_agents_prompt_internal_test.go
+++ b/internal/cli/import_native_agents_prompt_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/testenv"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
@@ -387,11 +388,11 @@ func TestPluginTOML_NativeAgentsRoundTrip(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			first, err := toml.Marshal(pluginTOML{Plugin: pluginTOMLSpec{ID: "toolkit@mp", NativeAgents: tc.in}})
+			first, err := toml.Marshal(source.Plugin{Plugin: source.PluginSpec{ID: "toolkit@mp", NativeAgents: tc.in}})
 			if err != nil {
 				t.Fatal(err)
 			}
-			var decoded pluginTOML
+			var decoded source.Plugin
 			if err := toml.Unmarshal(first, &decoded); err != nil {
 				t.Fatal(err)
 			}
@@ -451,7 +452,7 @@ func TestNativeAgentsSuffix_SanitizesAndStaysQuiet(t *testing.T) {
 func TestKeptLifecycleSummary_Sanitizes(t *testing.T) {
 	testenv.RequireContainer(t)
 	hostile := []string{"claude\x1b[31m"}
-	got := keptLifecycleSummary(pluginTOMLSpec{
+	got := keptLifecycleSummary(source.PluginSpec{
 		Agents:       []string{"codex\x1b[32m"},
 		NativeAgents: &hostile,
 		Update:       "track",

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -160,18 +160,18 @@ func pluginNativeAgentsUnset(home, id string) bool {
 	return existing.Plugin.NativeAgents == nil
 }
 
-// pluginInstallRefresh names the ONLY fields a (re-)install recomputes from the
-// fetched marketplace metadata. Everything else in source.PluginSpec is
-// USER-AUTHORED lifecycle state that a re-install must carry forward untouched.
+// pluginInstallRefresh names the fields installPluginInto recomputes from the
+// fetched marketplace metadata; everything else in source.PluginSpec is
+// user-authored lifecycle state a re-install carries forward untouched (#140).
+// It is a struct so that half of the classification lives in one place a test
+// can reflect over: TestPluginSpecFieldsAreClassified holds the preserved half
+// and fails when source.PluginSpec grows a field that is in neither (#234).
 //
-// It is a struct, not three lines inline, so the refreshed half of the
-// classification lives in production code, in one place a test can reflect
-// over; the preserved half is the test-side pluginSpecPreserved, and
-// TestPluginSpecFieldsAreClassified forces the two to partition
-// source.PluginSpec exactly — it fails when the struct grows a field that is
-// neither named here nor classified as preserved, which is what stops the #140
-// bug class from reappearing through a field nobody remembered to add to the
-// merge (#234).
+// `plugin upgrade` (pluginUpgradeRun) and the poll engine (applyPluginBump)
+// refresh Version and ManifestSHA on their own, outside applyTo: each rewrites
+// the whole decoded entry, so it preserves by construction, and its refreshed
+// set differs (no ID; a SHA only when one was computed). A field added here
+// does not reach them.
 type pluginInstallRefresh struct {
 	ID          untrusted.Text
 	Version     untrusted.Text
@@ -192,9 +192,9 @@ func (r pluginInstallRefresh) applyTo(base source.PluginSpec) source.PluginSpec 
 // pluginLifecycleBase returns the spec a (re-)install starts from, before the
 // install-refreshed fields are stamped onto it.
 //
-// existing is the spec already in plugins/<id>.toml, or nil for a first
-// install. Its lifecycle fields (the Agents allowlist, the Update policy, the
-// NativeAgents deferral, the Disabled bit) are user-authored, security-relevant
+// existing is the spec already in plugins/<id>.toml, or the zero spec for a
+// first install. Its lifecycle fields (the Agents allowlist, the Update policy,
+// the NativeAgents deferral, the Disabled bit) are user-authored, security-relevant
 // on-disk state — the allowlist scopes which agents a credential-bearing plugin
 // fans out to — so they are carried forward WHOLESALE rather than field by
 // field (issue #140).
@@ -202,15 +202,12 @@ func (r pluginInstallRefresh) applyTo(base source.PluginSpec) source.PluginSpec 
 // The three backfills below are for keys the file may legitimately OMIT, not a
 // re-listing of the lifecycle: each restores the value the omission means, so a
 // re-install over a file with no `agents` key still writes agents = ['*'] and a
-// first install (existing == nil, every field zero) produces the historical
+// first install (the zero spec, every field zero) produces the historical
 // artifact byte-for-byte — agents = ['*'], update = 'track', no disabled key —
-// which is what keeps `plugin add` and `import` producing identical canonical
-// files (see installPluginInto's doc comment).
-func pluginLifecycleBase(existing *source.PluginSpec, defaultNativeAgents []string) source.PluginSpec {
-	var base source.PluginSpec
-	if existing != nil {
-		base = *existing
-	}
+// the same defaults whether the install comes from `plugin add` or `import`
+// (see installPluginInto's doc comment).
+func pluginLifecycleBase(existing source.PluginSpec, defaultNativeAgents []string) source.PluginSpec {
+	base := existing
 	if len(base.Agents) == 0 {
 		base.Agents = []string{"*"}
 	}
@@ -234,12 +231,13 @@ func pluginLifecycleBase(existing *source.PluginSpec, defaultNativeAgents []stri
 // installPluginInto fetches plugin id from the named marketplace into the
 // plugin cache and writes plugins/<id>.toml, returning the written spec. mpName
 // may be empty (the marketplace is then searched for across all caches). It
-// does not print or acquire the global lock — callers do. Both `plugin install`
-// and `import` use it so the two produce byte-identical canonical artifacts.
-// defaultNativeAgents, when non-nil, seeds `native_agents` on a FIRST install
-// (it is ignored when plugins/<id>.toml already exists — an existing file's
-// lifecycle fields always win, per #140). `import` passes the agents whose
-// native config already enables this plugin; `plugin add` passes nil.
+// does not print or acquire the global lock — callers do. Both `plugin add` and
+// `import` use it, so the two write the same defaults into a new file.
+// defaultNativeAgents, when non-nil, seeds `native_agents` when the file has no
+// such key — on a first install, or over an existing file that never recorded
+// one; an existing key, even an empty list, always wins (#140). `import` passes
+// the agents whose native config already enables this plugin; `plugin add`
+// passes nil.
 func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (source.PluginSpec, error) {
 	// Resolve marketplace.json from the marketplace cache.
 	mpData, mpEntry, resolvedMP, err := resolveMarketplaceEntry(home, mpName, id)
@@ -287,10 +285,10 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (s
 	// comment-only — parses to rerr==nil and legitimately carries no lifecycle
 	// state, so it takes the defaults. agentsync's own iox.AtomicWrite never
 	// produces such a file; only external truncation would.)
-	var existingSpec *source.PluginSpec
+	var existingSpec source.PluginSpec
 	switch existing, rerr := readPluginTOML(pluginPath); {
 	case rerr == nil:
-		existingSpec = &existing.Plugin
+		existingSpec = existing.Plugin
 	case !errors.Is(rerr, os.ErrNotExist):
 		return source.PluginSpec{}, fmt.Errorf("existing %s is unreadable (%w); refusing to overwrite its agents/update/disabled with defaults — fix or remove it, then re-install", pluginPath, rerr)
 	}
@@ -957,7 +955,10 @@ func computeManifestSHA(home, id string, entry marketplace.PluginEntry, mpData [
 // lifecycle verbs (enable/disable/upgrade) must be able to read and rewrite a
 // file whose stray key the loader would reject, so `plugin disable` still works
 // on a hand-edited registry rather than failing with a decode error the user
-// cannot act on from here. Plugin.ID (toml:"-") is filled from the filename
+// cannot act on from here. The rewrite that follows keeps only the fields
+// source.Plugin models: a stray key, like a comment, is not carried into the
+// new file — which is why the docs promise to carry every MODELLED field
+// forward, not every key. Plugin.ID (toml:"-") is filled from the filename
 // stem exactly as loadPlugins fills it, so a source.Plugin from this function
 // means the same thing as one from source.Load.
 func readPluginTOML(path string) (source.Plugin, error) {

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -64,36 +64,6 @@ func findSub(parent *cobra.Command, name string) *cobra.Command {
 	return nil
 }
 
-// pluginTOML is the shape of plugins/<id>.toml.
-type pluginTOML struct {
-	Plugin pluginTOMLSpec `toml:"plugin"`
-}
-
-type pluginTOMLSpec struct {
-	// ID/Version mirror source.PluginSpec and originate from fetched marketplace
-	// metadata, so they are untrusted.Text (sanitize-on-print). The SHA/update
-	// fields are agentsync-controlled and stay plain strings.
-	ID          untrusted.Text `toml:"id"`
-	Version     untrusted.Text `toml:"version,omitempty"`
-	ManifestSHA string         `toml:"manifest_sha,omitempty"`
-	Update      string         `toml:"update,omitempty"`
-	Agents      []string       `toml:"agents,omitempty"`
-	// NativeAgents mirrors source.PluginSpec.NativeAgents — agents whose own
-	// plugin manager already installs this plugin, so apply must not project its
-	// components there. Populated by `import` and preserved across re-installs
-	// like every other lifecycle field.
-	//
-	// It is a POINTER for the same reason the canonical field is: `omitempty`
-	// drops an EMPTY slice, so a user's explicit `native_agents = []` ("defer to
-	// nobody, stop asking") vanished on the next rewrite and the decision was
-	// silently reverted — after which the next import re-seeded it, under
-	// --no-input without even asking. A nil pointer omits the key; a pointer to
-	// an empty slice writes `native_agents = []`. Pinned by
-	// TestPluginTOML_NativeAgentsRoundTrip.
-	NativeAgents *[]string `toml:"native_agents,omitempty"`
-	Disabled     bool      `toml:"disabled,omitempty"`
-}
-
 // ---- install ----------------------------------------------------------------
 
 // newPluginAddCmd is `plugin add`. It was `plugin install` until #200 F4, which
@@ -151,7 +121,7 @@ func pluginAddRun(cmd *cobra.Command, args []string) error {
 // spec matches those defaults — a genuine first install, or a re-install over a
 // TOML that already held the defaults — so the install status line only mentions
 // preserved state when there is some to mention.
-func keptLifecycleSummary(spec pluginTOMLSpec) string {
+func keptLifecycleSummary(spec source.PluginSpec) string {
 	var parts []string
 	defaultAgents := len(spec.Agents) == 1 && spec.Agents[0] == "*"
 	if !defaultAgents {
@@ -199,11 +169,11 @@ func pluginNativeAgentsUnset(home, id string) bool {
 // (it is ignored when plugins/<id>.toml already exists — an existing file's
 // lifecycle fields always win, per #140). `import` passes the agents whose
 // native config already enables this plugin; `plugin add` passes nil.
-func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (pluginTOMLSpec, error) {
+func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (source.PluginSpec, error) {
 	// Resolve marketplace.json from the marketplace cache.
 	mpData, mpEntry, resolvedMP, err := resolveMarketplaceEntry(home, mpName, id)
 	if err != nil {
-		return pluginTOMLSpec{}, err
+		return source.PluginSpec{}, err
 	}
 
 	// Compute cache path.
@@ -225,7 +195,7 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (p
 	fetcher := marketplace.Dispatch(src)
 	result, err := fetcher.Fetch(src, cacheDir)
 	if err != nil {
-		return pluginTOMLSpec{}, fmt.Errorf("fetch plugin %s: %w", id, err)
+		return source.PluginSpec{}, fmt.Errorf("fetch plugin %s: %w", id, err)
 	}
 
 	// Compute manifest SHA.
@@ -285,12 +255,12 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (p
 		// comment-only — parses to rerr==nil above and legitimately carries no allowlist
 		// to preserve, so it falls through to defaults. agentsync's own iox.AtomicWrite
 		// never produces such a file; only external truncation would.)
-		return pluginTOMLSpec{}, fmt.Errorf("existing %s is unreadable (%w); refusing to overwrite its agents/update/disabled with defaults — fix or remove it, then re-install", pluginPath, rerr)
+		return source.PluginSpec{}, fmt.Errorf("existing %s is unreadable (%w); refusing to overwrite its agents/update/disabled with defaults — fix or remove it, then re-install", pluginPath, rerr)
 	}
 	// A genuine first install (readPluginTOML returned os.ErrNotExist) keeps the
 	// byte-identical defaults so install/import still produce identical artifacts.
 
-	spec := pluginTOMLSpec{
+	spec := source.PluginSpec{
 		// id/marketplace are validated cache keys; wrap the composed id as Text to
 		// match the canonical model (the ManifestSHA below stays a plain string).
 		ID:           untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
@@ -304,12 +274,12 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (p
 	if result.Version != "" {
 		spec.Version = untrusted.Wrap(result.Version)
 	}
-	data, err := toml.Marshal(pluginTOML{Plugin: spec})
+	data, err := toml.Marshal(source.Plugin{Plugin: spec})
 	if err != nil {
-		return pluginTOMLSpec{}, fmt.Errorf("marshal plugin toml: %w", err)
+		return source.PluginSpec{}, fmt.Errorf("marshal plugin toml: %w", err)
 	}
 	if err := iox.AtomicWrite(pluginPath, data, 0o644); err != nil {
-		return pluginTOMLSpec{}, fmt.Errorf("write %s: %w", pluginPath, err)
+		return source.PluginSpec{}, fmt.Errorf("write %s: %w", pluginPath, err)
 	}
 	return spec, nil
 }
@@ -678,7 +648,7 @@ func pluginListRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	var names []string
-	plugins := map[string]pluginTOMLSpec{}
+	plugins := map[string]source.PluginSpec{}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
 			continue
@@ -727,7 +697,7 @@ func splitPluginRef(ref string) (id, mpName string) {
 // `plugin disable demo@wrong-mp` act on the demo installed from another
 // marketplace. An unqualified ref (typedMP == "") is unchanged. The recorded
 // value comes from a hand-editable file; %q renders any control bytes inert.
-func checkPluginRefMarketplace(existing pluginTOML, id, typedMP string) error {
+func checkPluginRefMarketplace(existing source.Plugin, id, typedMP string) error {
 	if typedMP == "" {
 		return nil
 	}
@@ -944,15 +914,31 @@ func computeManifestSHA(home, id string, entry marketplace.PluginEntry, mpData [
 }
 
 // readPluginTOML reads and parses a plugins/<id>.toml file.
-func readPluginTOML(path string) (pluginTOML, error) {
+//
+// The file has exactly ONE shape, source.Plugin — the canonical model the
+// loader, the projection layer and source.WritePlugin already use. The CLI used
+// to carry a private field-for-field duplicate of that struct, which is how a
+// lifecycle field could be added to one and missed by the other (#234).
+// Marshalling either produced identical bytes, so there was nothing to keep
+// them honest.
+//
+// Decoding is deliberately PERMISSIVE, unlike source.Load's strict decode: the
+// lifecycle verbs (enable/disable/upgrade) must be able to read and rewrite a
+// file whose stray key the loader would reject, so `plugin disable` still works
+// on a hand-edited registry rather than failing with a decode error the user
+// cannot act on from here. Plugin.ID (toml:"-") is filled from the filename
+// stem exactly as loadPlugins fills it, so a source.Plugin from this function
+// means the same thing as one from source.Load.
+func readPluginTOML(path string) (source.Plugin, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return pluginTOML{}, fmt.Errorf("read %s: %w", path, err)
+		return source.Plugin{}, fmt.Errorf("read %s: %w", path, err)
 	}
-	var p pluginTOML
+	var p source.Plugin
 	if err := toml.Unmarshal(data, &p); err != nil {
-		return pluginTOML{}, fmt.Errorf("parse %s: %w", path, err)
+		return source.Plugin{}, fmt.Errorf("parse %s: %w", path, err)
 	}
+	p.ID = untrusted.Wrap(strings.TrimSuffix(filepath.Base(path), ".toml"))
 	return p, nil
 }
 

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -160,6 +160,77 @@ func pluginNativeAgentsUnset(home, id string) bool {
 	return existing.Plugin.NativeAgents == nil
 }
 
+// pluginInstallRefresh names the ONLY fields a (re-)install recomputes from the
+// fetched marketplace metadata. Everything else in source.PluginSpec is
+// USER-AUTHORED lifecycle state that a re-install must carry forward untouched.
+//
+// It is a struct, not three lines inline, so the refreshed half of the
+// classification lives in production code, in one place a test can reflect
+// over; the preserved half is the test-side pluginSpecPreserved, and
+// TestPluginSpecFieldsAreClassified forces the two to partition
+// source.PluginSpec exactly — it fails when the struct grows a field that is
+// neither named here nor classified as preserved, which is what stops the #140
+// bug class from reappearing through a field nobody remembered to add to the
+// merge (#234).
+type pluginInstallRefresh struct {
+	ID          untrusted.Text
+	Version     untrusted.Text
+	ManifestSHA string
+}
+
+// applyTo overwrites the refreshed fields on base and returns the result. base
+// carries every other field through unchanged — preservation is the DEFAULT, so
+// a lifecycle field added to source.PluginSpec tomorrow survives a re-install
+// without anyone editing this function.
+func (r pluginInstallRefresh) applyTo(base source.PluginSpec) source.PluginSpec {
+	base.ID = r.ID
+	base.Version = r.Version
+	base.ManifestSHA = r.ManifestSHA
+	return base
+}
+
+// pluginLifecycleBase returns the spec a (re-)install starts from, before the
+// install-refreshed fields are stamped onto it.
+//
+// existing is the spec already in plugins/<id>.toml, or nil for a first
+// install. Its lifecycle fields (the Agents allowlist, the Update policy, the
+// NativeAgents deferral, the Disabled bit) are user-authored, security-relevant
+// on-disk state — the allowlist scopes which agents a credential-bearing plugin
+// fans out to — so they are carried forward WHOLESALE rather than field by
+// field (issue #140).
+//
+// The three backfills below are for keys the file may legitimately OMIT, not a
+// re-listing of the lifecycle: each restores the value the omission means, so a
+// re-install over a file with no `agents` key still writes agents = ['*'] and a
+// first install (existing == nil, every field zero) produces the historical
+// artifact byte-for-byte — agents = ['*'], update = 'track', no disabled key —
+// which is what keeps `plugin add` and `import` producing identical canonical
+// files (see installPluginInto's doc comment).
+func pluginLifecycleBase(existing *source.PluginSpec, defaultNativeAgents []string) source.PluginSpec {
+	var base source.PluginSpec
+	if existing != nil {
+		base = *existing
+	}
+	if len(base.Agents) == 0 {
+		base.Agents = []string{"*"}
+	}
+	if base.Update == "" {
+		base.Update = "track"
+	}
+	// The caller's seed applies only when the key is ABSENT. An existing
+	// deferral list wins for the same reason the allowlist does: a user who
+	// removed an agent from native_agents (having uninstalled the native copy)
+	// must not have it re-added by the next import, which would silently stop
+	// projecting to an agent they deliberately adopted. A deliberately EMPTIED
+	// list is itself a decision ("defer to nobody"), so it is preserved as-is —
+	// which is why the field is a pointer and this tests nil, not len.
+	if base.NativeAgents == nil && defaultNativeAgents != nil {
+		seed := defaultNativeAgents
+		base.NativeAgents = &seed
+	}
+	return base
+}
+
 // installPluginInto fetches plugin id from the named marketplace into the
 // plugin cache and writes plugins/<id>.toml, returning the written spec. mpName
 // may be empty (the marketplace is then searched for across all caches). It
@@ -207,70 +278,30 @@ func installPluginInto(home, id, mpName string, defaultNativeAgents []string) (s
 	// Write plugins/<id>.toml.
 	pluginPath := filepath.Join(home, "plugins", id+".toml")
 
-	// Lifecycle fields (Agents allowlist, Update policy, Disabled bit) are
-	// user-authored, security-relevant on-disk state: the allowlist scopes which
-	// agents a credential-bearing plugin fans out to. A re-install over an
-	// existing plugins/<id>.toml must PRESERVE them rather than reset them to the
-	// first-install defaults — silently re-broadening a narrowed allowlist would
-	// ship those credentials to agents the user deliberately excluded (issue
-	// #140). Only ID/Version/ManifestSHA are legitimately refreshed by install.
-	//
-	// A genuine first install (no prior TOML — a not-exist read falls through
-	// here) keeps the historical defaults byte-for-byte, so `install` and
-	// `import` still produce byte-identical canonical artifacts (see the doc
-	// comment above): Agents=["*"], Update="track", Disabled absent.
-	agents := []string{"*"}
-	var nativeAgents *[]string
-	if defaultNativeAgents != nil {
-		seed := defaultNativeAgents
-		nativeAgents = &seed
-	}
-	update := "track"
-	disabled := false
+	// Read the existing registry entry, if any. A parse failure on a file that
+	// EXISTS refuses the install: falling through to the first-install defaults
+	// would silently re-broaden a narrowed allowlist — the exact #140 loss this
+	// path exists to prevent — so refuse rather than reset a corrupt-but-present
+	// lifecycle file. The user can fix or remove it and re-install. ("Unparseable"
+	// here means a TOML *parse error*; a semantically-empty file — blank or
+	// comment-only — parses to rerr==nil and legitimately carries no lifecycle
+	// state, so it takes the defaults. agentsync's own iox.AtomicWrite never
+	// produces such a file; only external truncation would.)
+	var existingSpec *source.PluginSpec
 	switch existing, rerr := readPluginTOML(pluginPath); {
 	case rerr == nil:
-		if len(existing.Plugin.Agents) > 0 {
-			agents = existing.Plugin.Agents
-		}
-		// An existing file's deferral list wins over the caller's default, for
-		// the same reason the allowlist does: a user who removed an agent from
-		// native_agents (having uninstalled the native copy) must not have it
-		// re-added by the next import, which would silently stop projecting to
-		// an agent they deliberately adopted. Re-seed only when the key is
-		// absent — a deliberately EMPTIED list is a decision, so it is
-		// preserved as-is (non-nil and empty reads as "defer to nobody").
-		if existing.Plugin.NativeAgents != nil {
-			nativeAgents = existing.Plugin.NativeAgents
-		}
-		if existing.Plugin.Update != "" {
-			update = existing.Plugin.Update
-		}
-		disabled = existing.Plugin.Disabled
+		existingSpec = &existing.Plugin
 	case !errors.Is(rerr, os.ErrNotExist):
-		// The file EXISTS but is unparseable. Falling through to the ["*"]/track/false
-		// defaults would silently re-broaden a narrowed allowlist — the exact #140 loss
-		// this preserve path prevents — so refuse rather than reset a corrupt-but-present
-		// lifecycle file. The user can fix or remove it and re-install. ("Unparseable"
-		// here means a TOML *parse error*; a semantically-empty file — blank or
-		// comment-only — parses to rerr==nil above and legitimately carries no allowlist
-		// to preserve, so it falls through to defaults. agentsync's own iox.AtomicWrite
-		// never produces such a file; only external truncation would.)
 		return source.PluginSpec{}, fmt.Errorf("existing %s is unreadable (%w); refusing to overwrite its agents/update/disabled with defaults — fix or remove it, then re-install", pluginPath, rerr)
 	}
-	// A genuine first install (readPluginTOML returned os.ErrNotExist) keeps the
-	// byte-identical defaults so install/import still produce identical artifacts.
 
-	spec := source.PluginSpec{
+	spec := pluginInstallRefresh{
 		// id/marketplace are validated cache keys; wrap the composed id as Text to
-		// match the canonical model (the ManifestSHA below stays a plain string).
-		ID:           untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
-		Version:      mpEntry.Version,
-		ManifestSHA:  manifestSHA,
-		Update:       update,
-		Agents:       agents,
-		NativeAgents: nativeAgents,
-		Disabled:     disabled,
-	}
+		// match the canonical model (ManifestSHA stays a plain string).
+		ID:          untrusted.Wrap(id + "@" + resolveMarketplaceName(mpName)),
+		Version:     mpEntry.Version,
+		ManifestSHA: manifestSHA,
+	}.applyTo(pluginLifecycleBase(existingSpec, defaultNativeAgents))
 	if result.Version != "" {
 		spec.Version = untrusted.Wrap(result.Version)
 	}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -168,10 +168,9 @@ func pluginNativeAgentsUnset(home, id string) bool {
 // and fails when source.PluginSpec grows a field that is in neither (#234).
 //
 // `plugin upgrade` (pluginUpgradeRun) and the poll engine (applyPluginBump)
-// refresh Version and ManifestSHA on their own, outside applyTo: each rewrites
-// the whole decoded entry, so it preserves by construction, and its refreshed
-// set differs (no ID; a SHA only when one was computed). A field added here
-// does not reach them.
+// refresh only Version and ManifestSHA, each on its own conditions and outside
+// applyTo: both rewrite the whole decoded entry, so they preserve by
+// construction. A field added here does not reach them.
 type pluginInstallRefresh struct {
 	ID          untrusted.Text
 	Version     untrusted.Text

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -198,7 +198,7 @@ func (r pluginInstallRefresh) applyTo(base source.PluginSpec) source.PluginSpec 
 // fans out to — so they are carried forward WHOLESALE rather than field by
 // field (issue #140).
 //
-// The three backfills below are for keys the file may legitimately OMIT, not a
+// The three backfills below are for keys the file may omit or leave empty, not a
 // re-listing of the lifecycle: each restores the value the omission means, so a
 // re-install over a file with no `agents` key still writes agents = ['*'] and a
 // first install (the zero spec, every field zero) produces the historical

--- a/internal/cli/plugin_lifecycle_guard_internal_test.go
+++ b/internal/cli/plugin_lifecycle_guard_internal_test.go
@@ -91,6 +91,10 @@ func plantSentinels(t *testing.T, spec *source.PluginSpec) {
 	for i := 0; i < v.NumField(); i++ {
 		f := v.Field(i)
 		name := v.Type().Field(i).Name
+		if !f.CanSet() {
+			t.Fatalf("source.PluginSpec.%s is unexported; this proof plants by reflection and cannot "+
+				"reach it — export it, or teach plantSentinels another way in", name)
+		}
 		sentinel := "sentinel-" + name
 		switch {
 		case f.Kind() == reflect.String:
@@ -146,6 +150,24 @@ func TestInstallPreservesEveryLifecycleField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read back the written artifact: %v", err)
 	}
+	// What a refresh must write is what a FIRST install of the same fixture
+	// writes — the same entry and cache tree, in a home with no existing file.
+	// "Differs from the sentinel" alone would let a refresh that blanks a field
+	// pass, and the fixture's version is what makes Version load-bearing here.
+	fresh := t.TempDir()
+	writeMarketplaceCacheFixture(t, fresh, "test-mp", "demo")
+	first, err := installPluginInto(fresh, "demo", "test-mp", nil)
+	if err != nil {
+		t.Fatalf("first install for the expected refreshed values: %v", err)
+	}
+	if first.Version.Unverified() != "1.2.3" || first.ManifestSHA == "" {
+		t.Fatalf("the fixture must yield a non-empty version and manifest SHA for the refresh check to bite; got %+v", first)
+	}
+	wantRefreshed := map[string]any{
+		"ID":          first.ID,
+		"Version":     first.Version,
+		"ManifestSHA": first.ManifestSHA,
+	}
 
 	refreshed := map[string]bool{}
 	rt := reflect.TypeOf(pluginInstallRefresh{})
@@ -164,8 +186,13 @@ func TestInstallPreservesEveryLifecycleField(t *testing.T) {
 					name, why, gotF, wantF)
 			}
 		case refreshed[name]:
-			if reflect.DeepEqual(gotF, wantF) {
-				t.Errorf("re-install did not refresh %s: it still holds the stale on-disk value %#v", name, gotF)
+			exp, known := wantRefreshed[name]
+			if !known {
+				t.Fatalf("pluginInstallRefresh.%s has no expected value in this test; add it to wantRefreshed", name)
+			}
+			if !reflect.DeepEqual(gotF, exp) {
+				t.Errorf("re-install did not refresh %s: on disk %#v, want the fetched %#v (the stale sentinel was %#v)",
+					name, gotF, exp, wantF)
 			}
 		default:
 			// Unclassified: TestPluginSpecFieldsAreClassified reports it. Asserting
@@ -175,8 +202,8 @@ func TestInstallPreservesEveryLifecycleField(t *testing.T) {
 	// The caller's native_agents seed must NOT override an existing list — the
 	// sentinel above is an existing one. (Asserted separately because the loop
 	// above would also pass if the seed happened to equal the sentinel.)
-	if after.Plugin.NativeAgents == nil || (*after.Plugin.NativeAgents)[0] == "seed-agent" {
-		t.Errorf("the caller's native_agents seed overwrote an existing deferral list: %v", after.Plugin.NativeAgents)
+	if got := after.Plugin.DeferredAgents(); reflect.DeepEqual(got, []string{"seed-agent"}) {
+		t.Errorf("the caller's native_agents seed overwrote an existing deferral list: %v", got)
 	}
 }
 
@@ -187,7 +214,7 @@ func writeMarketplaceCacheFixture(t *testing.T, home, mpName, plugin string) {
 	t.Helper()
 	root := marketplaceCacheDir(home, mpName)
 	mpJSON := `{"name": "` + mpName + `", "owner": {"name": "tester"}, "plugins": [` +
-		`{"name": "` + plugin + `", "source": "./plugins/` + plugin + `"}]}`
+		`{"name": "` + plugin + `", "source": "./plugins/` + plugin + `", "version": "1.2.3"}]}`
 	mustWrite(t, filepath.Join(root, ".claude-plugin", "marketplace.json"), mpJSON)
 	mustWrite(t, filepath.Join(root, "plugins", plugin, ".claude-plugin", "plugin.json"),
 		`{"name": "`+plugin+`", "version": "1.0.0"}`)

--- a/internal/cli/plugin_lifecycle_guard_internal_test.go
+++ b/internal/cli/plugin_lifecycle_guard_internal_test.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// pluginSpecPreserved classifies every field of source.PluginSpec that a
+// re-install must carry forward from the existing plugins/<id>.toml. It is the
+// counterpart of pluginInstallRefresh, which names the fields an install
+// recomputes; together the two must account for the struct exactly.
+//
+// The value is a short note on WHY the field is user-authored state, so the map
+// stays a classification rather than a checklist.
+var pluginSpecPreserved = map[string]string{
+	"Update":       "the user's update policy (pinned|track|manual)",
+	"Agents":       "the user's fan-out allowlist — resetting it re-broadens a narrowed one (#140)",
+	"NativeAgents": "the deferral record; re-seeding it stops projecting to an adopted agent",
+	"Disabled":     "`plugin disable` state — resetting it silently re-enables the plugin",
+}
+
+// TestPluginSpecFieldsAreClassified fails when source.PluginSpec grows a field
+// that the install path neither refreshes nor preserves.
+//
+// This is the guard the preserve path never had. `installPluginInto` used to
+// merge the existing file field by field, so a new lifecycle field was dropped
+// by DEFAULT: it silently reverted to its zero value on every re-install and
+// re-import — the #140 bug class, and the "the model drifts from its artifact"
+// failure this repo treats as a bug. The merge is now wholesale, but the
+// classification still has to be honest, so this mirrors TestNewSecretFieldGuard
+// (internal/secrets): reflect over the struct, insist every field is accounted
+// for, and tell the author exactly what to do.
+func TestPluginSpecFieldsAreClassified(t *testing.T) {
+	refreshed := map[string]bool{}
+	rt := reflect.TypeOf(pluginInstallRefresh{})
+	for i := 0; i < rt.NumField(); i++ {
+		refreshed[rt.Field(i).Name] = true
+	}
+
+	st := reflect.TypeOf(source.PluginSpec{})
+	for i := 0; i < st.NumField(); i++ {
+		name := st.Field(i).Name
+		_, isPreserved := pluginSpecPreserved[name]
+		if refreshed[name] && isPreserved {
+			t.Errorf("source.PluginSpec.%s is classified BOTH refreshed and preserved; it must be exactly one", name)
+			continue
+		}
+		if !refreshed[name] && !isPreserved {
+			t.Errorf("source.PluginSpec.%s is unclassified: add it to pluginInstallRefresh if a (re-)install "+
+				"recomputes it from the fetched marketplace metadata, or to pluginSpecPreserved if it is "+
+				"user-authored lifecycle state a re-install must carry forward", name)
+		}
+	}
+
+	// The refresh struct must not name a field the spec does not have: a rename
+	// on the canonical side would otherwise leave applyTo stamping a field that
+	// no longer exists (a compile error) or, worse, a stale classification here.
+	for name := range refreshed {
+		if _, ok := st.FieldByName(name); !ok {
+			t.Errorf("pluginInstallRefresh.%s names no field of source.PluginSpec", name)
+		}
+	}
+	for name := range pluginSpecPreserved {
+		if _, ok := st.FieldByName(name); !ok {
+			t.Errorf("pluginSpecPreserved classifies %q, which is not a field of source.PluginSpec", name)
+		}
+	}
+}
+
+// plantSentinels fills every field of spec with a distinguishable non-zero
+// value, by reflection, so the round-trip below can prove each one survives.
+// Planting reflectively (rather than from a literal) is what makes the proof
+// survive a NEW field: the field is planted, asserted, and — if the preserve
+// path drops it — the assertion fails, with no test edit needed.
+//
+// A new field that is left UNCLASSIFIED, of a kind this function can plant
+// (string, bool, []string, *[]string), is skipped by the round-trip below, so
+// one cause yields exactly one failure — TestPluginSpecFieldsAreClassified's.
+// A field of any OTHER kind additionally fails
+// TestInstallPreservesEveryLifecycleField here, at the Fatalf, by design: the
+// proof must be taught the kind before it can claim to cover the field.
+func plantSentinels(t *testing.T, spec *source.PluginSpec) {
+	t.Helper()
+	v := reflect.ValueOf(spec).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		name := v.Type().Field(i).Name
+		sentinel := "sentinel-" + name
+		switch {
+		case f.Kind() == reflect.String:
+			f.SetString(sentinel)
+		case f.Kind() == reflect.Bool:
+			f.SetBool(true)
+		case f.Kind() == reflect.Slice && f.Type().Elem().Kind() == reflect.String:
+			f.Set(reflect.ValueOf([]string{sentinel}).Convert(f.Type()))
+		case f.Kind() == reflect.Pointer && f.Type().Elem().Kind() == reflect.Slice &&
+			f.Type().Elem().Elem().Kind() == reflect.String:
+			p := reflect.New(f.Type().Elem())
+			p.Elem().Set(reflect.ValueOf([]string{sentinel}).Convert(f.Type().Elem()))
+			f.Set(p)
+		default:
+			t.Fatalf("source.PluginSpec.%s has kind %s, which this test cannot plant a sentinel in; "+
+				"teach plantSentinels that kind so the preserve proof still covers every field", name, f.Kind())
+		}
+	}
+}
+
+// TestInstallPreservesEveryLifecycleField proves the classification is real:
+// every field pluginSpecPreserved claims is carried forward actually survives a
+// re-install, ON DISK, and every field pluginInstallRefresh claims is recomputed
+// actually replaces what was there. Without it the map could claim a coverage
+// the merge does not deliver — the same reason internal/secrets pairs its field
+// guard with TestWalkerVisitsEveryCoveredField.
+//
+// The oracle is the artifact, not the model: the sentinels are written as real
+// plugins/<id>.toml bytes and read back from the file installPluginInto wrote.
+func TestInstallPreservesEveryLifecycleField(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+	writeMarketplaceCacheFixture(t, home, "test-mp", "demo")
+
+	var planted source.PluginSpec
+	plantSentinels(t, &planted)
+	pluginPath := filepath.Join(home, "plugins", "demo.toml")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body, err := toml.Marshal(source.Plugin{Plugin: planted})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installPluginInto(home, "demo", "test-mp", []string{"seed-agent"}); err != nil {
+		t.Fatalf("re-install: %v", err)
+	}
+	after, err := readPluginTOML(pluginPath)
+	if err != nil {
+		t.Fatalf("read back the written artifact: %v", err)
+	}
+
+	refreshed := map[string]bool{}
+	rt := reflect.TypeOf(pluginInstallRefresh{})
+	for i := 0; i < rt.NumField(); i++ {
+		refreshed[rt.Field(i).Name] = true
+	}
+	got := reflect.ValueOf(after.Plugin)
+	want := reflect.ValueOf(planted)
+	for i := 0; i < got.NumField(); i++ {
+		name := got.Type().Field(i).Name
+		gotF, wantF := got.Field(i).Interface(), want.Field(i).Interface()
+		switch why, preserved := pluginSpecPreserved[name]; {
+		case preserved:
+			if !reflect.DeepEqual(gotF, wantF) {
+				t.Errorf("re-install did not preserve %s (%s): on disk %#v, want the existing %#v",
+					name, why, gotF, wantF)
+			}
+		case refreshed[name]:
+			if reflect.DeepEqual(gotF, wantF) {
+				t.Errorf("re-install did not refresh %s: it still holds the stale on-disk value %#v", name, gotF)
+			}
+		default:
+			// Unclassified: TestPluginSpecFieldsAreClassified reports it. Asserting
+			// here too would add a second, more confusing failure for one cause.
+		}
+	}
+	// The caller's native_agents seed must NOT override an existing list — the
+	// sentinel above is an existing one. (Asserted separately because the loop
+	// above would also pass if the seed happened to equal the sentinel.)
+	if after.Plugin.NativeAgents == nil || (*after.Plugin.NativeAgents)[0] == "seed-agent" {
+		t.Errorf("the caller's native_agents seed overwrote an existing deferral list: %v", after.Plugin.NativeAgents)
+	}
+}
+
+// writeMarketplaceCacheFixture lays down the marketplace cache tree that
+// installPluginInto resolves against: the entry it reads and the plugin
+// directory the relative fetcher copies from.
+func writeMarketplaceCacheFixture(t *testing.T, home, mpName, plugin string) {
+	t.Helper()
+	root := marketplaceCacheDir(home, mpName)
+	mpJSON := `{"name": "` + mpName + `", "owner": {"name": "tester"}, "plugins": [` +
+		`{"name": "` + plugin + `", "source": "./plugins/` + plugin + `"}]}`
+	mustWrite(t, filepath.Join(root, ".claude-plugin", "marketplace.json"), mpJSON)
+	mustWrite(t, filepath.Join(root, "plugins", plugin, ".claude-plugin", "plugin.json"),
+		`{"name": "`+plugin+`", "version": "1.0.0"}`)
+}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -14,22 +14,19 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// pluginTOMLFixture is the on-disk plugins/<id>.toml shape — the canonical
-// source.Plugin itself, not a third hand-maintained copy of the [plugin]
-// table (#234) — so lifecycle tests can assert against the REAL file on disk
-// (read back + parsed), not an in-memory struct that never touched the
-// filesystem — per CLAUDE.md's
-// "models must stay faithful to their on-disk artifacts" doctrine.
-type pluginTOMLFixture = source.Plugin
-
-// readPluginTOMLFixture reads plugins/<id>.toml back from disk and parses it.
-func readPluginTOMLFixture(t *testing.T, path string) pluginTOMLFixture {
+// readPluginTOMLFixture reads plugins/<id>.toml back from disk and parses it
+// into the canonical source.Plugin — the file's one shape, not a test-side copy
+// of the [plugin] table (#234) — so lifecycle tests assert against the REAL
+// file on disk (read back + parsed), not an in-memory struct that never touched
+// the filesystem, per CLAUDE.md's "models must stay faithful to their on-disk
+// artifacts" doctrine.
+func readPluginTOMLFixture(t *testing.T, path string) source.Plugin {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
-	var p pluginTOMLFixture
+	var p source.Plugin
 	if err := toml.Unmarshal(data, &p); err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
@@ -717,6 +714,45 @@ agents = ["claude"]
 	}
 }
 
+// TestPlugin_DisableEnablePreservesNativeAgents pins what the plugins guide
+// promises for the lifecycle verbs: `disable` and `enable` flip only the
+// disabled bit and carry every other modelled field forward — here the
+// native_agents deferral, which neither verb reads or writes on its own. The
+// bit itself is asserted too, so a verb that refused to rewrite the file could
+// not pass as "preserving"; and the allowlist is left EMPTY on purpose, so the
+// verbs are also caught backfilling `agents = ['*']` — that default is `add`'s
+// to write, and the guide attributes it to `add` alone.
+func TestPlugin_DisableEnablePreservesNativeAgents(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "marketplace", "add", makeLocalMarketplace(t, t.TempDir()))
+	mustRun(t, env, "plugin", "add", "demo@test-mp")
+	pluginPath := filepath.Join(tmp, ".agentsync", "plugins", "demo.toml")
+	writePluginTOMLBody(t, pluginPath,
+		"[plugin]\nid = 'demo@test-mp'\nupdate = 'track'\nagents = []\nnative_agents = ['claude']\n")
+
+	for _, tc := range []struct {
+		verb         string
+		wantDisabled bool
+	}{{"disable", true}, {"enable", false}} {
+		mustRun(t, env, "plugin", tc.verb, "demo")
+		data, err := os.ReadFile(pluginPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Contains(string(data), "disabled = true"); got != tc.wantDisabled {
+			t.Errorf("plugin %s must flip the disabled bit (want disabled=%v); file after %s:\n%s", tc.verb, tc.wantDisabled, tc.verb, data)
+		}
+		if !strings.Contains(string(data), "native_agents = ['claude']") {
+			t.Errorf("plugin %s must carry native_agents forward; file after %s:\n%s", tc.verb, tc.verb, data)
+		}
+		if strings.Contains(string(data), "agents = ['*']") {
+			t.Errorf("plugin %s must not backfill the allowlist default — only add does; file after %s:\n%s", tc.verb, tc.verb, data)
+		}
+	}
+}
+
 // TestPlugin_ReinstallPreservesAgentsUpdateDisabled is the regression for issue
 // #140's re-install data loss: `installPluginInto` hard-reset Agents/Update/
 // Disabled to the first-install defaults on every write, so re-installing an
@@ -765,8 +801,9 @@ func TestPlugin_ReinstallOverCorruptTOMLRefuses(t *testing.T) {
 // comment-only) parses successfully to an empty spec, so it carries no allowlist to
 // preserve and a re-install legitimately falls through to the defaults — unlike a corrupt/
 // unparseable file, which refuses (TestPlugin_ReinstallOverCorruptTOMLRefuses). The same
-// defaults apply to keys that are PRESENT but empty (`agents = []`, an empty `update`): the
-// backfill tests the value, not the key, which is what the user guide promises.
+// defaults apply to keys that are PRESENT but empty: `agents = []` decodes to a non-nil
+// empty slice (the case a nil check would miss) and an empty `update` decodes like an
+// absent one; both come back as the default, which is what the user guide promises.
 func TestPlugin_ReinstallOverEmptyTOMLUsesDefaults(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
@@ -1375,39 +1412,5 @@ func TestPlugin_UpgradeAfterBareIDInstall(t *testing.T) {
 	}
 	if out, err := runCLI(t, env, "plugin", "upgrade", "demo"); err != nil {
 		t.Fatalf("upgrade of a bare-id-installed plugin must re-search the caches, not look for a %q marketplace: %v\n%s", "default", err, out)
-	}
-}
-
-// TestPlugin_DisableEnablePreservesNativeAgents pins what the plugins guide
-// promises for the lifecycle verbs: `disable` and `enable` flip only the
-// disabled bit and carry every other modelled field forward — here the
-// native_agents deferral, which neither verb reads or writes on its own. The
-// bit itself is asserted too, so a verb that refused to rewrite the file could
-// not pass as "preserving".
-func TestPlugin_DisableEnablePreservesNativeAgents(t *testing.T) {
-	tmp := t.TempDir()
-	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
-	mustRun(t, env, "init")
-	mustRun(t, env, "marketplace", "add", makeLocalMarketplace(t, t.TempDir()))
-	mustRun(t, env, "plugin", "add", "demo@test-mp")
-	pluginPath := filepath.Join(tmp, ".agentsync", "plugins", "demo.toml")
-	writePluginTOMLBody(t, pluginPath,
-		"[plugin]\nid = 'demo@test-mp'\nupdate = 'track'\nagents = ['*']\nnative_agents = ['claude']\n")
-
-	for _, tc := range []struct {
-		verb         string
-		wantDisabled bool
-	}{{"disable", true}, {"enable", false}} {
-		mustRun(t, env, "plugin", tc.verb, "demo")
-		data, err := os.ReadFile(pluginPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := strings.Contains(string(data), "disabled = true"); got != tc.wantDisabled {
-			t.Errorf("plugin %s must flip the disabled bit (want disabled=%v); file after %s:\n%s", tc.verb, tc.wantDisabled, tc.verb, data)
-		}
-		if !strings.Contains(string(data), "native_agents = ['claude']") {
-			t.Errorf("plugin %s must carry native_agents forward; file after %s:\n%s", tc.verb, tc.verb, data)
-		}
 	}
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -11,26 +11,16 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// pluginTOMLFixture mirrors the on-disk plugins/<id>.toml [plugin] table so
-// lifecycle tests can assert against the REAL file on disk (read back + parsed),
-// not an in-memory struct that never touched the filesystem — per CLAUDE.md's
+// pluginTOMLFixture is the on-disk plugins/<id>.toml shape — the canonical
+// source.Plugin itself, not a third hand-maintained copy of the [plugin]
+// table (#234) — so lifecycle tests can assert against the REAL file on disk
+// (read back + parsed), not an in-memory struct that never touched the
+// filesystem — per CLAUDE.md's
 // "models must stay faithful to their on-disk artifacts" doctrine.
-type pluginTOMLFixture struct {
-	Plugin struct {
-		ID          string   `toml:"id"`
-		Version     string   `toml:"version"`
-		ManifestSHA string   `toml:"manifest_sha"`
-		Update      string   `toml:"update"`
-		Agents      []string `toml:"agents"`
-		// A POINTER, mirroring the production spec: this fixture exists to read
-		// the real artifact, so it must be able to tell "no key" from
-		// "native_agents = []" — the distinction the pointer exists for.
-		NativeAgents *[]string `toml:"native_agents"`
-		Disabled     bool      `toml:"disabled"`
-	} `toml:"plugin"`
-}
+type pluginTOMLFixture = source.Plugin
 
 // readPluginTOMLFixture reads plugins/<id>.toml back from disk and parses it.
 func readPluginTOMLFixture(t *testing.T, path string) pluginTOMLFixture {
@@ -774,7 +764,9 @@ func TestPlugin_ReinstallOverCorruptTOMLRefuses(t *testing.T) {
 // documented in installPluginInto: a semantically-EMPTY plugins/<id>.toml (blank or
 // comment-only) parses successfully to an empty spec, so it carries no allowlist to
 // preserve and a re-install legitimately falls through to the defaults — unlike a corrupt/
-// unparseable file, which refuses (TestPlugin_ReinstallOverCorruptTOMLRefuses).
+// unparseable file, which refuses (TestPlugin_ReinstallOverCorruptTOMLRefuses). The same
+// defaults apply to keys that are PRESENT but empty (`agents = []`, an empty `update`): the
+// backfill tests the value, not the key, which is what the user guide promises.
 func TestPlugin_ReinstallOverEmptyTOMLUsesDefaults(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
@@ -805,6 +797,21 @@ func TestPlugin_ReinstallOverEmptyTOMLUsesDefaults(t *testing.T) {
 	}
 	if got.Plugin.Update != "track" {
 		t.Fatalf("empty toml should fall through to default update=track, got %q", got.Plugin.Update)
+	}
+
+	// Present-but-empty keys: `agents = []` decodes to a non-nil empty slice and
+	// `update = ''` to the empty string; both mean "the default" and must be
+	// written as it, not carried forward as literally empty.
+	writePluginTOMLBody(t, pluginPath, "[plugin]\nid = 'demo@test-mp'\nagents = []\nupdate = ''\n")
+	if out, err := runCLI(t, env, "plugin", "add", "demo@test-mp"); err != nil {
+		t.Fatalf("re-install over empty keys should succeed, got: %v\n%s", err, out)
+	}
+	got = readPluginTOMLFixture(t, pluginPath)
+	if len(got.Plugin.Agents) != 1 || got.Plugin.Agents[0] != "*" {
+		t.Fatalf("an empty agents list should be written as the default [\"*\"], got %v", got.Plugin.Agents)
+	}
+	if got.Plugin.Update != "track" {
+		t.Fatalf("an empty update should be written as the default track, got %q", got.Plugin.Update)
 	}
 }
 
@@ -1371,11 +1378,13 @@ func TestPlugin_UpgradeAfterBareIDInstall(t *testing.T) {
 	}
 }
 
-// TestPlugin_EnableDisablePreserveNativeAgents pins what the plugins guide
+// TestPlugin_DisableEnablePreservesNativeAgents pins what the plugins guide
 // promises for the lifecycle verbs: `disable` and `enable` flip only the
 // disabled bit and carry every other modelled field forward — here the
-// native_agents deferral, which neither verb reads or writes on its own.
-func TestPlugin_EnableDisablePreserveNativeAgents(t *testing.T) {
+// native_agents deferral, which neither verb reads or writes on its own. The
+// bit itself is asserted too, so a verb that refused to rewrite the file could
+// not pass as "preserving".
+func TestPlugin_DisableEnablePreservesNativeAgents(t *testing.T) {
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	mustRun(t, env, "init")
@@ -1385,14 +1394,20 @@ func TestPlugin_EnableDisablePreserveNativeAgents(t *testing.T) {
 	writePluginTOMLBody(t, pluginPath,
 		"[plugin]\nid = 'demo@test-mp'\nupdate = 'track'\nagents = ['*']\nnative_agents = ['claude']\n")
 
-	for _, verb := range []string{"disable", "enable"} {
-		mustRun(t, env, "plugin", verb, "demo")
+	for _, tc := range []struct {
+		verb         string
+		wantDisabled bool
+	}{{"disable", true}, {"enable", false}} {
+		mustRun(t, env, "plugin", tc.verb, "demo")
 		data, err := os.ReadFile(pluginPath)
 		if err != nil {
 			t.Fatal(err)
 		}
+		if got := strings.Contains(string(data), "disabled = true"); got != tc.wantDisabled {
+			t.Errorf("plugin %s must flip the disabled bit (want disabled=%v); file after %s:\n%s", tc.verb, tc.wantDisabled, tc.verb, data)
+		}
 		if !strings.Contains(string(data), "native_agents = ['claude']") {
-			t.Errorf("plugin %s must carry native_agents forward; file after %s:\n%s", verb, verb, data)
+			t.Errorf("plugin %s must carry native_agents forward; file after %s:\n%s", tc.verb, tc.verb, data)
 		}
 	}
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -1370,3 +1370,29 @@ func TestPlugin_UpgradeAfterBareIDInstall(t *testing.T) {
 		t.Fatalf("upgrade of a bare-id-installed plugin must re-search the caches, not look for a %q marketplace: %v\n%s", "default", err, out)
 	}
 }
+
+// TestPlugin_EnableDisablePreserveNativeAgents pins what the plugins guide
+// promises for the lifecycle verbs: `disable` and `enable` flip only the
+// disabled bit and carry every other modelled field forward — here the
+// native_agents deferral, which neither verb reads or writes on its own.
+func TestPlugin_EnableDisablePreserveNativeAgents(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	mustRun(t, env, "init")
+	mustRun(t, env, "marketplace", "add", makeLocalMarketplace(t, t.TempDir()))
+	mustRun(t, env, "plugin", "add", "demo@test-mp")
+	pluginPath := filepath.Join(tmp, ".agentsync", "plugins", "demo.toml")
+	writePluginTOMLBody(t, pluginPath,
+		"[plugin]\nid = 'demo@test-mp'\nupdate = 'track'\nagents = ['*']\nnative_agents = ['claude']\n")
+
+	for _, verb := range []string{"disable", "enable"} {
+		mustRun(t, env, "plugin", verb, "demo")
+		data, err := os.ReadFile(pluginPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), "native_agents = ['claude']") {
+			t.Errorf("plugin %s must carry native_agents forward; file after %s:\n%s", verb, verb, data)
+		}
+	}
+}

--- a/internal/cli/plugin_toml_internal_test.go
+++ b/internal/cli/plugin_toml_internal_test.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
@@ -31,5 +35,59 @@ func TestReadPluginTOML_FillsIDFromFilename(t *testing.T) {
 	// thing; the two must not be confused for one another.
 	if got.Plugin.ID.Unverified() != "demo@test-mp" {
 		t.Errorf("PluginSpec.ID = %q, want the recorded ref %q", got.Plugin.ID.Unverified(), "demo@test-mp")
+	}
+}
+
+// TestReadPluginTOML_OuterIDNeverReachesTheFile pins the tag the stem fill
+// relies on. readPluginTOML sets source.Plugin.ID, and the lifecycle verbs
+// re-marshal that whole struct, so a top-level `id` key stays out of the file
+// ONLY because the field is toml:"-". Losing the tag would write `id = 'demo'`
+// above [plugin] on the next `plugin disable`, with every other test green.
+func TestReadPluginTOML_OuterIDNeverReachesTheFile(t *testing.T) {
+	testenv.RequireContainer(t)
+	path := filepath.Join(t.TempDir(), "demo.toml")
+	canonical, err := toml.Marshal(source.Plugin{Plugin: source.PluginSpec{
+		ID: "demo@test-mp", Update: "track", Agents: []string{"*"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, canonical, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readPluginTOML(path)
+	if err != nil {
+		t.Fatalf("readPluginTOML: %v", err)
+	}
+	if got.ID.Unverified() == "" {
+		t.Fatal("precondition: readPluginTOML must have filled Plugin.ID for this test to prove anything")
+	}
+	again, err := toml.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(again, canonical) {
+		t.Errorf("re-marshalling what readPluginTOML returned changed the bytes:\n--- canonical\n%s--- re-marshalled\n%s", canonical, again)
+	}
+	if strings.Contains(string(again), "id = 'demo'\n") {
+		t.Errorf("the filename-derived Plugin.ID must never be written as a key:\n%s", again)
+	}
+}
+
+// TestReadPluginTOML_ToleratesUnknownKeys pins the permissive decode the doc
+// comment promises: a lifecycle verb must be able to read (and rewrite) a
+// hand-edited registry file whose stray key source.Load would reject.
+func TestReadPluginTOML_ToleratesUnknownKeys(t *testing.T) {
+	testenv.RequireContainer(t)
+	path := filepath.Join(t.TempDir(), "demo.toml")
+	if err := os.WriteFile(path, []byte("[plugin]\nid = 'demo@test-mp'\nfuture_key = 'kept by nobody'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readPluginTOML(path)
+	if err != nil {
+		t.Fatalf("a stray key must not fail the lifecycle read: %v", err)
+	}
+	if got.Plugin.ID.Unverified() != "demo@test-mp" {
+		t.Errorf("PluginSpec.ID = %q, want %q", got.Plugin.ID.Unverified(), "demo@test-mp")
 	}
 }

--- a/internal/cli/plugin_toml_internal_test.go
+++ b/internal/cli/plugin_toml_internal_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// TestReadPluginTOML_FillsIDFromFilename pins the one thing readPluginTOML does
+// beyond decoding: source.Plugin.ID is toml:"-" — the id is the FILENAME, not a
+// key in the file — and source.Load's loadPlugins fills it from the stem. Now
+// that the CLI decodes into the same struct, it must mean the same thing there,
+// or a caller reaching for .ID would silently get "" for a plugin that has one.
+func TestReadPluginTOML_FillsIDFromFilename(t *testing.T) {
+	testenv.RequireContainer(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.toml")
+	if err := os.WriteFile(path, []byte("[plugin]\nid = 'demo@test-mp'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readPluginTOML(path)
+	if err != nil {
+		t.Fatalf("readPluginTOML: %v", err)
+	}
+	if got.ID.Unverified() != "demo" {
+		t.Errorf("Plugin.ID = %q, want the filename stem %q (source.Load fills it the same way)", got.ID.Unverified(), "demo")
+	}
+	// The inner spec id is the marketplace-qualified ref and is a different
+	// thing; the two must not be confused for one another.
+	if got.Plugin.ID.Unverified() != "demo@test-mp" {
+		t.Errorf("PluginSpec.ID = %q, want the recorded ref %q", got.Plugin.ID.Unverified(), "demo@test-mp")
+	}
+}

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -212,7 +212,11 @@ type SkillFile struct {
 type Plugin struct {
 	// ID is the plugin's filesystem id (the plugins/<id>.toml stem), originating
 	// from a marketplace install — untrusted.Text so a print site sanitizes it by
-	// construction; use Unverified() for path/lookup use.
+	// construction; use Unverified() for path/lookup use. The toml:"-" is
+	// load-bearing: the CLI fills this field from the filename and re-marshals
+	// the whole struct on every lifecycle rewrite, so a key tag here would put an
+	// `id` above [plugin]. Pinned by TestReadPluginTOML_OuterIDNeverReachesTheFile
+	// (internal/cli).
 	ID     untrusted.Text `toml:"-"`
 	Plugin PluginSpec     `toml:"plugin"`
 }

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -144,12 +144,12 @@ agentsync plugin remove   <id[@marketplace]>
 agentsync plugin list
 ```
 
-`disable`/`enable` flip only the `disabled` bit, and `add` rewrites only the
-three fields it re-fetches (`id`, `version`, `manifest_sha`) — every other
-field agentsync models in `plugins/<id>.toml` is carried forward from the file
-you have (an omitted key is written with its default; the file is rewritten, so
-comments and unmodelled keys are not kept), so your `agents` and
-`native_agents` targeting survives the full lifecycle untouched.
+`disable`/`enable` flip only the `disabled` bit. `add` rewrites only the three
+fields it re-fetches (`id`, `version`, `manifest_sha`) and carries every other
+field agentsync models in `plugins/<id>.toml` forward from the file you have; a
+key you omitted, or an `agents` you left empty, is written with its default.
+The file is rewritten, so comments and unmodelled keys are not kept. Your
+`agents` and `native_agents` targeting survives the full lifecycle.
 
 <LinkCard
 	title="Agent capability matrix"

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -145,10 +145,11 @@ agentsync plugin list
 ```
 
 `disable`/`enable` flip only the `disabled` bit, and `add` rewrites only the
-three fields it re-fetches (`id`, `version`, `manifest_sha`) — every other key
-in `plugins/<id>.toml` is carried forward from the file you have (an omitted key
-is written with its default), so your `agents` and `native_agents` targeting
-survives the full lifecycle untouched.
+three fields it re-fetches (`id`, `version`, `manifest_sha`) — every other
+field agentsync models in `plugins/<id>.toml` is carried forward from the file
+you have (an omitted key is written with its default; the file is rewritten, so
+comments and unmodelled keys are not kept), so your `agents` and
+`native_agents` targeting survives the full lifecycle untouched.
 
 <LinkCard
 	title="Agent capability matrix"

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -144,9 +144,11 @@ agentsync plugin remove   <id[@marketplace]>
 agentsync plugin list
 ```
 
-`disable`/`enable` flip only the `disabled` bit and `install` refreshes only the
-fetched fields — so your `agents` and `native_agents` targeting survives the
-full lifecycle untouched.
+`disable`/`enable` flip only the `disabled` bit, and `add` rewrites only the
+three fields it re-fetches (`id`, `version`, `manifest_sha`) — every other key
+in `plugins/<id>.toml` is carried forward from the file you have (an omitted key
+is written with its default), so your `agents` and `native_agents` targeting
+survives the full lifecycle untouched.
 
 <LinkCard
 	title="Agent capability matrix"

--- a/website/src/content/docs/guides/plugins.mdx
+++ b/website/src/content/docs/guides/plugins.mdx
@@ -147,7 +147,8 @@ agentsync plugin list
 `disable`/`enable` flip only the `disabled` bit. `add` rewrites only the three
 fields it re-fetches (`id`, `version`, `manifest_sha`) and carries every other
 field agentsync models in `plugins/<id>.toml` forward from the file you have; a
-key you omitted, or an `agents` you left empty, is written with its default.
+key you omitted, or an `agents` or `update` you left empty, is written with its
+default.
 The file is rewritten, so comments and unmodelled keys are not kept. Your
 `agents` and `native_agents` targeting survives the full lifecycle.
 


### PR DESCRIPTION
## Summary

Closes #234. Eighth PR in the #226 code-quality series (after #240, #244, #247, #249, #252, #253, #260). Two commits, each independently green and byte-identical to `main` on the artifact it touches, plus three review-loop commits.

**1. One struct** (`c264b73`). `plugins/<id>.toml` was described by two field-for-field identical structs: the canonical `source.Plugin`/`source.PluginSpec` and the CLI-private `pluginTOML`/`pluginTOMLSpec`, down to the `*[]string` `native_agents` pointer and the mirrored rationale comments. Two readers of one file is how a key gets added to one and missed by the other, and marshalling either produced identical bytes, so nothing kept them honest. The CLI now decodes, marshals and passes around the canonical struct at all seven sites (`installPluginInto`, `keptLifecycleSummary`, the three lifecycle edit paths, `pluginListRun`, `checkPluginRefMarketplace`, `readPluginTOML`), and the test-side `pluginTOMLFixture` — a third hand-kept copy of the table — is gone too (`readPluginTOMLFixture` returns the canonical struct). `readPluginTOML` also fills `Plugin.ID` from the filename stem exactly as `source.Load`'s `loadPlugins` does, so a `source.Plugin` from the CLI means what one from the loader means instead of carrying a silently empty id; that field is `toml:"-"`, so it cannot change bytes, and the tag is pinned. Decoding stays permissive, unlike the loader's strict decode, so the lifecycle verbs can still rewrite a hand-edited registry file; the doc comment says why, and that the rewrite keeps only the fields the struct models. `pluginTOMLSpec` occurrences: 0.

**2. Struct-level preserve** (`635be09`). `installPluginInto` carried the existing file forward field by field — `agents`, `native_agents`, `update`, `disabled`, named one at a time — so the next lifecycle field added to the struct and forgotten in that merge would have been silently reset to its default on every re-install and re-import: the #140 bug class, arriving through the code that prevents it. The merge is now wholesale: `pluginLifecycleBase` starts from the entire existing spec (or the zero spec on a first install) and backfills only the three keys a file may omit or leave empty (`agents` → `['*']`, `update` → `'track'`, the `native_agents` seed when the key is absent), and `pluginInstallRefresh{ID, Version, ManifestSHA}.applyTo` stamps just the three fields an install recomputes. Preservation is the default, so a new field survives without anyone editing the merge. The classification is guarded both ways, mirroring `TestNewSecretFieldGuard` + `TestWalkerVisitsEveryCoveredField` in `internal/secrets`: `TestPluginSpecFieldsAreClassified` reflects over `source.PluginSpec` and fails (naming the field and both remedies) when a field is neither in `pluginInstallRefresh` nor in the test-side `pluginSpecPreserved`, and `TestInstallPreservesEveryLifecycleField` plants a reflective sentinel in every field, runs the real `installPluginInto`, reads the result back off disk, and compares each refreshed field against a fresh first install of the same fixture — so the map cannot claim a coverage the merge does not deliver. Every documented semantic is unchanged: first-install defaults byte-for-byte, an omitted or empty key backfilled the same way, an explicitly empty `native_agents = []` preserved, an existing deferral list winning over `import`'s seed, and an unreadable existing file refused with the same message.

**Deliberately not done, for reviewers:** `pluginUpgradeRun` and `applyPluginBump` (`plugin_poll.go`) refresh only `Version`/`ManifestSHA`, each on its own conditions (upgrade's SHA is unconditional and its version conditional; the poll engine the reverse) and outside `applyTo` — both rewrite the whole decoded entry, so they preserve by construction; `pluginInstallRefresh`'s doc names them. `source.WritePlugin` was not adopted for the CLI's writes: it re-derives the path and re-runs `ValidateComponentID` with a different error string on a path the oracle pins. The outer `Plugin.ID` fill has no production consumer yet (every CLI reader uses `.Plugin.ID`); it is kept for meaning parity with the loader and pinned by `TestReadPluginTOML_FillsIDFromFilename` and, for its `toml:"-"` tag, by `TestReadPluginTOML_OuterIDNeverReachesTheFile` (which `source.Plugin.ID`'s comment cites — the only change under `internal/source`, comment-only). Pre-existing and untouched: `plugin add` stamps `version` from the marketplace entry even when empty, while `plugin upgrade` keeps the old version in that case; the `if result.Version != ""` override (only the npm fetcher sets it) has no test and no fetcher seam to add one without widening the PR; an install blanks `manifest_sha` when the tree hash fails while `applyPluginBump` guards on a computed SHA. The website plugins guide's paragraph also stops naming the retired `install` verb (now `add`). Follow-up candidates named by review: one shared `plugins/` writer (six `toml.Marshal` + `AtomicWrite` sites agree with `source.WritePlugin` only by coincidence); strict-decode alignment between the CLI and the loader.

**Review provenance.** The execution spec was reviewed before execution by a fresh reviewer who applied its code verbatim to a clone of the base, ran the byte-identity oracle, and found no blocker: four spec-completeness issues and five nits, all folded in as amendments before execution.

**Review loop.** Round 1 (four lenses on `635be09`; closed by `e2fcb30`): the correctness lens ran a 16-case differential oracle against the base and found the code byte-identical; three lenses converged on the new docs sentence "every other key is carried forward" overclaiming — the rewrite keeps only modelled fields and drops comments and unknown keys (pre-existing behaviour, new claim) — fixed in the user guide, the website guide, the CHANGELOG and `readPluginTOML`'s doc. The API-design lens found `installPluginInto`'s doc contradicting the code (the `native_agents` seed applies whenever the key is absent, existing file or not) — rewritten. The adversarial lens found the outer id fill made `source.Plugin.ID`'s `toml:"-"` load-bearing for six lifecycle rewrites with nothing pinning it, and that the sentinel test's refreshed half only proved inequality. The test-rigor lens's mutation sweep found the permissive decode and the enable/disable preservation of `native_agents` unpinned. All fixed. Round 2 (on `e2fcb30`; correctness CLEAN, adversarial NIT-only, API-design and test-rigor one ISSUE each; closed by `394d02c`): the sentence round 1 added about the two other refresh sites mis-described `plugin upgrade` — corrected; the user guide's new "an `agents` left empty takes the default" had no test (a backfill on nil rather than empty passed every suite) — `TestPlugin_ReinstallOverEmptyTOMLUsesDefaults` now re-installs over `agents = []` and `update = ''`; the lifecycle test passed against a `disable` that never rewrote the file — it now asserts the disabled bit; `source.Plugin.ID`'s comment cites its guard; four docs sentences narrowed. Round 3 (on `394d02c`; all four lenses CLEAN or NIT-only — the adversarial lens's two "ISSUEs" were against a PR body it read before the round-2 update landed, and the live body already carried every correction; closed by `d5f3836`): the test-side type alias, the repo's only one, deleted in favour of the canonical struct; the lifecycle test leaves the allowlist empty and asserts neither verb writes `agents = ['*']`, pinning the website guide's "only `add` backfills" (a backfill added to either verb had failed nothing), and moves beside the allowlist test it was renamed to match; the user guide's topic sentence has its "agentsync models" qualifier back and no longer says "untouched" of fields the re-install re-fetches, "canonical form" is replaced by what it meant (comments and unmodelled keys not kept, `disabled = false` written as no key, keys in agentsync's order), the website guide names an empty `update` beside an empty `agents`, the CHANGELOG drops a backfill parenthetical a release-note reader does not need, and `pluginLifecycleBase`'s doc says the backfills cover keys the file may omit or leave empty. Declined with reason across rounds: pinning the `result.Version` override (no seam); the `manifest_sha` blanking (pre-existing behaviour); the hand-built cache fixture (matches the `writeMarketplaceCacheJSON` precedent). Nothing overruled.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

**Byte-identity oracle.** Two binaries, `main` at `a2c671b` and each of `c264b73` and `635be09`, were run through a 13-command lifecycle on a local marketplace fixture (`plugin add`, re-add, `import claude:plugin`, `enable`, `disable`, `update`-mode changes, `plugin upgrade`, a hand-edited file with `update='manual'`, `agents=['codex']`, `native_agents=['claude']`, `disabled=true` and stale version/SHA, an explicitly empty `native_agents = []`, a corrupt file, a comment-only file), snapshotting `plugins/demo.toml` after each marked step and capturing stdout, stderr and exit codes. `diff -r` between the base output and each head output is **empty**: 10 snapshots plus the 48-line transcript. Run three times independently (planner, spec reviewer, executor); the round-1 correctness lens added a 16-case `installPluginInto` differential: identical bytes and error text in all 16.

**New or extended tests** (`internal/cli/plugin_toml_internal_test.go`, `internal/cli/plugin_lifecycle_guard_internal_test.go`, `internal/cli/plugin_test.go`; two literals in `import_native_agents_prompt_internal_test.go` switch to the canonical struct): `TestReadPluginTOML_FillsIDFromFilename`; `TestReadPluginTOML_OuterIDNeverReachesTheFile` (canonical bytes round-trip through `readPluginTOML` + `toml.Marshal` unchanged); `TestReadPluginTOML_ToleratesUnknownKeys`; `TestPluginSpecFieldsAreClassified`; `TestInstallPreservesEveryLifecycleField` (sentinels in every field survive a real re-install on disk; each refreshed field equals a fresh first install's value); `TestPlugin_DisableEnablePreservesNativeAgents` (both verbs, through the CLI, flip the disabled bit, carry `native_agents` forward, and do not backfill an empty allowlist); `TestPlugin_ReinstallOverEmptyTOMLUsesDefaults` (extended: `agents = []` and `update = ''` are written as their defaults).

**Break-verifies** (each mutation asserted to land exactly once and to compile, literal fail sets from `go test -json` over the whole `internal/cli` package, files restored from a `cp` backup and sha-checked):
- Adding an unclassified `Pinned bool` to `source.PluginSpec` → exactly `TestPluginSpecFieldsAreClassified`; adding a `Priority int` → that test and `TestInstallPreservesEveryLifecycleField` (the planter refuses a kind it cannot fill, by design).
- `applyTo` also resetting `Agents`, `Disabled` or `Update` → `TestInstallPreservesEveryLifecycleField` + `TestPlugin_ReinstallPreservesAgentsUpdateDisabled`; also resetting `NativeAgents` → those two plus six adoption/deferral tests; blanking `Version` in `applyTo` → the sentinel test plus `TestPlugin_InstallSanitizesUntrustedVersion`, `TestPlugin_ListSanitizesUntrustedVersion`, `TestPluginPoll_DetectsManifestSHADrift`, `TestExplainPath_PluginOriginAttributed`.
- Deleting the `agents` backfill → `TestApply_PluginAgentsAllowlistNarrowsFanOut`, `TestImportApply_NativePluginIsNotDuplicated`, `TestPlugin_FirstInstallDefaults`, `TestPlugin_ReinstallOverEmptyTOMLUsesDefaults`; deleting the `update` backfill → the last two; backfilling `agents` only when nil rather than empty → exactly `TestPlugin_ReinstallOverEmptyTOMLUsesDefaults`.
- Seed gate on `len(DeferredAgents()) == 0` instead of `nil` → exactly `TestImport_PreservesAnExplicitlyEmptyDeferral`; seed always winning → that test and the sentinel test; an always-empty seed → five tests, without a panic.
- Disabling the unreadable-file refusal → exactly `TestPlugin_ReinstallOverCorruptTOMLRefuses`; dropping the stem fill → `TestReadPluginTOML_FillsIDFromFilename` and the round-trip test's precondition.
- Retagging the outer `ID` to `toml:"id,omitempty"` → exactly `TestReadPluginTOML_OuterIDNeverReachesTheFile`; a `DisallowUnknownFields` decoder → exactly `TestReadPluginTOML_ToleratesUnknownKeys`; dropping `native_agents` in either `enable` or `disable` → exactly `TestPlugin_DisableEnablePreservesNativeAgents`; a `disable` that returns before rewriting → that test and eight others; a backfill of `agents = ['*']` added to `disable`, or to `enable` → exactly `TestPlugin_DisableEnablePreservesNativeAgents` (round 3).

**Post-conditions:** `pluginTOMLSpec`, `pluginTOML{` and `pluginTOMLFixture` occurrences 0; `//nolint` in `internal/cli/plugin.go` 3 → 3; `.golangci.yml`, `internal/secrets/`, `internal/capture/` absent from the diff; `internal/source/schema.go` changes by one comment only; every plugin-TOML reader uses `.Plugin.ID`; the byte pins in `plugin_agents_test.go`, `import_native_agents_prompt_internal_test.go` and `internal/source/iss162_test.go` pass unchanged.

**Gates,** each commit independently and again on the head: `go build`, `go vet`, `gofmt -l` empty, gofumpt + `go mod tidy` rewrote nothing, `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` (29 packages ok, zero `-json` failures), `-race ./internal/cli/...` ok, `-tags=e2e` ok, `-tags=bdd` ok, `GOOS=windows go build ./...` ok, `GOTOOLCHAIN=go1.26.2 golangci-lint@v2.12.2 run ./...` → 0 issues.

- [ ] `just test-release` is green (the release bar) — `just` is not installable in this session; every layer the recipe orchestrates was run directly as listed above, and CI's hermetic `test-release` job runs on the PR.
- [x] `just lint` is clean — run directly with the pinned toolchain; `go.mod`/`go.sum` untouched.

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [ ] If this touches `internal/secrets`, `internal/capture`, or any
      `source.Write*` path, I've re-read the secret-handling invariants in
      `CLAUDE.md` / `SECURITY.md` and not weakened them. — Not applicable, checked: `source.PluginSpec` carries no secret-bearing field and is not in `walkSecretFields`, which never descends into `c.Plugins` (a plugin's MCP servers reach the walker only after `marketplace.LoadProjected` projects them into `c.MCPServers`), so it has no place in `TestNewSecretFieldGuard`'s list. The CLI's writes stay `toml.Marshal` + `iox.AtomicWrite` on a templated `source.Plugin` built from marketplace metadata — not a `secrets.Resolved` and not a dest→source write-back, so `capture.Capture` is not implicated. No `source.Write*` call is introduced; nothing under `internal/secrets` or `internal/capture` changes, and `internal/source` changes by one comment.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/components.md` (the `internal/cli` key list names `readPluginTOML`, `pluginLifecycleBase` and `pluginInstallRefresh`, with the backfill), `docs/user-guide.md` and `website/src/content/docs/guides/plugins.mdx` (the re-install paragraph states the rule precisely: three re-fetched fields rewritten, every other modelled field carried forward, an omitted or empty key written with its default, the file rewritten rather than patched), `CHANGELOG.md` (`[Unreleased] / Changed`, `Internal:`). No CLI surface or capability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4VNyoCuGXx7pYxNfLVbFG