### PR TITLE
fix(render): keep shared dests; refuse FIFO and symlink dest writes

### DIFF
--- a/internal/adapter/claude/apply.go
+++ b/internal/adapter/claude/apply.go
@@ -3,7 +3,6 @@ package claude
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -25,7 +24,10 @@ func (a *Adapter) Apply(ops []adapter.FileOp, w adapter.DestWriter) error {
 // so we still pass the raw FileOp (carrying op.Content) along.
 func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy == "merge-json-keys" {
-		existing := readJSONFile(op.Path)
+		existing, err := readJSONFile(op.Path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", op.Path, err)
+		}
 		ours, err := jsonkeys.DecodeObject(op.Content)
 		if err != nil {
 			return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
@@ -40,16 +42,19 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	return w.Write(op, op.Content)
 }
 
-func readJSONFile(path string) map[string]any {
-	data, err := os.ReadFile(path)
+func readJSONFile(path string) (map[string]any, error) {
+	data, err := adapter.ReadExisting(path)
 	if err != nil {
-		return map[string]any{}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
 	}
 	// Decode preserving json.Number so a foreign integer > 2^53 isn't rounded
 	// when the merged file is re-marshalled.
 	m, err := jsonkeys.DecodeObject(data)
 	if err != nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
-	return m
+	return m, nil
 }

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -79,14 +79,12 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 				continue
 			}
 			skillDir := filepath.Join(p.SkillsDir, e.Name())
-			data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+			data, present, err := adapter.ReadFileOptional(filepath.Join(skillDir, "SKILL.md"))
 			if err != nil {
-				// A directory with no SKILL.md is not a skill — skip silently.
-				// A present-but-unreadable SKILL.md is surfaced (never a silent
-				// drop) so the user can fix it, matching the parse-error warning.
-				if !os.IsNotExist(err) {
-					fmt.Fprintf(warn, "warning: skipping skill %q: read SKILL.md: %v\n", e.Name(), err)
-				}
+				fmt.Fprintf(warn, "warning: skipping skill %q: read SKILL.md: %v\n", e.Name(), err)
+				continue
+			}
+			if !present {
 				continue
 			}
 			fm, body, lenient, err := ParseFrontmatterWithReport(data)

--- a/internal/adapter/claude/ingest_plugins.go
+++ b/internal/adapter/claude/ingest_plugins.go
@@ -3,7 +3,6 @@ package claude
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -32,12 +31,12 @@ func (a *Adapter) IngestPlugins(scope adapter.Scope, project string) ([]adapter.
 		return nil, nil, err
 	}
 	p := ResolvePaths(a.opts.TargetRoot, project, scope == adapter.ScopeProject)
-	data, err := os.ReadFile(p.Settings)
+	data, present, err := adapter.ReadFileOptional(p.Settings)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil, nil
-		}
 		return nil, nil, fmt.Errorf("read %s: %w", p.Settings, err)
+	}
+	if !present {
+		return nil, nil, nil
 	}
 	var top map[string]any
 	if json.Unmarshal(data, &top) != nil {

--- a/internal/adapter/cline/apply.go
+++ b/internal/adapter/cline/apply.go
@@ -3,7 +3,6 @@ package cline
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -24,7 +23,10 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-json-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing := readJSONFile(op.Path)
+	existing, err := readJSONFile(op.Path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", op.Path, err)
+	}
 	ours, err := jsonkeys.DecodeObject(op.Content)
 	if err != nil {
 		return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
@@ -40,14 +42,17 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 // readJSONFile reads and decodes a JSON object file, returning an empty map on
 // any read/parse error. Decode preserves json.Number so a foreign integer > 2^53
 // isn't rounded when the merged file is re-marshalled.
-func readJSONFile(path string) map[string]any {
-	data, err := os.ReadFile(path)
+func readJSONFile(path string) (map[string]any, error) {
+	data, err := adapter.ReadExisting(path)
 	if err != nil {
-		return map[string]any{}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
 	}
 	m, err := jsonkeys.DecodeObject(data)
 	if err != nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
-	return m
+	return m, nil
 }

--- a/internal/adapter/codex/apply.go
+++ b/internal/adapter/codex/apply.go
@@ -2,7 +2,6 @@ package codex
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -32,8 +31,8 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	// coerced to "empty file": MergeTOML would then merge our section into an
 	// empty map and the write would silently drop the user's foreign config.toml
 	// keys. Fail loud instead.
-	existing, err := os.ReadFile(op.Path)
-	if err != nil && !os.IsNotExist(err) {
+	existing, err := adapter.ReadExisting(op.Path)
+	if err != nil {
 		return fmt.Errorf("read %s: %w", op.Path, err)
 	}
 	ours, err := jsonkeys.DecodeObject(op.Content)

--- a/internal/adapter/cursor/apply.go
+++ b/internal/adapter/cursor/apply.go
@@ -3,7 +3,6 @@ package cursor
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
@@ -28,7 +27,10 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-json-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing := readJSONFile(op.Path)
+	existing, err := readJSONFile(op.Path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", op.Path, err)
+	}
 	ours, err := jsonkeys.DecodeObject(op.Content)
 	if err != nil {
 		return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
@@ -60,14 +62,17 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 // readJSONFile reads and decodes a JSON object file, returning an empty map on
 // any read/parse error. Decode preserves json.Number so a foreign integer > 2^53
 // isn't rounded when the merged file is re-marshalled.
-func readJSONFile(path string) map[string]any {
-	data, err := os.ReadFile(path)
+func readJSONFile(path string) (map[string]any, error) {
+	data, err := adapter.ReadExisting(path)
 	if err != nil {
-		return map[string]any{}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
 	}
 	m, err := jsonkeys.DecodeObject(data)
 	if err != nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
-	return m
+	return m, nil
 }

--- a/internal/adapter/gemini/apply.go
+++ b/internal/adapter/gemini/apply.go
@@ -1,10 +1,7 @@
 package gemini
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -33,8 +30,8 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-jsonc-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing, err := os.ReadFile(op.Path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	existing, err := adapter.ReadExisting(op.Path)
+	if err != nil {
 		return fmt.Errorf("read %s: %w", op.Path, err)
 	}
 	ours, err := jsonkeys.DecodeObject(op.Content)

--- a/internal/adapter/generic/apply.go
+++ b/internal/adapter/generic/apply.go
@@ -1,10 +1,7 @@
 package generic
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -31,8 +28,8 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-jsonc-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing, err := os.ReadFile(op.Path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	existing, err := adapter.ReadExisting(op.Path)
+	if err != nil {
 		return fmt.Errorf("read %s: %w", op.Path, err)
 	}
 	ours, err := jsonkeys.DecodeObject(op.Content)

--- a/internal/adapter/opencode/apply.go
+++ b/internal/adapter/opencode/apply.go
@@ -2,7 +2,6 @@ package opencode
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -20,7 +19,10 @@ func (a *Adapter) Apply(ops []adapter.FileOp, w adapter.DestWriter) error {
 
 func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy == "merge-jsonc-keys" {
-		existing, _ := os.ReadFile(op.Path)
+		existing, err := adapter.ReadExisting(op.Path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", op.Path, err)
+		}
 		ours, err := jsonkeys.DecodeObject(op.Content)
 		if err != nil {
 			return fmt.Errorf("parse our payload: %w", err)

--- a/internal/adapter/readoptional.go
+++ b/internal/adapter/readoptional.go
@@ -1,6 +1,15 @@
 package adapter
 
-import "os"
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ErrNotRegularFile is returned when path exists but is not a regular file
+// (FIFO, directory, device, socket). Callers must treat it as a loud error,
+// never as "absent": os.ReadFile on a FIFO blocks forever (#242).
+var ErrNotRegularFile = errors.New("not a regular file")
 
 // ReadFileOptional reads the file at path while distinguishing a genuinely-absent
 // file from one that is present but unreadable, so an ingest read never conflates
@@ -10,9 +19,9 @@ import "os"
 //   - (nil, false, nil)  when the file is absent (os.IsNotExist) — the only
 //     legitimate "component not present" case, which callers skip silently;
 //   - (nil, false, err)  for any OTHER read error (permission, EISDIR from a
-//     directory sitting where a file is expected, transient I/O), which callers
-//     MUST surface — return it (or, for a per-entry read inside a loop, warn) —
-//     rather than treat as "absent".
+//     directory sitting where a file is expected, a FIFO, transient I/O), which
+//     callers MUST surface — return it (or, for a per-entry read inside a loop,
+//     warn) — rather than treat as "absent".
 //
 // The hazard this guards against: an ingest read that acts only on the err==nil
 // branch of os.ReadFile reads an unreadable-but-present file identically to an
@@ -21,7 +30,21 @@ import "os"
 // cleared it" and can destructively write nothing back over the canonical source
 // (often a committed dotfiles repo). Only os.IsNotExist is a benign skip; every
 // other error is loud.
+//
+// A FIFO is present-but-unreadable: os.ReadFile does not fail, it blocks in
+// open(2). The shape check uses Stat (follows symlinks) so a link to a FIFO
+// is refused the same way as a bare one.
 func ReadFileOptional(path string) (data []byte, present bool, err error) {
+	fi, statErr := os.Stat(path)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil, false, nil
+		}
+		return nil, false, statErr
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("%w: %s", ErrNotRegularFile, path)
+	}
 	data, err = os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -30,6 +53,20 @@ func ReadFileOptional(path string) (data []byte, present bool, err error) {
 		return nil, false, err
 	}
 	return data, true, nil
+}
+
+// ReadExisting returns dest bytes, or (nil, nil) if the path is absent.
+// A present non-regular dest (FIFO, directory) returns ErrNotRegularFile
+// without opening the path.
+func ReadExisting(path string) ([]byte, error) {
+	data, present, err := ReadFileOptional(path)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+	return data, nil
 }
 
 // ReadDirOptional lists the directory at path with the same absent-vs-error

--- a/internal/adapter/readoptional_unix_test.go
+++ b/internal/adapter/readoptional_unix_test.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package adapter_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+)
+
+func TestReadFileOptional_FIFODoesNotBlock(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	done := make(chan struct{})
+	var data []byte
+	var present bool
+	var err error
+	go func() {
+		defer close(done)
+		data, present, err = adapter.ReadFileOptional(fifo)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReadFileOptional BLOCKED on a FIFO")
+	}
+	if err == nil || present || data != nil {
+		t.Fatalf("FIFO: got data=%v present=%v err=%v; want nil,false,err", data, present, err)
+	}
+	if !errors.Is(err, adapter.ErrNotRegularFile) {
+		t.Fatalf("FIFO: want ErrNotRegularFile, got %v", err)
+	}
+	if os.IsNotExist(err) {
+		t.Fatalf("a present FIFO must not report as absent: %v", err)
+	}
+}

--- a/internal/adapter/roo/apply.go
+++ b/internal/adapter/roo/apply.go
@@ -3,7 +3,6 @@ package roo
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -24,7 +23,10 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-json-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing := readJSONFile(op.Path)
+	existing, err := readJSONFile(op.Path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", op.Path, err)
+	}
 	ours, err := jsonkeys.DecodeObject(op.Content)
 	if err != nil {
 		return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
@@ -40,14 +42,17 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 // readJSONFile reads and decodes a JSON object file, returning an empty map on
 // any read/parse error. Decode preserves json.Number so a foreign integer > 2^53
 // isn't rounded when the merged file is re-marshalled.
-func readJSONFile(path string) map[string]any {
-	data, err := os.ReadFile(path)
+func readJSONFile(path string) (map[string]any, error) {
+	data, err := adapter.ReadExisting(path)
 	if err != nil {
-		return map[string]any{}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
 	}
 	m, err := jsonkeys.DecodeObject(data)
 	if err != nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
-	return m
+	return m, nil
 }

--- a/internal/adapter/windsurf/apply.go
+++ b/internal/adapter/windsurf/apply.go
@@ -3,7 +3,6 @@ package windsurf
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/jsonkeys"
@@ -24,7 +23,10 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 	if op.MergeStrategy != "merge-json-keys" {
 		return w.Write(op, op.Content)
 	}
-	existing := readJSONFile(op.Path)
+	existing, err := readJSONFile(op.Path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", op.Path, err)
+	}
 	ours, err := jsonkeys.DecodeObject(op.Content)
 	if err != nil {
 		return fmt.Errorf("parse our payload for %s: %w", op.Path, err)
@@ -40,14 +42,17 @@ func (a *Adapter) applyWrite(op adapter.FileOp, w adapter.DestWriter) error {
 // readJSONFile reads and decodes a JSON object file, returning an empty map on
 // any read/parse error. Decode preserves json.Number so a foreign integer > 2^53
 // isn't rounded when the merged file is re-marshalled.
-func readJSONFile(path string) map[string]any {
-	data, err := os.ReadFile(path)
+func readJSONFile(path string) (map[string]any, error) {
+	data, err := adapter.ReadExisting(path)
 	if err != nil {
-		return map[string]any{}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
 	}
 	m, err := jsonkeys.DecodeObject(data)
 	if err != nil {
-		return map[string]any{}
+		return map[string]any{}, nil
 	}
-	return m
+	return m, nil
 }

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -454,8 +454,9 @@ func planSyncCounts(plan render.RenderPlan, wouldChange map[string]bool) (toWrit
 func removalCounts(plan render.RenderPlan, s *state.Targets, userHome string, sc adapter.Scope, projectRoot string) (removedKeys, removedFiles, appliedOps int) {
 	appliedOps = plan.Total()
 	fileDeletes := map[string]bool{}
+	keep := render.StillRenderedWholeFiles(plan, userHome)
 	for name, res := range plan.PerAgent {
-		for _, del := range render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
+		for _, del := range render.FilterOrphanDeletes(render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops), keep, userHome) {
 			// Count only what apply will actually remove. An orphan whose
 			// destination cannot be read is SKIPPED with a warning, and its state
 			// entry is kept so the next run retries — so counting it here would
@@ -510,11 +511,12 @@ func removedLabel(keys, files int) string {
 // reads.
 func baselinePaths(plan render.RenderPlan, s *state.Targets, userHome string, sc adapter.Scope, projectRoot string) map[string]bool {
 	out := map[string]bool{}
+	keep := render.StillRenderedWholeFiles(plan, userHome)
 	for name, res := range plan.PerAgent {
 		for _, op := range res.Ops {
 			out[op.Path] = true
 		}
-		for _, del := range render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops) {
+		for _, del := range render.FilterOrphanDeletes(render.OrphanDeletes(s, userHome, name, sc, projectRoot, res.Ops), keep, userHome) {
 			out[del.Path] = true
 		}
 	}

--- a/internal/cli/dest_fifo_e2e_unix_test.go
+++ b/internal/cli/dest_fifo_e2e_unix_test.go
@@ -113,10 +113,10 @@ func TestCommandsDoNotHangOnNonRegularDestination(t *testing.T) {
 				{args: []string{"status"}},
 				{args: []string{"diff"}},
 				{args: []string{"reconcile", "--auto-safe"}},
-				{args: []string{"apply", "--dry-run"}, skip: "#241: render.Writer.Write's convergence read is unguarded"},
-				{args: []string{"apply"}, skip: "#241: render.Writer.Write's convergence read is unguarded"},
+				{args: []string{"apply", "--dry-run"}},
+				{args: []string{"apply"}},
 				{args: []string{"reconcile", "--auto-override"}, skip: "#241: [o]verride queues into render.Writer.Write"},
-				{args: []string{"import", "claude"}, skip: "#242: the adapter Ingest reads are unguarded"},
+				{args: []string{"import", "claude"}},
 			} {
 				args := tc.args
 				t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/internal/cli/destread.go
+++ b/internal/cli/destread.go
@@ -118,7 +118,7 @@ const (
 // so that, once a user has opted in, a link that still cannot be read is
 // reported as broken rather than as "set the switch".
 //
-// It mirrors iox.resolveSymlinkDest, the write side, through the shared
+// It mirrors iox.ResolveSymlinkDest, the write side, through the shared
 // iox.SymlinkDestAllowed, so the read side and apply cannot disagree about
 // whether a symlinked destination is supported. The mirror is a POLICY one, not
 // a literal prediction: apply only errors when the CONTENT differs (its

--- a/internal/iox/atomic.go
+++ b/internal/iox/atomic.go
@@ -21,7 +21,7 @@ var ErrSymlinkDest = errors.New("destination is a symlink")
 
 // SymlinkDestAllowed reports whether the user has opted in to symlinked
 // destinations. It is the single reading of AllowSymlinkDestEnv: the write side
-// (resolveSymlinkDest) and the diagnostic read side (internal/cli/destread.go)
+// (ResolveSymlinkDest) and the diagnostic read side (internal/cli/destread.go)
 // both ask it, so they cannot disagree about whether a symlinked destination is
 // a supported configuration.
 func SymlinkDestAllowed() bool { return os.Getenv(AllowSymlinkDestEnv) == "1" }
@@ -63,7 +63,7 @@ func SymlinkDestAllowed() bool { return os.Getenv(AllowSymlinkDestEnv) == "1" }
 //
 // Parent directory is created if missing (with mode 0o755).
 func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
-	resolved, err := resolveSymlinkDest(dest)
+	resolved, err := ResolveSymlinkDest(dest)
 	if err != nil {
 		return err
 	}
@@ -120,12 +120,12 @@ func AtomicWrite(dest string, data []byte, mode os.FileMode) error {
 	return nil
 }
 
-// resolveSymlinkDest inspects dest. If it is a symlink, it is either
+// ResolveSymlinkDest inspects dest. If it is a symlink, it is either
 // rejected (default) or resolved (when AGENTSYNC_ALLOW_SYMLINK_DEST=1)
 // so the underlying file is updated in place. This preserves the symlink
 // itself, which is what chezmoi/Stow users want — a rename onto the link
 // would replace it with a regular file.
-func resolveSymlinkDest(dest string) (string, error) {
+func ResolveSymlinkDest(dest string) (string, error) {
 	info, err := os.Lstat(dest)
 	if err != nil {
 		// Missing dest is fine — caller is about to create it.

--- a/internal/render/iss162_test.go
+++ b/internal/render/iss162_test.go
@@ -65,6 +65,30 @@ func TestWrite_ChmodReconverges(t *testing.T) {
 	}
 }
 
+func TestWrite_ChmodRefusesSymlinkDest(t *testing.T) {
+	testenv.RequireContainer(t)
+	home := t.TempDir()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "run.sh")
+	content := []byte("#!/bin/sh\necho hi\n")
+	if err := os.WriteFile(target, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.sh")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	op := adapter.FileOp{Action: adapter.ActionWrite, Path: link, Content: content, Mode: 0o755}
+	w := render.NewWriter(state.New(), home, home, adapter.ScopeUser, "", "claude")
+	err := w.Write(op, content)
+	if err == nil {
+		t.Fatal("chmod through a symlink dest must refuse when AGENTSYNC_ALLOW_SYMLINK_DEST is unset")
+	}
+	if fi, _ := os.Stat(target); fi.Mode().Perm() != 0o644 {
+		t.Fatalf("target mode mutated through the link: %v", fi.Mode().Perm())
+	}
+}
+
 // TestRecordOpsState_MergeTomlNumericNoFalseDrift pins issue #162 item F after
 // the review-loop correction: a merge-toml-keys owned value whose leaf is numeric
 // (e.g. a codex MCP `timeout` — a routine passthrough Extra field) records

--- a/internal/render/pipeline.go
+++ b/internal/render/pipeline.go
@@ -408,6 +408,9 @@ func applyPlan(
 	seen := map[string][]byte{}
 	seenBy := map[string]string{}
 	deletedOrphans := map[string]struct{}{}
+	// Paths any enabled agent still writes this run. orphanDeletes is per-agent
+	// and would otherwise delete a shared dest a sibling still renders (#246).
+	stillRendered := StillRenderedWholeFiles(p, userHome)
 	for _, name := range reg.Names() {
 		res, ok := p.PerAgent[name]
 		if !ok {
@@ -475,6 +478,9 @@ func applyPlan(
 		// path across agents that share a skills dir (claude + opencode →
 		// .claude/skills/), since the first agent's writer already removed it.
 		for _, del := range orphanDeletes(st, userHome, name, scope, project, res.Ops) {
+			if _, keep := stillRendered[paths.HomeRelative(userHome, del.Path)]; keep {
+				continue
+			}
 			if _, done := deletedOrphans[del.Path]; done {
 				continue
 			}

--- a/internal/render/state_apply.go
+++ b/internal/render/state_apply.go
@@ -237,6 +237,42 @@ func OrphanDeletes(s *state.Targets, userHome, agent string, scope adapter.Scope
 	return orphanDeletes(s, userHome, agent, scope, project, ops)
 }
 
+// StillRenderedWholeFiles is every whole-file write destination any agent in
+// the plan still emits, keyed HOME-relative like state file keys. Apply uses
+// it to keep shared dests (e.g. ~/.agents/skills) when one agent stops
+// rendering them and another still does (#246).
+func StillRenderedWholeFiles(p RenderPlan, userHome string) map[string]struct{} {
+	keep := map[string]struct{}{}
+	for _, res := range p.PerAgent {
+		for _, op := range res.Ops {
+			if op.Action != adapter.ActionWrite {
+				continue
+			}
+			if IsKeyMerge(op.MergeStrategy) {
+				continue
+			}
+			keep[paths.HomeRelative(userHome, op.Path)] = struct{}{}
+		}
+	}
+	return keep
+}
+
+// FilterOrphanDeletes drops deletes for paths another agent in the plan still
+// renders. removalCounts / baselinePaths must use the same rule as Apply.
+func FilterOrphanDeletes(dels []adapter.FileOp, keep map[string]struct{}, userHome string) []adapter.FileOp {
+	if len(keep) == 0 {
+		return dels
+	}
+	out := dels[:0]
+	for _, del := range dels {
+		if _, ok := keep[paths.HomeRelative(userHome, del.Path)]; ok {
+			continue
+		}
+		out = append(out, del)
+	}
+	return out
+}
+
 // orphanDeletes returns delete FileOps for files this agent owns in state —
 // entries whose SourceID is under one of orphanReclaimedPrefixes — that the
 // current plan no longer renders. It is how `apply` converges a destination when

--- a/internal/render/state_apply_test.go
+++ b/internal/render/state_apply_test.go
@@ -190,6 +190,26 @@ func TestPruneStaleState_AmbiguousPathPrefixKeepsLiveKey(t *testing.T) {
 	}
 }
 
+func TestFilterOrphanDeletes_KeepsSharedPath(t *testing.T) {
+	home := "/Users/me"
+	shared := filepath.Join(home, ".agents", "skills", "demo", "SKILL.md")
+	dels := []adapter.FileOp{{Action: adapter.ActionDelete, Path: shared}}
+	keep := render.StillRenderedWholeFiles(render.RenderPlan{
+		PerAgent: map[string]render.AgentResult{
+			"codex": {Ops: []adapter.FileOp{{Action: adapter.ActionWrite, Path: shared, Content: []byte("x")}}},
+		},
+	}, home)
+	got := render.FilterOrphanDeletes(dels, keep, home)
+	if len(got) != 0 {
+		t.Fatalf("a dest another agent still writes must not be deleted: %+v", got)
+	}
+	alone := filepath.Join(home, ".agents", "skills", "gone", "SKILL.md")
+	got = render.FilterOrphanDeletes([]adapter.FileOp{{Action: adapter.ActionDelete, Path: alone}}, keep, home)
+	if len(got) != 1 || got[0].Path != alone {
+		t.Fatalf("an unshared orphan must still delete: %+v", got)
+	}
+}
+
 func TestRecordState_SkipsDeleteOps(t *testing.T) {
 	s := state.New()
 	err := render.RecordOpsState(s, "/tmp", "claude", adapter.ScopeUser, "", []adapter.FileOp{{

--- a/internal/render/writer.go
+++ b/internal/render/writer.go
@@ -197,6 +197,12 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 	// so there is nothing to back up. The same read drives the dry-run preview:
 	// it is what lets `apply --dry-run` label a converged destination "synced"
 	// rather than "write".
+	// Shape first: os.ReadFile on a FIFO blocks forever (#241). A symlink to a
+	// regular file is Stat-regular, so this still allows the content compare;
+	// chmod below must not follow that link unless the user opted in (#248).
+	if !isRegularOrAbsent(op.Path) {
+		return fmt.Errorf("write %s: destination is not a regular file", op.Path)
+	}
 	if cur, err := os.ReadFile(op.Path); err == nil && bytes.Equal(cur, finalBytes) {
 		// Bytes converged — but the file MODE may still have drifted (e.g. an
 		// executable skill script that lost its +x bit). A content-identical
@@ -214,8 +220,12 @@ func (w *Writer) Write(op adapter.FileOp, finalBytes []byte) error {
 					w.wouldChange[op.Path] = true
 					return nil
 				}
-				if cerr := os.Chmod(op.Path, want); cerr != nil {
-					return fmt.Errorf("chmod %s to %o: %w", op.Path, want, cerr)
+				chmodPath, rerr := iox.ResolveSymlinkDest(op.Path)
+				if rerr != nil {
+					return rerr
+				}
+				if cerr := os.Chmod(chmodPath, want); cerr != nil {
+					return fmt.Errorf("chmod %s to %o: %w", chmodPath, want, cerr)
 				}
 				// A real (mode-only) change: owned and written, NOT unchanged, so
 				// the apply summary counts it rather than reporting "up to date".
@@ -379,10 +389,9 @@ func IsRegularOrAbsent(path string) bool { return isRegularOrAbsent(path) }
 // caught as well as a bare one. That matters because os.Open on a FIFO with no
 // writer BLOCKS rather than failing: without this, the pre-delete read below
 // would hang forever on a FIFO left at a destination path, in the real apply and
-// in `apply --dry-run` alike. It does NOT cover Writer.Write's convergence read,
-// which never calls it — so `apply --dry-run` still hangs on a FIFO at a
-// RENDERED destination (#241). A dangling symlink reports absent, which is
-// the right answer — the link is removable and carries nothing to preserve.
+// in `apply --dry-run` alike. Writer.Write's convergence read uses this same
+// gate (#241). A dangling symlink reports absent, which is the right answer —
+// the link is removable and carries nothing to preserve.
 func isRegularOrAbsent(path string) bool {
 	fi, err := os.Stat(path)
 	if err != nil {

--- a/internal/render/writer_fifo_unix_test.go
+++ b/internal/render/writer_fifo_unix_test.go
@@ -66,6 +66,24 @@ func TestOrphanDeleteWillProceed_FIFO(t *testing.T) {
 //
 // The FIFO must also survive: agentsync cannot read it, so it cannot rule out
 // content worth preserving, so it must not remove it.
+func TestWriterWrite_FIFODoesNotBlock(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(tmp, "pipe.md")
+	mkfifo(t, fifo)
+	w := render.NewWriter(state.New(), home, tmp, adapter.ScopeUser, "", "claude")
+	op := adapter.FileOp{Action: adapter.ActionWrite, Path: fifo, Content: []byte("x"), Mode: 0o644}
+	withinTimeout(t, "Writer.Write FIFO", func() {
+		err := w.Write(op, []byte("x"))
+		if err == nil {
+			t.Error("write through a FIFO must error, not succeed")
+		}
+	})
+}
+
 func TestWriterDelete_FIFODoesNotBlock(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, ".agentsync")

--- a/internal/render/writer_test.go
+++ b/internal/render/writer_test.go
@@ -467,6 +467,56 @@ func TestRenderApply_SharedWriteDivergence(t *testing.T) {
 	})
 }
 
+// TestRenderApply_SharedOrphanKeptWhenSiblingStillWrites is #246: both agents
+// own a shared dest in state; this run only the keeper still renders it.
+// Registry order is alphabetical, so opencode (dropper) runs after claude
+// (keeper). Without the keep-set, apply deleted the dest after the keeper
+// wrote, then RecordOpsState failed on the missing file.
+func TestRenderApply_SharedOrphanKeptWhenSiblingStillWrites(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, ".agentsync")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(tmp, ".claude", "skills", "x", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("shared-body")
+	if err := os.WriteFile(dest, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	write := adapter.FileOp{Action: adapter.ActionWrite, Path: dest, Content: body, Mode: 0o644, SourceID: "skills/x/SKILL.md"}
+	st := state.New()
+	if err := render.RecordOpsState(st, tmp, "claude", adapter.ScopeUser, "", []adapter.FileOp{write}); err != nil {
+		t.Fatal(err)
+	}
+	if err := render.RecordOpsState(st, tmp, "opencode", adapter.ScopeUser, "", []adapter.FileOp{write}); err != nil {
+		t.Fatal(err)
+	}
+	reg := adapter.NewRegistry()
+	if err := reg.Register(&fakeJSONApply{name: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(&fakeJSONApply{name: "opencode"}); err != nil {
+		t.Fatal(err)
+	}
+	plan := render.RenderPlan{PerAgent: map[string]render.AgentResult{
+		"claude":   {Ops: []adapter.FileOp{write}},
+		"opencode": {},
+	}}
+	if _, _, _, err := render.Apply(plan, reg, st, home, tmp, adapter.ScopeUser, ""); err != nil {
+		t.Fatalf("apply must succeed when the dropper sorts after the keeper: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("shared dest was deleted: %v", err)
+	}
+	if string(got) != "shared-body" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 // TestRenderApply_IntraAgentDivergenceMessage pins that the shared-write guard
 // tells the truth about WHO collided.
 //


### PR DESCRIPTION
Fixes #246, #248, and #242 (and the apply-side FIFO hang in #241, same Writer.Write path as #248).

### #246 — shared dest orphan delete
`apply` computed orphan deletes per agent and never excluded a path another enabled agent still rendered. Codex/Factory/agy sharing `.agents/skills` could delete-then-rewrite or delete-then-fail depending on registry order.

Apply now collects whole-file write paths from the full plan (`StillRenderedWholeFiles`) and skips those deletes. `removalCounts` / `baselinePaths` use the same filter.

### #248 — chmod through a symlink
`Writer.Write`'s content-identical arm called `os.Chmod` on the dest path, which follows symlinks even when `AGENTSYNC_ALLOW_SYMLINK_DEST` is unset. Chmod now goes through `iox.ResolveSymlinkDest`.

### #242 / #241 — FIFO dest hangs
`os.ReadFile` on a FIFO blocks in `open(2)`. Shape-check before open:

- `adapter.ReadFileOptional` / `ReadExisting` (ingest + merge reads)
- `Writer.Write` via `isRegularOrAbsent`

Unskipped the ready-made `import claude` / `apply` rows in `dest_fifo_e2e_unix_test.go`. Remaining `reconcile --auto-override` skip is still #241's override path if it does not go through `Write` the same way; apply itself is covered.

### Tests
Container: `TestFilterOrphanDeletes_KeepsSharedPath`, `TestWrite_ChmodRefusesSymlinkDest`, `TestReadFileOptional_FIFODoesNotBlock`, `TestCommandsDoNotHangOnNonRegularDestination`.