### PR TITLE
refactor(cli): one enabled-agent walk, one RFC 6901 home, one importer head, one projection copy (#235, PR 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,30 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **Internal: four duplicated helpers in the CLI collapse to one each**
+  ([#235](https://github.com/spxrogers/agentsync/issues/235)). Eight commands
+  open-coded the same walk over `[agents]` to answer "which agents may this run
+  touch"; four of them also built the membership map the `--agents` filter
+  validates against and four did not, and two sorted the result while six left
+  it in Go's randomized map order. There is now one `enabledAgentNames`, and it
+  SORTS — so every command visits agents in a stable order rather than a
+  different one each run. Every list agentsync currently PRINTS was already
+  sorted or grouped downstream, so no output moves; what changes is the answer
+  when the order is load-bearing. Measured with two unregistered agents enabled,
+  over forty runs: `apply` blamed either agent before (36/4) and the same one
+  after (40/0). RFC 6901 pointer escaping had five hand-rolled copies across
+  three packages, each of which had to get a non-symmetric order right in both
+  directions; it now lives once in `internal/jsonkeys`, with the order argument
+  written down and pinned by a round-trip table. The `ProjectionResult` →
+  `source.Canonical` component copy moved out of its three CLI call sites and
+  next to the struct it copies, with a reflective guard, so a seventh component
+  kind cannot be added to a plugin projection and silently dropped from
+  `explain`, `plugin explain` and `plugin poll`. And import's five
+  per-component importers share their opening filter rather than repeating it
+  five times. Verified with a scripted 44-command lifecycle across four agents:
+  the transcript and every file under the home are byte-identical before and
+  after.
+
 - **Internal: a plugin's `plugins/<id>.toml` has one schema and one preserve
   rule**
   ([#234](https://github.com/spxrogers/agentsync/issues/234)). The file was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,15 +281,16 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   disagreed on, `/`, now names the whole document everywhere, as
   `internal/render` already read it (the CLI's two resolvers read it as the
   `""` key); it can only come from a hand-edited state key or a rendered
-  document with a top-level empty key, which no adapter produces. The
-  `ProjectionResult` → `source.Canonical` component copy moved out of its three
-  CLI call sites and next to the struct it copies, with a reflective guard, so a
-  seventh component kind cannot be added to a plugin projection and silently
-  dropped from `explain`, `plugin explain` and `plugin poll`. And import's five
-  per-component importers share their opening filter rather than repeating it
-  five times. Verified with a scripted 44-command lifecycle across four agents:
-  the transcript and every file under the home are byte-identical before and
-  after.
+  document with a top-level empty key, which no adapter produces today. The list
+  of destination items `import` reports as present but not captured is now
+  sorted rather than in map order. The `ProjectionResult` → `source.Canonical`
+  component copy moved out of its three CLI call sites and next to the struct it
+  copies, with a reflective guard, so a seventh component kind cannot be added
+  to a plugin projection and silently dropped from `explain`, `plugin explain`
+  and `plugin poll`. And import's five per-component importers share their
+  opening filter rather than repeating it five times. Verified with a scripted
+  44-command lifecycle across four agents: the transcript and every file under
+  the home are byte-identical before and after.
 
 - **Internal: a plugin's `plugins/<id>.toml` has one schema and one preserve
   rule**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,14 +283,15 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   `""` key); it can only come from a hand-edited state key or a rendered
   document with a top-level empty key, which no adapter produces today. The list
   of destination items `import` reports as present but not captured is now
-  sorted rather than in map order. The `ProjectionResult` → `source.Canonical`
-  component copy moved out of its three CLI call sites and next to the struct it
-  copies, with a reflective guard, so a seventh component kind cannot be added
-  to a plugin projection and silently dropped from `explain`, `plugin explain`
-  and `plugin poll`. And import's five per-component importers share their
-  opening filter rather than repeating it five times. Verified with a scripted
-  44-command lifecycle across four agents: the transcript and every file under
-  the home are byte-identical before and after.
+  sorted within each destination file rather than in map order. The
+  `ProjectionResult` → `source.Canonical` component copy moved out of its three
+  CLI call sites and next to the struct it copies, with a reflective guard, so a
+  seventh component kind cannot be added to a plugin projection and silently
+  dropped from `explain`, `plugin explain` and `plugin poll`. And import's five
+  per-component importers share their opening filter rather than repeating it
+  five times. Verified with a scripted 44-command lifecycle across four agents:
+  the transcript and every file under the home are byte-identical before and
+  after.
 
 - **Internal: a plugin's `plugins/<id>.toml` has one schema and one preserve
   rule**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,14 +274,18 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   sorted or grouped downstream, so no output moves; what changes is the answer
   when the order is load-bearing. Measured with two unregistered agents enabled,
   over forty runs: `apply` blamed either agent before (36/4) and the same one
-  after (40/0). RFC 6901 pointer escaping had five hand-rolled copies across
+  after (40/0). RFC 6901 pointer escaping had seven hand-rolled copies across
   three packages, each of which had to get a non-symmetric order right in both
   directions; it now lives once in `internal/jsonkeys`, with the order argument
-  written down and pinned by a round-trip table. The `ProjectionResult` →
-  `source.Canonical` component copy moved out of its three CLI call sites and
-  next to the struct it copies, with a reflective guard, so a seventh component
-  kind cannot be added to a plugin projection and silently dropped from
-  `explain`, `plugin explain` and `plugin poll`. And import's five
+  written down and pinned by a round-trip table. The one pointer those copies
+  disagreed on, `/`, now names the whole document everywhere, as
+  `internal/render` already read it (the CLI's two resolvers read it as the
+  `""` key); it can only come from a hand-edited state key or a rendered
+  document with a top-level empty key, which no adapter produces. The
+  `ProjectionResult` → `source.Canonical` component copy moved out of its three
+  CLI call sites and next to the struct it copies, with a reflective guard, so a
+  seventh component kind cannot be added to a plugin projection and silently
+  dropped from `explain`, `plugin explain` and `plugin poll`. And import's five
   per-component importers share their opening filter rather than repeating it
   five times. Verified with a scripted 44-command lifecycle across four agents:
   the transcript and every file under the home are byte-identical before and

--- a/docs/components.md
+++ b/docs/components.md
@@ -70,7 +70,14 @@ is the only package that depends on nearly all the others.
   the default an omitted or empty key means), so a field added to
   `source.PluginSpec` is preserved by default rather than dropped by default
   (#234; the CLI's private duplicate of the struct, and the field-by-field merge
-  that went with it, are gone).
+  that went with it, are gone); `enabledAgentNames(cfg)` (`agents_flag.go`) —
+  the one "which agents may this run touch" extraction, returning the exact
+  `([]string, map[string]bool)` pair `selectAgents` takes, SORTED (eight commands
+  open-coded it, in three different shapes, before #235); `matchImportable`
+  (`import.go`) — the head every per-component importer shares (filter by name,
+  drop plugin-provided entries, refuse a named miss), while the tail stays
+  per-component because the five genuinely disagree about id validation and
+  write funnel.
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
   `revert`, `status`, `diff`, `reconcile`, `import`, `doctor`, `check`,
   `mcp {add,remove,list,enable,disable}`,
@@ -80,7 +87,7 @@ is the only package that depends on nearly all the others.
   `migrate subagents`, `explain <path>`,
   `version`.
 - **Depends on:** adapter, source, state, secrets, paths, render, marketplace,
-  project, drift, git, iox, ui, log.
+  project, drift, git, iox, jsonkeys, ui, log.
 - **Files:** `root.go` + one file per command group + shared helpers
   (`destread.go`, `planwalk.go`).
 
@@ -481,7 +488,11 @@ drift state's `SchemaVersion`.
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin
 manifests into canonical components.
 - **Key:** `Marketplace`, `PluginEntry`, `Source`, `PluginManifest`;
-  `ProjectionResult`; `Project`/`ProjectWithReader`; `ProjectInstalled`
+  `ProjectionResult` + its `Canonical()` / `ReplaceComponentsIn()` (the
+  projection→canonical component copy lives next to the struct, not in three CLI
+  call sites, so a new component kind cannot be added here and silently dropped
+  from every diagnostic surface — reflectively guarded);
+  `Project`/`ProjectWithReader`; `ProjectInstalled`
   (one installed plugin in isolation — lets `explain <id>` attribute coverage to
   the named plugin rather than the flattened union); `Fetcher` (interface) with
   `GitFetcher`/`NPMFetcher`/`RelativeFetcher`; `LoadProjected`/
@@ -532,9 +543,17 @@ Atomic file IO and locking.
 
 ### `internal/jsonkeys`
 Per-key JSON-pointer merge that preserves foreign keys and uses `json.Number`
-(no float64 rounding).
-- **Key:** `DecodeObject`; `DecodeYAML`; `MergeKeys(existing, ours, ownedPointers)`.
-- **Files:** `jsonkeys.go`.
+(no float64 rounding). It is also the single home for RFC 6901 pointer
+mechanics: `EscapeToken`/`UnescapeToken` were hand-rolled five times across
+three packages before #235, and their order of operations is not symmetric
+(escape does `~` first, decode does `~1` first), so getting either backwards
+silently corrupts any key holding a `/` or a `~`.
+- **Key:** `DecodeObject`; `DecodeYAML`; `MergeKeys(existing, ours, ownedPointers)`;
+  `EscapeToken`/`UnescapeToken`/`SplitPointer`; `Get(m, ptr) (any, bool)` — the
+  one pointer resolver, whose presence bool separates "absent" from "present and
+  null" (`render.RecordOpsState` needs the difference; the CLI's drift
+  diagnostics discard it).
+- **Files:** `jsonkeys.go`, `jsonc.go`, `pointer.go`.
 
 ### `internal/paths`
 Resolves `AGENTSYNC_HOME`, `AGENTSYNC_TARGET_ROOT`, and `$HOME`; converts between

--- a/docs/components.md
+++ b/docs/components.md
@@ -74,10 +74,11 @@ is the only package that depends on nearly all the others.
   the one "which agents may this run touch" extraction, returning the exact
   `([]string, map[string]bool)` pair `selectAgents` takes, SORTED (eight commands
   open-coded it, in three different shapes, before #235); `matchImportable`
-  (`import.go`) — the head every per-component importer shares (filter by name,
-  drop plugin-provided entries, refuse a named miss), while the tail stays
-  per-component because the five genuinely disagree about id validation and
-  write funnel.
+  (`import.go`) — the head five of the six per-component importers share
+  (filter by name, drop plugin-provided entries, refuse a named miss; hooks keep
+  their own because their join key is an opaque signature), while the tail
+  stays per-component because the five genuinely disagree about id validation
+  and write funnel.
 - **Commands:** `init`, `agent {add,remove,list,enable,disable}`, `apply`,
   `revert`, `status`, `diff`, `reconcile`, `import`, `doctor`, `check`,
   `mcp {add,remove,list,enable,disable}`,
@@ -488,7 +489,7 @@ drift state's `SchemaVersion`.
 Models the Claude marketplace/plugin format, fetches sources, and projects plugin
 manifests into canonical components.
 - **Key:** `Marketplace`, `PluginEntry`, `Source`, `PluginManifest`;
-  `ProjectionResult` + its `Canonical()` / `ReplaceComponentsIn()` (the
+  `ProjectionResult` + its `AsCanonical()` / `ReplaceComponentsIn()` (the
   projection→canonical component copy lives next to the struct, not in three CLI
   call sites, so a new component kind cannot be added here and silently dropped
   from every diagnostic surface — reflectively guarded);
@@ -544,7 +545,7 @@ Atomic file IO and locking.
 ### `internal/jsonkeys`
 Per-key JSON-pointer merge that preserves foreign keys and uses `json.Number`
 (no float64 rounding). It is also the single home for RFC 6901 pointer
-mechanics: `EscapeToken`/`UnescapeToken` were hand-rolled five times across
+mechanics: `EscapeToken`/`UnescapeToken` were hand-rolled seven times across
 three packages before #235, and their order of operations is not symmetric
 (escape does `~` first, decode does `~1` first), so getting either backwards
 silently corrupts any key holding a `/` or a `~`.

--- a/internal/cli/agents_flag.go
+++ b/internal/cli/agents_flag.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
+
+	"github.com/spxrogers/agentsync/internal/source"
 )
 
 // `--agents` is the ONE grammar for "which agents does this RUN act on"
@@ -55,4 +58,38 @@ func selectAgents(cmd *cobra.Command, enabledAgents []string, enabled map[string
 		return enabledAgents, nil
 	}
 	return resolveAgentFilter(names, enabled)
+}
+
+// enabledAgentNames answers "which agents is this run allowed to touch" in the
+// exact pair selectAgents takes: the enabled names as a slice, and the same set
+// as a membership map for the --agents allowlist check.
+//
+// Eight commands needed that pair and each open-coded the same five-line map
+// walk (apply, status, diff, reconcile, explain, plugin upgrade --lossless,
+// plugin explain, plugin poll). Four of them also built the `enabled` map,
+// four did not, and two re-sorted afterwards — so "enabled agents" had two
+// shapes and three orderings depending on which file you read. One helper
+// means a change to what "enabled" means (a future per-scope override, say)
+// lands once.
+//
+// The result is SORTED. The map walk it replaces was unordered, so every caller
+// already had to be order-insensitive; sorting only removes a source of
+// nondeterminism (render.Plan visits agents in this order, so an error from two
+// mis-rendering agents used to name whichever one the runtime happened to reach
+// first). explain and plugin explain sorted explicitly for exactly this reason
+// — that sort now lives here, once, for all of them.
+//
+// Both returns are non-nil even when nothing is enabled: callers test len(), and
+// an empty map is a valid "nothing is enabled" answer for selectAgents.
+func enabledAgentNames(cfg source.Config) ([]string, map[string]bool) {
+	names := make([]string, 0, len(cfg.Agents))
+	enabled := make(map[string]bool, len(cfg.Agents))
+	for name, ag := range cfg.Agents {
+		if ag.Enabled {
+			names = append(names, name)
+			enabled[name] = true
+		}
+	}
+	sort.Strings(names)
+	return names, enabled
 }

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -133,14 +133,7 @@ func runApplyPipeline(cmd *cobra.Command, home string, o applyOpts) error {
 		return err
 	}
 
-	agents := []string{}
-	enabled := map[string]bool{}
-	for name, ag := range c.Config.Agents {
-		if ag.Enabled {
-			agents = append(agents, name)
-			enabled[name] = true
-		}
-	}
+	agents, enabled := enabledAgentNames(c.Config)
 	// --agents narrows the apply to a validated allowlist, with the SAME parsing
 	// status/diff use (#200 F10). Applied after the enabled set is built, so an
 	// unknown or disabled name is rejected rather than silently rendering nothing.

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -74,14 +74,7 @@ func newDiffCmd() *cobra.Command {
 				return err
 			}
 			reg := registryFactory()
-			var enabledAgents []string
-			enabled := map[string]bool{}
-			for name, ag := range c.Config.Agents {
-				if ag.Enabled {
-					enabledAgents = append(enabledAgents, name)
-					enabled[name] = true
-				}
-			}
+			enabledAgents, enabled := enabledAgentNames(c.Config)
 			// --agents narrows the diff to a validated allowlist, mirroring
 			// `status --agents` exactly (same split/star/validation and the same
 			// empty-rejection message) so the two read-only commands stay

--- a/internal/cli/enabled_agents_internal_test.go
+++ b/internal/cli/enabled_agents_internal_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestEnabledAgentNames pins the pair's contract: enabled agents only, SORTED,
+// with a membership map that agrees with the slice, and both non-nil when
+// nothing is enabled.
+//
+// The sort is the load-bearing part. The eight map walks this replaced were
+// unordered, and two of them (explain, plugin explain) re-sorted afterwards
+// precisely because the order reaches the user — render.Plan visits agents in
+// this order and `--json` emits rows in it. Centralizing the sort is what makes
+// the other six deterministic too.
+func TestEnabledAgentNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     source.Config
+		want    []string
+		wantMap map[string]bool
+	}{
+		{
+			name:    "empty config",
+			cfg:     source.Config{},
+			want:    []string{},
+			wantMap: map[string]bool{},
+		},
+		{
+			name: "all disabled",
+			cfg: source.Config{Agents: map[string]source.Agent{
+				"claude": {Enabled: false},
+				"codex":  {Enabled: false},
+			}},
+			want:    []string{},
+			wantMap: map[string]bool{},
+		},
+		{
+			name: "only the enabled ones, sorted",
+			cfg: source.Config{Agents: map[string]source.Agent{
+				"zed":      {Enabled: true},
+				"claude":   {Enabled: true},
+				"opencode": {Enabled: false},
+				"codex":    {Enabled: true},
+			}},
+			want:    []string{"claude", "codex", "zed"},
+			wantMap: map[string]bool{"claude": true, "codex": true, "zed": true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Repeat: Go randomizes map iteration, so a single pass can agree
+			// with the sorted expectation by luck. Ten passes cannot.
+			for i := 0; i < 10; i++ {
+				got, enabled := enabledAgentNames(tc.cfg)
+				if got == nil {
+					t.Fatal("names must be non-nil even when nothing is enabled")
+				}
+				if enabled == nil {
+					t.Fatal("the membership map must be non-nil even when nothing is enabled")
+				}
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("pass %d: names = %v, want %v", i, got, tc.want)
+				}
+				if !reflect.DeepEqual(enabled, tc.wantMap) {
+					t.Fatalf("pass %d: enabled = %v, want %v", i, enabled, tc.wantMap)
+				}
+				// The two returns must describe the same set: selectAgents
+				// validates an --agents allowlist against the MAP and returns the
+				// SLICE when the flag is absent, so a disagreement would let an
+				// agent be selectable but never rendered (or vice versa).
+				if len(got) != len(enabled) {
+					t.Fatalf("pass %d: slice/map disagree: %v vs %v", i, got, enabled)
+				}
+				for _, n := range got {
+					if !enabled[n] {
+						t.Fatalf("pass %d: %q is in the slice but not the map", i, n)
+					}
+				}
+			}
+		})
+	}
+}
+
+// enabledAgentLoopSites reports the files whose source contains the open-coded
+// enabled-agent walk this helper replaced: a `range` over an agents map whose
+// body tests `.Enabled`. Factored out of the repo walk so the guard can be
+// exercised against a synthetic source (see the negative control).
+func enabledAgentLoopSites(src string) bool {
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "range") || !strings.Contains(line, ".Agents") {
+			continue
+		}
+		// The `if ag.Enabled {` test is the next line in every copy this
+		// replaced; allow a couple of lines of slack for a reformat.
+		for j := i + 1; j < len(lines) && j <= i+3; j++ {
+			if strings.Contains(lines[j], ".Enabled") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestEnabledAgentExtractionIsInOnePlace pins that "which agents are enabled"
+// has ONE definition.
+//
+// Eight copies of this walk existed before #235, in apply, status, diff,
+// reconcile, explain, plugin (upgrade --lossless), plugin explain and plugin
+// poll. Four built the `enabled` membership map and four did not; two sorted
+// the result and six did not. Nothing forced them to agree, so "enabled
+// agents" quietly meant three different things depending on which command you
+// ran.
+//
+// DELIBERATELY NOT MATCHED: check.go walks `c.Config.Agents` to validate EVERY
+// declared agent name, enabled or not — a different question with a different
+// answer, and its loop body does not test .Enabled, so the guard does not see
+// it. internal/project/project.go likewise merges the whole [agents] table.
+//
+// LIMIT: the pattern is line-shaped. A walk written with a helper variable, or
+// with the .Enabled test more than three lines below the range, slips past. It
+// catches the copy-paste that actually happened eight times, not every spelling.
+func TestEnabledAgentExtractionIsInOnePlace(t *testing.T) {
+	repoRoot := repoRootFromCaller(t)
+
+	allowed := map[string]string{
+		"internal/cli/agents_flag.go": "enabledAgentNames — the one enabled-agent extraction",
+	}
+
+	var unexpected []string
+	seen := map[string]bool{}
+	if err := walkRepoGoFiles(repoRoot, func(rel, src string) {
+		if !enabledAgentLoopSites(src) {
+			return
+		}
+		if _, ok := allowed[rel]; ok {
+			seen[rel] = true
+			return
+		}
+		unexpected = append(unexpected, rel)
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("an open-coded enabled-agent walk outside internal/cli/agents_flag.go:\n  %s\n\n"+
+			"Call enabledAgentNames(cfg) instead — it returns the exact ([]string, map[string]bool) pair selectAgents takes.",
+			strings.Join(unexpected, "\n  "))
+	}
+	for rel, reason := range allowed {
+		if !seen[rel] {
+			t.Errorf("%s is allowlisted (%s) but no longer contains the walk — drop it from the allowlist", rel, reason)
+		}
+	}
+
+	// NEGATIVE CONTROL — a guard that has stopped biting must fail HERE rather
+	// than pass silently.
+	t.Run("negative control", func(t *testing.T) {
+		reintroduced := "func run() {\n\tvar agents []string\n\tfor name, ag := range c.Config.Agents {\n" +
+			"\t\tif ag.Enabled {\n\t\t\tagents = append(agents, name)\n\t\t}\n\t}\n}\n"
+		if !enabledAgentLoopSites(reintroduced) {
+			t.Fatal("the guard must flag a reintroduced enabled-agent walk")
+		}
+		// check.go's shape: a walk over the same map that never tests .Enabled.
+		validateAll := "\tfor name := range c.Config.Agents {\n\t\tif err := validateAgent(name); err != nil {\n\t\t\treturn err\n\t\t}\n\t}\n"
+		if enabledAgentLoopSites(validateAll) {
+			t.Fatal("validating every declared agent is a different question; the guard must not flag it")
+		}
+		// Neither token alone is the walk.
+		if enabledAgentLoopSites("\tfor _, x := range xs {\n\t\tif x.Enabled {\n\t\t}\n\t}\n") {
+			t.Fatal("a .Enabled test over some other collection is not an agents walk")
+		}
+	})
+}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -219,13 +218,7 @@ func explainRun(cmd *cobra.Command, rawPath, ptr string, jsonOut bool) error {
 	}
 
 	reg := registryFactory()
-	var agents []string
-	for name, ag := range c.Config.Agents {
-		if ag.Enabled {
-			agents = append(agents, name)
-		}
-	}
-	sort.Strings(agents)
+	agents, _ := enabledAgentNames(c.Config)
 	// Resolve secrets for HASHING only, exactly as `status` does: apply writes
 	// (and RecordOpsState hashes) the secret-RESOLVED content, so hashing a
 	// templated render would classify every synced ${secret:…}/${env:…} item as

--- a/internal/cli/explain_model.go
+++ b/internal/cli/explain_model.go
@@ -433,15 +433,7 @@ func pluginOrigins(in explainInputs) map[string]explainPluginOrigin {
 			ID:      pluginOriginLabel(pl),
 			Version: pl.Plugin.Version.Unverified(),
 		}
-		projected := source.Canonical{
-			MCPServers: proj.MCPServers,
-			Skills:     proj.Skills,
-			Subagents:  proj.Subagents,
-			Commands:   proj.Commands,
-			Hooks:      proj.Hooks,
-			LSPServers: proj.LSPServers,
-		}
-		for _, k := range canonicalComponentKeys(projected) {
+		for _, k := range canonicalComponentKeys(proj.Canonical()) {
 			o := origin
 			o.AlsoAuthored = authored[k]
 			// First plugin wins the slot, matching the concatenation order

--- a/internal/cli/explain_model.go
+++ b/internal/cli/explain_model.go
@@ -433,7 +433,7 @@ func pluginOrigins(in explainInputs) map[string]explainPluginOrigin {
 			ID:      pluginOriginLabel(pl),
 			Version: pl.Plugin.Version.Unverified(),
 		}
-		for _, k := range canonicalComponentKeys(proj.Canonical()) {
+		for _, k := range canonicalComponentKeys(proj.AsCanonical()) {
 			o := origin
 			o.AlsoAuthored = authored[k]
 			// First plugin wins the slot, matching the concatenation order

--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -48,30 +48,37 @@ func TestHashAtPointer_AbsentVsNull(t *testing.T) {
 }
 
 // pointerEscapeCall matches RFC 6901 token escaping spelled by hand as a
-// ReplaceAll — strings.ReplaceAll, bytes.ReplaceAll, or the hand-written
-// replaceAll internal/render once carried — whose last two operands are one of
-// the four escape pairs ('~'→"~0", '/'→"~1", "~1"→'/', "~0"→'~'). Only the
-// exact pairs match: a ReplaceAll that flattens '/' to '~' for a cache key is
-// not an escape. The first operand may itself be a call one level deep.
+// ReplaceAll or Replace — strings.ReplaceAll, bytes.ReplaceAll, the older
+// strings.Replace(…, -1), or the hand-written replaceAll internal/render once
+// carried — whose operands are one of the four escape pairs ('~'→"~0",
+// '/'→"~1", "~1"→'/', "~0"→'~'). Only the exact pairs match: a ReplaceAll that
+// flattens '/' to '~' for a cache key is not an escape. The first operand may
+// itself be a call one level deep.
 var pointerEscapeCall = regexp.MustCompile(
-	`(?i)replaceall\((?:[^()]|\([^()]*\))*,\s*(?:` +
+	`(?i)replace(?:all)?\((?:[^()]|\([^()]*\))*,\s*(?:` +
 		`(?:\[\]byte\()?"~"\)?\s*,\s*(?:\[\]byte\()?"~0"\)?|` +
 		`(?:\[\]byte\()?"/"\)?\s*,\s*(?:\[\]byte\()?"~1"\)?|` +
 		`(?:\[\]byte\()?"~1"\)?\s*,\s*(?:\[\]byte\()?"/"\)?|` +
 		`(?:\[\]byte\()?"~0"\)?\s*,\s*(?:\[\]byte\()?"~"\)?` +
-		`)\s*\)`,
+		`)(?:\s*,\s*-?\d+)?\s*\)`,
 )
 
 // pointerEscapeReplacer matches the other complete spelling of the same thing:
-// a strings.NewReplacer whose operands are all drawn from the escape alphabet,
-// e.g. strings.NewReplacer("~", "~0", "/", "~1").
-var pointerEscapeReplacer = regexp.MustCompile(`(?i)newreplacer\((?:\s*"(?:~0|~1|~|/)"\s*,){1,3}\s*"(?:~0|~1|~|/)"\s*\)`)
+// a strings.NewReplacer whose operands are WHOLE escape pairs, e.g.
+// strings.NewReplacer("~", "~0", "/", "~1"). A NewReplacer("/", "~") is the
+// same cache-key flattening pointerEscapeCall declines to flag.
+var pointerEscapeReplacer = regexp.MustCompile(
+	`(?i)newreplacer\((?:\s*` + pointerEscapePair + `\s*,)*\s*` + pointerEscapePair + `\s*\)`,
+)
 
-// pointerEscapeSites reports whether src contains either shape outside a line
-// comment (a doc comment is allowed to QUOTE the call it warns against).
-// Factored out of the repo walk so the guard can be exercised against a
-// synthetic source (see the negative control).
-func pointerEscapeSites(src string) bool {
+const pointerEscapePair = `(?:"~"\s*,\s*"~0"|"/"\s*,\s*"~1"|"~1"\s*,\s*"/"|"~0"\s*,\s*"~")`
+
+// pointerEscapeSite reports the first hand-rolled escape in src — the matched
+// call text and which shape it is — ignoring FULL-LINE // comments, so a doc
+// comment may quote the call it warns against. Factored out of the repo walk
+// so the guard can be exercised against a synthetic source (see the negative
+// control).
+func pointerEscapeSite(src string) (string, bool) {
 	var code []string
 	for _, line := range strings.Split(src, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "//") {
@@ -80,7 +87,13 @@ func pointerEscapeSites(src string) bool {
 		code = append(code, line)
 	}
 	joined := strings.Join(code, "\n")
-	return pointerEscapeCall.MatchString(joined) || pointerEscapeReplacer.MatchString(joined)
+	if m := pointerEscapeCall.FindString(joined); m != "" {
+		return "a ReplaceAll pair: " + m, true
+	}
+	if m := pointerEscapeReplacer.FindString(joined); m != "" {
+		return "a NewReplacer over the pairs: " + m, true
+	}
+	return "", false
 }
 
 // TestPointerEscapingIsInOnePlace pins that RFC 6901 token escaping has ONE
@@ -94,11 +107,14 @@ func pointerEscapeSites(src string) bool {
 // holding a '/' or a '~'. This is the mirror of
 // TestEnabledAgentExtractionIsInOnePlace for the higher-stakes of the two.
 //
-// LIMIT: the matcher is textual and shape-based. It sees the two complete
-// spellings a copy-paste produces — a ReplaceAll per pair and a NewReplacer —
-// with literal operands; a hand-written byte loop, a rune switch, or a
-// ReplaceAll over variables slips past, and a call inside a string literal
-// (not a comment) is flagged. The repo's go/ast guards (cleanupop_guard_test.go
+// LIMIT: the matcher is textual and shape-based. It sees the complete
+// spellings a copy-paste produces — a ReplaceAll or Replace per pair, or a
+// NewReplacer over the pairs — with literal operands. A hand-written byte
+// loop, a rune switch, a ReplaceAll over variables, or a "~"+"0" split
+// literal slips past. Only a FULL-LINE // comment is skipped: a trailing
+// comment, a /* */ block, or a raw string literal quoting the call is flagged
+// (an interpreted string literal is not, its quotes being escaped), and the
+// walk never visits _test.go. The repo's go/ast guards (cleanupop_guard_test.go
 // in internal/adapter, output_vocabulary_test.go here) would be exact; a few
 // lines of regexp are proportionate for a guard whose job is to catch the
 // copy that actually happened seven times.
@@ -112,21 +128,23 @@ func TestPointerEscapingIsInOnePlace(t *testing.T) {
 	var unexpected []string
 	seen := map[string]bool{}
 	if err := walkRepoGoFiles(repoRoot, func(rel, src string) {
-		if !pointerEscapeSites(src) {
+		site, ok := pointerEscapeSite(src)
+		if !ok {
 			return
 		}
 		if _, ok := allowed[rel]; ok {
 			seen[rel] = true
 			return
 		}
-		unexpected = append(unexpected, rel)
+		unexpected = append(unexpected, rel+": "+site)
 	}); err != nil {
 		t.Fatalf("walk: %v", err)
 	}
 	sort.Strings(unexpected)
 	if len(unexpected) > 0 {
 		t.Errorf("a hand-rolled RFC 6901 escape outside internal/jsonkeys/pointer.go:\n  %s\n\n"+
-			"Call jsonkeys.EscapeToken / jsonkeys.UnescapeToken instead — the order is not symmetric and is pinned there.",
+			"Call jsonkeys.EscapeToken / jsonkeys.UnescapeToken instead — the order is not symmetric and is pinned there. "+
+			"A site that genuinely must spell it by hand goes in this test's allowlist, with its reason.",
 			strings.Join(unexpected, "\n  "))
 	}
 	for rel, reason := range allowed {
@@ -148,9 +166,10 @@ func TestPointerEscapingIsInOnePlace(t *testing.T) {
 			`k := strings.ReplaceAll(filepath.ToSlash(p), "/", "~1")`,
 			`var esc = strings.NewReplacer("~", "~0", "/", "~1")`,
 			`var unesc = strings.NewReplacer("~1", "/", "~0", "~")`,
+			`s = strings.Replace(s, "~", "~0", -1)`,
 			"\t// a comment above the call does not hide it\n\ts = strings.ReplaceAll(s, \"~\", \"~0\")\n",
 		} {
-			if !pointerEscapeSites(reintroduced) {
+			if _, ok := pointerEscapeSite(reintroduced); !ok {
 				t.Fatalf("the guard must flag a reintroduced escape: %s", reintroduced)
 			}
 		}
@@ -158,13 +177,14 @@ func TestPointerEscapingIsInOnePlace(t *testing.T) {
 			`s = strings.ReplaceAll(s, "a", "b")`,
 			`s = strings.ReplaceAll(s, "~", "-")`,
 			`s = strings.ReplaceAll(s, "\\", "/")`,
-			`key := strings.ReplaceAll(rel, "/", "~")`, // flattening a path for a cache key is not an escape
+			`key := strings.ReplaceAll(rel, "/", "~")`,          // flattening a path for a cache key is not an escape
+			`key := strings.NewReplacer("/", "~").Replace(rel)`, // the same flattening, spelled the other way
 			`r := strings.NewReplacer("/", "-", "~", "_")`,
 			`// escapes ("~0" for "~", "~1" for "/") are supported.`,
 			`// e.g. strings.ReplaceAll(s, "~", "~0") — do not hand-roll this; call jsonkeys.EscapeToken.`,
 		} {
-			if pointerEscapeSites(unrelated) {
-				t.Fatalf("the guard must not flag an unrelated replace or a comment quoting the call: %s", unrelated)
+			if site, ok := pointerEscapeSite(unrelated); ok {
+				t.Fatalf("the guard must not flag an unrelated replace or a comment quoting the call: %s (matched %s)", unrelated, site)
 			}
 		}
 	})

--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -7,8 +7,8 @@ import "testing"
 // CollectPointers escapes those (~→~0, /→~1), but getPointerValue split the
 // pointer without decoding, so it looked up the literal "foo~0bar" key instead
 // of the real "foo~bar" key → nil source value → phantom drift forever. Every
-// other pointer getter (getJSONPointer, render.getPointerOK, jsonkeys
-// splitPointer) decodes; this one didn't.
+// other pointer getter decoded; this one didn't. All of them now share
+// jsonkeys.Get.
 func TestGetPointerValue_DecodesRFC6901(t *testing.T) {
 	m := map[string]any{
 		"mcpServers": map[string]any{

--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
 
 // TestGetPointerValue_DecodesRFC6901 is the regression for status/diff
 // misclassifying drift on a managed item whose id contains '~' or '/'.
@@ -40,4 +45,91 @@ func TestHashAtPointer_AbsentVsNull(t *testing.T) {
 	if h := hashAtPointer(mn, "/k"); h == "" {
 		t.Fatal("present-null must hash, not be treated as absent")
 	}
+}
+
+// pointerEscapeCall matches RFC 6901 token escaping spelled by hand: a
+// ReplaceAll — strings.ReplaceAll, bytes.ReplaceAll, or the hand-written
+// replaceAll internal/render once carried — whose operands are the '~'/'/' ↔
+// "~0"/"~1" pairs, in either direction.
+var pointerEscapeCall = regexp.MustCompile(`(?i)replaceall\([^()]*,\s*(?:\[\]byte\()?"(~0|~1|~|/)"\)?\s*,\s*(?:\[\]byte\()?"(~0|~1|~|/)"\)?\s*\)`)
+
+// pointerEscapeSites reports whether src contains such a call. Factored out of
+// the repo walk so the guard can be exercised against a synthetic source (see
+// the negative control).
+func pointerEscapeSites(src string) bool { return pointerEscapeCall.MatchString(src) }
+
+// TestPointerEscapingIsInOnePlace pins that RFC 6901 token escaping has ONE
+// definition: jsonkeys.EscapeToken / jsonkeys.UnescapeToken.
+//
+// Seven copies existed before #235, across internal/cli, internal/render and
+// internal/jsonkeys, and each had to get a non-symmetric order right ('~' first
+// when escaping, "~1" first when decoding). The escape feeds
+// render.CollectPointers, which mints the state file's keys, so an eighth copy
+// with the order backwards would report phantom drift forever for any id
+// holding a '/' or a '~'. This is the mirror of
+// TestEnabledAgentExtractionIsInOnePlace for the higher-stakes of the two.
+//
+// LIMIT: the pattern is call-shaped. A hand-written byte loop, or a ReplaceAll
+// whose operands are variables rather than literals, slips past. It catches
+// the four-line copy-paste that actually happened seven times, not every
+// spelling.
+func TestPointerEscapingIsInOnePlace(t *testing.T) {
+	repoRoot := repoRootFromCaller(t)
+
+	allowed := map[string]string{
+		"internal/jsonkeys/pointer.go": "EscapeToken/UnescapeToken — the one RFC 6901 escape",
+	}
+
+	var unexpected []string
+	seen := map[string]bool{}
+	if err := walkRepoGoFiles(repoRoot, func(rel, src string) {
+		if !pointerEscapeSites(src) {
+			return
+		}
+		if _, ok := allowed[rel]; ok {
+			seen[rel] = true
+			return
+		}
+		unexpected = append(unexpected, rel)
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("a hand-rolled RFC 6901 escape outside internal/jsonkeys/pointer.go:\n  %s\n\n"+
+			"Call jsonkeys.EscapeToken / jsonkeys.UnescapeToken instead — the order is not symmetric and is pinned there.",
+			strings.Join(unexpected, "\n  "))
+	}
+	for rel, reason := range allowed {
+		if !seen[rel] {
+			t.Errorf("%s is allowlisted (%s) but no longer contains the escape — drop it from the allowlist", rel, reason)
+		}
+	}
+
+	// NEGATIVE CONTROL — a guard that has stopped biting must fail HERE rather
+	// than pass silently.
+	t.Run("negative control", func(t *testing.T) {
+		for _, reintroduced := range []string{
+			`s = strings.ReplaceAll(s, "~", "~0")`,
+			`s = strings.ReplaceAll(s, "/", "~1")`,
+			`p = strings.ReplaceAll(p, "~1", "/")`,
+			`return strings.ReplaceAll(strings.ReplaceAll(tok, "~1", "/"), "~0", "~")`,
+			`s = replaceAll(s, "~", "~0")`,
+			`b = bytes.ReplaceAll(b, []byte("~0"), []byte("~"))`,
+		} {
+			if !pointerEscapeSites(reintroduced) {
+				t.Fatalf("the guard must flag a reintroduced escape: %s", reintroduced)
+			}
+		}
+		for _, unrelated := range []string{
+			`s = strings.ReplaceAll(s, "a", "b")`,
+			`s = strings.ReplaceAll(s, "~", "-")`,
+			`s = strings.ReplaceAll(s, "\\", "/")`,
+			`// escapes ("~0" for "~", "~1" for "/") are supported.`,
+		} {
+			if pointerEscapeSites(unrelated) {
+				t.Fatalf("the guard must not flag an unrelated ReplaceAll or a comment: %s", unrelated)
+			}
+		}
+	})
 }

--- a/internal/cli/getpointer_test.go
+++ b/internal/cli/getpointer_test.go
@@ -47,16 +47,41 @@ func TestHashAtPointer_AbsentVsNull(t *testing.T) {
 	}
 }
 
-// pointerEscapeCall matches RFC 6901 token escaping spelled by hand: a
+// pointerEscapeCall matches RFC 6901 token escaping spelled by hand as a
 // ReplaceAll — strings.ReplaceAll, bytes.ReplaceAll, or the hand-written
-// replaceAll internal/render once carried — whose operands are the '~'/'/' ↔
-// "~0"/"~1" pairs, in either direction.
-var pointerEscapeCall = regexp.MustCompile(`(?i)replaceall\([^()]*,\s*(?:\[\]byte\()?"(~0|~1|~|/)"\)?\s*,\s*(?:\[\]byte\()?"(~0|~1|~|/)"\)?\s*\)`)
+// replaceAll internal/render once carried — whose last two operands are one of
+// the four escape pairs ('~'→"~0", '/'→"~1", "~1"→'/', "~0"→'~'). Only the
+// exact pairs match: a ReplaceAll that flattens '/' to '~' for a cache key is
+// not an escape. The first operand may itself be a call one level deep.
+var pointerEscapeCall = regexp.MustCompile(
+	`(?i)replaceall\((?:[^()]|\([^()]*\))*,\s*(?:` +
+		`(?:\[\]byte\()?"~"\)?\s*,\s*(?:\[\]byte\()?"~0"\)?|` +
+		`(?:\[\]byte\()?"/"\)?\s*,\s*(?:\[\]byte\()?"~1"\)?|` +
+		`(?:\[\]byte\()?"~1"\)?\s*,\s*(?:\[\]byte\()?"/"\)?|` +
+		`(?:\[\]byte\()?"~0"\)?\s*,\s*(?:\[\]byte\()?"~"\)?` +
+		`)\s*\)`,
+)
 
-// pointerEscapeSites reports whether src contains such a call. Factored out of
-// the repo walk so the guard can be exercised against a synthetic source (see
-// the negative control).
-func pointerEscapeSites(src string) bool { return pointerEscapeCall.MatchString(src) }
+// pointerEscapeReplacer matches the other complete spelling of the same thing:
+// a strings.NewReplacer whose operands are all drawn from the escape alphabet,
+// e.g. strings.NewReplacer("~", "~0", "/", "~1").
+var pointerEscapeReplacer = regexp.MustCompile(`(?i)newreplacer\((?:\s*"(?:~0|~1|~|/)"\s*,){1,3}\s*"(?:~0|~1|~|/)"\s*\)`)
+
+// pointerEscapeSites reports whether src contains either shape outside a line
+// comment (a doc comment is allowed to QUOTE the call it warns against).
+// Factored out of the repo walk so the guard can be exercised against a
+// synthetic source (see the negative control).
+func pointerEscapeSites(src string) bool {
+	var code []string
+	for _, line := range strings.Split(src, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code = append(code, line)
+	}
+	joined := strings.Join(code, "\n")
+	return pointerEscapeCall.MatchString(joined) || pointerEscapeReplacer.MatchString(joined)
+}
 
 // TestPointerEscapingIsInOnePlace pins that RFC 6901 token escaping has ONE
 // definition: jsonkeys.EscapeToken / jsonkeys.UnescapeToken.
@@ -69,10 +94,14 @@ func pointerEscapeSites(src string) bool { return pointerEscapeCall.MatchString(
 // holding a '/' or a '~'. This is the mirror of
 // TestEnabledAgentExtractionIsInOnePlace for the higher-stakes of the two.
 //
-// LIMIT: the pattern is call-shaped. A hand-written byte loop, or a ReplaceAll
-// whose operands are variables rather than literals, slips past. It catches
-// the four-line copy-paste that actually happened seven times, not every
-// spelling.
+// LIMIT: the matcher is textual and shape-based. It sees the two complete
+// spellings a copy-paste produces — a ReplaceAll per pair and a NewReplacer —
+// with literal operands; a hand-written byte loop, a rune switch, or a
+// ReplaceAll over variables slips past, and a call inside a string literal
+// (not a comment) is flagged. The repo's go/ast guards (cleanupop_guard_test.go
+// in internal/adapter, output_vocabulary_test.go here) would be exact; a few
+// lines of regexp are proportionate for a guard whose job is to catch the
+// copy that actually happened seven times.
 func TestPointerEscapingIsInOnePlace(t *testing.T) {
 	repoRoot := repoRootFromCaller(t)
 
@@ -116,6 +145,10 @@ func TestPointerEscapingIsInOnePlace(t *testing.T) {
 			`return strings.ReplaceAll(strings.ReplaceAll(tok, "~1", "/"), "~0", "~")`,
 			`s = replaceAll(s, "~", "~0")`,
 			`b = bytes.ReplaceAll(b, []byte("~0"), []byte("~"))`,
+			`k := strings.ReplaceAll(filepath.ToSlash(p), "/", "~1")`,
+			`var esc = strings.NewReplacer("~", "~0", "/", "~1")`,
+			`var unesc = strings.NewReplacer("~1", "/", "~0", "~")`,
+			"\t// a comment above the call does not hide it\n\ts = strings.ReplaceAll(s, \"~\", \"~0\")\n",
 		} {
 			if !pointerEscapeSites(reintroduced) {
 				t.Fatalf("the guard must flag a reintroduced escape: %s", reintroduced)
@@ -125,10 +158,13 @@ func TestPointerEscapingIsInOnePlace(t *testing.T) {
 			`s = strings.ReplaceAll(s, "a", "b")`,
 			`s = strings.ReplaceAll(s, "~", "-")`,
 			`s = strings.ReplaceAll(s, "\\", "/")`,
+			`key := strings.ReplaceAll(rel, "/", "~")`, // flattening a path for a cache key is not an escape
+			`r := strings.NewReplacer("/", "-", "~", "_")`,
 			`// escapes ("~0" for "~", "~1" for "/") are supported.`,
+			`// e.g. strings.ReplaceAll(s, "~", "~0") — do not hand-roll this; call jsonkeys.EscapeToken.`,
 		} {
 			if pointerEscapeSites(unrelated) {
-				t.Fatalf("the guard must not flag an unrelated ReplaceAll or a comment: %s", unrelated)
+				t.Fatalf("the guard must not flag an unrelated replace or a comment quoting the call: %s", unrelated)
 			}
 		}
 	})

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -581,32 +581,48 @@ func unimportedDestPointers(agentsyncHome, srcHome, agentName string, reg *adapt
 		if jsonErr := jsonUnmarshalLoose(op.Content, &ours); jsonErr != nil {
 			continue
 		}
-		ownedPtrs := map[string]bool{}
-		ourSections := map[string]bool{}
-		for k := range ours {
-			ourSections[jsonkeys.EscapeToken(k)] = true
-		}
-		for _, p := range collectStateSeedPointers(ours) {
-			ownedPtrs[p] = true
-		}
-		// Walk existing's second-level pointers and flag ones agentsync's
-		// canonical doesn't own — but ONLY under top-level sections the
-		// canonical actually renders (mirrors render.scopeOwnedToSections).
-		// Pointers under sections agentsync doesn't model at all (Claude
-		// Code's runtime state, telemetry, unmodeled settings) are out of
-		// scope: the merge-keys writer leaves them untouched on apply, so
-		// flagging them would be noise — and the previous "will trigger
-		// ForeignCollision" prediction for them was factually wrong (the
-		// per-pointer OwnedKeys check fires only for keys this op writes).
-		for _, p := range collectStateSeedPointers(existing) {
-			if ownedPtrs[p] {
-				continue
-			}
-			if !ourSections[firstPointerSegmentEsc(p)] {
-				continue
-			}
+		for _, p := range foreignPointersInOurSections(ours, existing) {
 			out = append(out, op.Path+"#"+p)
 		}
+	}
+	return out
+}
+
+// foreignPointersInOurSections walks existing's second-level pointers and
+// returns the ones agentsync's canonical (ours) doesn't own — but ONLY under
+// top-level sections the canonical actually renders (mirrors
+// render.scopeOwnedToSections). Pointers under sections agentsync doesn't model
+// at all (Claude Code's runtime state, telemetry, unmodeled settings) are out
+// of scope: the merge-keys writer leaves them untouched on apply, so flagging
+// them would be noise — and the previous "will trigger ForeignCollision"
+// prediction for them was factually wrong (the per-pointer OwnedKeys check
+// fires only for keys this op writes).
+//
+// The section set is keyed by the ESCAPED top-level key because it is compared
+// against the first segment of a collectStateSeedPointers pointer, which is
+// escaped: a key holding a '/' or a '~' escapes to something other than
+// itself, so a set keyed by the raw key would never match, and every foreign
+// pointer under that section would go unreported. Pure, with no I/O, so
+// TestUnimportedSectionSetAgreesWithSeedPointers can pin exactly that on the
+// production code rather than on a re-spelling of it.
+func foreignPointersInOurSections(ours, existing map[string]any) []string {
+	ownedPtrs := map[string]bool{}
+	ourSections := map[string]bool{}
+	for k := range ours {
+		ourSections[jsonkeys.EscapeToken(k)] = true
+	}
+	for _, p := range collectStateSeedPointers(ours) {
+		ownedPtrs[p] = true
+	}
+	var out []string
+	for _, p := range collectStateSeedPointers(existing) {
+		if ownedPtrs[p] {
+			continue
+		}
+		if !ourSections[firstPointerSegmentEsc(p)] {
+			continue
+		}
+		out = append(out, p)
 	}
 	return out
 }
@@ -1307,52 +1323,6 @@ func hookDisplay(h source.Hook) string {
 // it exists because a hook's key is an opaque length-prefixed signature rather
 // than a name anyone could act on. Pass nil wherever the key IS the display name,
 // which is every kind except hooks.
-// matchImportable is the head every per-component importer shares: narrow the
-// ingested components to the requested one (name == "" means all), drop the
-// entries an installed plugin already provides, and turn "you asked for a
-// specific item and it is not there" into the one refusal message all five
-// spell the same way.
-//
-// kind is the skipPluginProvided/pluginProvided key ("mcp", "lsp", "skill",
-// "subagent", "command"); label is how that kind is spoken in the not-found
-// error ("mcp server", not "mcp"). The two differ for exactly the two server
-// kinds, which is why they are separate parameters rather than one string used
-// twice.
-//
-// An EMPTY result with no error is the "nothing to do" answer, NOT an error:
-// a bulk import of an agent that has no skills is a success that imports
-// nothing. Callers must return early on it rather than falling through — the
-// two capture-backed importers would otherwise hand capture.Capture an empty
-// component list. The idiom at every call site is:
-//
-//	matched, err := matchImportable(…)
-//	if err != nil || len(matched) == 0 {
-//		return nil, err
-//	}
-//
-// The TAIL stays per-component on purpose: the five disagree about id
-// validation (command downgrades an invalid name to a warning in bulk mode so
-// one bad native file cannot abort the run; the rest refuse outright) and about
-// the write funnel (mcp/lsp go through capture.Capture, the file-backed three
-// through source.Write*). Folding those into a table would mean a config
-// parameter per disagreement, which is the same code with more indirection.
-func matchImportable[T any](io *importIO, kind, label, name string, items []T, key func(T) string) ([]T, error) {
-	var matched []T
-	for _, it := range items {
-		if name == "" || key(it) == name {
-			matched = append(matched, it)
-		}
-	}
-	matched, err := skipPluginProvided(io, kind, name, matched, key, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(matched) == 0 && name != "" {
-		return nil, fmt.Errorf("%s %q not found in native config", label, name)
-	}
-	return matched, nil
-}
-
 func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string, displayOf func(T) string) ([]T, error) {
 	// Nothing matched → nothing to wrongly capture, so an unusable filter is
 	// harmless here. Checking this FIRST keeps a broken plugin cache from
@@ -1396,6 +1366,53 @@ func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameO
 			"(capturing it would collide with the plugin's own on the next apply)", kind, display, plugin)
 	}
 	return out, nil
+}
+
+// matchImportable is the head five of the six per-component importers share
+// (hooks keep their own: their join key is an opaque signature that needs
+// skipPluginProvided's displayOf): narrow the ingested components to the
+// requested one (name == "" means all), drop the entries an installed plugin
+// already provides, and turn "you asked for a specific item and it is not
+// there" into the one refusal message all five spell the same way.
+//
+// kind is the skipPluginProvided/pluginProvided key ("mcp", "lsp", "skill",
+// "subagent", "command"); label is how that kind is spoken in the not-found
+// error ("mcp server", not "mcp"). The two differ for exactly the two server
+// kinds, which is why they are separate parameters rather than one string used
+// twice.
+//
+// An EMPTY result with no error is the "nothing to do" answer, NOT an error:
+// a bulk import of an agent that has no skills is a success that imports
+// nothing. Callers must return early on it rather than falling through — the
+// two capture-backed importers would otherwise hand capture.Capture an empty
+// component list. The idiom at every call site is:
+//
+//	matched, err := matchImportable(…)
+//	if err != nil || len(matched) == 0 {
+//		return nil, err
+//	}
+//
+// The TAIL stays per-component on purpose: the five disagree about id
+// validation (command downgrades an invalid name to a warning in bulk mode so
+// one bad native file cannot abort the run; the rest refuse outright) and about
+// the write funnel (mcp/lsp go through capture.Capture, the file-backed three
+// through source.Write*). Folding those into a table would mean a config
+// parameter per disagreement, which is the same code with more indirection.
+func matchImportable[T any](io *importIO, kind, label, name string, items []T, key func(T) string) ([]T, error) {
+	var matched []T
+	for _, it := range items {
+		if name == "" || key(it) == name {
+			matched = append(matched, it)
+		}
+	}
+	matched, err := skipPluginProvided(io, kind, name, matched, key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(matched) == 0 && name != "" {
+		return nil, fmt.Errorf("%s %q not found in native config", label, name)
+	}
+	return matched, nil
 }
 
 func importSkill(io *importIO, home string, c source.Canonical, name string) ([]string, error) {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -932,14 +932,26 @@ func (i *importIO) detailf(format string, args ...any) {
 	i.p.Fdetailf(i.err, format, args...)
 }
 
-// notef emits an INFO diagnostic about how agentsync is proceeding, as opposed
-// to warn's "something about your data needs attention".
+// notef is note + fmt.Sprintf, mirroring warnf/warn.
 //
-// Both tiers exist deliberately: an import that silently changes course (seeding
-// state, retiring a stale hook) is worth saying out loud, but saying it at WARN
-// would train the user to ignore the label that actually means "look at this".
+// The two used to be independent one-liners over ui.Fdiagf, differing only in
+// that note wrapped its message in a "%s" and notef passed the format through —
+// a distinction without a difference, since Fdiagf itself Sprintf's. Two
+// spellings of one output tier meant a change to that tier (its label, its
+// stream, its prefix) had to be made twice or be made inconsistent. Byte
+// equality is pinned by TestImportIONotefEqualsNote.
+//
+// note, not notef, is the spelling for an ALREADY-FORMATTED message: notef
+// Sprintf's, so a percent verb left in the text would still be reinterpreted.
+// `go vet` enforces that split — its printf analyzer recognizes notef as a
+// wrapper and rejects a non-constant format here.
+//
+// Both tiers (note/notef vs warn/warnf) exist deliberately: an import that
+// silently changes course (seeding state, retiring a stale hook) is worth
+// saying out loud, but saying it at WARN would train the user to ignore the
+// label that actually means "look at this".
 func (i *importIO) notef(format string, args ...any) {
-	i.p.Fdiagf(i.err, ui.LevelInfo, format, args...)
+	i.note(fmt.Sprintf(format, args...))
 }
 
 // infof prints an informational RESULT line on stdout — a "nothing to do"
@@ -1116,21 +1128,9 @@ func importAllComponents(io *importIO, home string, a adapter.Adapter, agentName
 // re-references secrets and preserves source-only fields for every server.
 // When io.dryRun is set it reports the targets without writing.
 func importMCP(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
-	var matched []source.MCPServer
-	for _, m := range c.MCPServers {
-		if name == "" || m.ID == name {
-			matched = append(matched, m)
-		}
-	}
-	matched, err := skipPluginProvided(io, "mcp", name, matched, func(m source.MCPServer) string { return m.ID }, nil)
-	if err != nil {
+	matched, err := matchImportable(io, "mcp", "mcp server", name, c.MCPServers, func(m source.MCPServer) string { return m.ID })
+	if err != nil || len(matched) == 0 {
 		return nil, err
-	}
-	if len(matched) == 0 {
-		if name != "" {
-			return nil, fmt.Errorf("mcp server %q not found in native config", name)
-		}
-		return nil, nil
 	}
 	// Validate ids up front (before any write, and in dry-run) so the preview
 	// matches a real import and a bulk write is atomic on a bad id.
@@ -1346,6 +1346,52 @@ func hookDisplay(h source.Hook) string {
 // it exists because a hook's key is an opaque length-prefixed signature rather
 // than a name anyone could act on. Pass nil wherever the key IS the display name,
 // which is every kind except hooks.
+// matchImportable is the head every per-component importer shares: narrow the
+// ingested components to the requested one (name == "" means all), drop the
+// entries an installed plugin already provides, and turn "you asked for a
+// specific item and it is not there" into the one refusal message all five
+// spell the same way.
+//
+// kind is the skipPluginProvided/pluginProvided key ("mcp", "lsp", "skill",
+// "subagent", "command"); label is how that kind is spoken in the not-found
+// error ("mcp server", not "mcp"). The two differ for exactly the two server
+// kinds, which is why they are separate parameters rather than one string used
+// twice.
+//
+// An EMPTY result with no error is the "nothing to do" answer, NOT an error:
+// a bulk import of an agent that has no skills is a success that imports
+// nothing. Callers must return early on it rather than falling through — the
+// two capture-backed importers would otherwise hand capture.Capture an empty
+// component list. The idiom at every call site is:
+//
+//	matched, err := matchImportable(…)
+//	if err != nil || len(matched) == 0 {
+//		return nil, err
+//	}
+//
+// The TAIL stays per-component on purpose: the five disagree about id
+// validation (command downgrades an invalid name to a warning in bulk mode so
+// one bad native file cannot abort the run; the rest refuse outright) and about
+// the write funnel (mcp/lsp go through capture.Capture, the file-backed three
+// through source.Write*). Folding those into a table would mean a config
+// parameter per disagreement, which is the same code with more indirection.
+func matchImportable[T any](io *importIO, kind, label, name string, items []T, key func(T) string) ([]T, error) {
+	var matched []T
+	for _, it := range items {
+		if name == "" || key(it) == name {
+			matched = append(matched, it)
+		}
+	}
+	matched, err := skipPluginProvided(io, kind, name, matched, key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(matched) == 0 && name != "" {
+		return nil, fmt.Errorf("%s %q not found in native config", label, name)
+	}
+	return matched, nil
+}
+
 func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameOf func(T) string, displayOf func(T) string) ([]T, error) {
 	// Nothing matched → nothing to wrongly capture, so an unusable filter is
 	// harmless here. Checking this FIRST keeps a broken plugin cache from
@@ -1392,21 +1438,9 @@ func skipPluginProvided[T any](io *importIO, kind, name string, items []T, nameO
 }
 
 func importSkill(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
-	var matched []source.Skill
-	for _, sk := range c.Skills {
-		if name == "" || sk.Name == name {
-			matched = append(matched, sk)
-		}
-	}
-	matched, err := skipPluginProvided(io, "skill", name, matched, func(sk source.Skill) string { return sk.Name }, nil)
-	if err != nil {
+	matched, err := matchImportable(io, "skill", "skill", name, c.Skills, func(sk source.Skill) string { return sk.Name })
+	if err != nil || len(matched) == 0 {
 		return nil, err
-	}
-	if len(matched) == 0 {
-		if name != "" {
-			return nil, fmt.Errorf("skill %q not found in native config", name)
-		}
-		return nil, nil
 	}
 	for _, sk := range matched {
 		if err := source.ValidateComponentID("skill", sk.Name); err != nil {
@@ -1437,21 +1471,9 @@ func importSkill(io *importIO, home string, c source.Canonical, name string) ([]
 }
 
 func importSubagent(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
-	var matched []source.Subagent
-	for _, sa := range c.Subagents {
-		if name == "" || sa.Name == name {
-			matched = append(matched, sa)
-		}
-	}
-	matched, err := skipPluginProvided(io, "subagent", name, matched, func(sa source.Subagent) string { return sa.Name }, nil)
-	if err != nil {
+	matched, err := matchImportable(io, "subagent", "subagent", name, c.Subagents, func(sa source.Subagent) string { return sa.Name })
+	if err != nil || len(matched) == 0 {
 		return nil, err
-	}
-	if len(matched) == 0 {
-		if name != "" {
-			return nil, fmt.Errorf("subagent %q not found in native config", name)
-		}
-		return nil, nil
 	}
 	for _, sa := range matched {
 		if err := source.ValidateComponentID("subagent", sa.Name); err != nil {
@@ -1475,21 +1497,9 @@ func importSubagent(io *importIO, home string, c source.Canonical, name string) 
 }
 
 func importCommand(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
-	var matched []source.Command
-	for _, cm := range c.Commands {
-		if name == "" || cm.Name == name {
-			matched = append(matched, cm)
-		}
-	}
-	matched, err := skipPluginProvided(io, "command", name, matched, func(cm source.Command) string { return cm.Name }, nil)
-	if err != nil {
+	matched, err := matchImportable(io, "command", "command", name, c.Commands, func(cm source.Command) string { return cm.Name })
+	if err != nil || len(matched) == 0 {
 		return nil, err
-	}
-	if len(matched) == 0 {
-		if name != "" {
-			return nil, fmt.Errorf("command %q not found in native config", name)
-		}
-		return nil, nil
 	}
 	// An invalid captured name (a namespaced Gemini command like "git/commit"
 	// carries its subdirectory in the name, which the canonical flat namespace
@@ -1585,21 +1595,9 @@ func importHook(io *importIO, home string, c source.Canonical, name string) ([]s
 }
 
 func importLSP(io *importIO, home string, c source.Canonical, name string) ([]string, error) {
-	var matched []source.LSPServer
-	for _, ls := range c.LSPServers {
-		if name == "" || ls.ID == name {
-			matched = append(matched, ls)
-		}
-	}
-	matched, err := skipPluginProvided(io, "lsp", name, matched, func(ls source.LSPServer) string { return ls.ID }, nil)
-	if err != nil {
+	matched, err := matchImportable(io, "lsp", "lsp server", name, c.LSPServers, func(ls source.LSPServer) string { return ls.ID })
+	if err != nil || len(matched) == 0 {
 		return nil, err
-	}
-	if len(matched) == 0 {
-		if name != "" {
-			return nil, fmt.Errorf("lsp server %q not found in native config", name)
-		}
-		return nil, nil
 	}
 	for _, ls := range matched {
 		if err := source.ValidateComponentID("lsp", ls.ID); err != nil {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -566,6 +566,9 @@ func unimportedDestPointers(agentsyncHome, srcHome, agentName string, reg *adapt
 		return nil
 	}
 	var out []string
+	// ops is a slice in the adapter's render order, and each op's pointers come
+	// back sorted from foreignPointersInOurSections, so the list is stable end
+	// to end: per destination file, in that file's pointer order.
 	for _, op := range ops {
 		if !render.IsKeyMerge(op.MergeStrategy) {
 			continue

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -603,8 +604,12 @@ func unimportedDestPointers(agentsyncHome, srcHome, agentName string, reg *adapt
 // escaped: a key holding a '/' or a '~' escapes to something other than
 // itself, so a set keyed by the raw key would never match, and every foreign
 // pointer under that section would go unreported. Pure, with no I/O, so
-// TestUnimportedSectionSetAgreesWithSeedPointers can pin exactly that on the
-// production code rather than on a re-spelling of it.
+// TestForeignPointersInOurSections can pin exactly that on the production code
+// rather than on a re-spelling of it.
+//
+// The result is SORTED: it is printed to the user, and collectStateSeedPointers
+// walks a map, so without the sort the same destination file would list its
+// uncaptured items in a different order on every run.
 func foreignPointersInOurSections(ours, existing map[string]any) []string {
 	ownedPtrs := map[string]bool{}
 	ourSections := map[string]bool{}
@@ -624,6 +629,7 @@ func foreignPointersInOurSections(ours, existing map[string]any) []string {
 		}
 		out = append(out, p)
 	}
+	sort.Strings(out)
 	return out
 }
 
@@ -1627,7 +1633,7 @@ func importMemory(io *importIO, home string, c source.Canonical) ([]string, erro
 		// No markers (collision/legacy) but the source is fragment-composed:
 		// writing the expanded body would inline the @imports and orphan the
 		// fragment files — skip with a warning rather than flatten silently.
-		io.notef("skipping memory import — canonical memory uses fragments/ and the imported memory has no reversible markers; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.")
+		io.note("skipping memory import — canonical memory uses fragments/ and the imported memory has no reversible markers; writing it back would inline the fragments and orphan their files. Edit memory/ directly, then apply.")
 		return nil, nil
 	default:
 		if !io.dryRun {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/capture"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/marketplace"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/project"
@@ -97,7 +98,7 @@ func collectStateSeedPointers(m map[string]any) []string {
 // matches render.RecordOpsState skipping never-landed pointers — a present-null
 // value still hashes.
 func hashAtPointer(m map[string]any, ptr string) string {
-	v, ok := getJSONPointer(m, ptr)
+	v, ok := jsonkeys.Get(m, ptr)
 	if !ok {
 		return ""
 	}
@@ -107,37 +108,6 @@ func hashAtPointer(m map[string]any, ptr string) string {
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
-}
-
-// getJSONPointer resolves a "/a/b/c" RFC 6901 pointer against m. The bool is
-// false when any segment is missing — distinct from a present value that
-// happens to be null. We re-implement here rather than exporting
-// render.getPointer because keeping that helper unexported preserves the
-// current package boundary.
-func getJSONPointer(m map[string]any, ptr string) (any, bool) {
-	if ptr == "" || ptr[0] != '/' {
-		return m, true
-	}
-	parts := strings.Split(ptr[1:], "/")
-	for i, p := range parts {
-		// Decode RFC 6901 escapes.
-		p = strings.ReplaceAll(p, "~1", "/")
-		p = strings.ReplaceAll(p, "~0", "~")
-		parts[i] = p
-	}
-	var cur any = m
-	for _, p := range parts {
-		mm, ok := cur.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		v, exists := mm[p]
-		if !exists {
-			return nil, false
-		}
-		cur = v
-	}
-	return cur, true
 }
 
 // newImportCmd returns the "import" subcommand.
@@ -614,7 +584,7 @@ func unimportedDestPointers(agentsyncHome, srcHome, agentName string, reg *adapt
 		ownedPtrs := map[string]bool{}
 		ourSections := map[string]bool{}
 		for k := range ours {
-			ourSections[escapePointerSegment(k)] = true
+			ourSections[jsonkeys.EscapeToken(k)] = true
 		}
 		for _, p := range collectStateSeedPointers(ours) {
 			ownedPtrs[p] = true
@@ -651,15 +621,6 @@ func firstPointerSegmentEsc(ptr string) string {
 		return ptr[:i]
 	}
 	return ptr
-}
-
-// escapePointerSegment escapes a top-level map key into its JSON-pointer form
-// (~ → ~0, / → ~1), matching the encoding collectStateSeedPointers emits, so
-// the section set used for filtering agrees byte-for-byte.
-func escapePointerSegment(k string) string {
-	k = strings.ReplaceAll(k, "~", "~0")
-	k = strings.ReplaceAll(k, "/", "~1")
-	return k
 }
 
 // seedStateFromCurrentDest re-renders the canonical for agent and writes

--- a/internal/cli/import_shared_internal_test.go
+++ b/internal/cli/import_shared_internal_test.go
@@ -288,9 +288,12 @@ func TestGetPointerValueRefusesAnUnrootedPointer(t *testing.T) {
 //
 // Second, the result is sorted. It is printed verbatim as the "exists in the
 // destination but agentsync did not capture" list, and the walk underneath
-// ranges a map; the fixture has eight foreign pointers so that map order
-// cannot come out sorted by accident (1 in 40320) and the expected slice is
-// compared WITHOUT sorting it first.
+// ranges a map. The fixture has eight foreign pointers in four sections and
+// the expected slice is compared WITHOUT sorting it first. That is not a free
+// permutation of eight — render.CollectPointers emits each section's children
+// contiguously, so the unsorted walk reaches only a few dozen orderings — but
+// measured with the sort removed, the sorted one came up well under once in a
+// hundred runs: an unsorted implementation fails here on essentially every run.
 func TestForeignPointersInOurSections(t *testing.T) {
 	ours := map[string]any{
 		"a~b":   map[string]any{"x": 1},

--- a/internal/cli/import_shared_internal_test.go
+++ b/internal/cli/import_shared_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 
@@ -276,34 +275,47 @@ func TestGetPointerValueRefusesAnUnrootedPointer(t *testing.T) {
 	}
 }
 
-// TestUnimportedSectionSetAgreesWithSeedPointers pins that the section set
-// unimportedDestPointers filters against is built with the SAME escaping
+// TestForeignPointersInOurSections pins the two things unimportedDestPointers'
+// walk must get right before its result reaches the user.
+//
+// First, the section set it filters against is built with the SAME escaping
 // collectStateSeedPointers uses for its pointers' first segment. A key holding
 // a '/' or a '~' escapes to something other than itself, so a section set
 // keyed by the raw key would never match the seed pointer for it, and every
-// foreign pointer under that section would go unreported.
+// foreign pointer under that section would go unreported. This exercises the
+// PRODUCTION function, not a re-spelling of its section set: drop the escape
+// there and the escaped sections below vanish from the result.
 //
-// It exercises the PRODUCTION function, foreignPointersInOurSections, not a
-// re-spelling of its section set: drop the escape there and the two escaped
-// sections below vanish from the result.
-func TestUnimportedSectionSetAgreesWithSeedPointers(t *testing.T) {
+// Second, the result is sorted. It is printed verbatim as the "exists in the
+// destination but agentsync did not capture" list, and the walk underneath
+// ranges a map; the fixture has eight foreign pointers so that map order
+// cannot come out sorted by accident (1 in 40320) and the expected slice is
+// compared WITHOUT sorting it first.
+func TestForeignPointersInOurSections(t *testing.T) {
 	ours := map[string]any{
 		"a~b":   map[string]any{"x": 1},
 		"c/d":   map[string]any{"y": 2},
 		"plain": map[string]any{"z": 3},
+		"~":     map[string]any{"w": 4},
 	}
 	existing := map[string]any{
-		"a~b":       map[string]any{"x": 1, "foreign1": true},
-		"c/d":       map[string]any{"y": 2, "foreign2": true},
-		"plain":     map[string]any{"z": 3, "foreign3": true},
-		"unmodeled": map[string]any{"w": 4}, // a section ours does not render: out of scope
+		"a~b":       map[string]any{"x": 1, "f2": true, "f1": true},
+		"c/d":       map[string]any{"y": 2, "f4": true, "f3": true},
+		"plain":     map[string]any{"z": 3, "f6": true, "f5": true},
+		"~":         map[string]any{"w": 4, "f8": true, "f7": true},
+		"unmodeled": map[string]any{"v": 5}, // a section ours does not render: out of scope
 	}
 	got := foreignPointersInOurSections(ours, existing)
-	sort.Strings(got)
-	want := []string{"/a~0b/foreign1", "/c~1d/foreign2", "/plain/foreign3"}
+	want := []string{
+		"/a~0b/f1", "/a~0b/f2",
+		"/c~1d/f3", "/c~1d/f4",
+		"/plain/f5", "/plain/f6",
+		"/~0/f7", "/~0/f8",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("foreign pointers = %q, want %q "+
-			"(an escaped section gone missing means the section set was keyed by the raw key)", got, want)
+			"(an escaped section gone missing means the section set was keyed by the raw key; "+
+			"the right set in another order means the result is no longer sorted)", got, want)
 	}
 }
 

--- a/internal/cli/import_shared_internal_test.go
+++ b/internal/cli/import_shared_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
@@ -175,4 +176,97 @@ func TestMatchImportable(t *testing.T) {
 			t.Fatal("an unusable plugin filter must refuse the import, not proceed with an empty skip set")
 		}
 	})
+}
+
+// TestHashAtPointerSeesOnlyRootedPointers keeps a now-dead branch dead.
+//
+// hashAtPointer used to call a private getJSONPointer that answered a pointer
+// with no leading "/" by returning the WHOLE document; it now calls
+// jsonkeys.Get, which treats a bare "abc" as "/abc". That difference is
+// unreachable, and this test is what makes "unreachable" a fact rather than a
+// claim: hashAtPointer's only pointer source is collectStateSeedPointers, which
+// is render.CollectPointers, which builds every pointer by prefixing "/".
+//
+// If a future caller feeds hashAtPointer pointers from somewhere else — the
+// state file, say, which is user-editable — this test is the place that stops
+// being true, and the rooted-pointer guard getPointerValue keeps is the pattern
+// to copy.
+func TestHashAtPointerSeesOnlyRootedPointers(t *testing.T) {
+	// Keys chosen to exercise the escape path, including ones that would
+	// produce an unrooted pointer if the "/" prefix were ever dropped.
+	dest := map[string]any{
+		"mcpServers": map[string]any{"a/b": map[string]any{"command": "x"}, "a~b": "y"},
+		"scalar":     "s",
+		"":           "empty key",
+		"/leading":   "slash key",
+	}
+	ptrs := collectStateSeedPointers(dest)
+	if len(ptrs) == 0 {
+		t.Fatal("no pointers collected — the test would pass vacuously")
+	}
+	for _, p := range ptrs {
+		if !strings.HasPrefix(p, "/") {
+			t.Errorf("collectStateSeedPointers emitted an unrooted pointer %q; "+
+				"hashAtPointer's jsonkeys.Get would resolve it as a top-level key lookup", p)
+		}
+		// And every one of them must actually resolve, which is the other half
+		// of the claim: a pointer whose escaping disagreed with the document's
+		// real keys would hash "" forever and report phantom drift.
+		if h := hashAtPointer(dest, p); h == "" {
+			t.Errorf("pointer %q collected from the document does not resolve in it", p)
+		}
+	}
+}
+
+// TestGetPointerValueRefusesAnUnrootedPointer pins the one thing
+// getPointerValue does that jsonkeys.Get deliberately does not.
+//
+// jsonkeys.Get is lenient about the leading "/" (RFC 6901 leaves a malformed
+// pointer undefined, and the key-merge machinery builds its own pointers). This
+// caller cannot be: planwalk resolves pointers read back from the state FILE,
+// which a user can hand-edit, and answering `"mcpServers"` — a string that is
+// not a pointer — with a top-level key lookup would silently compare the wrong
+// value and report clean or drifted on the strength of it.
+func TestGetPointerValueRefusesAnUnrootedPointer(t *testing.T) {
+	m := map[string]any{
+		"mcpServers": map[string]any{"a": "v"},
+		"top":        "t",
+	}
+	for _, ptr := range []string{"mcpServers", "top", "mcpServers/a", ""} {
+		if got := getPointerValue(m, ptr); got != nil {
+			t.Errorf("getPointerValue(%q) = %#v, want nil — a string with no leading %q is not a pointer", ptr, got, "/")
+		}
+	}
+	// The rooted forms still resolve, so the guard is a guard and not a mute.
+	if got := getPointerValue(m, "/top"); got != "t" {
+		t.Errorf(`getPointerValue("/top") = %#v, want "t"`, got)
+	}
+	if got := getPointerValue(m, "/mcpServers/a"); got != "v" {
+		t.Errorf(`getPointerValue("/mcpServers/a") = %#v, want "v"`, got)
+	}
+	// A lone "/" is rooted and names the WHOLE document (jsonkeys.Get yields
+	// no tokens for it), not the "" key RFC 6901 assigns it — the one contract
+	// the copy this replaced did not share. Pinned so the change is deliberate.
+	if got := getPointerValue(m, "/"); !reflect.DeepEqual(got, m) {
+		t.Errorf(`getPointerValue("/") = %#v, want the whole document`, got)
+	}
+}
+
+// TestUnimportedSectionSetAgreesWithSeedPointers pins that the section set
+// unimportedDestPointers filters against is built with the SAME escaping
+// collectStateSeedPointers uses for its pointers' first segment. A key holding
+// a '/' or a '~' escapes to something other than itself, so a section set
+// keyed by the raw key would never match the seed pointer for it and the
+// whole section would be misreported as foreign.
+func TestUnimportedSectionSetAgreesWithSeedPointers(t *testing.T) {
+	ours := map[string]any{"a~b": map[string]any{"x": 1}, "c/d": "v", "plain": map[string]any{"y": 2}}
+	sections := map[string]bool{}
+	for k := range ours {
+		sections[jsonkeys.EscapeToken(k)] = true
+	}
+	for _, p := range collectStateSeedPointers(ours) {
+		if !sections[firstPointerSegmentEsc(p)] {
+			t.Errorf("seed pointer %q: no section in %v", p, sections)
+		}
+	}
 }

--- a/internal/cli/import_shared_internal_test.go
+++ b/internal/cli/import_shared_internal_test.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/ui"
+)
+
+// newImportIOForTest builds an importIO whose out and err both land in one
+// buffer, so a test can assert on the interleaved transcript the user sees.
+func newImportIOForTest() (*importIO, *bytes.Buffer) {
+	var out bytes.Buffer
+	p := &ui.Printer{Out: &out, Err: &out}
+	return &importIO{p: p, out: &out, err: &out}, &out
+}
+
+// TestImportIONotefEqualsNote pins that the two INFO-tier emitters are ONE
+// emitter, and that collapsing them changed no byte.
+//
+// They were independent one-liners over ui.Fdiagf, differing only in that note
+// wrapped its message in a "%s" and notef passed the format through. That is a
+// distinction WITHOUT a difference: Fdiagf itself Sprintf's, so
+// Fdiagf(w, lvl, "%s", Sprintf(f, a...)) and Fdiagf(w, lvl, f, a...) produce
+// the same bytes for every input. Two spellings of one tier meant a change to
+// that tier — its label, its stream, its prefix — had to be made twice or be
+// made inconsistent. This test is the equality the collapse rests on.
+//
+// NOTE for anyone tempted to "fix" notef so a PREFORMATTED message survives
+// verbatim: it does not, it never did, and `go vet` is what stops that from
+// mattering — the printf analyzer recognizes notef as a wrapper and rejects a
+// non-constant format at the call site. note(msg) is the spelling for an
+// already-formatted string, which is why it is the one that survives.
+func TestImportIONotefEqualsNote(t *testing.T) {
+	cases := []struct {
+		name   string
+		format string
+		args   []any
+	}{
+		{name: "plain", format: "retired canonical hooks/x.toml", args: nil},
+		{name: "with verbs", format: "could not reverse markers (%v) for %q", args: []any{"boom", "PreToolUse"}},
+		// A format carrying a literal %% must come out identical from both spellings.
+		{name: "percent in the message", format: "50%% done: %s", args: []any{"reading"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ioN, bufN := newImportIOForTest()
+			ioF, bufF := newImportIOForTest()
+
+			// note(Sprintf(...)) is what a caller that formats first writes.
+			msg := fmt.Sprintf(tc.format, tc.args...)
+			ioN.note(msg)
+			ioF.notef(tc.format, tc.args...)
+
+			if bufN.String() != bufF.String() {
+				t.Fatalf("note and notef must emit the same bytes:\n note:  %q\n notef: %q", bufN.String(), bufF.String())
+			}
+			if strings.Contains(bufF.String(), "MISSING") || strings.Contains(bufF.String(), "EXTRA") {
+				t.Fatalf("notef mangled the message: %q", bufF.String())
+			}
+		})
+	}
+}
+
+// TestMatchImportable pins the head all five per-component importers share.
+//
+// Three behaviours are load-bearing and were previously re-typed five times:
+// an empty name means "all"; an empty RESULT with no error is the "nothing to
+// do" answer (a bulk import of an agent with no skills is a success); and a
+// NAMED item that is absent is a refusal worded with the kind's spoken label,
+// which differs from its internal key for exactly the two server kinds.
+func TestMatchImportable(t *testing.T) {
+	all := []source.Skill{{Name: "alpha"}, {Name: "beta"}}
+	key := func(sk source.Skill) string { return sk.Name }
+
+	t.Run("empty name matches all", func(t *testing.T) {
+		io, _ := newImportIOForTest()
+		got, err := matchImportable(io, "skill", "skill", "", all, key)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if !reflect.DeepEqual(got, all) {
+			t.Fatalf("got %v, want %v", got, all)
+		}
+	})
+
+	t.Run("named match narrows to one", func(t *testing.T) {
+		io, _ := newImportIOForTest()
+		got, err := matchImportable(io, "skill", "skill", "beta", all, key)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if len(got) != 1 || got[0].Name != "beta" {
+			t.Fatalf("got %v, want just beta", got)
+		}
+	})
+
+	t.Run("bulk with nothing to import is not an error", func(t *testing.T) {
+		io, _ := newImportIOForTest()
+		got, err := matchImportable(io, "skill", "skill", "", nil, key)
+		if err != nil {
+			t.Fatalf("an agent with no skills is a successful no-op import; got err %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %v, want nothing", got)
+		}
+	})
+
+	t.Run("named miss refuses with the spoken label", func(t *testing.T) {
+		// The label, not the key: "mcp server %q not found", never "mcp %q".
+		for _, tc := range []struct{ kind, label, want string }{
+			{"skill", "skill", `skill "nope" not found in native config`},
+			{"mcp", "mcp server", `mcp server "nope" not found in native config`},
+			{"lsp", "lsp server", `lsp server "nope" not found in native config`},
+		} {
+			io, _ := newImportIOForTest()
+			_, err := matchImportable(io, tc.kind, tc.label, "nope", all, key)
+			if err == nil {
+				t.Fatalf("%s: naming an absent item must refuse", tc.kind)
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("%s: err = %q, want %q", tc.kind, err.Error(), tc.want)
+			}
+		}
+	})
+
+	// The two plugin-filter subtests run over the MCP kind, whose key ("mcp")
+	// and spoken label ("mcp server") DIFFER. skipPluginProvided must receive
+	// the KEY — it looks up "mcp/alpha" in the plugin-provided set and speaks
+	// `mcp "alpha"` — so a helper that handed it the label would drop nothing
+	// here and refuse nothing, which a skill-only fixture (key == label) could
+	// never notice.
+	servers := []source.MCPServer{{ID: "alpha"}, {ID: "beta"}}
+	serverKey := func(m source.MCPServer) string { return m.ID }
+
+	t.Run("plugin-provided entries are dropped in bulk", func(t *testing.T) {
+		io, buf := newImportIOForTest()
+		io.pluginProvided = map[string]string{"mcp/alpha": "toolkit@mp"}
+		got, err := matchImportable(io, "mcp", "mcp server", "", servers, serverKey)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "beta" {
+			t.Fatalf("got %v, want just beta", got)
+		}
+		if !strings.Contains(buf.String(), "toolkit@mp") {
+			t.Fatalf("the skip must say which plugin provides it; got %q", buf.String())
+		}
+		if !strings.Contains(buf.String(), `mcp "alpha"`) {
+			t.Fatalf("the skip names the item by KIND (`mcp \"alpha\"`), not by label; got %q", buf.String())
+		}
+	})
+
+	t.Run("naming a plugin-provided item refuses", func(t *testing.T) {
+		io, _ := newImportIOForTest()
+		io.pluginProvided = map[string]string{"mcp/alpha": "toolkit@mp"}
+		_, err := matchImportable(io, "mcp", "mcp server", "alpha", servers, serverKey)
+		if err == nil {
+			t.Fatal("asking for a plugin-provided item by name must refuse, not silently import nothing")
+		}
+		if !strings.HasPrefix(err.Error(), `mcp "alpha" is provided by the plugin "toolkit@mp"`) {
+			t.Fatalf("the refusal comes from skipPluginProvided and names the item by KIND; got %q", err)
+		}
+	})
+
+	t.Run("a broken plugin filter fails closed", func(t *testing.T) {
+		io, _ := newImportIOForTest()
+		io.pluginProvidedErr = errors.New("cache gone")
+		if _, err := matchImportable(io, "skill", "skill", "", all, key); err == nil {
+			t.Fatal("an unusable plugin filter must refuse the import, not proceed with an empty skip set")
+		}
+	})
+}

--- a/internal/cli/import_shared_internal_test.go
+++ b/internal/cli/import_shared_internal_test.go
@@ -2,13 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
-	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/ui"
 )
@@ -216,6 +220,26 @@ func TestHashAtPointerSeesOnlyRootedPointers(t *testing.T) {
 			t.Errorf("pointer %q collected from the document does not resolve in it", p)
 		}
 	}
+
+	// The fixture's top-level "" key makes collectStateSeedPointers emit the
+	// pointer "/" — so "/" CAN come from CollectPointers, and this is where the
+	// one contract the unification changed is pinned on the import side: "/"
+	// names the WHOLE document (as internal/render always read it), not the ""
+	// key the deleted CLI resolver answered with. Requiring the whole-document
+	// hash is what makes the assertion load-bearing; "hashes to something" held
+	// under both readings.
+	if !slices.Contains(ptrs, "/") {
+		t.Fatalf("the fixture's top-level %q key must yield the pointer \"/\"; got %q", "", ptrs)
+	}
+	whole, err := json.Marshal(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(whole)
+	if got, want := hashAtPointer(dest, "/"), hex.EncodeToString(sum[:]); got != want {
+		t.Errorf("hashAtPointer(dest, \"/\") = %s, want the whole-document hash %s "+
+			"(a resolver answering \"/\" with dest[\"\"] hashes \"empty key\" instead)", got, want)
+	}
 }
 
 // TestGetPointerValueRefusesAnUnrootedPointer pins the one thing
@@ -256,17 +280,60 @@ func TestGetPointerValueRefusesAnUnrootedPointer(t *testing.T) {
 // unimportedDestPointers filters against is built with the SAME escaping
 // collectStateSeedPointers uses for its pointers' first segment. A key holding
 // a '/' or a '~' escapes to something other than itself, so a section set
-// keyed by the raw key would never match the seed pointer for it and the
-// whole section would be misreported as foreign.
+// keyed by the raw key would never match the seed pointer for it, and every
+// foreign pointer under that section would go unreported.
+//
+// It exercises the PRODUCTION function, foreignPointersInOurSections, not a
+// re-spelling of its section set: drop the escape there and the two escaped
+// sections below vanish from the result.
 func TestUnimportedSectionSetAgreesWithSeedPointers(t *testing.T) {
-	ours := map[string]any{"a~b": map[string]any{"x": 1}, "c/d": "v", "plain": map[string]any{"y": 2}}
-	sections := map[string]bool{}
-	for k := range ours {
-		sections[jsonkeys.EscapeToken(k)] = true
+	ours := map[string]any{
+		"a~b":   map[string]any{"x": 1},
+		"c/d":   map[string]any{"y": 2},
+		"plain": map[string]any{"z": 3},
 	}
-	for _, p := range collectStateSeedPointers(ours) {
-		if !sections[firstPointerSegmentEsc(p)] {
-			t.Errorf("seed pointer %q: no section in %v", p, sections)
-		}
+	existing := map[string]any{
+		"a~b":       map[string]any{"x": 1, "foreign1": true},
+		"c/d":       map[string]any{"y": 2, "foreign2": true},
+		"plain":     map[string]any{"z": 3, "foreign3": true},
+		"unmodeled": map[string]any{"w": 4}, // a section ours does not render: out of scope
+	}
+	got := foreignPointersInOurSections(ours, existing)
+	sort.Strings(got)
+	want := []string{"/a~0b/foreign1", "/c~1d/foreign2", "/plain/foreign3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("foreign pointers = %q, want %q "+
+			"(an escaped section gone missing means the section set was keyed by the raw key)", got, want)
+	}
+}
+
+// TestImportersSpeakTheirLabelOnANamedMiss pins the label WIRING at the five
+// real call sites, which TestMatchImportable cannot: that table hands the
+// helper its own (kind, label) pairs, so it proves the helper and not the
+// strings each importer passes. Every tail starts with matchImportable, so an
+// empty canonical and a name that is not there refuse before home is touched.
+func TestImportersSpeakTheirLabelOnANamedMiss(t *testing.T) {
+	type importer func(io *importIO, home string, c source.Canonical, name string) ([]string, error)
+	for _, tc := range []struct {
+		name string
+		run  importer
+		want string
+	}{
+		{"mcp", importMCP, `mcp server "nope" not found in native config`},
+		{"skill", importSkill, `skill "nope" not found in native config`},
+		{"subagent", importSubagent, `subagent "nope" not found in native config`},
+		{"command", importCommand, `command "nope" not found in native config`},
+		{"lsp", importLSP, `lsp server "nope" not found in native config`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			io, _ := newImportIOForTest()
+			_, err := tc.run(io, "", source.Canonical{}, "nope")
+			if err == nil {
+				t.Fatal("naming an absent item must refuse")
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("err = %q, want %q", err.Error(), tc.want)
+			}
+		})
 	}
 }

--- a/internal/cli/planwalk.go
+++ b/internal/cli/planwalk.go
@@ -307,9 +307,11 @@ func walkPlanItems(w planWalk) []planItem {
 // (RFC 6901 leaves the malformed case undefined); the refusal is this caller's
 // policy, applied where the untrusted input enters.
 //
-// `/` yields no tokens and names the WHOLE document, not the `""` key RFC 6901
-// assigns it. The two CLI resolvers this replaced answered `/` with the `""`
-// key; `/` never comes from CollectPointers, only from a hand-edited state key.
+// `/` names the WHOLE document, as jsonkeys.Get documents — the reading
+// internal/render already had; the CLI resolver this replaced answered `/`
+// with the `""` key. It is reachable from a hand-edited state key, or from
+// CollectPointers over a rendered document with a top-level `""` key, which no
+// adapter renders today.
 func getPointerValue(m map[string]any, ptr string) any {
 	if !strings.HasPrefix(ptr, "/") {
 		return nil

--- a/internal/cli/planwalk.go
+++ b/internal/cli/planwalk.go
@@ -307,11 +307,8 @@ func walkPlanItems(w planWalk) []planItem {
 // (RFC 6901 leaves the malformed case undefined); the refusal is this caller's
 // policy, applied where the untrusted input enters.
 //
-// `/` names the WHOLE document, as jsonkeys.Get documents — the reading
-// internal/render already had; the CLI resolver this replaced answered `/`
-// with the `""` key. It is reachable from a hand-edited state key, or from
-// render.CollectPointers over a rendered document with a top-level `""` key,
-// which no adapter renders today.
+// `/` names the WHOLE document, not the `""` key; jsonkeys.Get documents that
+// reading, where it came from, and where such a pointer can arise.
 func getPointerValue(m map[string]any, ptr string) any {
 	if !strings.HasPrefix(ptr, "/") {
 		return nil

--- a/internal/cli/planwalk.go
+++ b/internal/cli/planwalk.go
@@ -310,8 +310,8 @@ func walkPlanItems(w planWalk) []planItem {
 // `/` names the WHOLE document, as jsonkeys.Get documents — the reading
 // internal/render already had; the CLI resolver this replaced answered `/`
 // with the `""` key. It is reachable from a hand-edited state key, or from
-// CollectPointers over a rendered document with a top-level `""` key, which no
-// adapter renders today.
+// render.CollectPointers over a rendered document with a top-level `""` key,
+// which no adapter renders today.
 func getPointerValue(m map[string]any, ptr string) any {
 	if !strings.HasPrefix(ptr, "/") {
 		return nil

--- a/internal/cli/planwalk.go
+++ b/internal/cli/planwalk.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/drift"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/state"
 )
@@ -291,4 +293,27 @@ func walkPlanItems(w planWalk) []planItem {
 		}
 	}
 	return out
+}
+
+// getPointerValue resolves ptr against m for the drift diagnostics, which treat
+// "absent" and "present and null" alike (both mean "no value to compare"), so
+// jsonkeys.Get's presence signal is discarded.
+//
+// The rooted-pointer guard is NOT dead code and does not belong in jsonkeys:
+// planwalk feeds this pointers read back from the state file, which is a file on
+// disk a user can hand-edit. A pointer that does not start with "/" is not a
+// pointer, and answering it with a top-level key lookup would silently compare
+// the wrong thing. jsonkeys.Get is deliberately lenient about the leading slash
+// (RFC 6901 leaves the malformed case undefined); the refusal is this caller's
+// policy, applied where the untrusted input enters.
+//
+// `/` yields no tokens and names the WHOLE document, not the `""` key RFC 6901
+// assigns it. The two CLI resolvers this replaced answered `/` with the `""`
+// key; `/` never comes from CollectPointers, only from a hand-edited state key.
+func getPointerValue(m map[string]any, ptr string) any {
+	if !strings.HasPrefix(ptr, "/") {
+		return nil
+	}
+	v, _ := jsonkeys.Get(m, ptr)
+	return v
 }

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -446,12 +446,7 @@ func pluginUpgradeRun(cmd *cobra.Command, args []string, lossless bool) error {
 		if cerr != nil {
 			return fmt.Errorf("load source: %w", cerr)
 		}
-		var agents []string
-		for name, ag := range c.Config.Agents {
-			if ag.Enabled {
-				agents = append(agents, name)
-			}
-		}
+		agents, _ := enabledAgentNames(c.Config)
 		isLossy, lerr := entryIsLossy(home, id, mpEntry, marketplaceCacheDir(home, resolvedMP), c.Config, registryFactory(), agents, userHome)
 		switch {
 		case lerr != nil:

--- a/internal/cli/plugin_explain.go
+++ b/internal/cli/plugin_explain.go
@@ -222,12 +222,7 @@ func explainPluginReport(fs afero.Fs, c source.Canonical, pl source.Plugin, agen
 	}
 	// Replace (not append to) the flattened component lists with only this
 	// plugin's, so the plan and the report's counts cover this plugin alone.
-	scoped.MCPServers = proj.MCPServers
-	scoped.Skills = proj.Skills
-	scoped.Subagents = proj.Subagents
-	scoped.Commands = proj.Commands
-	scoped.Hooks = proj.Hooks
-	scoped.LSPServers = proj.LSPServers
+	proj.ReplaceComponentsIn(&scoped)
 
 	plan, err := render.Plan(secrets.ForRender(scoped), reg, agents, adapter.ScopeUser, "", nil, paths.HomeDir(paths.OSEnv{}))
 	if err != nil {

--- a/internal/cli/plugin_explain.go
+++ b/internal/cli/plugin_explain.go
@@ -140,15 +140,9 @@ func runExplainEmpty(p *ui.Printer, jsonOut bool) error {
 // subagents/LSPs. We re-project each requested plugin in isolation
 // (marketplace.ProjectInstalled) and build its plan from only those components.
 func runExplain(w io.Writer, p *ui.Printer, fs afero.Fs, c source.Canonical, wanted []source.Plugin, home, pluginCacheRoot string, jsonOut bool) error {
-	// Collect enabled agents. Sort so `--json` row order is deterministic
-	// (PrintJSON emits rows in this slice order verbatim).
-	var agents []string
-	for name, ag := range c.Config.Agents {
-		if ag.Enabled {
-			agents = append(agents, name)
-		}
-	}
-	sort.Strings(agents)
+	// Enabled agents, sorted by enabledAgentNames so `--json` row order is
+	// deterministic (PrintJSON emits rows in this slice order verbatim).
+	agents, _ := enabledAgentNames(c.Config)
 
 	reg := registryFactory()
 

--- a/internal/cli/plugin_owner_internal_test.go
+++ b/internal/cli/plugin_owner_internal_test.go
@@ -78,22 +78,10 @@ func TestPluginOwnerForKeyItem(t *testing.T) {
 	}
 }
 
-// TestUnescapeJSONPointer pins the decode order: ~0 must be decoded LAST, or
-// "~01" would wrongly become "/" instead of the literal "~1".
-func TestUnescapeJSONPointer(t *testing.T) {
-	for _, tc := range []struct{ in, want string }{
-		{"plain", "plain"},
-		{"with~1slash", "with/slash"},
-		{"with~0tilde", "with~tilde"},
-		{"~01", "~1"},
-		{"~1~0", "/~"},
-		{"", ""},
-	} {
-		if got := unescapeJSONPointer(tc.in); got != tc.want {
-			t.Errorf("unescapeJSONPointer(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
+// The decode-order test that used to live here moved to
+// internal/jsonkeys/pointer_test.go (TestEscapeUnescapeToken) along with the
+// implementation: pluginOwnerForKeyItem now calls jsonkeys.UnescapeToken rather
+// than carrying the fourth hand-rolled copy of those two ReplaceAlls.
 
 // TestPluginProvidedSourceIDs_RegistersBothServerKeyForms pins the dual keying
 // that the key-item table above deliberately does not cover.

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -499,12 +499,7 @@ func swapDir(src, dst string) error {
 // agent and was not about targeting at all.
 func filterSafeBumps(home string, bumps []marketplace.Bump, fetched map[string]map[string]marketplace.PluginEntry, cfg source.Config, userHome string, warn io.Writer) (safe, lossy, unevaluable []marketplace.Bump) {
 	reg := registryFactory()
-	var agents []string
-	for name, ag := range cfg.Agents {
-		if ag.Enabled {
-			agents = append(agents, name)
-		}
-	}
+	agents, _ := enabledAgentNames(cfg)
 	for _, b := range bumps {
 		isLossy, err := bumpIsLossy(home, b, fetched, cfg, reg, agents, userHome)
 		if err != nil {

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -633,7 +633,7 @@ func projectedSkips(entry marketplace.PluginEntry, cacheDir string, cfg source.C
 	if err != nil {
 		return nil, err
 	}
-	mini := proj.Canonical()
+	mini := proj.AsCanonical()
 	mini.Config = cfg
 	plan, err := render.Plan(secrets.ForRender(mini), reg, agents, adapter.ScopeUser, "", nil, userHome)
 	if err != nil {

--- a/internal/cli/plugin_poll.go
+++ b/internal/cli/plugin_poll.go
@@ -633,15 +633,8 @@ func projectedSkips(entry marketplace.PluginEntry, cacheDir string, cfg source.C
 	if err != nil {
 		return nil, err
 	}
-	mini := source.Canonical{
-		Config:     cfg,
-		MCPServers: proj.MCPServers,
-		Skills:     proj.Skills,
-		Subagents:  proj.Subagents,
-		Commands:   proj.Commands,
-		Hooks:      proj.Hooks,
-		LSPServers: proj.LSPServers,
-	}
+	mini := proj.Canonical()
+	mini.Config = cfg
 	plan, err := render.Plan(secrets.ForRender(mini), reg, agents, adapter.ScopeUser, "", nil, userHome)
 	if err != nil {
 		return nil, err

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/render"
 	"github.com/spxrogers/agentsync/internal/secrets"
@@ -868,14 +869,7 @@ func pluginOwnerForKeyItem(sourceID, ptr string, owners map[string]string) strin
 	if len(parts) < 2 {
 		return ""
 	}
-	return owners[kind+"/"+unescapeJSONPointer(parts[1])]
-}
-
-// unescapeJSONPointer decodes one JSON-pointer reference token (RFC 6901 §3):
-// "~1" is '/' and "~0" is '~'. Order matters — ~0 must be decoded last, or
-// "~01" would wrongly become "/" instead of "~1".
-func unescapeJSONPointer(tok string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(tok, "~1", "/"), "~0", "~")
+	return owners[kind+"/"+jsonkeys.UnescapeToken(parts[1])]
 }
 
 // collectReconcileItems builds reconcile's flat item list from a rendered plan

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -372,14 +372,7 @@ func newReconcileSession(cmd *cobra.Command, in io.Reader, auto reconcileAuto, a
 		return nil, nil, err
 	}
 	reg := registryFactory()
-	var agents []string
-	enabled := map[string]bool{}
-	for name, ag := range c.Config.Agents {
-		if ag.Enabled {
-			agents = append(agents, name)
-			enabled[name] = true
-		}
-	}
+	agents, enabled := enabledAgentNames(c.Config)
 	// --agents narrows the pass, with the same parsing status/diff/apply use.
 	if len(agents) > 0 {
 		sel, aerr := selectAgents(cmd, agents, enabled, agentsCSV)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1025,25 +1025,3 @@ func standardizeJSONC(data []byte) ([]byte, error) {
 	v.Standardize()
 	return v.Pack(), nil
 }
-
-func getPointerValue(m map[string]any, ptr string) any {
-	if !strings.HasPrefix(ptr, "/") {
-		return nil
-	}
-	parts := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
-	var cur any = m
-	for _, p := range parts {
-		// Decode RFC 6901 escapes so a managed id containing '~' or '/'
-		// (which CollectPointers escaped to ~0/~1) matches the real key.
-		// Without this, status/diff looked up the literal escaped key, found
-		// nothing, and reported phantom drift forever for that item.
-		p = strings.ReplaceAll(p, "~1", "/")
-		p = strings.ReplaceAll(p, "~0", "~")
-		mp, ok := cur.(map[string]any)
-		if !ok {
-			return nil
-		}
-		cur = mp[p]
-	}
-	return cur
-}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -148,14 +148,7 @@ func newStatusCmd() *cobra.Command {
 				return err
 			}
 			reg := registryFactory()
-			var enabledAgents []string
-			enabled := map[string]bool{}
-			for name, ag := range c.Config.Agents {
-				if ag.Enabled {
-					enabledAgents = append(enabledAgents, name)
-					enabled[name] = true
-				}
-			}
+			enabledAgents, enabled := enabledAgentNames(c.Config)
 			// --agents narrows the report (and the plan) to the requested
 			// agent(s); orphan-state warnings still consider the FULL enabled
 			// set so a deselected agent isn't mistaken for an orphaned one.

--- a/internal/jsonkeys/jsonkeys.go
+++ b/internal/jsonkeys/jsonkeys.go
@@ -1,5 +1,9 @@
 // Package jsonkeys implements per-key JSON pointer merge used by adapters that
 // need to own a subset of keys inside a shared JSON (or JSONC) config file.
+//
+// It is also the single home for RFC 6901 pointer mechanics (pointer.go):
+// EscapeToken and UnescapeToken for reference tokens, SplitPointer, and Get,
+// the one pointer resolver every package walks a document with.
 package jsonkeys
 
 import (

--- a/internal/jsonkeys/jsonkeys.go
+++ b/internal/jsonkeys/jsonkeys.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"sigs.k8s.io/yaml"
 )
@@ -205,7 +204,7 @@ func deepCopyValue(v any) any {
 }
 
 func pointerExists(m map[string]any, ptr string) bool {
-	parts := splitPointer(ptr)
+	parts := SplitPointer(ptr)
 	var cur any = m
 	for _, p := range parts {
 		mp, ok := cur.(map[string]any)
@@ -221,7 +220,7 @@ func pointerExists(m map[string]any, ptr string) bool {
 }
 
 func deletePointer(m map[string]any, ptr string) {
-	parts := splitPointer(ptr)
+	parts := SplitPointer(ptr)
 	if len(parts) == 0 {
 		return
 	}
@@ -237,19 +236,4 @@ func deletePointer(m map[string]any, ptr string) {
 		}
 		cur = next
 	}
-}
-
-func splitPointer(ptr string) []string {
-	ptr = strings.TrimPrefix(ptr, "/")
-	if ptr == "" {
-		return nil
-	}
-	raw := strings.Split(ptr, "/")
-	out := make([]string, len(raw))
-	for i, s := range raw {
-		s = strings.ReplaceAll(s, "~1", "/")
-		s = strings.ReplaceAll(s, "~0", "~")
-		out[i] = s
-	}
-	return out
 }

--- a/internal/jsonkeys/pointer.go
+++ b/internal/jsonkeys/pointer.go
@@ -41,7 +41,10 @@ func UnescapeToken(tok string) string {
 
 // SplitPointer splits a JSON pointer into its decoded reference tokens. A
 // leading "/" is optional; the empty pointer (the whole document) yields no
-// tokens.
+// tokens — and so does "/": the leading slash is stripped BEFORE the empty
+// check, so "/" is the empty pointer here, not the one-token pointer naming
+// the "" key that RFC 6901 makes it. This is where the "/" reading Get
+// documents is implemented.
 func SplitPointer(ptr string) []string {
 	ptr = strings.TrimPrefix(ptr, "/")
 	if ptr == "" {
@@ -68,8 +71,8 @@ func SplitPointer(ptr string) []string {
 // assigns it — the reading internal/render's resolver already had. The two CLI
 // resolvers this replaced answered `/` with the `""` key instead, so this is
 // the one pointer the copies disagreed on. It is reachable from a hand-edited
-// state key, or from CollectPointers over a rendered document with a top-level
-// `""` key, which no adapter renders today.
+// state key, or from render.CollectPointers over a rendered document with a
+// top-level `""` key, which no adapter renders today.
 func Get(m map[string]any, ptr string) (any, bool) {
 	var cur any = m
 	for _, p := range SplitPointer(ptr) {

--- a/internal/jsonkeys/pointer.go
+++ b/internal/jsonkeys/pointer.go
@@ -1,0 +1,82 @@
+package jsonkeys
+
+import "strings"
+
+// RFC 6901 reference-token escaping lives here and ONLY here.
+//
+// Before #235 there were five hand-rolled copies of these four lines — in this
+// package, in internal/render (twice, over a hand-written replaceAll), and in
+// three internal/cli helpers. Each copy had to get the ORDER right in both
+// directions, and the order is not symmetric: escaping does '~' first, decoding
+// does "~1" first. Get either backwards and "~01" decodes to "/" instead of the
+// "~1" the user wrote — a managed MCP server id containing a '/' or '~' then
+// looks up a key that does not exist and reports phantom drift forever. Five
+// chances to get it wrong, one place to fix it.
+
+// EscapeToken encodes one string as an RFC 6901 §3 reference token: '~' becomes
+// "~0" and '/' becomes "~1".
+//
+// ORDER IS LOAD-BEARING: '~' must be escaped FIRST. Escaping '/' first would
+// turn "a/b" into "a~1b" and the subsequent '~' pass would re-escape that
+// introduced tilde into "a~01b", which decodes back to "a~1b" — a silently
+// corrupted key.
+func EscapeToken(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+// UnescapeToken decodes one RFC 6901 §3 reference token: "~1" is '/' and "~0"
+// is '~'.
+//
+// ORDER IS LOAD-BEARING, and it is the MIRROR of EscapeToken's: "~1" must be
+// decoded FIRST. Decoding "~0" first would turn the literal token "~01" into
+// "~1" and the subsequent pass would decode that into "/" — where the token
+// means the two characters "~1".
+func UnescapeToken(tok string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(tok, "~1", "/"), "~0", "~")
+}
+
+// SplitPointer splits a JSON pointer into its decoded reference tokens. A
+// leading "/" is optional; the empty pointer (the whole document) yields no
+// tokens.
+func SplitPointer(ptr string) []string {
+	ptr = strings.TrimPrefix(ptr, "/")
+	if ptr == "" {
+		return nil
+	}
+	raw := strings.Split(ptr, "/")
+	out := make([]string, len(raw))
+	for i, s := range raw {
+		out[i] = UnescapeToken(s)
+	}
+	return out
+}
+
+// Get resolves ptr against m, walking only through objects. The bool is false
+// when any segment is absent or when an intermediate value is not an object —
+// distinct from a present value that happens to be null, which returns
+// (nil, true). The empty pointer names the whole document and returns (m, true).
+//
+// This is the one pointer resolver. internal/render's RecordOpsState relies on
+// the presence signal to avoid recording a pointer that never landed on disk;
+// the CLI's drift diagnostics discard it and treat absent as nil.
+//
+// `/` yields no tokens and names the WHOLE document, not the `""` key RFC 6901
+// assigns it. The two CLI resolvers this replaced answered `/` with the `""`
+// key; `/` never comes from CollectPointers, only from a hand-edited state key.
+func Get(m map[string]any, ptr string) (any, bool) {
+	var cur any = m
+	for _, p := range SplitPointer(ptr) {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		v, present := mm[p]
+		if !present {
+			return nil, false
+		}
+		cur = v
+	}
+	return cur, true
+}

--- a/internal/jsonkeys/pointer.go
+++ b/internal/jsonkeys/pointer.go
@@ -4,14 +4,16 @@ import "strings"
 
 // RFC 6901 reference-token escaping lives here and ONLY here.
 //
-// Before #235 there were five hand-rolled copies of these four lines — in this
-// package, in internal/render (twice, over a hand-written replaceAll), and in
-// three internal/cli helpers. Each copy had to get the ORDER right in both
-// directions, and the order is not symmetric: escaping does '~' first, decoding
-// does "~1" first. Get either backwards and "~01" decodes to "/" instead of the
-// "~1" the user wrote — a managed MCP server id containing a '/' or '~' then
-// looks up a key that does not exist and reports phantom drift forever. Five
-// chances to get it wrong, one place to fix it.
+// Before #235 there were seven hand-rolled copies of these lines — two
+// encoders and five decoders: a decoder in this package; an encoder and a
+// decoder in internal/render (over a hand-written replaceAll); and an encoder
+// and three decoders across internal/cli's import, status and reconcile
+// helpers. Each copy had to get the ORDER right in both directions, and the
+// order is not symmetric: escaping does '~' first, decoding does "~1" first.
+// Get either backwards and "~01" decodes to "/" instead of the "~1" the user
+// wrote — a managed MCP server id containing a '/' or '~' then looks up a key
+// that does not exist and reports phantom drift forever. Seven chances to get
+// it wrong, one place to fix it.
 
 // EscapeToken encodes one string as an RFC 6901 §3 reference token: '~' becomes
 // "~0" and '/' becomes "~1".
@@ -63,8 +65,11 @@ func SplitPointer(ptr string) []string {
 // the CLI's drift diagnostics discard it and treat absent as nil.
 //
 // `/` yields no tokens and names the WHOLE document, not the `""` key RFC 6901
-// assigns it. The two CLI resolvers this replaced answered `/` with the `""`
-// key; `/` never comes from CollectPointers, only from a hand-edited state key.
+// assigns it — the reading internal/render's resolver already had. The two CLI
+// resolvers this replaced answered `/` with the `""` key instead, so this is
+// the one pointer the copies disagreed on. It is reachable from a hand-edited
+// state key, or from CollectPointers over a rendered document with a top-level
+// `""` key, which no adapter renders today.
 func Get(m map[string]any, ptr string) (any, bool) {
 	var cur any = m
 	for _, p := range SplitPointer(ptr) {

--- a/internal/jsonkeys/pointer_test.go
+++ b/internal/jsonkeys/pointer_test.go
@@ -1,0 +1,141 @@
+package jsonkeys_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
+)
+
+// TestEscapeUnescapeToken pins the ORDER of the two ReplaceAlls in both
+// directions — the whole reason RFC 6901 escaping belongs in one place.
+//
+// Escaping must do '~' first: doing '/' first turns "a/b" into "a~1b", and the
+// tilde pass then re-escapes the tilde IT just introduced into "a~01b", which
+// decodes back to the literal "a~1b" rather than "a/b".
+//
+// Decoding must do "~1" first, the mirror: decoding "~0" first turns the token
+// "~01" into "~1", and the next pass turns that into "/" — where the token
+// means the two characters "~1".
+//
+// This table absorbed internal/cli's TestUnescapeJSONPointer, which pinned the
+// decode half against the third of four copies of the same four lines.
+func TestEscapeUnescapeToken(t *testing.T) {
+	t.Run("unescape", func(t *testing.T) {
+		for _, tc := range []struct{ in, want string }{
+			{"plain", "plain"},
+			{"with~1slash", "with/slash"},
+			{"with~0tilde", "with~tilde"},
+			{"~01", "~1"},
+			{"~1~0", "/~"},
+			{"", ""},
+		} {
+			if got := jsonkeys.UnescapeToken(tc.in); got != tc.want {
+				t.Errorf("UnescapeToken(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("escape", func(t *testing.T) {
+		for _, tc := range []struct{ in, want string }{
+			{"plain", "plain"},
+			{"with/slash", "with~1slash"},
+			{"with~tilde", "with~0tilde"},
+			{"~1", "~01"},
+			{"/~", "~1~0"},
+			{"", ""},
+		} {
+			if got := jsonkeys.EscapeToken(tc.in); got != tc.want {
+				t.Errorf("EscapeToken(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		}
+	})
+
+	// Round-trip: every key an agent config can hold must survive
+	// escape→unescape unchanged. An order mistake in EITHER direction breaks
+	// this for the adversarial keys, which is exactly the phantom-drift bug a
+	// managed MCP server id containing '~' or '/' used to produce.
+	t.Run("round trip", func(t *testing.T) {
+		for _, k := range []string{
+			"", "plain", "a/b", "a~b", "~1", "~0", "~01", "a~1b", "a~0b",
+			"~", "/", "//", "~~", "mcpServers", "amp.mcpServers", "a/b~c/~1d",
+		} {
+			if got := jsonkeys.UnescapeToken(jsonkeys.EscapeToken(k)); got != k {
+				t.Errorf("round trip of %q: escaped %q, decoded back to %q",
+					k, jsonkeys.EscapeToken(k), got)
+			}
+		}
+	})
+}
+
+// TestSplitPointerAndGet pins the resolver's contract, including the two edges
+// every previous copy spelled differently: the whole-document pointer, and the
+// difference between an absent pointer and a present null.
+func TestSplitPointerAndGet(t *testing.T) {
+	t.Run("split", func(t *testing.T) {
+		for _, tc := range []struct {
+			in   string
+			want []string
+		}{
+			{"", nil},
+			{"/", nil},
+			{"/a", []string{"a"}},
+			{"a", []string{"a"}}, // the leading slash is optional here
+			{"/a/b", []string{"a", "b"}},
+			{"/mcpServers/a~1b", []string{"mcpServers", "a/b"}},
+			{"/mcpServers/a~0b", []string{"mcpServers", "a~b"}},
+			// An empty reference token is legal (RFC 6901 §3): "/a//b" names
+			// the "" key under "a".
+			{"/a//b", []string{"a", "", "b"}},
+		} {
+			if got := jsonkeys.SplitPointer(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitPointer(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		}
+	})
+
+	doc := map[string]any{
+		"mcpServers": map[string]any{
+			"a/b":    map[string]any{"command": "x"},
+			"a~b":    "scalar",
+			"nulled": nil,
+		},
+		"scalar": "s",
+	}
+
+	t.Run("get", func(t *testing.T) {
+		for _, tc := range []struct {
+			ptr     string
+			want    any
+			present bool
+		}{
+			{"", doc, true}, // the whole document
+			// A lone "/" is the whole document too (no tokens), NOT the "" key
+			// RFC 6901 assigns it — the contract the two CLI resolvers moved to.
+			{"/", doc, true},
+			{"/scalar", "s", true},
+			{"/mcpServers/a~1b/command", "x", true},
+			{"/mcpServers/a~0b", "scalar", true},
+			// Present with a null value: (nil, TRUE). RecordOpsState relies on
+			// this to hash a key that landed as null rather than skip it.
+			{"/mcpServers/nulled", nil, true},
+			// Absent: (nil, FALSE).
+			{"/mcpServers/missing", nil, false},
+			{"/missing", nil, false},
+			// Cannot descend through a scalar.
+			{"/scalar/deeper", nil, false},
+			// The literal escaped key must NOT resolve — that is the phantom
+			// drift bug: looking up "a~1b" verbatim finds nothing forever.
+			{"/mcpServers/a~1b~1c", nil, false},
+		} {
+			got, present := jsonkeys.Get(doc, tc.ptr)
+			if present != tc.present {
+				t.Errorf("Get(%q) presence = %v, want %v", tc.ptr, present, tc.present)
+				continue
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Get(%q) = %#v, want %#v", tc.ptr, got, tc.want)
+			}
+		}
+	})
+}

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -37,6 +37,44 @@ type ProjectionResult struct {
 	LSPServers []source.LSPServer
 }
 
+// Canonical returns this projection as a source.Canonical carrying ONLY the
+// projected components — no Config, no Memory, no Plugins.
+//
+// Three callers in internal/cli hand-copied the same six fields out of a
+// ProjectionResult (explain's plugin attribution, `plugin explain`'s per-plugin
+// report, `plugin poll`'s lossiness probe). A field-by-field copy in the
+// CONSUMER is the silent-drop shape CLAUDE.md names: add a seventh component
+// kind here and all three keep compiling while quietly projecting nothing for
+// it — no test fails, no invariant breaks, the data is just gone. Owning the
+// copy next to the struct means the seventh field is added in one place, and
+// TestProjectionResultCanonicalCoversEveryField fails if it is added to the
+// struct and not to this method.
+func (r ProjectionResult) Canonical() source.Canonical {
+	return source.Canonical{
+		MCPServers: r.MCPServers,
+		Skills:     r.Skills,
+		Subagents:  r.Subagents,
+		Commands:   r.Commands,
+		Hooks:      r.Hooks,
+		LSPServers: r.LSPServers,
+	}
+}
+
+// ReplaceComponentsIn overwrites c's component lists with this projection's,
+// leaving everything else on c (Config, Memory, Plugins) untouched. It is the
+// "narrow an already-loaded canonical to one plugin" spelling of Canonical();
+// both copy the same fields, so neither can see a component kind the other
+// misses.
+func (r ProjectionResult) ReplaceComponentsIn(c *source.Canonical) {
+	proj := r.Canonical()
+	c.MCPServers = proj.MCPServers
+	c.Skills = proj.Skills
+	c.Subagents = proj.Subagents
+	c.Commands = proj.Commands
+	c.Hooks = proj.Hooks
+	c.LSPServers = proj.LSPServers
+}
+
 // Project loads the plugin's components and returns them as canonical entries:
 //   - Reads cacheDir/.claude-plugin/plugin.json (when present) for the primary
 //     component list; a missing plugin.json is fine (the manifest is optional —

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -38,9 +38,10 @@ type ProjectionResult struct {
 }
 
 // AsCanonical returns this projection as a source.Canonical carrying ONLY the
-// projected components — no Config, no Memory, no Plugins. It copies slice
-// HEADERS, not elements: the returned lists alias the projection's backing
-// arrays, exactly as the three hand-copies it replaced did.
+// projected components — no Config, no Memory, no Plugins. Both it and
+// ReplaceComponentsIn copy slice HEADERS, never elements: the lists they hand
+// out alias the projection's backing arrays, as the three hand-copies they
+// replaced did, and the guard test pins that alongside field coverage.
 //
 // Three callers in internal/cli hand-copied the same six fields out of a
 // ProjectionResult (explain's plugin attribution, `plugin explain`'s per-plugin

--- a/internal/marketplace/projection.go
+++ b/internal/marketplace/projection.go
@@ -37,8 +37,10 @@ type ProjectionResult struct {
 	LSPServers []source.LSPServer
 }
 
-// Canonical returns this projection as a source.Canonical carrying ONLY the
-// projected components — no Config, no Memory, no Plugins.
+// AsCanonical returns this projection as a source.Canonical carrying ONLY the
+// projected components — no Config, no Memory, no Plugins. It copies slice
+// HEADERS, not elements: the returned lists alias the projection's backing
+// arrays, exactly as the three hand-copies it replaced did.
 //
 // Three callers in internal/cli hand-copied the same six fields out of a
 // ProjectionResult (explain's plugin attribution, `plugin explain`'s per-plugin
@@ -47,9 +49,9 @@ type ProjectionResult struct {
 // kind here and all three keep compiling while quietly projecting nothing for
 // it — no test fails, no invariant breaks, the data is just gone. Owning the
 // copy next to the struct means the seventh field is added in one place, and
-// TestProjectionResultCanonicalCoversEveryField fails if it is added to the
+// TestProjectionResultAsCanonicalCoversEveryField fails if it is added to the
 // struct and not to this method.
-func (r ProjectionResult) Canonical() source.Canonical {
+func (r ProjectionResult) AsCanonical() source.Canonical {
 	return source.Canonical{
 		MCPServers: r.MCPServers,
 		Skills:     r.Skills,
@@ -62,11 +64,11 @@ func (r ProjectionResult) Canonical() source.Canonical {
 
 // ReplaceComponentsIn overwrites c's component lists with this projection's,
 // leaving everything else on c (Config, Memory, Plugins) untouched. It is the
-// "narrow an already-loaded canonical to one plugin" spelling of Canonical();
+// "narrow an already-loaded canonical to one plugin" spelling of AsCanonical();
 // both copy the same fields, so neither can see a component kind the other
 // misses.
 func (r ProjectionResult) ReplaceComponentsIn(c *source.Canonical) {
-	proj := r.Canonical()
+	proj := r.AsCanonical()
 	c.MCPServers = proj.MCPServers
 	c.Skills = proj.Skills
 	c.Subagents = proj.Subagents

--- a/internal/marketplace/projection_canonical_test.go
+++ b/internal/marketplace/projection_canonical_test.go
@@ -1,0 +1,91 @@
+package marketplace_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/marketplace"
+	"github.com/spxrogers/agentsync/internal/source"
+)
+
+// TestProjectionResultCanonicalCoversEveryField is the reflective guard for the
+// six-field copy: every exported field of ProjectionResult must reach the
+// source.Canonical that Canonical() returns.
+//
+// This is the CLAUDE.md "model drifts from its artifact" class in miniature. The
+// copy used to live in three CLI call sites, so adding a seventh component kind
+// to ProjectionResult would have left all three compiling and silently dropping
+// it — a plugin's new component kind would project into the plan for a real
+// apply and vanish from `explain`, `plugin explain` and `plugin poll`'s
+// lossiness probe, with nothing to fail.
+//
+// The guard works by NAME, not by position: it fills every field of a fresh
+// ProjectionResult with a one-element slice, runs the copy, and requires the
+// same-named field on source.Canonical to be non-empty afterwards. A field
+// added to ProjectionResult with no Canonical counterpart fails the lookup arm
+// instead — which is the right failure: a projected component kind the canonical
+// model cannot hold is a schema change, not a copy bug.
+func TestProjectionResultCanonicalCoversEveryField(t *testing.T) {
+	var r marketplace.ProjectionResult
+	rv := reflect.ValueOf(&r).Elem()
+	rt := rv.Type()
+
+	// Fill each field with exactly one zero-valued element, so "did it arrive"
+	// is a length check that cannot be satisfied by a nil slice.
+	for i := 0; i < rt.NumField(); i++ {
+		f := rv.Field(i)
+		if f.Kind() != reflect.Slice {
+			t.Fatalf("%s: ProjectionResult fields are component slices; %s is %s — "+
+				"teach this guard what a non-slice field means before adding one",
+				rt.Field(i).Name, rt.Field(i).Name, f.Kind())
+		}
+		f.Set(reflect.MakeSlice(f.Type(), 1, 1))
+	}
+	if rt.NumField() == 0 {
+		t.Fatal("ProjectionResult has no fields — the guard would pass vacuously")
+	}
+
+	check := func(t *testing.T, what string, got source.Canonical) {
+		t.Helper()
+		cv := reflect.ValueOf(got)
+		for i := 0; i < rt.NumField(); i++ {
+			name := rt.Field(i).Name
+			cf := cv.FieldByName(name)
+			if !cf.IsValid() {
+				t.Errorf("%s: ProjectionResult.%s has no source.Canonical.%s to copy into — "+
+					"a projected component kind the canonical model cannot hold is a schema change",
+					what, name, name)
+				continue
+			}
+			if cf.Len() != 1 {
+				t.Errorf("%s: ProjectionResult.%s was not copied (Canonical.%s has %d entries, want 1) — "+
+					"add it to ProjectionResult.Canonical()", what, name, name, cf.Len())
+			}
+		}
+	}
+
+	check(t, "Canonical()", r.Canonical())
+
+	// ReplaceComponentsIn must cover exactly the same set, and must leave the
+	// non-component fields of its target alone — that is the whole reason it
+	// exists rather than an assignment.
+	target := source.Canonical{
+		Config: source.Config{Agents: map[string]source.Agent{"claude": {Enabled: true}}},
+		Memory: source.Memory{Body: "keep me"},
+		// TWO plugins, not one: the "was it copied" arm below looks for
+		// exactly one element, so a pre-filled field of length one could mask a
+		// field ReplaceComponentsIn forgot to copy.
+		Plugins: []source.Plugin{{}, {}},
+	}
+	r.ReplaceComponentsIn(&target)
+	check(t, "ReplaceComponentsIn()", target)
+	if target.Memory.Body != "keep me" {
+		t.Errorf("ReplaceComponentsIn clobbered Memory: %q", target.Memory.Body)
+	}
+	if len(target.Config.Agents) != 1 {
+		t.Errorf("ReplaceComponentsIn clobbered Config.Agents: %v", target.Config.Agents)
+	}
+	if len(target.Plugins) != 2 {
+		t.Errorf("ReplaceComponentsIn clobbered Plugins: %v", target.Plugins)
+	}
+}

--- a/internal/marketplace/projection_canonical_test.go
+++ b/internal/marketplace/projection_canonical_test.go
@@ -25,6 +25,11 @@ import (
 // added to ProjectionResult with no Canonical counterpart fails the lookup arm
 // instead — which is the right failure: a projected component kind the canonical
 // model cannot hold is a schema change, not a copy bug.
+//
+// It also pins the documented aliasing contract: both methods copy slice
+// headers, so each copied list must share its backing array with the
+// projection's. A deep copy would pass the coverage arm and silently change
+// what a caller that later appends to or mutates the projection observes.
 func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 	var r marketplace.ProjectionResult
 	rv := reflect.ValueOf(&r).Elem()
@@ -60,6 +65,11 @@ func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 			if cf.Len() != 1 {
 				t.Errorf("%s: ProjectionResult.%s was not copied (Canonical.%s has %d entries, want 1) — "+
 					"add it to ProjectionResult.%s", what, name, name, cf.Len(), what)
+				continue
+			}
+			if cf.Pointer() != rv.Field(i).Pointer() {
+				t.Errorf("%s: ProjectionResult.%s was deep-copied — the documented contract is a header copy "+
+					"that aliases the projection's backing array", what, name)
 			}
 		}
 	}

--- a/internal/marketplace/projection_canonical_test.go
+++ b/internal/marketplace/projection_canonical_test.go
@@ -20,7 +20,7 @@ import (
 // lossiness probe, with nothing to fail.
 //
 // The guard works by NAME, not by position: it fills every field of a fresh
-// ProjectionResult with a one-element slice, runs the copy, and requires the
+// ProjectionResult with a two-element slice, runs the copy, and requires the
 // same-named field on source.Canonical to be non-empty afterwards. A field
 // added to ProjectionResult with no Canonical counterpart fails the lookup arm
 // instead — which is the right failure: a projected component kind the canonical
@@ -30,13 +30,20 @@ import (
 // headers, so each copied list must share its backing array with the
 // projection's. A deep copy would pass the coverage arm and silently change
 // what a caller that later appends to or mutates the projection observes.
+// Each field is filled with TWO elements, not one, so a copy of a one-element
+// prefix (r.X[:1] — same first-element address, wrong length) fails the length
+// arm rather than passing the aliasing arm. A zero-sized element type would
+// let a fresh MakeSlice and a deep copy share the runtime's zero-size base
+// address and pass the aliasing arm vacuously; every component type is a
+// struct with fields, so none is zero-sized today.
 func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 	var r marketplace.ProjectionResult
 	rv := reflect.ValueOf(&r).Elem()
 	rt := rv.Type()
 
-	// Fill each field with exactly one zero-valued element, so "did it arrive"
-	// is a length check that cannot be satisfied by a nil slice.
+	// Fill each field with exactly two zero-valued elements, so "did it arrive"
+	// is a length check that cannot be satisfied by a nil slice or by a
+	// one-element prefix of the right backing array.
 	for i := 0; i < rt.NumField(); i++ {
 		f := rv.Field(i)
 		if f.Kind() != reflect.Slice {
@@ -44,7 +51,7 @@ func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 				"teach this guard what a non-slice field means before adding one",
 				rt.Field(i).Name, rt.Field(i).Name, f.Kind())
 		}
-		f.Set(reflect.MakeSlice(f.Type(), 1, 1))
+		f.Set(reflect.MakeSlice(f.Type(), 2, 2))
 	}
 	if rt.NumField() == 0 {
 		t.Fatal("ProjectionResult has no fields — the guard would pass vacuously")
@@ -62,9 +69,9 @@ func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 					what, name, name)
 				continue
 			}
-			if cf.Len() != 1 {
-				t.Errorf("%s: ProjectionResult.%s was not copied (Canonical.%s has %d entries, want 1) — "+
-					"add it to ProjectionResult.%s", what, name, name, cf.Len(), what)
+			if cf.Len() != 2 {
+				t.Errorf("%s: ProjectionResult.%s was not copied whole (Canonical.%s has %d entries, want 2) — "+
+					"add it to ProjectionResult.%s, as a header copy of the full list", what, name, name, cf.Len(), what)
 				continue
 			}
 			if cf.Pointer() != rv.Field(i).Pointer() {
@@ -82,10 +89,10 @@ func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 	target := source.Canonical{
 		Config: source.Config{Agents: map[string]source.Agent{"claude": {Enabled: true}}},
 		Memory: source.Memory{Body: "keep me"},
-		// TWO plugins, not one: the "was it copied" arm below looks for
-		// exactly one element, so a pre-filled field of length one could mask a
-		// field ReplaceComponentsIn forgot to copy.
-		Plugins: []source.Plugin{{}, {}},
+		// THREE plugins, not two: the "was it copied" arm below looks for
+		// exactly two elements, so a pre-filled field of length two could mask
+		// a field ReplaceComponentsIn forgot to copy.
+		Plugins: []source.Plugin{{}, {}, {}},
 	}
 	r.ReplaceComponentsIn(&target)
 	check(t, "ReplaceComponentsIn()", target)
@@ -95,7 +102,7 @@ func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 	if len(target.Config.Agents) != 1 {
 		t.Errorf("ReplaceComponentsIn clobbered Config.Agents: %v", target.Config.Agents)
 	}
-	if len(target.Plugins) != 2 {
+	if len(target.Plugins) != 3 {
 		t.Errorf("ReplaceComponentsIn clobbered Plugins: %v", target.Plugins)
 	}
 }

--- a/internal/marketplace/projection_canonical_test.go
+++ b/internal/marketplace/projection_canonical_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spxrogers/agentsync/internal/source"
 )
 
-// TestProjectionResultCanonicalCoversEveryField is the reflective guard for the
-// six-field copy: every exported field of ProjectionResult must reach the
-// source.Canonical that Canonical() returns.
+// TestProjectionResultAsCanonicalCoversEveryField is the reflective guard for
+// the six-field copy: every exported field of ProjectionResult must reach the
+// source.Canonical that AsCanonical() returns.
 //
 // This is the CLAUDE.md "model drifts from its artifact" class in miniature. The
 // copy used to live in three CLI call sites, so adding a seventh component kind
@@ -25,7 +25,7 @@ import (
 // added to ProjectionResult with no Canonical counterpart fails the lookup arm
 // instead — which is the right failure: a projected component kind the canonical
 // model cannot hold is a schema change, not a copy bug.
-func TestProjectionResultCanonicalCoversEveryField(t *testing.T) {
+func TestProjectionResultAsCanonicalCoversEveryField(t *testing.T) {
 	var r marketplace.ProjectionResult
 	rv := reflect.ValueOf(&r).Elem()
 	rt := rv.Type()
@@ -59,12 +59,12 @@ func TestProjectionResultCanonicalCoversEveryField(t *testing.T) {
 			}
 			if cf.Len() != 1 {
 				t.Errorf("%s: ProjectionResult.%s was not copied (Canonical.%s has %d entries, want 1) — "+
-					"add it to ProjectionResult.Canonical()", what, name, name, cf.Len())
+					"add it to ProjectionResult.%s", what, name, name, cf.Len(), what)
 			}
 		}
 	}
 
-	check(t, "Canonical()", r.Canonical())
+	check(t, "AsCanonical()", r.AsCanonical())
 
 	// ReplaceComponentsIn must cover exactly the same set, and must leave the
 	// non-component fields of its target alone — that is the whole reason it

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/secrets"
 	"github.com/spxrogers/agentsync/internal/source"
@@ -236,7 +237,7 @@ func scopeOwnedToSections(owned []string, content []byte) []string {
 	}
 	sections := make(map[string]struct{}, len(ours))
 	for k := range ours {
-		sections[escapeJSONPointer(k)] = struct{}{}
+		sections[jsonkeys.EscapeToken(k)] = struct{}{}
 	}
 	var out []string
 	for _, p := range owned {
@@ -294,7 +295,7 @@ func orphanCleanupOps(s *state.Targets, a adapter.Adapter, agent string, scope a
 		var ours map[string]any
 		if json.Unmarshal(op.Content, &ours) == nil {
 			for k := range ours {
-				secs[escapeJSONPointer(k)] = struct{}{}
+				secs[jsonkeys.EscapeToken(k)] = struct{}{}
 			}
 		}
 	}

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/source"
 	"github.com/spxrogers/agentsync/internal/state"
@@ -320,7 +321,7 @@ func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scop
 				return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
 			}
 			for _, ptr := range CollectPointers(ours, "") {
-				v, present := getPointerOK(final, ptr)
+				v, present := jsonkeys.Get(final, ptr)
 				if !present {
 					// The pointer is not in the post-apply file. In a normal
 					// (full-success) apply every pointer in `ours` lands on
@@ -373,12 +374,12 @@ func RecordOpsState(s *state.Targets, userHome, agent string, scope adapter.Scop
 func CollectPointers(m map[string]any, prefix string) []string {
 	var out []string
 	for k, v := range m {
-		ptr := prefix + "/" + escapeJSONPointer(k)
+		ptr := prefix + "/" + jsonkeys.EscapeToken(k)
 		switch vv := v.(type) {
 		case map[string]any:
 			// Drill one level: each child key becomes a pointer.
 			for kk := range vv {
-				out = append(out, ptr+"/"+escapeJSONPointer(kk))
+				out = append(out, ptr+"/"+jsonkeys.EscapeToken(kk))
 			}
 		default:
 			out = append(out, ptr)
@@ -387,76 +388,13 @@ func CollectPointers(m map[string]any, prefix string) []string {
 	return out
 }
 
-func escapeJSONPointer(s string) string {
-	s = replaceAll(s, "~", "~0")
-	s = replaceAll(s, "/", "~1")
-	return s
-}
-
-func replaceAll(s, from, to string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); {
-		if i+len(from) <= len(s) && s[i:i+len(from)] == from {
-			out = append(out, to...)
-			i += len(from)
-			continue
-		}
-		out = append(out, s[i])
-		i++
-	}
-	return string(out)
-}
-
+// getPointer is jsonkeys.Get with the presence signal discarded, for the one
+// caller that cannot act on the difference between "absent" and "present and
+// null". RecordOpsState uses jsonkeys.Get directly because it MUST tell them
+// apart — it records a hash only for a pointer that actually landed on disk.
 func getPointer(m map[string]any, ptr string) any {
-	v, _ := getPointerOK(m, ptr)
+	v, _ := jsonkeys.Get(m, ptr)
 	return v
-}
-
-// getPointerOK is getPointer with an explicit presence signal so callers can
-// distinguish "pointer absent from the document" from "pointer present with a
-// null value" — getPointer returns nil for both. RecordOpsState relies on this
-// to avoid recording a pointer that never landed on disk.
-func getPointerOK(m map[string]any, ptr string) (any, bool) {
-	parts := splitPtr(ptr)
-	var cur any = m
-	for _, p := range parts {
-		mm, ok := cur.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		v, present := mm[p]
-		if !present {
-			return nil, false
-		}
-		cur = v
-	}
-	return cur, true
-}
-
-func splitPtr(ptr string) []string {
-	if len(ptr) > 0 && ptr[0] == '/' {
-		ptr = ptr[1:]
-	}
-	if ptr == "" {
-		return nil
-	}
-	parts := []string{}
-	cur := []byte{}
-	for i := 0; i < len(ptr); i++ {
-		if ptr[i] == '/' {
-			parts = append(parts, string(cur))
-			cur = cur[:0]
-			continue
-		}
-		cur = append(cur, ptr[i])
-	}
-	parts = append(parts, string(cur))
-	for i, p := range parts {
-		p = replaceAll(p, "~1", "/")
-		p = replaceAll(p, "~0", "~")
-		parts[i] = p
-	}
-	return parts
 }
 
 func hashAny(v any) string {

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -392,5 +394,27 @@ func TestPruneStaleState_SiblingColonProjectRootSurvives(t *testing.T) {
 	if _, ok := s.Files[longKey]; !ok {
 		t.Fatalf("a SIBLING project whose root merely shares a ':'-delimited prefix "+
 			"must keep its ownership; have %+v", s.Files)
+	}
+}
+
+// TestCollectPointersEscapesKeys pins, in the package that MINTS the state
+// file's keys, that CollectPointers escapes every segment per RFC 6901 with '~'
+// handled before '/': "a/b" must become "a~1b" and "c~d" must become "c~0d",
+// never "a~01b" or "c~10d". The cli-side tests pin the same order through
+// jsonkeys; this one fails on its own if render ever stops routing through it.
+func TestCollectPointersEscapesKeys(t *testing.T) {
+	doc := map[string]any{
+		"a/b":  map[string]any{"c~d": 1, "plain": 2},
+		"~":    "lone tilde",
+		"/":    "lone slash",
+		"~1":   "already-escaped-looking",
+		"":     "empty key",
+		"leaf": true,
+	}
+	got := render.CollectPointers(doc, "")
+	sort.Strings(got)
+	want := []string{"/", "/a~1b/c~0d", "/a~1b/plain", "/leaf", "/~0", "/~01", "/~1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectPointers = %q, want %q", got, want)
 	}
 }

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/iox"
+	"github.com/spxrogers/agentsync/internal/jsonkeys"
 	"github.com/spxrogers/agentsync/internal/paths"
 	"github.com/spxrogers/agentsync/internal/state"
 	"github.com/spxrogers/agentsync/internal/untrusted"
@@ -543,7 +544,7 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 			backupPath = dest
 		}
 		w.reports = append(w.reports, CollisionReport{
-			Agent: w.agent, Path: op.Path, Pointer: "/" + escapeJSONPointer(k), BackupTo: backupPath,
+			Agent: w.agent, Path: op.Path, Pointer: "/" + jsonkeys.EscapeToken(k), BackupTo: backupPath,
 		})
 	}
 
@@ -552,7 +553,7 @@ func (w *Writer) maybeBackupKeyOp(op adapter.FileOp) error {
 		if _, owned := w.state.Keys[stateKey]; owned {
 			continue
 		}
-		ev, present := getPointerOK(existingMap, ptr)
+		ev, present := jsonkeys.Get(existingMap, ptr)
 		if !present {
 			continue
 		}


### PR DESCRIPTION
## Summary

First of three PRs for #235 (the last sub-issue of the #226 code-quality series; PR 2 will carry the boundary moves, PR 3 the two behaviour changes). This PR closes the four **duplication** items — the ones that are behaviour-neutral by construction and so admit a byte-identity oracle — in five commits, each independently green, plus three review-loop commits. The survey behind the split, with every item re-located against the current tree, is summarized at the end.

**1. One enabled-agent extraction** (`0acd081`). Eight commands open-coded the same walk over `[agents]` to answer "which agents may this run touch" (`apply`, `status`, `diff`, `reconcile`, `explain`, `plugin upgrade --lossless`, `plugin explain`, `plugin poll`); four also built the membership map the `--agents` filter validates against, four did not, and two sorted the result while six left it in Go's randomized map order. `enabledAgentNames(cfg)` in `agents_flag.go` now returns the exact `([]string, map[string]bool)` pair `selectAgents` takes, **sorted**. Every list agentsync prints was already sorted or grouped downstream, so no output moves; what changes is the answer when order is load-bearing — measured with two unregistered agents enabled over forty runs, `apply` blamed either one before (36/4) and the same one after (40/0). A repo-walk guard, `TestEnabledAgentExtractionIsInOnePlace`, fails if the walk is open-coded again.

**2. One projection copy** (`1601488`). Three CLI sites hand-copied the same six component lists out of a `marketplace.ProjectionResult` — the silent-drop shape CLAUDE.md names: add a seventh component kind and all three keep compiling while projecting nothing for it. `ProjectionResult.AsCanonical()` and `ReplaceComponentsIn(*source.Canonical)` now live next to the struct, and `TestProjectionResultAsCanonicalCoversEveryField` reflects over the struct so a field added to it and not to either copy fails, naming the method that missed it. (Named `AsCanonical`, not `Canonical`, so CLAUDE.md's `.Canonical()` audit grep for a `secrets.Resolved` unwrap stays clean in `internal/cli`.)

**3. One INFO emitter and one importer head** (`f35a184`). The issue's premise that `importIO.note`/`notef` diverged is wrong — they were already byte-equal (`ui.Fdiagf` formats internally) — so the collapse (`notef` delegates to `note`, mirroring `warnf`/`warn`) fixes no bug and the doc says so; `go vet`'s printf analyzer is what keeps a non-constant format out of `notef`. Five of the six per-component importers shared a verbatim 15-line head (filter by name, drop plugin-provided entries, refuse a named miss); that head is now the generic `matchImportable`. Hooks keep their own head (their join key is an opaque signature that needs `displayOf`). The tails stay per-component on purpose: the five genuinely disagree about id validation and about the write funnel (mcp/lsp through `capture.Capture`, the file-backed three through `source.Write*`), and a table would only re-encode those disagreements as parameters.

**4. One RFC 6901 home** (`0a21da0`). Seven hand-rolled escape/unescape copies across three packages (two encoders and five decoders; the issue counted four), each of which had to get a non-symmetric order right in both directions (`~` first when escaping, `~1` first when decoding). They now live once in `internal/jsonkeys` (`EscapeToken`, `UnescapeToken`, `SplitPointer`, `Get`) with the order argument written down and pinned by a round-trip table over 21 adversarial tokens, by a test in `internal/render` (the package that mints the state file's keys), and by a repo-walk guard against an eighth copy. This is the item with teeth: the escape feeds `render.CollectPointers`, which builds state-file keys, so a mistake would report phantom drift forever. The two CLI resolvers this replaced are gone; `getPointerValue` survives as a one-liner over `jsonkeys.Get` and moves to `planwalk.go` next to its only callers (so PR 2 does not re-move fresh lines), keeping its rooted-pointer guard because its pointers come from a state file a user can hand-edit. **One small, real semantic change:** the two deleted CLI resolvers answered the pointer `/` with the `""` key RFC 6901 assigns it; `jsonkeys.Get` — like `internal/render`'s own resolver already did — treats `/` as the whole document, so this aligns the CLI with render rather than inventing a reading. `render.CollectPointers` emits `/` only for a rendered document with a top-level empty key, which no adapter produces; otherwise it can only come from a hand-edited state key. Documented on both functions and pinned in three tests, including the import-side hash of `/`.

**5. Docs** (`24af880`): `docs/components.md` (`internal/cli`, `internal/jsonkeys`, `internal/marketplace` key lists; `jsonkeys` joins `internal/cli`'s dependencies), CHANGELOG under `[Unreleased] / Changed` (`Internal:`).

**Deliberately left, for reviewers:** the `note`/`notef` mutation (not routing one through the other) is equivalent by construction and the report says so. Test-file placement (`enabled_agents_internal_test.go` beside the existing `agents_flag_test.go`; `getpointer_test.go` testing what now lives in `planwalk.go`) is left as is: PR 2 relocates several `internal/cli` helpers between files and will re-place their tests, so moving them twice buys nothing. The oracle normalizes one pre-existing nondeterminism unrelated to this PR: `claude.Ingest` ranges a map, so `import`'s per-server lines come out in random order on `main` — filed as #263.

**Review provenance.** The execution spec was reviewed before execution by a fresh reviewer who replicated it in a clone of the base and found it not executable verbatim (several new files were described, not given); the reviewer's own replication became the executable source, with eleven amendments folded in. The 9c item of #235 (`loadSecretsConfig`'s second config load) was examined and declined in writing by #237 (closing #228) and is tracked as #238; PR 3 will record that.

**Review loop, round 1** (on `24af880`, closed by `57ecd5b`; four independent lenses, all read-only): two lenses converged on `matchImportable` having been inserted between `skipPluginProvided`'s doc comment and its func (the comments fused; `go doc` showed `skipPluginProvided` undocumented) — moved. The `/` comment claimed `CollectPointers` never emits it; it does, for a top-level `""` key, and the test whose fixture has exactly that key only asserted "hashes to something" — comment corrected on both functions and in the CHANGELOG, test now requires the whole-document hash. `TestUnimportedSectionSetAgreesWithSeedPointers` rebuilt the section set in-test and stayed green when production dropped the escape — the walk is now the pure `foreignPointersInOurSections` and the test calls it. The five importers' not-found labels were unpinned at the call sites — `TestImportersSpeakTheirLabelOnANamedMiss`. No guard existed against an eighth escape copy while the sibling dedup had one — `TestPointerEscapingIsInOnePlace`. `internal/render` pinned none of its own escape order — `TestCollectPointersEscapesKeys`. The copy count was five in three shipped places (seven is right); `Canonical()` renamed to `AsCanonical()`; the `jsonkeys` package doc now names `pointer.go`; the guard's remedy names the method that failed; slice-header aliasing stated.

**Review loop, round 2** (on `57ecd5b`, closed by `c568e04`): one ISSUE — `SplitPointer`'s doc read as RFC-conformant while being where the `/` deviation is implemented — fixed on the function. Four lenses converged on the escape guard's shape: it now matches only the four exact escape pairs (a `/`→`~` cache-key flattening is not an escape), allows one level of nested call as the first operand, also catches `strings.NewReplacer` over the escape alphabet (which passed it before), and skips line comments so a doc comment may quote the call; the negative control covers each both ways and the LIMIT names the go/ast guards as the exact alternative. `foreignPointersInOurSections` returned map order and its result is printed verbatim by `import` — now sorted, pinned by the renamed `TestForeignPointersInOurSections` without sorting in the test, and noted in the CHANGELOG. The slice-header aliasing the doc describes is now pinned by the reflective guard. A `notef` call with no arguments on a constant string, contrary to the new `notef` doc, now calls `note`. Two bare `CollectPointers` mentions now say `render.CollectPointers`; the CHANGELOG's "no adapter produces" now carries the same "today" hedge as the code comment. Left as explanatory, unpinned, and hedged: "no adapter renders a top-level `""` key today".

**Review loop, round 3** (on `c568e04`, closed by `3bbae0c`): NIT-only across all four lenses, two of them "ship it"; every NIT taken. Four lenses measured the "1 in 40320" claim in `TestForeignPointersInOurSections` and found it false (each section's children are emitted contiguously, so only a few dozen orderings are reachable) — the comment now reports the measurement it can stand behind, no permutation count. The guard's `NewReplacer` regexp let a two-operand `strings.NewReplacer("/", "~")` flattening through — now whole pairs only; the `strings.Replace(…, -1)` spelling is also matched; the failure names the matched call and its shape and points at the allowlist; the LIMIT says precisely what is skipped (a full-line `//` comment) and what is still flagged (trailing and block comments and raw string literals quoting the call). The aliasing pin could be satisfied by a one-element prefix copy — each field is now filled with two elements so a prefix fails the length arm, with a note on the one vacuous case (a zero-sized element type). `getPointerValue`'s `/` paragraph, a verbatim second copy of `jsonkeys.Get`'s that had already drifted once, now points at `Get`. The CHANGELOG says the uncaptured-items list is sorted within each destination file, and `unimportedDestPointers` notes why that is deterministic end to end (`ops` is a slice in render order). Still deferred to PR 2: test-file placement.

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

**Byte-identity oracle.** A base binary from `0cd3f80` and a head binary from `24af880` were run through a 44-command lifecycle (init, agent enable/disable across a 1-agent and a 4-agent configuration, `apply`, `status`/`status --json`, `diff`, `reconcile --auto-*`, `explain` and `explain --json` on paths and pointers, `import` for all five component kinds against fixtures whose ids carry both `/` and `~` (`tilde~0srv` appears in the state keys unchanged), plugin add/upgrade including both `--lossless` upgrades, `plugin explain --json`, `plugin poll`), three runs per configuration, capturing every transcript and every file under the home. All 36 base/head comparisons byte-identical; the only normalization is sorting `import`'s per-server lines (#263). A cross-binary state-file round-trip (base `apply` → head `status`/`diff`, and the reverse) is clean in both directions. The round-1 commit changes no behaviour (one pure-function extraction, one rename, comments, tests, docs). The round-2 commit changes one thing a user can see: the "exists in the destination but agentsync did not capture" list that `import` prints is now sorted within each destination file; it came out in map order before, differently on every run.

**New tests:** `TestEnabledAgentNames` (sorted; membership map; empty config yields non-nil empties), `TestEnabledAgentExtractionIsInOnePlace` (repo-walk guard with a negative control), `TestProjectionResultAsCanonicalCoversEveryField` (reflective; both methods; slice-header aliasing pinned with two-element fills so a prefix copy fails; `ReplaceComponentsIn` leaves Config/Memory/Plugins alone), `TestImportIONotefEqualsNote`, `TestMatchImportable` (including kind ≠ label routing to the plugin-provided refusal), `TestImportersSpeakTheirLabelOnANamedMiss` (the five real importers' not-found messages), `TestForeignPointersInOurSections` (over the production function; escaped sections and sorted output), `TestHashAtPointerSeesOnlyRootedPointers` (now also requiring the whole-document hash for `/`), `TestPointerEscapingIsInOnePlace` (repo-walk guard against another hand-rolled escape — the four exact pairs as `ReplaceAll` or `Replace(…, -1)`, one level of nested call, and `strings.NewReplacer` over whole pairs — skipping full-line comments, with a negative control both ways), `TestEscapeUnescapeRoundTrip` / `TestSplitPointerAndGet` in `internal/jsonkeys` (21 adversarial tokens; `/` → whole document), the moved `TestUnescapeJSONPointer`, `TestCollectPointersEscapesKeys` in `internal/render`, and `TestGetPointerValueRefusesAnUnrootedPointer` (plus `/` → whole document).

**Break-verifies** (each mutation asserted to land exactly once and to compile, literal fail sets from `go test -json` over the whole package, files restored from a `cp` backup and sha-checked). Original five commits: swapping the escape order → the round-trip table plus the planwalk key-merge characterization; swapping the unescape order → the same; `SplitPointer` keeping the leading slash → ~100 tests; `enabledAgentNames` including disabled agents → 3 tests; not sorting → `TestEnabledAgentNames`; `AsCanonical()` forgetting `Hooks` → the reflective guard; `ReplaceComponentsIn` forgetting a field → the guard; `matchImportable` passing the label as the kind → `TestMatchImportable`'s plugin-provided subtests plus two import tests; the rooted-pointer guard removed → its test; `CollectPointers` unescaping → 3 tests. Round 1: `importLSP`'s label → exactly the new label test; the section-set escape dropped → exactly `TestForeignPointersInOurSections` (previously: nothing); `SplitPointer` answering `/` with `[""]` → the whole-document hash assertion plus the two jsonkeys/planwalk pins; an eighth `ReplaceAll` copy in `status.go` → exactly the new guard; the escape-order swap → the new render test plus seven cli/jsonkeys tests; `Hooks` dropped from `ReplaceComponentsIn` → the guard, naming `ReplaceComponentsIn()`. Round 2: a `strings.NewReplacer` copy and a nested-first-operand `ReplaceAll` copy in `status.go` → each exactly the guard; a comment quoting the call → nothing (by design); the sort removed from `foreignPointersInOurSections` → exactly its test; `Skills` deep-copied in `AsCanonical` → exactly the guard's aliasing arm. Round 3: a `strings.NewReplacer("/", "~")` flattening → nothing (by design); a `strings.Replace(…, -1)` copy → exactly the guard; a `Skills[:1]` prefix in `AsCanonical` → the guard's length arm plus the explain attribution test that sees the truncated list; the sort removed → exactly `TestForeignPointersInOurSections`. Equivalent by construction, reported not hidden: `notef` not routed through `note`.

**Post-conditions:** `getJSONPointer`, `escapePointerSegment`, `unescapeJSONPointer`, `escapeJSONPointer`, `splitPtr`, `getPointerOK` — 0 definitions (two test comments still name the moved test); one enabled-agent walk and one RFC 6901 escape in the repo, each pinned by a repo-walk guard; `.golangci.yml`, `internal/secrets/`, `internal/capture/` absent from the diff; no new `//nolint`; no `.Canonical()` call anywhere in `internal/cli`; `TestEveryCommandDeclaresScopeStance` passes.

**Gates,** each commit independently and again on the head: `go build`, `go vet`, `gofmt -l` empty, gofumpt + `go mod tidy` rewrote nothing, `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` (29 packages ok, zero `-json` failures), `-race ./internal/cli/...` ok, `-tags=e2e` ok, `-tags=bdd` ok, `GOOS=windows go build ./...` ok, `GOTOOLCHAIN=go1.26.2 golangci-lint@v2.12.2 run ./...` → 0 issues.

- [ ] `just test-release` is green (the release bar) — `just` is not installable in this session; every layer the recipe orchestrates was run directly as listed above, and CI's hermetic `test-release` job runs on the PR.
- [x] `just lint` is clean — run directly with the pinned toolchain; `go.mod`/`go.sum` untouched.

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [ ] If this touches `internal/secrets`, `internal/capture`, or any
      `source.Write*` path, I've re-read the secret-handling invariants in
      `CLAUDE.md` / `SECURITY.md` and not weakened them. — Not applicable, checked: nothing under `internal/secrets` or `internal/capture` changes; the importer head refactor moves no write — the two capture-backed importers still call `capture.Capture` and the three file-backed ones still call `source.Write*`, in their untouched tails; no `secrets.Resolved` is unwrapped; the `forbidigo` fence is untouched (no `//nolint` added or removed).
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/components.md` and `CHANGELOG.md`; no CLI surface or capability change; `docs/architecture.md` has no prose about pointer escaping to update (checked).

## The #235 survey, in brief

All nine items re-located against `0cd3f80`: items 1, 2, 4, 5 (this PR) still present, with item 1 at eight sites and item 2 at seven copies; item 3 still present and worse than stated (the crush adapter's root key `mcp` collides with OpenCode's, so `writeBackKeyItem` silently mis-translates crush key items today — PR 3, since it needs an adapter-side native→canonical MCP inverse and an `Adapter`-contract doc update); items 6, 7, 8 and the vault, subagent-migration and plugin-drift moves still present (PR 2); the `os.Exit(130)` replacement (PR 3); `loadSecretsConfig`'s second load declined by #237 and tracked as #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4VNyoCuGXx7pYxNfLVbFG