### PR TITLE
fix: MCP write-back derives kind and dialect from the rendering adapter; secret edit interrupts through the normal exit path (#235, PR 3 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   extension. A registry-wide guard fails the build if an adapter renders an MCP
   key-merge op without declaring its inverse, so the class cannot come back as
   agents are added. The refusal that remains names the *component kind* rather
-  than a list of roots.
+  than a list of roots, and a destination that cannot be read or parsed at the
+  moment of write-back (missing, non-regular, truncated) is refused by name
+  instead of being reported as a missing root key.
 - **`reconcile` no longer reports an edited MCP server as deleted when its id
   contains `~`** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
   JSON pointer segments are RFC 6901 encoded, so a server id such as `til~de`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,9 +325,10 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   context: the editor is signalled (and, if it ignores that, stopped after a
   two-second grace, so the command can never hang waiting for it), the command
   returns through the normal error path so every deferred cleanup runs, and the
-  process still exits **130** and still prints nothing. Nothing is saved once
-  the user has interrupted, including an interrupt that lands after the editor
-  exits but before the re-encrypt.
+  process still exits **130** and still prints nothing. Nothing is saved when
+  the interrupt lands before the re-encrypt begins, including one that lands
+  after the editor exits; an interrupt during the re-encrypt itself is absorbed
+  so the vault is never left half-written.
 
 - **Internal: shared helpers, command bodies and domain logic move to where
   they belong** ([#235](https://github.com/spxrogers/agentsync/issues/235)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,11 +317,11 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 - **`secret edit` no longer exits the process from a signal handler
   goroutine** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
   SIGINT/SIGTERM while the decrypted vault was on disk removed the temp file and
-  then called `os.Exit(130)` directly, which skipped every *other* deferred
-  cleanup (the global lock's release above all), could fire in the middle of
-  re-encrypting the vault, and was untestable by construction — an `os.Exit`
-  from a goroutine takes the test binary with it, so nothing could assert that
-  the cleartext copy was actually gone. The interrupt now cancels the editor's
+  then called `os.Exit(130)` directly from a goroutine, which could fire in the
+  middle of re-encrypting the vault, left a still-running editor orphaned on the
+  terminal, and was untestable by construction — an `os.Exit` from a goroutine
+  takes the test binary with it, so nothing could assert that the cleartext copy
+  was actually gone. The interrupt now cancels the editor's
   context: the editor is signalled (and, if it ignores that, stopped after a
   two-second grace, so the command can never hang waiting for it), the command
   returns through the normal error path so every deferred cleanup runs, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,21 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Changed
 
+- **`secret edit` no longer exits the process from a signal handler
+  goroutine** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
+  SIGINT/SIGTERM while the decrypted vault was on disk removed the temp file and
+  then called `os.Exit(130)` directly, which skipped every *other* deferred
+  cleanup (the global lock's release above all), could fire in the middle of
+  re-encrypting the vault, and was untestable by construction — an `os.Exit`
+  from a goroutine takes the test binary with it, so nothing could assert that
+  the cleartext copy was actually gone. The interrupt now cancels the editor's
+  context: the editor is signalled (and, if it ignores that, stopped after a
+  two-second grace, so the command can never hang waiting for it), the command
+  returns through the normal error path so every deferred cleanup runs, and the
+  process still exits **130** and still prints nothing. Nothing is saved once
+  the user has interrupted, including an interrupt that lands after the editor
+  exits but before the re-encrypt.
+
 - **Internal: shared helpers, command bodies and domain logic move to where
   they belong** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
   Nothing a user runs changes. Helpers every drift surface calls were reachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   than a list of roots, and a destination that cannot be read or parsed at the
   moment of write-back (missing, non-regular, truncated) is refused by name
   instead of being reported as a missing root key.
+- **`reconcile`'s write-back of a Continue MCP file no longer copies the native
+  YAML verbatim into the canonical source**
+  ([#235](https://github.com/spxrogers/agentsync/issues/235)). Continue is the
+  one adapter that renders an MCP server as a whole file
+  (`.continue/mcpServers/<id>.yaml`), so a hand-edited server went down the
+  whole-file write-back path — the verbatim copy meant for skills, subagents,
+  commands and memory. `[w]` / `--auto-writeback` then overwrote
+  `~/.agentsync/mcp/<id>.toml` with the YAML (every later command failed with
+  `toml: expected character =`) and, because that path bypasses
+  `capture.Capture`, persisted the `${secret:…}` values the render had resolved
+  in cleartext. The whole-file arm now refuses every MCP, LSP and hook component
+  by kind and points at `agentsync import continue:mcp:<id>`, which captures the
+  edit through Continue's own translator with the secrets re-referenced. The bug
+  predates the write-back change above; its review found it.
 - **`reconcile` no longer reports an edited MCP server as deleted when its id
   contains `~`** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
   JSON pointer segments are RFC 6901 encoded, so a server id such as `til~de`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,11 +324,12 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
   was actually gone. The interrupt now cancels the editor's
   context: the editor is signalled (and, if it ignores that, stopped after a
   two-second grace, so the command can never hang waiting for it), the command
-  returns through the normal error path so every deferred cleanup runs, and the
-  process still exits **130** and still prints nothing. Nothing is saved when
-  the interrupt lands before the re-encrypt begins, including one that lands
-  after the editor exits; an interrupt during the re-encrypt itself is absorbed
-  so the vault is never left half-written.
+  returns through the normal error path so every deferred cleanup runs, and —
+  for an interrupt that lands before the re-encrypt begins, including one that
+  lands after the editor exits — nothing is saved, the process still exits
+  **130** and still prints nothing. An interrupt during the re-encrypt itself is
+  absorbed so the vault is never left half-written: that save completes and is
+  reported as usual, with exit code 0.
 
 - **Internal: shared helpers, command bodies and domain logic move to where
   they belong** ([#235](https://github.com/spxrogers/agentsync/issues/235)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,57 @@ source layout, CLI surface, and state schema are stabilizing but may still chang
 
 ### Fixed
 
+- **`reconcile`'s MCP write-back translates through the agent that rendered the
+  destination, instead of guessing from the JSON pointer's top-level key**
+  ([#235](https://github.com/spxrogers/agentsync/issues/235)). The key-level
+  `[w]rite-back` picked its native→canonical MCP translation from a hard-coded
+  list of three pointer roots — `mcpServers` → Claude's 1:1 JSON shape, `mcp` →
+  OpenCode, `mcp_servers` → Codex — and those roots are neither a fixed set nor
+  unique to one agent, so the list was wrong three separate ways:
+  - **Crush was silently translated as OpenCode.** Crush's config also keys MCP
+    under `mcp`, so its entries went through OpenCode's dialect (an array-shaped
+    `command`, `environment` rather than `env`). A stdio server's `args` and
+    `env` were moved out of the canonical model into the `[server.extra]`
+    passthrough table — corrupting the server for every *other* agent it fans
+    out to. For a server whose `env` held a `${secret:…}` value the damage was
+    visible instead: `Extra` is outside re-reference's reach, so
+    `capture.Capture`'s fail-closed leak backstop refused the whole write-back
+    and the edit could never be persisted at all.
+  - **Cursor, Gemini, Windsurf, Roo and Cline were silently translated as
+    Claude.** All five also key MCP under `mcpServers`. Gemini's `httpUrl` and
+    Windsurf's `serverUrl` are not Claude's `url`, so a remote server's URL left
+    the canonical model entirely and reappeared as an `[server.extra]` key with
+    an empty `type`; Roo's `streamable-http` was not canonicalized to `http`.
+    Cursor's dialect happens to match Claude's, so it was unaffected in fact.
+    Gemini's mismatch also produced a spurious `conflict:` and a non-zero exit
+    when one server fanned out to Gemini *and* a correctly-translated agent.
+  - **Every other root was refused.** Zed (`context_servers`), Copilot
+    (`servers`) and Amp (the flat `amp.mcpServers`) reported `write-back for
+    pointer … is not implemented in v1` and exited non-zero, and
+    `agentsync explain <path>#<pointer>` answered "assembled from several
+    canonical sources" for them rather than naming `mcp/<id>.toml` — and
+    printed no `component:` line at all, so none of the item's transforms,
+    plugin origin or secret references could be matched either.
+
+  Both the component kind and the dialect are now derived: the kind from the
+  op's `SourceID` (the way the plugin-owner lookup already did it), the dialect
+  from the rendering adapter via the new optional `adapter.MCPSpecIngester`
+  extension. A registry-wide guard fails the build if an adapter renders an MCP
+  key-merge op without declaring its inverse, so the class cannot come back as
+  agents are added. The refusal that remains names the *component kind* rather
+  than a list of roots.
+- **`reconcile` no longer reports an edited MCP server as deleted when its id
+  contains `~`** ([#235](https://github.com/spxrogers/agentsync/issues/235)).
+  JSON pointer segments are RFC 6901 encoded, so a server id such as `til~de`
+  reaches write-back as the segment `til~0de`. That segment was used raw to look
+  the server up in the destination, the lookup missed, and a miss is the
+  signal for "the user deleted this server natively" — so `reconcile
+  --auto-writeback` printed `write-back: removed source mcp/til~0de.toml
+  (destination dropped …)`, silently discarded the user's edit, and left the
+  next `apply` to overwrite the destination back (and `explain` named the
+  component `til~0de`). The segment is now decoded before it is used as a
+  destination key, a canonical filename or a component name.
+
 - **`marketplace add` no longer registers a marketplace whose cache it failed to
   put in place** ([#233](https://github.com/spxrogers/agentsync/issues/233)).
   When a marketplace's declared name differs from the name derived from its URL

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,11 @@ can resolve secrets into native config files. Areas of particular interest:
   `--auto-writeback` — and is path-bounded to `~/.agentsync`; import's
   stale-hook retirement) — a deletion carries no secret content to persist,
   and anything that writes content back still goes through `capture.Capture`.
+  The whole-file text write-back (skills, subagents, commands, memory) copies
+  rendered text that was never secret-resolved, and refuses the secret-bearing
+  kinds — MCP, LSP, hooks — by kind, so an agent that renders a server as a
+  whole file (Continue) cannot have its resolved YAML copied verbatim into the
+  canonical tree.
   The alternative `backend = "env"` stores nothing: `${secret:…}` resolves from
   the process environment at apply time, so there is no vault, no identity file
   and no decryption — the credential's protection is whatever protects the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -432,11 +432,15 @@ Implemented by every adapter that renders MCP as a key-merge op — claude,
 opencode, codex, cursor, gemini, windsurf, roo, cline, and the generic breadth
 tier (per its `Spec`'s `MCPTarget`, so each dialect knob is honored on
 write-back exactly as on ingest). **Continue does not implement it**: it renders
-one whole *file* per server (`MergeStrategy: "replace"`), so its write-back goes
-down the whole-file path, and its own `IngestMCPSpec` operand is an element of a
-YAML `mcpServers` list inside a block rather than a root-keyed value. Each
-implementation delegates to the SAME package translator the adapter's `Ingest`
-uses, so a dialect has exactly one definition.
+one whole *file* per server (`MergeStrategy: "replace"`), and its own
+`IngestMCPSpec` operand is an element of a YAML `mcpServers` list inside a block
+rather than a root-keyed value. Its MCP write-back does not go down the
+whole-file path either — that arm copies the destination verbatim, which for a
+secret-bearing kind would put YAML into a canonical TOML file and persist
+resolved secrets in cleartext — so `reconcile` refuses it and points at
+`agentsync import continue:mcp:<id>` (see §5). Each implementation delegates to
+the SAME package translator the adapter's `Ingest` uses, so a dialect has
+exactly one definition.
 
 The registry-wide guard `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer`
 (`internal/cli`) renders a real two-server MCP fixture (one stdio, one remote)
@@ -859,6 +863,19 @@ the whole class. An adapter that renders an MCP key-merge op without declaring
 its inverse is REFUSED rather than guessed at, and the registry-wide guard
 `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` turns that state into a
 failing test.
+
+**The whole-file arm applies the same rule from the other side.** It copies the
+destination verbatim into the canonical file the SourceID names — right for the
+text components (skills, subagents, commands, memory), whose canonical form *is*
+the rendered text, and wrong for the structured, secret-bearing kinds
+`walkSecretFields` visits — so a SourceID under `mcp/`, `lsp/` or `hooks/` is
+refused there by kind, with `agentsync import <agent>:<component>:<name>` as the
+remedy (it captures the edit through the adapter's `Ingest` and
+`capture.Capture`). Continue's per-server YAML is the one render that reaches
+that arm today; before the refusal, `[w]` overwrote `~/.agentsync/mcp/<id>.toml`
+with the YAML and persisted the resolved secrets in cleartext, outside
+`capture.Capture`. Pinned by `TestWriteBackFileItem_Refusals` and
+`TestReconcile_Writeback_ContinueWholeFileIsRefused`.
 
 Pointer segments are RFC 6901 encoded, so the entry segment is DECODED
 (`jsonkeys.UnescapeToken`) before it is used as a destination map key or a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,7 +236,14 @@ comments in the rewritten file (a documented v1 limit).
 
 ### PluginIngester (read-only)
 
-One **optional** extension sits beside the core interface:
+Several **optional** extensions sit beside the core interface — an adapter
+implements one only if the agent has the concept, and callers type-assert for
+it: `PluginIngester` (below), `MCPSpecIngester`, `HookIngestGuard`,
+`HookEventNamer`, `VersionedDirs` and `WarnEmitter`. The first two are
+**read-only by construction**: they exist to let the *capture* direction ask the
+adapter a question, and neither has a `Render`-side counterpart.
+
+The first of them:
 
 ```go
 type PluginIngester interface {
@@ -384,6 +391,62 @@ read-only-on-import, components-only-on-apply rule above:
   on `apply` like every other adapter.
 
 See the capability matrix for source links.
+
+### MCPSpecIngester (read-only)
+
+```go
+type MCPSpecIngester interface {
+    IngestMCPSpec(raw map[string]any) source.MCPServerSpec
+}
+```
+
+An agent whose native MCP config is a **key-merge object** — one root key
+holding one entry per server — implements this **optional** extension so the
+dest→source path can translate a *single* native server entry back to the
+canonical model **in that agent's own dialect**. Reconcile's key-level
+`[w]rite-back` type-asserts for it; an adapter that does not implement it has
+its MCP key items refused rather than mistranslated.
+
+Read-only, on the same terms as `PluginIngester`: `IngestMCPSpec` is an inverse
+of `Render`, not a second render path, and the spec it returns reaches
+`~/.agentsync/` only through `capture.Capture` (§5).
+
+**Why the dialect must come from the rendering adapter, not from the pointer's
+root key.** Root keys are per-agent *data*, not a fixed set, and they
+**collide**: `/mcpServers` is Claude's *and* Cursor's, Gemini's, Windsurf's,
+Roo's, Cline's and eleven breadth-tier agents'; `/mcp` is OpenCode's *and*
+Crush's. Selecting the translator by root key therefore cannot be made correct
+— it silently hands a Crush entry to OpenCode's inverse (array-shaped
+`command`, `environment`), demoting `args`/`env` into the `Extra` passthrough,
+and hands Gemini's `httpUrl` / Windsurf's `serverUrl` to Claude's 1:1 shape,
+dropping the URL out of the model entirely. The rendering adapter is the only
+thing that knows which bytes it wrote, so the inverse belongs to it.
+
+An **optional interface** rather than a method on `Adapter` (which would force
+all 31 adapters, `noop` and Continue included, to implement a contract they
+cannot honor) or a registry-side `name → func` table (which is exactly the
+hand-maintained allowlist this interface exists to delete). The name follows
+the `PluginIngester` precedent: it says what the implementor *does*.
+
+Implemented by every adapter that renders MCP as a key-merge op — claude,
+opencode, codex, cursor, gemini, windsurf, roo, cline, and the generic breadth
+tier (per its `Spec`'s `MCPTarget`, so each dialect knob is honored on
+write-back exactly as on ingest). **Continue does not implement it**: it renders
+one whole *file* per server (`MergeStrategy: "replace"`), so its write-back goes
+down the whole-file path, and its own `IngestMCPSpec` operand is an element of a
+YAML `mcpServers` list inside a block rather than a root-keyed value. Each
+implementation delegates to the SAME package translator the adapter's `Ingest`
+uses, so a dialect has exactly one definition.
+
+The registry-wide guard `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer`
+(`internal/cli`) renders a real two-server MCP fixture (one stdio, one remote)
+through every registered adapter at both scopes and fails if one emits an MCP
+key-merge `FileOp` without implementing the interface — *and* asserts that
+feeding each adapter's own rendered entry back through its own
+`IngestMCPSpec` returns the modeled fields as modeled fields, never demoted
+into `Extra`. That second half is what makes "route write-back through the
+rendering adapter" a guarantee: the routing is only correct if each
+implementor's inverse is faithful to its own render.
 
 ### Plugin component namespacing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -840,6 +840,33 @@ blaming a plugin that does not own it. Continue is the one adapter that renders 
 **whole-file** op (one file per server), so servers are registered under both the
 bare `mcp/<id>` key and the `mcp/<id>.toml` SourceID form.
 
+**Key-level write-back derives BOTH the kind and the dialect.** The kind comes
+from the op's SourceID, exactly as above (`cli.keyItemKind`, the single
+derivation the plugin-owner lookup, the pointer→source inversion and `explain`'s
+pointer→component mapping all share).
+The **dialect** — how to read one native server entry back into the canonical
+model — comes from the **rendering adapter**, through the optional
+[`adapter.MCPSpecIngester`](#mcpspecingester-read-only) extension, never from
+the pointer's root key. Selecting a translator by root key cannot be made
+correct, because root keys *collide*: `/mcpServers` is Claude's and also
+Cursor's, Gemini's, Windsurf's, Roo's, Cline's and eleven breadth-tier agents';
+`/mcp` is OpenCode's and also Crush's. A root-keyed selector therefore handed a
+Crush entry to OpenCode's inverse — demoting `args`/`env` into the `Extra`
+passthrough — and Gemini's `httpUrl` or Windsurf's `serverUrl` to Claude's 1:1
+shape, dropping the URL out of the model entirely, while refusing every root
+nobody had added to the list. Asking the adapter that wrote the bytes removes
+the whole class. An adapter that renders an MCP key-merge op without declaring
+its inverse is REFUSED rather than guessed at, and the registry-wide guard
+`TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` makes that state
+unrepresentable.
+
+Pointer segments are RFC 6901 encoded, so the entry segment is DECODED
+(`jsonkeys.UnescapeToken`) before it is used as a destination map key or a
+canonical filename. Using it raw was a live bug: an MCP server id containing
+`~` arrived as `til~0de`, missed the destination map, and a miss is the
+tombstone signal — so an *edited* server was reported as a destination-side
+deletion and the user's edit was discarded.
+
 Both lookups are scoped to the canonical the render actually uses: at project
 scope that is the project-only overlay, so a user-scope plugin never shadows a
 project component that merely shares its name.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -434,11 +434,11 @@ tier (per its `Spec`'s `MCPTarget`, so each dialect knob is honored on
 write-back exactly as on ingest). **Continue does not implement it**: it renders
 one whole *file* per server (`MergeStrategy: "replace"`), and its own
 `IngestMCPSpec` operand is an element of a YAML `mcpServers` list inside a block
-rather than a root-keyed value. Its MCP write-back does not go down the
-whole-file path either — that arm copies the destination verbatim, which for a
+rather than a root-keyed value. Its MCP write-back reaches the whole-file arm
+but is refused there — that arm copies the destination verbatim, which for a
 secret-bearing kind would put YAML into a canonical TOML file and persist
-resolved secrets in cleartext — so `reconcile` refuses it and points at
-`agentsync import continue:mcp:<id>` (see §5). Each implementation delegates to
+resolved secrets in cleartext — and `reconcile` points at
+`agentsync import continue:mcp:<id>` instead (see §5). Each implementation delegates to
 the SAME package translator the adapter's `Ingest` uses, so a dialect has
 exactly one definition.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -857,8 +857,8 @@ shape, dropping the URL out of the model entirely, while refusing every root
 nobody had added to the list. Asking the adapter that wrote the bytes removes
 the whole class. An adapter that renders an MCP key-merge op without declaring
 its inverse is REFUSED rather than guessed at, and the registry-wide guard
-`TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` makes that state
-unrepresentable.
+`TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` turns that state into a
+failing test.
 
 Pointer segments are RFC 6901 encoded, so the entry segment is DECODED
 (`jsonkeys.UnescapeToken`) before it is used as a destination map key or a

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -130,13 +130,15 @@ transport is inferred from which url key is present) has nowhere to record it, s
 canonical `sse` server is written with just its url and **canonicalizes back as
 `http`** if later captured via `import`/`reconcile` — the same acknowledged
 `sse → http` flip the deep OpenCode/Windsurf/Cline adapters carry (an apply-only
-flow is unaffected). Every one of these dialect knobs is honored on
-`reconcile` write-back as well as on `import`, because the write-back asks the
-rendering adapter for the inverse rather than guessing from the config's
-top-level key — which matters most here, where four different top-level keys are
-in play and two of them collide with a deep adapter's. The Gemini-lineage **qwen** dialect is the exception: it splits
+flow is unaffected). The Gemini-lineage **qwen** dialect is the exception: it splits
 the two remote transports across two url keys (`httpUrl` = streamable HTTP, `url` =
 SSE), so it preserves `sse`.
+
+Every one of these dialect knobs is honored on `reconcile` write-back as well as
+on `import`, because the write-back asks the rendering adapter for the inverse
+rather than guessing from the config's top-level key — which matters most in
+this tier, where five different top-level keys are in play and two of them
+(`mcpServers`, crush's `mcp`) are also a deep adapter's.
 
 **Detection.** Detect is informational only (it drives `doctor`'s per-agent line;
 it never gates apply), and most breadth agents are detected by a binary on `PATH`
@@ -239,7 +241,10 @@ does through `import`, including the transport normalizations described below.
 Pinned by `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` (every registered
 adapter's own render→ingest round trip keeps the modeled fields modeled) and
 `TestReconcile_Writeback_MCPDialects` (the end-to-end apply → hand-edit →
-write-back path, per dialect).
+write-back path, per dialect). One documented edge on that converse: a
+non-string value inside a string-typed native field (a number in `args`, a bool
+in `env`) is dropped by every dialect's inverse, on `import` and on `reconcile`
+write-back alike — it is neither modeled nor passed through.
 
 **Claude**
 

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -235,13 +235,20 @@ literally, never resolved.)
 
 Conversely, a field agentsync DOES model never ends up in that passthrough table:
 `reconcile`'s `[w]rite-back` reads a native MCP entry back through the **rendering
-adapter's own** inverse-of-render (`adapter.MCPSpecIngester`), so every dialect on
-this page — deep and breadth-tier — round-trips through `reconcile` exactly as it
-does through `import`, including the transport normalizations described below.
-Pinned by `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` (every registered
-adapter's own render→ingest round trip keeps the modeled fields modeled) and
+adapter's own** inverse-of-render (`adapter.MCPSpecIngester`), so every
+**key-merge** dialect on this page — deep and breadth-tier — round-trips through
+`reconcile` exactly as it does through `import`, including the transport
+normalizations described below. Continue, the one adapter that renders each MCP
+server as a whole file, is the exception: `reconcile` refuses to write that file
+back (the whole-file path copies bytes verbatim and can neither translate the
+YAML nor re-reference secrets) and points at `agentsync import
+continue:mcp:<id>`, which round-trips it. Pinned by
+`TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` (every registered
+adapter's own render→ingest round trip keeps the modeled fields modeled),
 `TestReconcile_Writeback_MCPDialects` (the end-to-end apply → hand-edit →
-write-back path, per dialect). One documented edge on that converse: a
+write-back path, per dialect) and
+`TestReconcile_Writeback_ContinueWholeFileIsRefused`. One documented edge on
+that converse: a
 non-string value inside a string-typed native field (a number in `args`, a bool
 in `env`) is dropped by every dialect's inverse, on `import` and on `reconcile`
 write-back alike — it is neither modeled nor passed through.

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -130,7 +130,11 @@ transport is inferred from which url key is present) has nowhere to record it, s
 canonical `sse` server is written with just its url and **canonicalizes back as
 `http`** if later captured via `import`/`reconcile` — the same acknowledged
 `sse → http` flip the deep OpenCode/Windsurf/Cline adapters carry (an apply-only
-flow is unaffected). The Gemini-lineage **qwen** dialect is the exception: it splits
+flow is unaffected). Every one of these dialect knobs is honored on
+`reconcile` write-back as well as on `import`, because the write-back asks the
+rendering adapter for the inverse rather than guessing from the config's
+top-level key — which matters most here, where four different top-level keys are
+in play and two of them collide with a deep adapter's. The Gemini-lineage **qwen** dialect is the exception: it splits
 the two remote transports across two url keys (`httpUrl` = streamable HTTP, `url` =
 SSE), so it preserves `sse`.
 
@@ -226,6 +230,16 @@ doesn't model (e.g. `timeout`, `disabled`, `cwd`) are preserved verbatim through
 passthrough `[server.extra]` table on import/reconcile and re-rendered on apply,
 rather than dropped. (`Extra` is verbatim only — `${secret:…}` there is written
 literally, never resolved.)
+
+Conversely, a field agentsync DOES model never ends up in that passthrough table:
+`reconcile`'s `[w]rite-back` reads a native MCP entry back through the **rendering
+adapter's own** inverse-of-render (`adapter.MCPSpecIngester`), so every dialect on
+this page — deep and breadth-tier — round-trips through `reconcile` exactly as it
+does through `import`, including the transport normalizations described below.
+Pinned by `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` (every registered
+adapter's own render→ingest round trip keeps the modeled fields modeled) and
+`TestReconcile_Writeback_MCPDialects` (the end-to-end apply → hand-edit →
+write-back path, per dialect).
 
 **Claude**
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -368,10 +368,12 @@ frontmatter-less always-apply rule); commands → `.continue/prompts/<name>.md`
 prompt blocks. Skills/subagents/hooks/LSP have no faithful Continue target and
 are skipped with a report (Skill/Subagent/Hook/LSP). No
 `PluginIngester`. Deliberately implements **no** `adapter.MCPSpecIngester`: its
-MCP is one whole FILE per server (`replace`), so write-back goes down the
-whole-file path, and its own `IngestMCPSpec` operand is an element of a block's
-YAML `mcpServers` LIST, not a root-keyed value — the interface's contract would
-not hold. See
+MCP is one whole FILE per server (`replace`), and its own `IngestMCPSpec`
+operand is an element of a block's YAML `mcpServers` LIST, not a root-keyed
+value — the interface's contract would not hold. `reconcile`'s write-back
+refuses that file rather than copying it verbatim (the whole-file arm can
+neither translate the YAML nor re-reference secrets); `agentsync import
+continue:mcp:<id>` captures the edit. See
 [architecture § MCPSpecIngester](architecture.md#mcpspecingester-read-only).
 - **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter/Extra helpers), secrets,

--- a/docs/components.md
+++ b/docs/components.md
@@ -202,6 +202,14 @@ shared cross-agent dir it writes into, and MUST return nil at project scope (see
 [architecture § VersionedDirs](architecture.md#versioneddirs-optional)).
 - **Key:** `Adapter` (interface); `DestWriter` (interface);
   `VersionedDirs` (optional interface, `VersionRoots`); `NonEmptyDirs` (helper);
+  `MCPSpecIngester` (optional interface, READ-ONLY — `IngestMCPSpec(raw
+  map[string]any) source.MCPServerSpec`: the native→canonical inverse for ONE
+  server entry of a key-merge MCP object, in the rendering adapter's own
+  dialect. It is how reconcile's key-level write-back picks a translator without
+  a pointer-root allowlist — root keys collide (`/mcpServers` is six deep
+  adapters plus eleven breadth agents; `/mcp` is OpenCode and Crush), so only
+  the adapter that wrote the bytes can invert them. See
+  [architecture § MCPSpecIngester](architecture.md#mcpspecingester-read-only));
   `Scope` (`ScopeUser`/`ScopeProject`); `FileOp` (with typed `Action` — zero
   value `ActionWrite` — and `OpKind`; `NewCleanupOp` builds the one `OpCleanup`
   op); `Skip` (with `SkipKind`);
@@ -256,8 +264,9 @@ agentsync-internal namespace — symmetric on capture and render — so one adap
 synthetic metadata (continuedev's `__block_version`/`__block_schema`) can never
 leak into another agent's config; see
 [architecture.md § 8](architecture.md#8-secrets--how-the-leak-is-prevented).
-- **Key:** `New(Options) *Adapter`; the `Adapter` + `PluginIngester` methods;
-  `ParseFrontmatter`/`EncodeFrontmatter`; `MergeKeys`; `MergeExtra`/`ExtraNativeKeys`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `PluginIngester` +
+  `MCPSpecIngester` methods; `ParseFrontmatter`/`EncodeFrontmatter`; `MergeKeys`;
+  `IngestMCPSpec`; `MergeExtra`/`ExtraNativeKeys`.
 - **Depends on:** adapter, secrets, source, paths, iox, jsonkeys.
 - **Files:** `claude.go`, `homedir.go`, `render.go`, `ingest.go`, `ingest_plugins.go`,
   `apply.go`, `paths.go`, `frontmatter.go`, `skill.go`, `command.go`,
@@ -266,7 +275,8 @@ leak into another agent's config; see
 ### `internal/adapter/opencode`
 The OpenCode adapter — MCP, memory, skills, subagents, commands via JSONC
 round-trip (`tailscale/hujson`). Skips Hook and LSP (reported with a warning).
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, secrets, source, paths, iox.
 - **Files:** `opencode.go`, `homedir.go`, `render.go`, `ingest.go`, `apply.go`, `paths.go`,
   `skill.go`, `subagent.go`, `command.go`, `memory.go`, `settings.go`.
@@ -290,8 +300,8 @@ the claude/gemini/cursor twins: a non-`command` handler *type* is representable
 (Codex parses-and-skips unknown types; Render re-emits `Type` verbatim with a
 reported reduced Skip) and therefore never refused — only unmodeled fields
 trigger retirement.
-- **Key:** `New(Options) *Adapter`; the `Adapter` + `PluginIngester` methods;
-  `MergeTOML`; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `PluginIngester` +
+  `MCPSpecIngester` methods; `MergeTOML`; `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter helpers), secrets, source,
   paths, iox, jsonkeys, go-toml/v2.
 - **Files:** `codex.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `ingest_plugins.go`,
@@ -317,7 +327,8 @@ refused whole, never captured lossily — and implements
 `adapter.HookIngestGuard` (`RefusedHookEvents`, reporting refused events under
 their *canonical* names), so a Cursor-side native enrichment triggers import's
 stale-hook retirement just like a Claude- or Gemini-side one.
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter/skill/extra helpers),
   secrets, source, paths, iox, jsonkeys, afero.
 - **Files:** `cursor.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `apply.go`,
@@ -339,7 +350,8 @@ never captured lossily — and implements `adapter.HookIngestGuard`
 (`RefusedHookEvents`, reporting refused events under their *canonical* names),
 so a Gemini-side native enrichment triggers import's stale-hook retirement just
 like a Claude-side one.
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter helpers), secrets, source,
   paths, iox, jsonkeys, go-toml/v2.
 - **Files:** `gemini.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `apply.go`,
@@ -355,7 +367,12 @@ Continue "blocks" — one file per item, so there is **no key-merge**
 frontmatter-less always-apply rule); commands → `.continue/prompts/<name>.md`
 prompt blocks. Skills/subagents/hooks/LSP have no faithful Continue target and
 are skipped with a report (Skill/Subagent/Hook/LSP). No
-`PluginIngester`.
+`PluginIngester`. Deliberately implements **no** `adapter.MCPSpecIngester`: its
+MCP is one whole FILE per server (`replace`), so write-back goes down the
+whole-file path, and its own `IngestMCPSpec` operand is an element of a block's
+YAML `mcpServers` LIST, not a root-keyed value — the interface's contract would
+not hold. See
+[architecture § MCPSpecIngester](architecture.md#mcpspecingester-read-only).
 - **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter/Extra helpers), secrets,
   source, paths, iox, sigs.k8s.io/yaml.
@@ -374,7 +391,8 @@ remote uses `serverUrl`), skipped (reported) at project scope. **Memory** and
 skipped. It **implements `WarnEmitter`**: `Ingest` emits a warning when a workspace
 rule lacks the agentsync-rendered `trigger: always_on` frontmatter. No
 `PluginIngester`.
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (Extra helpers), secrets, source,
   paths, iox, jsonkeys.
 - **Files:** `windsurf.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `apply.go`,
@@ -389,7 +407,8 @@ The Roo Code adapter — MCP, memory, and slash commands via clean filesystem
 `argument-hint`), both at user *and* project scope. Roo's global MCP is VS Code
 globalStorage (not targeted — user-scope MCP is reported as a skip). Skips
 Skill/Subagent/Hook/LSP. No `PluginIngester`.
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (frontmatter/Extra helpers), secrets,
   source, paths, iox, jsonkeys.
 - **Files:** `roo.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `apply.go`, `paths.go`,
@@ -407,7 +426,8 @@ global rules live in `~/Documents/Cline/` (also not targeted). Skills/subagents/
 hooks/LSP have no Cline concept and are skipped. Emits no Ingest warnings
 (rules/workflows are plain markdown), so it does not implement `WarnEmitter`. No
 `PluginIngester`.
-- **Key:** `New(Options) *Adapter`; the `Adapter` methods; `IngestMCPSpec`.
+- **Key:** `New(Options) *Adapter`; the `Adapter` + `MCPSpecIngester` methods;
+  `IngestMCPSpec`.
 - **Depends on:** adapter, adapter/claude (Extra helpers), secrets, source,
   paths, iox, jsonkeys.
 - **Files:** `cline.go`, `homedir.go`, `render.go`, `mcp.go`, `ingest.go`, `apply.go`,
@@ -430,8 +450,13 @@ uniform — so the tier reuses the deep adapters' shared `claude.SkillFileOps`
 projection; an agent's `Skills` target is usually the cross-vendor `.agents/skills/`
 (byte-identical to Codex, so the render pipeline dedupes the ops). Breadth agents
 register through the normal registry and flow through apply/import (drift, secrets,
-capture). Adding an agent is a verified table row, not a package.
-- **Key:** `Spec`, `New(Spec, Options) *Adapter`; the `Adapter` methods; `Specs()`.
+capture). Adding an agent is a verified table row, not a package. It implements
+`adapter.MCPSpecIngester` per-Spec, so reconcile's key-level write-back inverts a
+native entry through THIS agent's dialect knobs — the collision that made a
+pointer-root allowlist unfixable (crush's `/mcp` is OpenCode's; eleven breadth
+agents share Claude's `/mcpServers`) is answered by asking the rendering adapter.
+- **Key:** `Spec`, `New(Spec, Options) *Adapter`; the `Adapter` +
+  `MCPSpecIngester` methods; `Specs()`.
 - **Depends on:** adapter, adapter/claude (Extra + SkillFileOps helpers), secrets,
   source, paths, iox, jsonkeys.
 - **Files:** `generic.go`, `homedir.go`, `render.go`, `ingest.go`, `apply.go`, `specs.go`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -721,6 +721,15 @@ fat-fingered paste or an empty `pbpaste`/`1password` pipe would otherwise store 
 silently-broken secret that resolves to `""` at apply time); pass `--allow-empty`
 to store an empty value deliberately.
 
+`secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
+window in which your secrets exist in cleartext on disk. **Interrupting it
+(Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
+decrypted copy, saves nothing, and exits `130` — the shell's "killed by Ctrl-C"
+code — without printing anything. An editor that ignores the interrupt is given
+a couple of seconds to exit on its own and then stopped, so the command can
+never hang waiting for it. Nothing is written to the vault unless the editor
+exits normally *and* the edited file passes the same validation `apply` uses.
+
 `${secret:…}` is resolved at apply time and written into native config; `${env:…}`
 pulls from the environment. The resolved value is **never** captured back into
 your source — `agentsync diff` even redacts it so a piped diff can't leak it.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -724,7 +724,9 @@ to store an empty value deliberately.
 `secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
-decrypted copy, saves nothing, and exits `130` — the shell's "killed by Ctrl-C"
+decrypted copy, saves nothing (unless the interrupt lands during the final
+re-encrypt, which is allowed to finish so the vault is never half-written), and
+exits `130` — the shell's "killed by Ctrl-C"
 code — without printing anything. An editor that ignores the interrupt is given
 a couple of seconds to exit on its own and then stopped, so the command can
 never hang waiting for it. Nothing is written to the vault unless the editor

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -725,14 +725,14 @@ to store an empty value deliberately.
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
 decrypted copy, saves nothing, and exits `130` — the shell's "killed by Ctrl-C"
-code — without printing anything. An editor that ignores the interrupt is given
-a couple of seconds to exit on its own and then stopped, so the command can
-never hang waiting for it. Nothing is written to the vault unless the editor
-exits normally *and* the edited file passes the same validation `apply` uses.
-The one exception is an interrupt that lands during the final re-encrypt
-itself: that write is allowed to finish so the vault is never half-written, and
-the command then reports the save and exits `0` as if it had not been
-interrupted.
+code — without printing anything. The one exception to that is an interrupt
+that lands during the final re-encrypt itself: that write is allowed to finish
+so the vault is never half-written, and the command then reports the save and
+exits `0` as if it had not been interrupted. An editor that ignores the
+interrupt is given a couple of seconds to exit on its own and then stopped, so
+the command can never hang waiting for it. Nothing is written to the vault
+unless the editor exits normally *and* the edited file passes the same
+validation `apply` uses.
 
 `${secret:…}` is resolved at apply time and written into native config; `${env:…}`
 pulls from the environment. The resolved value is **never** captured back into

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -724,13 +724,15 @@ to store an empty value deliberately.
 `secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
-decrypted copy, saves nothing (unless the interrupt lands during the final
-re-encrypt, which is allowed to finish so the vault is never half-written), and
-exits `130` — the shell's "killed by Ctrl-C"
+decrypted copy, saves nothing, and exits `130` — the shell's "killed by Ctrl-C"
 code — without printing anything. An editor that ignores the interrupt is given
 a couple of seconds to exit on its own and then stopped, so the command can
 never hang waiting for it. Nothing is written to the vault unless the editor
 exits normally *and* the edited file passes the same validation `apply` uses.
+The one exception is an interrupt that lands during the final re-encrypt
+itself: that write is allowed to finish so the vault is never half-written, and
+the command then reports the save and exits `0` as if it had not been
+interrupted.
 
 `${secret:…}` is resolved at apply time and written into native config; `${env:…}`
 pulls from the environment. The resolved value is **never** captured back into

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -382,6 +382,53 @@ type PluginIngester interface {
 	IngestPlugins(scope Scope, project string) ([]NativeMarketplace, []NativePlugin, error)
 }
 
+// MCPSpecIngester is an OPTIONAL extension to Adapter: an agent whose native MCP
+// config is a KEY-MERGE object — one root key holding one entry per server —
+// implements it so a dest→source write-back can translate a SINGLE native server
+// entry back to the canonical model in that agent's own dialect. Callers
+// type-assert for it (`reconcile`'s key-level [w]rite-back); an adapter that does
+// not implement it has its MCP key items refused rather than mistranslated.
+//
+// **Read-only by design, like PluginIngester.** IngestMCPSpec is an INVERSE of
+// Render, never a second render path: the spec it returns is destination-derived
+// and goes to the canonical source only through capture.Capture, which
+// re-references secrets and runs the fail-closed leak backstop. It must not
+// write anything.
+//
+// The operand is the value at `<root key>/<server id>` in the DECODED
+// destination object (`map[string]any` — JSON, JSONC, or TOML; the pipeline's
+// merge currency), exactly what the adapter's own Ingest passes to its
+// translator. The implementation MUST therefore be the same function Ingest
+// uses, not a second copy: the dialect is the thing that drifts (OpenCode's
+// array-shaped `command` and `environment`; Codex's `http_headers`; Gemini's
+// `httpUrl`; Windsurf's `serverUrl`; Roo's `streamable-http`; the generic tier's
+// per-Spec `MCPTarget` knobs), and a divergent copy silently moves modeled
+// fields into `Extra` on capture.
+//
+// **Why an optional interface rather than a method on Adapter or a
+// registry-side table.** A method on Adapter would force all 31 adapters —
+// including `noop` and Continue, neither of which has a root-keyed MCP object —
+// to implement a method whose contract they cannot honor. A registry-side
+// name→func table is exactly the hand-maintained allowlist this interface
+// exists to delete: it rots the moment an agent is added. The optional
+// interface follows the PluginIngester precedent (name what the implementor
+// DOES) and puts the dialect in the one place that already owns it — the
+// adapter that rendered the bytes being read back.
+//
+// Implemented by every adapter that renders MCP as a key-merge op: claude,
+// opencode, codex, cursor, gemini, windsurf, roo, cline, and the generic
+// breadth tier (per its Spec's MCPTarget). Continue does NOT implement it — it
+// renders one whole FILE per server (`MergeStrategy: "replace"`), so its
+// write-back goes through the whole-file path and its own IngestMCPSpec operand
+// is an element of a YAML `mcpServers` LIST inside a block, not a root-keyed
+// value. The registry-wide guard TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer
+// (internal/cli) renders a real MCP fixture through every registered adapter and
+// fails if one emits an MCP key-merge FileOp without implementing this
+// interface, so a new MCP-capable adapter cannot ship without its inverse.
+type MCPSpecIngester interface {
+	IngestMCPSpec(raw map[string]any) source.MCPServerSpec
+}
+
 // HookIngestGuard is an OPTIONAL extension to Adapter for agents whose hook
 // ingest REFUSES unrepresentable native events (unmodeled fields; on most
 // adapters also non-command handlers) rather than capturing a lossy subset. RefusedHookEvents re-reads the

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -427,10 +427,10 @@ type PluginIngester interface {
 // breadth tier (per its Spec's MCPTarget). Continue does NOT implement it — it
 // renders one whole FILE per server (`MergeStrategy: "replace"`), and its own
 // IngestMCPSpec operand is an element of a YAML `mcpServers` LIST inside a
-// block, not a root-keyed value. Its MCP write-back does not go through the
-// whole-file path either: that arm copies the destination verbatim, which for a
+// block, not a root-keyed value. Its MCP write-back reaches the whole-file arm
+// but is REFUSED there: that arm copies the destination verbatim, which for a
 // secret-bearing kind would put YAML into a canonical TOML file and persist
-// resolved secrets in cleartext, so reconcile REFUSES it and points at
+// resolved secrets in cleartext, so reconcile refuses the kind and points at
 // `agentsync import continue:mcp:<id>`, which captures the edit through Ingest
 // and capture.Capture. The registry-wide guard TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer
 // (internal/cli) renders a real MCP fixture through every registered adapter and

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -415,13 +415,24 @@ type PluginIngester interface {
 // DOES) and puts the dialect in the one place that already owns it — the
 // adapter that rendered the bytes being read back.
 //
+// The signature returns no error: a native value the dialect cannot represent
+// (a number inside a string-typed field such as `args`, say) is DROPPED, on
+// write-back exactly as on Ingest, never stringified and never passed through
+// Extra. Refusing instead would need every implementor and every Ingest to
+// return an error; the residual is documented at the reconcile call site and in
+// the capability matrix, and pinned by characterization tests.
+//
 // Implemented by every adapter that renders MCP as a key-merge op: claude,
 // opencode, codex, cursor, gemini, windsurf, roo, cline, and the generic
 // breadth tier (per its Spec's MCPTarget). Continue does NOT implement it — it
-// renders one whole FILE per server (`MergeStrategy: "replace"`), so its
-// write-back goes through the whole-file path and its own IngestMCPSpec operand
-// is an element of a YAML `mcpServers` LIST inside a block, not a root-keyed
-// value. The registry-wide guard TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer
+// renders one whole FILE per server (`MergeStrategy: "replace"`), and its own
+// IngestMCPSpec operand is an element of a YAML `mcpServers` LIST inside a
+// block, not a root-keyed value. Its MCP write-back does not go through the
+// whole-file path either: that arm copies the destination verbatim, which for a
+// secret-bearing kind would put YAML into a canonical TOML file and persist
+// resolved secrets in cleartext, so reconcile REFUSES it and points at
+// `agentsync import continue:mcp:<id>`, which captures the edit through Ingest
+// and capture.Capture. The registry-wide guard TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer
 // (internal/cli) renders a real MCP fixture through every registered adapter and
 // fails if one emits an MCP key-merge FileOp without implementing this
 // interface, so a new MCP-capable adapter cannot ship without its inverse.

--- a/internal/adapter/claude/ingest.go
+++ b/internal/adapter/claude/ingest.go
@@ -52,15 +52,7 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 				if !ok {
 					continue
 				}
-				m := source.MCPServer{ID: id, Server: source.MCPServerSpec{
-					Type:    asStr(spec["type"]),
-					Command: asStr(spec["command"]),
-					Args:    asStrSlice(spec["args"]),
-					Env:     asStrMap(spec["env"]),
-					URL:     asStr(spec["url"]),
-					Headers: asStrMap(spec["headers"]),
-					Extra:   ExtraNativeKeys(spec, "type", "command", "args", "env", "url", "headers"),
-				}}
+				m := source.MCPServer{ID: id, Server: IngestMCPSpec(spec)}
 				c.MCPServers = append(c.MCPServers, m)
 			}
 		}
@@ -206,6 +198,34 @@ func (a *Adapter) Ingest(scope adapter.Scope, project string) (source.Canonical,
 	}
 
 	return c, nil
+}
+
+// IngestMCPSpec translates one Claude-native MCP server table — the value under
+// `~/.claude.json` / `.mcp.json` `mcpServers.<id>` — into the canonical
+// MCPServerSpec. Claude's on-disk shape matches the canonical model 1:1, so the
+// modeled fields carry over verbatim and any other native key (timeout,
+// disabled, cwd, …) is preserved in Extra.
+//
+// Exported and used by Ingest so reconcile's key-level write-back reconstructs a
+// Claude MCP server through the SAME translation the adapter reads with, rather
+// than through a json.Unmarshal that happens to agree today. See
+// adapter.MCPSpecIngester.
+func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return source.MCPServerSpec{
+		Type:    asStr(raw["type"]),
+		Command: asStr(raw["command"]),
+		Args:    asStrSlice(raw["args"]),
+		Env:     asStrMap(raw["env"]),
+		URL:     asStr(raw["url"]),
+		Headers: asStrMap(raw["headers"]),
+		Extra:   ExtraNativeKeys(raw, "type", "command", "args", "env", "url", "headers"),
+	}
+}
+
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
 }
 
 func asStr(v any) string { s, _ := v.(string); return s }

--- a/internal/adapter/cline/mcp.go
+++ b/internal/adapter/cline/mcp.go
@@ -128,6 +128,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // agentTargeted reports whether the agents allowlist includes cline. An empty/nil
 // list or a "*" entry means all agents are targeted.
 func agentTargeted(name string, agents []string) bool {

--- a/internal/adapter/codex/mcp.go
+++ b/internal/adapter/codex/mcp.go
@@ -119,6 +119,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 func asStr(v any) string { s, _ := v.(string); return s }
 
 // asBoolPtr returns a pointer to v when it is a bool, else nil. Used so an

--- a/internal/adapter/cursor/mcp.go
+++ b/internal/adapter/cursor/mcp.go
@@ -92,6 +92,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // agentTargeted reports whether the agents allowlist includes cursor. An
 // empty/nil list or a "*" entry means all agents are targeted.
 func agentTargeted(name string, agents []string) bool {

--- a/internal/adapter/gemini/mcp.go
+++ b/internal/adapter/gemini/mcp.go
@@ -187,6 +187,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // agentTargeted reports whether the agents allowlist includes gemini. An
 // empty/nil list or a "*" entry means all agents are targeted.
 func agentTargeted(name string, agents []string) bool {

--- a/internal/adapter/generic/ingest.go
+++ b/internal/adapter/generic/ingest.go
@@ -170,6 +170,14 @@ func ingestMCPSpec(t MCPTarget, raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester for the breadth tier by
+// applying THIS agent's Spec dialect — the same MCPTarget Ingest reads with, so
+// a per-agent knob (RootKey, TransportKey, StdioValue, RemoteURLKey, SSEURLKey)
+// can never be honored on read and missed on write-back.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return ingestMCPSpec(a.spec.MCP, raw)
+}
+
 func asStr(v any) string { s, _ := v.(string); return s }
 
 func asStrSlice(v any) []string {

--- a/internal/adapter/opencode/ingest.go
+++ b/internal/adapter/opencode/ingest.go
@@ -274,6 +274,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // canonicalMCPType maps OpenCode's transport ("local"/"remote") back to the
 // canonical model's stdio/http. OpenCode has no separate sse transport, so a
 // remote server normalises to "http" on write-back (an apply-only flow is

--- a/internal/adapter/roo/mcp.go
+++ b/internal/adapter/roo/mcp.go
@@ -162,6 +162,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // agentTargeted reports whether the agents allowlist includes roo. An empty/nil
 // list or a "*" entry means all agents are targeted.
 func agentTargeted(name string, agents []string) bool {

--- a/internal/adapter/windsurf/mcp.go
+++ b/internal/adapter/windsurf/mcp.go
@@ -140,6 +140,12 @@ func IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
 	}
 }
 
+// IngestMCPSpec satisfies adapter.MCPSpecIngester by delegating to the package
+// translator Ingest uses, so the dialect has exactly one definition.
+func (a *Adapter) IngestMCPSpec(raw map[string]any) source.MCPServerSpec {
+	return IngestMCPSpec(raw)
+}
+
 // agentTargeted reports whether the agents allowlist includes windsurf. An
 // empty/nil list or a "*" entry means all agents are targeted.
 func agentTargeted(name string, agents []string) bool {

--- a/internal/cli/destread.go
+++ b/internal/cli/destread.go
@@ -32,9 +32,9 @@ var errDestNotRegular = errors.New("not a regular file")
 // which keys on that token, words its advice for both.
 var errDestUnstattable = errors.New("cannot stat destination")
 
-// pathlessStatErr strips the redundant path from a *fs.PathError, mirroring
+// pathlessErr strips the redundant path from a *fs.PathError, mirroring
 // secrets.pathlessErr. errors.Is still matches the underlying errno.
-func pathlessStatErr(err error) error {
+func pathlessErr(err error) error {
 	var pe *fs.PathError
 	if errors.As(err, &pe) {
 		return pe.Err
@@ -98,7 +98,7 @@ func readDestBytes(path string) ([]byte, error) {
 			// "read dest X: cannot stat destination: stat X: ...". Unwrapping to
 			// the bare errno keeps errors.Is matching BOTH this sentinel and the
 			// underlying syscall error.
-			return nil, fmt.Errorf("%w: %w", errDestUnstattable, pathlessStatErr(serr))
+			return nil, fmt.Errorf("%w: %w", errDestUnstattable, pathlessErr(serr))
 		}
 		return nil, errDestNotRegular
 	}

--- a/internal/cli/destread.go
+++ b/internal/cli/destread.go
@@ -95,7 +95,7 @@ func readDestBytes(path string) ([]byte, error) {
 		if _, serr := os.Stat(path); serr != nil {
 			// Pathless, for the reason errDestNotRegular carries no path: the
 			// caller supplies it, and a *fs.PathError would make reconcile print
-			// "read dest X: cannot stat destination: stat X: ...". Unwrapping to
+			// "read destination X: cannot stat destination: stat X: ...". Unwrapping to
 			// the bare errno keeps errors.Is matching BOTH this sentinel and the
 			// underlying syscall error.
 			return nil, fmt.Errorf("%w: %w", errDestUnstattable, pathlessErr(serr))

--- a/internal/cli/destread_unix_internal_test.go
+++ b/internal/cli/destread_unix_internal_test.go
@@ -603,8 +603,8 @@ func TestReadDestBytesReportsAStatFailureAsItself(t *testing.T) {
 			"to the shape sentinel and keep base parity", err)
 	}
 	// Pathless, like its sibling sentinel: the caller supplies the path, and a
-	// *fs.PathError here makes reconcile print "read dest X: cannot stat
-	// destination: stat X: ...". Counting occurrences rather than asserting a
+	// *fs.PathError here makes reconcile print "read destination X: cannot
+	// stat destination: stat X: ...". Counting occurrences rather than asserting a
 	// literal keeps this from breaking on a reworded message.
 	if n := strings.Count(err.Error(), a); n != 0 {
 		t.Errorf("error = %q names the path %d time(s); it must carry none — the caller "+

--- a/internal/cli/explain_model.go
+++ b/internal/cli/explain_model.go
@@ -176,7 +176,7 @@ func fileItem(in explainInputs, it planItem, skips []adapter.Skip,
 func keyItem(in explainInputs, it planItem, skips []adapter.Skip, origins map[string]explainPluginOrigin,
 	secretRefs map[secrets.RefLocation][]string, hookEvents []string,
 ) explainItem {
-	kind, name := componentFromPointer(in.reg, it.agent, it.ptr, hookEvents)
+	kind, name := componentFromPointer(in.reg, it.agent, it.op.SourceID, it.ptr, hookEvents)
 
 	item := explainItem{
 		Pointer:    it.ptr,
@@ -248,7 +248,7 @@ func sourceOf(in explainInputs, srcID, kind string) *explainSource {
 // pointer shape (the mcp/lsp/hooks container families), falling back to the
 // op-level SourceID when the pointer names no single source.
 func pointerSource(in explainInputs, agent, ptr, opSourceID string, hookEvents []string) *explainSource {
-	abs := pointerSourceFile(in.reg, in.srcHome, agent, ptr, hookEvents)
+	abs := pointerSourceFile(in.reg, in.srcHome, agent, opSourceID, ptr, hookEvents)
 	if abs == "" {
 		if opSourceID == "" {
 			return nil
@@ -300,18 +300,27 @@ func componentFromSourceID(srcID string) (kind, name string) {
 
 // componentFromPointer maps a NATIVE key-merge pointer to (kind, name), routing
 // hooks through the same canonical-event inversion reconcile's write-back uses.
-func componentFromPointer(reg *adapter.Registry, agent, ptr string, hookEvents []string) (kind, name string) {
-	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
-	if len(parts) < 2 || parts[1] == "" {
+//
+// The kind comes from the op's SourceID (keyItemKind) and the name from the
+// DECODED pointer segment (keyItemPointerParts) — the same two derivations
+// reconcile's write-back and pointerSourceFile use. This used to be a fourth
+// copy of the pointer-root allowlist, with the same two defects: a breadth-tier
+// root nobody had listed (zed's /context_servers, copilot's /servers, amp's
+// /amp.mcpServers) answered ("", "") so `explain` printed no component line and
+// matched no skip, plugin origin or secret reference for the item, and a
+// `~`-bearing server id was reported under its escaped spelling (`til~0de`).
+func componentFromPointer(reg *adapter.Registry, agent, sourceID, ptr string, hookEvents []string) (kind, name string) {
+	_, id, ok := keyItemPointerParts(ptr)
+	if !ok {
 		return "", ""
 	}
-	switch parts[0] {
-	case "mcpServers", "mcp", "mcp_servers":
-		return "mcp", parts[1]
-	case "lspServers", "lsp":
-		return "lsp", parts[1]
+	switch keyItemKind(sourceID) {
+	case "mcp":
+		return "mcp", id
+	case "lsp":
+		return "lsp", id
 	case "hooks":
-		if event, ok := canonicalHookEvent(reg, agent, parts[1], hookEvents); ok {
+		if event, ok := canonicalHookEvent(reg, agent, id, hookEvents); ok {
 			return "hook", event
 		}
 		return "hook", ""

--- a/internal/cli/mcpspecingester_guard_test.go
+++ b/internal/cli/mcpspecingester_guard_test.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/render"
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/source"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// mcpDialectFixtures are the two canonical MCP servers whose ROUND TRIP through
+// an adapter's own native bytes is what this guard checks: one stdio server
+// (command + args + env) and one remote server (url + headers). Between them
+// they populate every modeled MCPServerSpec field any dialect has a slot for,
+// so a dialect that silently demotes a modeled field into the `Extra`
+// passthrough is caught whichever side of the transport split it lives on.
+func mcpDialectFixtures() []source.MCPServer {
+	return []source.MCPServer{
+		{ID: "stdiosrv", Server: source.MCPServerSpec{
+			Type:    "stdio",
+			Command: "npx",
+			Args:    []string{"-y", "@modelcontextprotocol/server-github"},
+			Env:     map[string]string{"GITHUB_TOKEN": "xyz"},
+		}},
+		{ID: "remotesrv", Server: source.MCPServerSpec{
+			Type:    "http",
+			URL:     "https://api.example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer tok"},
+		}},
+	}
+}
+
+// TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer is the registry-wide guard
+// for the adapter.MCPSpecIngester contract, and the reason reconcile's key-level
+// write-back no longer carries a hand-maintained pointer-root allowlist.
+//
+// Two assertions, both anchored to the ADAPTER'S OWN ON-DISK BYTES rather than
+// to a model (CLAUDE.md, "models must stay faithful to their on-disk
+// artifacts"):
+//
+//  1. COVERAGE — every registered adapter that emits an MCP key-merge FileOp
+//     MUST implement adapter.MCPSpecIngester. Without this, adding an
+//     MCP-capable agent silently reintroduces the old failure mode: its key
+//     items are refused (a root key nothing recognises) or, worse, translated
+//     through whichever adapter happens to share its root key.
+//  2. FIDELITY — feeding the adapter's OWN rendered native entry back through
+//     its OWN IngestMCPSpec must return the modeled fields as MODELED fields,
+//     never demoted into the `Extra` passthrough. This is what makes "route the
+//     write-back through the rendering adapter" a guarantee rather than a hope:
+//     the routing is correct only if each implementor's inverse is faithful to
+//     its own render. (The ROUTING itself is pinned at the CLI level, by the
+//     per-dialect reconcile write-back tests — a guard at this layer cannot see
+//     which translator reconcile picks.)
+//
+// It runs over the whole registry, so it covers all 22 generic specs as well as
+// the nine deep adapters.
+func TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer(t *testing.T) {
+	testenv.RequireContainer(t)
+	fixture := source.Canonical{MCPServers: mcpDialectFixtures()}
+	resolved := secrets.ForRender(fixture)
+	want := map[string]source.MCPServerSpec{}
+	for _, m := range fixture.MCPServers {
+		want[m.ID] = m.Server
+	}
+
+	reg := registryFactory()
+	checked := 0
+	for _, name := range reg.Names() {
+		a := reg.Lookup(name)
+		if a == nil {
+			t.Fatalf("registry has name %q but Lookup returned nil", name)
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, sc := range []struct {
+				name    string
+				scope   adapter.Scope
+				project string
+			}{
+				{"user", adapter.ScopeUser, ""},
+				{"project", adapter.ScopeProject, t.TempDir()},
+			} {
+				ops, _, err := a.Render(resolved, sc.scope, sc.project)
+				if err != nil {
+					t.Fatalf("[%s/%s] Render: %v", name, sc.name, err)
+				}
+				for _, op := range ops {
+					if !render.IsKeyMerge(op.MergeStrategy) || !isMCPSourceID(op.SourceID) {
+						continue
+					}
+					ing, ok := a.(adapter.MCPSpecIngester)
+					if !ok {
+						t.Fatalf("[%s/%s] emits an MCP key-merge op (%s) but does NOT implement "+
+							"adapter.MCPSpecIngester — reconcile's key-level write-back has no "+
+							"dialect for it and must refuse or mistranslate it",
+							name, sc.name, op.Path)
+					}
+					var top map[string]any
+					if err := json.Unmarshal(op.Content, &top); err != nil {
+						t.Fatalf("[%s/%s] decode rendered MCP op content: %v", name, sc.name, err)
+					}
+					servers := mcpRootServers(top, want)
+					if servers == nil {
+						t.Fatalf("[%s/%s] rendered MCP op %s carries no root object holding the "+
+							"fixture servers; content=%s", name, sc.name, op.Path, op.Content)
+					}
+					for id, raw := range servers {
+						entry, ok := raw.(map[string]any)
+						if !ok {
+							t.Fatalf("[%s/%s] rendered server %q is not an object", name, sc.name, id)
+						}
+						got := ing.IngestMCPSpec(entry)
+						assertMCPRoundTrip(t, name, sc.name, id, want[id], got)
+						checked++
+					}
+				}
+			}
+		})
+	}
+	// Guard against a vacuously-green run.
+	if checked == 0 {
+		t.Fatal("no adapter rendered an MCP key-merge op for the fixture; the guard is vacuous")
+	}
+}
+
+// isMCPSourceID reports whether a FileOp's SourceID names the MCP component —
+// the same SourceID-derived kind test reconcile's write-back and plugin-owner
+// lookup use, rather than a pointer-root allowlist.
+func isMCPSourceID(id string) bool { return len(id) >= 4 && id[:4] == "mcp/" }
+
+// mcpRootServers finds the rendered op's server map without knowing the
+// adapter's root key: it is the top-level value that is an object keyed by the
+// fixture server ids. Deriving it beats a second copy of the root-key table.
+func mcpRootServers(top map[string]any, want map[string]source.MCPServerSpec) map[string]any {
+	for _, v := range top {
+		m, ok := v.(map[string]any)
+		if !ok || len(m) == 0 {
+			continue
+		}
+		all := true
+		for id := range m {
+			if _, known := want[id]; !known {
+				all = false
+				break
+			}
+		}
+		if all {
+			return m
+		}
+	}
+	return nil
+}
+
+// assertMCPRoundTrip pins the modeled fields a dialect DOES have a slot for. It
+// deliberately does not assert Type: the transport-keyless dialects have nowhere
+// to record it and canonicalize sse→http by documented design
+// (docs/capability-matrix.md). What it does assert is that a field the dialect
+// wrote is read back as the MODELED field and not as Extra passthrough.
+func assertMCPRoundTrip(t *testing.T, agent, scope, id string, want, got source.MCPServerSpec) {
+	t.Helper()
+	if want.Command != "" {
+		if got.Command != want.Command {
+			t.Errorf("[%s/%s] %s: Command = %q, want %q", agent, scope, id, got.Command, want.Command)
+		}
+		if !reflect.DeepEqual(got.Args, want.Args) {
+			t.Errorf("[%s/%s] %s: Args = %v, want %v (a modeled field demoted to Extra?)", agent, scope, id, got.Args, want.Args)
+		}
+		if !reflect.DeepEqual(got.Env, want.Env) {
+			t.Errorf("[%s/%s] %s: Env = %v, want %v (a modeled field demoted to Extra?)", agent, scope, id, got.Env, want.Env)
+		}
+	}
+	if want.URL != "" {
+		if got.URL != want.URL {
+			t.Errorf("[%s/%s] %s: URL = %q, want %q (the dialect's url key not inverted?)", agent, scope, id, got.URL, want.URL)
+		}
+		if !reflect.DeepEqual(got.Headers, want.Headers) {
+			t.Errorf("[%s/%s] %s: Headers = %v, want %v", agent, scope, id, got.Headers, want.Headers)
+		}
+	}
+	for _, modeled := range []string{"type", "command", "args", "env", "url", "headers"} {
+		if _, bad := got.Extra[modeled]; bad {
+			t.Errorf("[%s/%s] %s: Extra carries the modeled key %q — the translator demoted a "+
+				"canonical field into passthrough", agent, scope, id, modeled)
+		}
+	}
+}

--- a/internal/cli/mcpspecingester_guard_test.go
+++ b/internal/cli/mcpspecingester_guard_test.go
@@ -88,7 +88,7 @@ func TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer(t *testing.T) {
 					t.Fatalf("[%s/%s] Render: %v", name, sc.name, err)
 				}
 				for _, op := range ops {
-					if !render.IsKeyMerge(op.MergeStrategy) || !isMCPSourceID(op.SourceID) {
+					if !render.IsKeyMerge(op.MergeStrategy) || keyItemKind(op.SourceID) != "mcp" {
 						continue
 					}
 					ing, ok := a.(adapter.MCPSpecIngester)
@@ -106,6 +106,13 @@ func TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer(t *testing.T) {
 					if servers == nil {
 						t.Fatalf("[%s/%s] rendered MCP op %s carries no root object holding the "+
 							"fixture servers; content=%s", name, sc.name, op.Path, op.Content)
+					}
+					if len(servers) != len(want) {
+						// mcpRootServers accepts a SUBSET of the fixture ids, so a
+						// dialect that dropped one server would otherwise shrink the
+						// fidelity check silently.
+						t.Fatalf("[%s/%s] rendered %d of the %d fixture servers; content=%s",
+							name, sc.name, len(servers), len(want), op.Content)
 					}
 					for id, raw := range servers {
 						entry, ok := raw.(map[string]any)
@@ -125,11 +132,6 @@ func TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer(t *testing.T) {
 		t.Fatal("no adapter rendered an MCP key-merge op for the fixture; the guard is vacuous")
 	}
 }
-
-// isMCPSourceID reports whether a FileOp's SourceID names the MCP component —
-// the same SourceID-derived kind test reconcile's write-back and plugin-owner
-// lookup use, rather than a pointer-root allowlist.
-func isMCPSourceID(id string) bool { return len(id) >= 4 && id[:4] == "mcp/" }
 
 // mcpRootServers finds the rendered op's server map without knowing the
 // adapter's root key: it is the top-level value that is an object keyed by the

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -1508,11 +1508,11 @@ func writeBackFileItem(home string, it reconcileItem) error {
 		// arm's advice suggests [o]verride: Writer.Write's convergence read
 		// follows the link, and its mode arm chmods the TARGET through it
 		// before the symlink policy is consulted (#248).
-		return fmt.Errorf("read dest %s: destination is a symlink agentsync is not reading through — "+
+		return fmt.Errorf("read destination %s: destination is a symlink agentsync is not reading through — "+
 			"set %s=1 (for apply, status, diff, reconcile and explain) to read and write through the link, replace the link with a "+
 			"regular file, or [i]gnore to suppress this item", it.op.Path, iox.AllowSymlinkDestEnv)
 	case symlinkUnresolvable:
-		return fmt.Errorf("read dest %s: destination is a symlink whose target cannot be resolved "+
+		return fmt.Errorf("read destination %s: destination is a symlink whose target cannot be resolved "+
 			"(dangling, loop, or unreadable; apply refuses it too) — fix or replace the link, or [i]gnore "+
 			"to suppress this item", it.op.Path)
 	}
@@ -1528,6 +1528,29 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	}
 	if strings.HasSuffix(srcID, "(multiple)") {
 		return fmt.Errorf("write-back for %s is unsafe: the dest is the concatenation of multiple source fragments. Persisting the whole dest into one of them would strand the others. Edit the source fragments under %s/ directly, then apply", it.op.Path, home)
+	}
+	// The whole-file arm copies the destination VERBATIM into the canonical file
+	// the SourceID names. That is right for the text components — skills,
+	// subagents, commands, memory — whose canonical form IS the rendered text.
+	// It is wrong for the structured, secret-bearing kinds walkSecretFields
+	// visits (MCP, LSP, hooks): the render wrote the agent's native dialect with
+	// every `${secret:…}` RESOLVED, so a verbatim copy would put that dialect
+	// (Continue's YAML) into a canonical TOML file — every later load fails to
+	// parse it — and persist the resolved cleartext outside capture.Capture's
+	// re-reference and leak backstop, the bug class the secret invariants exist
+	// to prevent. Continue's per-server MCP file is the one whole-file render of
+	// such a kind today; `import <agent>:<component>:<name>` captures the same
+	// edit through the adapter's Ingest and capture.Capture, so point there.
+	// (ToSlash: Continue builds the SourceID with filepath.Join.)
+	if kind := keyItemKind(filepath.ToSlash(srcID)); kind != "" {
+		name := strings.TrimSuffix(filepath.Base(srcID), ".toml")
+		component := strings.TrimSuffix(kind, "s") // import's selector grammar: mcp | lsp | hook
+		return fmt.Errorf("write-back for %s is refused: it is %s's whole-file render of the %s component %q, and the "+
+			"whole-file path copies the destination verbatim — that would put %s's native dialect into the canonical "+
+			"TOML file and persist the secrets the render resolved in cleartext. Capture the edit with "+
+			"`agentsync import %s:%s:%s` (which translates it and re-references the secrets), or edit %s directly, "+
+			"then apply; or use [o]verride / [i]gnore",
+			it.op.Path, it.agentName, kind, name, it.agentName, it.agentName, component, name, filepath.Join(home, srcID))
 	}
 	// Memory is fragment-aware. If apply wrote fragment markers, reverse them
 	// into AGENTS.md + the fragment files instead of writing the expanded dest

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -1387,6 +1387,10 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	}
 	rootKey, serverID, ok := keyItemPointerParts(it.ptr)
 	if !ok {
+		// Defensive, and unreachable while render.CollectPointers emits a
+		// one-segment pointer only for a SCALAR root value: an MCP root is an
+		// object, so every mcp/ key item carries a server segment. Kept so a
+		// future pointer shape refuses rather than indexes a nil map.
 		return fmt.Errorf("write-back for pointer %q names no MCP server (expected /<root key>/<server id>) — "+
 			"choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item", it.ptr)
 	}
@@ -1412,11 +1416,23 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	// a missing root key.
 	data, err := readDestBytes(it.op.Path)
 	if err != nil {
-		return fmt.Errorf("read destination %s: %w", it.op.Path, err)
+		// The same split writeBackFileItem makes: [o]verride is the right
+		// remedy for an absent or unreadable file (the re-render restores it)
+		// and the WRONG one for a non-regular file, where the convergence read
+		// hangs (#241). pathlessStatErr keeps the path to one mention:
+		// os.ReadFile's *fs.PathError carries it, readDestBytes' sentinels
+		// deliberately do not.
+		if errors.Is(err, errDestNotRegular) {
+			return fmt.Errorf("read destination %s: %w — remove or replace the non-regular file at that "+
+				"path and re-run, or [i]gnore to suppress this item", it.op.Path, err)
+		}
+		return fmt.Errorf("read destination %s: %w — use [o]verride to restore it from canonical, or "+
+			"[i]gnore to suppress this item", it.op.Path, pathlessStatErr(err))
 	}
 	dest := map[string]any{}
 	if err := decodeDestBytes(it.op.MergeStrategy, data, &dest); err != nil {
-		return fmt.Errorf("destination %s does not parse (%s): %w", it.op.Path, it.op.MergeStrategy, err)
+		return fmt.Errorf("destination %s does not parse (%s): %w — choose [o]verride to push canonical to "+
+			"the dest, or [i]gnore to suppress this item", it.op.Path, it.op.MergeStrategy, err)
 	}
 	servers, _ := dest[rootKey].(map[string]any)
 	if servers == nil {
@@ -1509,7 +1525,7 @@ func writeBackFileItem(home string, it reconcileItem) error {
 		// through to the write. Leaving it out of the advice is only right for
 		// the non-regular case above.
 		return fmt.Errorf("read dest %s: %w — use [o]verride to restore it from canonical, "+
-			"or [i]gnore to suppress this item", it.op.Path, err)
+			"or [i]gnore to suppress this item", it.op.Path, pathlessStatErr(err))
 	}
 	srcID := it.op.SourceID
 	if srcID == "" {

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -1416,18 +1416,7 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	// a missing root key.
 	data, err := readDestBytes(it.op.Path)
 	if err != nil {
-		// The same split writeBackFileItem makes: [o]verride is the right
-		// remedy for an absent or unreadable file (the re-render restores it)
-		// and the WRONG one for a non-regular file, where the convergence read
-		// hangs (#241). pathlessStatErr keeps the path to one mention:
-		// os.ReadFile's *fs.PathError carries it, readDestBytes' sentinels
-		// deliberately do not.
-		if errors.Is(err, errDestNotRegular) {
-			return fmt.Errorf("read destination %s: %w — remove or replace the non-regular file at that "+
-				"path and re-run, or [i]gnore to suppress this item", it.op.Path, err)
-		}
-		return fmt.Errorf("read destination %s: %w — use [o]verride to restore it from canonical, or "+
-			"[i]gnore to suppress this item", it.op.Path, pathlessStatErr(err))
+		return destReadRefusal(it.op.Path, err)
 	}
 	dest := map[string]any{}
 	if err := decodeDestBytes(it.op.MergeStrategy, data, &dest); err != nil {
@@ -1472,6 +1461,33 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	return nil
 }
 
+// destReadRefusal words a failed destination read for the prompt, for both
+// the key-item and the whole-file write-back: the path once (os.ReadFile's
+// *fs.PathError carries it and readDestBytes' sentinels deliberately do not,
+// so pathlessErr strips the copy), and a named next step — the user is
+// mid-prompt with a keystroke to choose, and "not a regular file" alone does
+// not say which one gets them unstuck.
+//
+// The next step deliberately omits [o]verride for a NON-REGULAR destination.
+// Override re-applies through render.Writer.Write, whose convergence read is
+// not shape-guarded, so on that exact item it does not fail — it HANGS
+// (measured: `reconcile --auto-override` rc=124, #241). An earlier version of
+// the whole-file message recommended it, which walked the user out of a clean
+// refusal and into an unbounded wedge; restore the suggestion only once #241
+// is fixed. Every other read failure keeps the peers' remedy set: the common
+// one is an ABSENT destination — the user deleted a managed file, which is
+// itself drift — and there [o]verride is both safe and usually the fix, since
+// Writer.Write's convergence read gets ENOENT and falls straight through to
+// the write.
+func destReadRefusal(path string, err error) error {
+	if errors.Is(err, errDestNotRegular) {
+		return fmt.Errorf("read destination %s: %w — remove or replace the non-regular file at that "+
+			"path and re-run, or [i]gnore to suppress this item", path, err)
+	}
+	return fmt.Errorf("read destination %s: %w — use [o]verride to restore it from canonical, or "+
+		"[i]gnore to suppress this item", path, pathlessErr(err))
+}
+
 // writeBackFileItem handles file-level (replace strategy) items by copying
 // the destination file back into the corresponding source location verbatim.
 // This covers subagents, commands, memory, and skill files in v1.
@@ -1502,30 +1518,9 @@ func writeBackFileItem(home string, it reconcileItem) error {
 	}
 	data, err := readDestBytes(readPath)
 	if err != nil {
-		// Named next steps, like this function's other refusals: the user is
-		// mid-prompt with a keystroke to choose, and "read dest X: not a regular
-		// file" alone does not tell them which one gets them unstuck.
-		//
-		// This arm's advice deliberately omits [o]verride, as the symlink
-		// arms' does, unlike the absent arm below. It re-applies through
-		// render.Writer.Write, whose convergence read is not
-		// shape-guarded, so on this exact item it does not fail — it HANGS
-		// (measured: `reconcile --auto-override` rc=124).
-		// An earlier version of this message recommended it, which walked the
-		// user out of a clean refusal and into an unbounded wedge. Restore that
-		// suggestion only once #241 is fixed.
-		if errors.Is(err, errDestNotRegular) {
-			return fmt.Errorf("read dest %s: %w — remove or replace the non-regular file at "+
-				"that path and re-run, or [i]gnore to suppress this item", it.op.Path, err)
-		}
-		// Any other read failure keeps the peers' remedy set. The common one is
-		// an ABSENT destination — the user deleted a managed file, which is
-		// itself drift — and there [o]verride is both safe and usually the fix:
-		// Writer.Write's convergence read gets ENOENT and falls straight
-		// through to the write. Leaving it out of the advice is only right for
-		// the non-regular case above.
-		return fmt.Errorf("read dest %s: %w — use [o]verride to restore it from canonical, "+
-			"or [i]gnore to suppress this item", it.op.Path, pathlessStatErr(err))
+		// The symlink arms above omit [o]verride for their own reason (#248);
+		// destReadRefusal omits it for a non-regular file for #241's.
+		return destReadRefusal(it.op.Path, err)
 	}
 	srcID := it.op.SourceID
 	if srcID == "" {

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,9 +13,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
-	"github.com/spxrogers/agentsync/internal/adapter/claude"
-	"github.com/spxrogers/agentsync/internal/adapter/codex"
-	"github.com/spxrogers/agentsync/internal/adapter/opencode"
 	"github.com/spxrogers/agentsync/internal/capture"
 	"github.com/spxrogers/agentsync/internal/drift"
 	"github.com/spxrogers/agentsync/internal/iox"
@@ -819,6 +815,54 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 	return out
 }
 
+// keyItemKind returns the canonical component kind a key-merge op's SourceID
+// names — "mcp", "lsp" or "hooks" — or "" for an op with no per-entry canonical
+// provenance. Every key-merge op carries a section-wide SourceID naming its kind
+// ("mcp/* (multiple)", "hooks/* (multiple)"), and Continue's whole-file MCP form
+// is "mcp/<id>.toml", so a prefix test covers both spellings.
+//
+// This is the ONE place the kind is derived, shared by write-back and the
+// pointer→source-file inversion. It is deliberately NOT derived from the
+// pointer's root key: root keys are per-agent data that both grow and COLLIDE
+// (see pluginOwnerForKeyItem's comment), so any root-keyed classification is
+// wrong for some agent.
+func keyItemKind(sourceID string) string {
+	switch {
+	case strings.HasPrefix(sourceID, "mcp/"):
+		return "mcp"
+	case strings.HasPrefix(sourceID, "lsp/"):
+		return "lsp"
+	case strings.HasPrefix(sourceID, "hooks/"):
+		return "hooks"
+	default:
+		return ""
+	}
+}
+
+// keyItemPointerParts splits a key-merge JSON pointer into its container root
+// key and the DECODED second segment (the server id / hook event). ok is false
+// when the pointer has no non-empty second segment, i.e. it names no single
+// entry.
+//
+// The second segment is JSON-pointer ENCODED on the way in — render.CollectPointers
+// builds every pointer with jsonkeys.EscapeToken — so it must be decoded before
+// it is used as a map key or a canonical filename (RFC 6901 §3: ~1 → "/", ~0 →
+// "~"). Using it raw was a live bug: an MCP server id containing "~" reached
+// write-back as "srv~0id", missed the destination map, and was reported as a
+// destination-side DELETION ("write-back: removed source mcp/srv~0id.toml") —
+// discarding the user's edit while telling them it had been persisted.
+//
+// The root key is returned VERBATIM: it is a single pointer segment produced by
+// the adapter's own render, and it is only ever used to index the decoded
+// destination object, never as a path.
+func keyItemPointerParts(ptr string) (rootKey, id string, ok bool) {
+	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
+	if len(parts) < 2 || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], jsonkeys.UnescapeToken(parts[1]), true
+}
+
 // pluginOwnerForKeyItem resolves the plugin owning the MCP/LSP server a
 // key-level item points at, or "" for a hand-declared one.
 //
@@ -853,8 +897,8 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 // implemented, this returns "" rather than silently permitting the capture — the
 // empty map is the thing to fix, and it is one place.
 //
-// Pointer segments are JSON-pointer encoded, so ~1/~0 are decoded first
-// (RFC 6901 §3) — an id containing '/' would otherwise never match.
+// Pointer segments are JSON-pointer encoded, so keyItemPointerParts decodes
+// ~1/~0 first (RFC 6901 §3) — an id containing '/' would otherwise never match.
 func pluginOwnerForKeyItem(sourceID, ptr string, owners map[string]string) string {
 	var kind string
 	switch {
@@ -865,11 +909,11 @@ func pluginOwnerForKeyItem(sourceID, ptr string, owners map[string]string) strin
 	default:
 		return "" // hooks, or a shape with no per-entry provenance
 	}
-	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
-	if len(parts) < 2 {
+	_, id, ok := keyItemPointerParts(ptr)
+	if !ok {
 		return ""
 	}
-	return owners[kind+"/"+jsonkeys.UnescapeToken(parts[1])]
+	return owners[kind+"/"+id]
 }
 
 // collectReconcileItems builds reconcile's flat item list from a rendered plan
@@ -1064,7 +1108,7 @@ func (s *reconcileSession) attemptWriteBack(it reconcileItem) bool {
 	if srcFile != "" {
 		prior, priorWritten = s.writtenSources[srcFile]
 	}
-	werr := writeBackItem(s.cmd, s.home, it)
+	werr := s.writeBackItem(it)
 	if errors.Is(werr, errDestDroppedServer) {
 		// Tombstone: the user deleted this MCP server from the native config, and
 		// chose write-back (per-item [w], confirmed bulk [W], or --auto-writeback)
@@ -1154,13 +1198,23 @@ func (s *reconcileSession) itemSourceFile(it reconcileItem) string {
 		}
 		return filepath.Join(s.home, it.op.SourceID)
 	}
-	return pointerSourceFile(s.reg, s.home, it.agentName, it.ptr, s.hookEvents)
+	return pointerSourceFile(s.reg, s.home, it.agentName, it.op.SourceID, it.ptr, s.hookEvents)
 }
 
 // pointerSourceFile maps a NATIVE key-merge JSON pointer back to the canonical
 // source file that produced it. It is shared by reconcile's write-back and
 // `agentsync explain <path>#<pointer>`, which is the feature that made the
 // renamed-hook-event translation below load-bearing rather than latent.
+//
+// sourceID is the op's SourceID and is what names the component KIND
+// (keyItemKind) — never the pointer's root key. Root keys are per-agent data
+// that grow with every agent added and collide across agents, so the old
+// root allowlist ("mcpServers"/"mcp"/"mcp_servers", "lspServers"/"lsp") answered
+// "" for every breadth-tier root nobody remembered to add: `explain
+// <path>#/context_servers/<id>` (zed), `#/servers/<id>` (copilot) and
+// `#/amp.mcpServers/<id>` (amp) reported "assembled from several canonical
+// sources" instead of naming mcp/<id>.toml, and reconcile's multi-agent fan-out
+// guard could not see those items at all.
 //
 // agent names the rendering adapter, which matters for hooks: a RENAMING agent
 // (gemini `BeforeTool`, cursor `preToolUse`) spells the pointer segment
@@ -1178,18 +1232,18 @@ func (s *reconcileSession) itemSourceFile(it reconcileItem) string {
 // inversion costs a map lookup instead of rebuilding all 31 adapters per call.
 //
 // Returns "" when the pointer names no single canonical source-of-record.
-func pointerSourceFile(reg *adapter.Registry, home, agent, ptr string, canonicalEvents []string) string {
-	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
-	if len(parts) < 2 || parts[1] == "" {
+func pointerSourceFile(reg *adapter.Registry, home, agent, sourceID, ptr string, canonicalEvents []string) string {
+	_, id, ok := keyItemPointerParts(ptr)
+	if !ok {
 		return ""
 	}
-	switch parts[0] {
-	case "mcpServers", "mcp", "mcp_servers":
-		return filepath.Join(home, "mcp", parts[1]+".toml")
-	case "lspServers", "lsp":
-		return filepath.Join(home, "lsp", parts[1]+".toml")
+	switch keyItemKind(sourceID) {
+	case "mcp":
+		return filepath.Join(home, "mcp", id+".toml")
+	case "lsp":
+		return filepath.Join(home, "lsp", id+".toml")
 	case "hooks":
-		event, ok := canonicalHookEvent(reg, agent, parts[1], canonicalEvents)
+		event, ok := canonicalHookEvent(reg, agent, id, canonicalEvents)
 		if !ok {
 			return ""
 		}
@@ -1261,7 +1315,12 @@ func canonicalHookEvents(c source.Canonical) []string {
 // writeBackItem persists the current destination value for item it back into
 // the canonical source (~/.agentsync/). Only MCP-server items are fully
 // supported in v1; other item types fall back to a raw file copy.
-func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
+//
+// A session method, not a free function, because the key-item path needs the
+// session's adapter registry: the native→canonical MCP translation belongs to
+// the adapter that RENDERED the destination (adapter.MCPSpecIngester), and the
+// registry is the only thing that maps it.agentName to that adapter.
+func (s *reconcileSession) writeBackItem(it reconcileItem) error {
 	// A plugin-provided component has no canonical file of its own: it is
 	// re-derived from the plugin cache on every load. Writing the destination
 	// back would MINT one under ~/.agentsync/, and the next load would hold two
@@ -1286,97 +1345,100 @@ func writeBackItem(cmd *cobra.Command, home string, it reconcileItem) error {
 			what, it.pluginOwner, it.pluginOwner)
 	}
 	if it.ptr != "" {
-		return writeBackKeyItem(cmd, home, it)
+		return s.writeBackKeyItem(it)
 	}
-	return writeBackFileItem(home, it)
+	return writeBackFileItem(s.home, it)
 }
 
-// writeBackKeyItem handles key-level (merge-json-keys / merge-jsonc-keys) items.
-// For MCP servers it reconstructs a source.MCPServer from the destination JSON
-// and writes it with source.WriteMCP.
+// writeBackKeyItem handles key-level (merge-json-keys / merge-jsonc-keys /
+// merge-toml-keys) items. For MCP servers it reconstructs a source.MCPServer
+// from the destination and writes it through capture.Capture.
+//
+// Two things are DERIVED rather than matched against a list of pointer roots,
+// for the same reason pluginOwnerForKeyItem derives its kind (see the long
+// comment there):
+//
+//   - The component KIND comes from the op's SourceID ("mcp/…"). Root keys are
+//     per-agent DATA, not a fixed set — and they COLLIDE. `/mcpServers` is
+//     Claude's and also Cursor's, Gemini's, Windsurf's, Roo's, Cline's and
+//     eleven breadth-tier agents'; `/mcp` is OpenCode's and also Crush's. A
+//     hand-maintained root allowlist therefore cannot be made correct: it
+//     refused every root nobody remembered to add (zed's /context_servers,
+//     copilot's /servers, amp's /amp.mcpServers) AND silently mistranslated
+//     every root it matched for the wrong agent.
+//   - The DIALECT comes from the RENDERING ADAPTER, via the optional
+//     adapter.MCPSpecIngester extension. Only the adapter that wrote the bytes
+//     knows how to read them back: OpenCode's array-shaped `command` and
+//     `environment`, Codex's `http_headers`, Gemini's `httpUrl`, Windsurf's
+//     `serverUrl`, Roo's `streamable-http`, the breadth tier's per-Spec
+//     MCPTarget knobs. Routing by root key handed a Crush entry to OpenCode's
+//     inverse (demoting `args`/`env` into the Extra passthrough) and Gemini's
+//     or Windsurf's to Claude's 1:1 shape (dropping the URL out of the model
+//     entirely). Both were silent.
 //
 // For other key-level items (hooks, LSP, future shapes) write-back is not
 // implemented and we return a clear error so the user is not silently lied
 // to: the prior code returned nil and printed "write-back: <label>", giving
 // the impression the hand-edit had been persisted when in fact it had not
 // — the next apply would then destroy the user's edit.
-func writeBackKeyItem(cmd *cobra.Command, home string, it reconcileItem) error {
-	dest := readDestFile(it.op.MergeStrategy, it.op.Path)
-	// Expected ptr shape: /mcpServers/<serverID>/... (claude), /mcp/<serverID>/...
-	// (opencode), or /mcp_servers/<serverID>/... (codex). The container key also
-	// tells us the dest shape: Claude's `mcpServers` value matches the canonical
-	// model 1:1, but OpenCode's `mcp` and Codex's `mcp_servers` values are NATIVE
-	// shapes (OpenCode: command as a string array, `environment` not `env`, type
-	// local|remote; Codex: `http_headers`, url-implies-http), so they must be
-	// translated through the adapter's inverse-of-Render rather than unmarshaled.
-	parts := strings.SplitN(strings.TrimPrefix(it.ptr, "/"), "/", 3)
-	if len(parts) >= 2 && (parts[0] == "mcpServers" || parts[0] == "mcp" || parts[0] == "mcp_servers") {
-		topKey := parts[0]
-		serverID := parts[1]
-		// serverID comes from the (native-config-derived) JSON pointer and can
-		// hold control bytes; keep the raw value for lookup/canonical ID but use
-		// a sanitized copy in any error surfaced to the terminal (issue #93/#171).
-		serverIDDisp := ui.Sanitize(serverID)
-		mcpServers, _ := dest[topKey].(map[string]any)
-		if mcpServers == nil {
-			return fmt.Errorf("%s not found in destination", topKey)
-		}
-		specRaw, ok := mcpServers[serverID]
-		if !ok {
-			// Server removed from dest: the user deleted it from the native
-			// config and chose write-back (per-item [w], confirmed bulk [W], or
-			// --auto-writeback) to persist that. Signal a tombstone;
-			// attemptWriteBack deletes the canonical mcp/<id>.toml through the
-			// approved os.Remove funnel (a pure deletion carries no secret), with
-			// the multi-agent fan-out guard.
-			return errDestDroppedServer
-		}
-		var spec source.MCPServerSpec
-		switch topKey {
-		case "mcp":
-			// OpenCode native shape → canonical, via the single adapter translator.
-			rawMap, _ := specRaw.(map[string]any)
-			if rawMap == nil {
-				return fmt.Errorf("opencode mcp spec %s is not an object", serverIDDisp)
-			}
-			spec = opencode.IngestMCPSpec(rawMap)
-		case "mcp_servers":
-			// Codex native shape (TOML-decoded map) → canonical.
-			rawMap, _ := specRaw.(map[string]any)
-			if rawMap == nil {
-				return fmt.Errorf("codex mcp spec %s is not an object", serverIDDisp)
-			}
-			spec = codex.IngestMCPSpec(rawMap)
-		default:
-			// Claude's mcpServers value matches the canonical model 1:1.
-			specBytes, err := json.Marshal(specRaw)
-			if err != nil {
-				return fmt.Errorf("marshal mcp spec %s: %w", serverIDDisp, err)
-			}
-			if err := json.Unmarshal(specBytes, &spec); err != nil {
-				return fmt.Errorf("unmarshal mcp spec %s: %w", serverIDDisp, err)
-			}
-			// json.Unmarshal into the struct drops unmodeled native keys; capture
-			// them into Extra so write-back is not field-lossy (matching ingest and
-			// the opencode/codex branches above).
-			if rawMap, ok := specRaw.(map[string]any); ok {
-				spec.Extra = claude.ExtraNativeKeys(rawMap, "type", "command", "args", "env", "url", "headers")
-			}
-		}
-		// The spec was reconstructed from the destination, where apply wrote any
-		// ${secret:…} as resolved cleartext and which never carries source-only
-		// fields (agents/enabled). capture.Capture re-references the secrets and
-		// preserves those fields before writing — the same single boundary import
-		// uses, so the two paths can't drift apart again.
-		single := source.Canonical{MCPServers: []source.MCPServer{{ID: serverID, Server: spec}}}
-		if _, err := capture.Capture(home, &single, capture.Opts{Warn: cmd.ErrOrStderr()}); err != nil {
-			return err
-		}
-		return nil
+func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
+	if keyItemKind(it.op.SourceID) != "mcp" {
+		// Unsupported component kind (hooks, lsp, or an op with no per-entry
+		// canonical provenance). DO NOT silently no-op — the success message
+		// would be a lie.
+		return fmt.Errorf("write-back for pointer %q is not implemented in v1; only MCP-server items can be "+
+			"written back today — choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item", it.ptr)
 	}
-	// Unsupported pointer shape (hooks, lsp, …). DO NOT silently no-op —
-	// the success message would be a lie.
-	return fmt.Errorf("write-back for pointer %q is not implemented in v1; only /mcpServers/* (claude), /mcp/* (opencode) and /mcp_servers/* (codex) items can be written back today — choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item", it.ptr)
+	rootKey, serverID, ok := keyItemPointerParts(it.ptr)
+	if !ok {
+		return fmt.Errorf("write-back for pointer %q names no MCP server (expected /<root key>/<server id>) — "+
+			"choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item", it.ptr)
+	}
+	// serverID is decoded from a JSON pointer and becomes a canonical filename;
+	// keep the raw value for the dest lookup and the canonical ID but use a
+	// sanitized copy in any error surfaced to the terminal (issue #93/#171).
+	serverIDDisp := ui.Sanitize(serverID)
+	ing, ok := s.reg.Lookup(it.agentName).(adapter.MCPSpecIngester)
+	if !ok {
+		// Defensive, and unreachable while the registry-wide guard
+		// TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer holds: an adapter
+		// that renders an MCP key-merge op MUST declare its inverse. Refusing
+		// beats guessing a dialect — a wrong guess writes a mistranslated
+		// canonical server that the next apply pushes to every other agent.
+		return fmt.Errorf("write-back for pointer %q is not implemented for agent %s: its adapter declares no "+
+			"native MCP translation — choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item",
+			it.ptr, ui.Sanitize(it.agentName))
+	}
+	dest := readDestFile(it.op.MergeStrategy, it.op.Path)
+	servers, _ := dest[rootKey].(map[string]any)
+	if servers == nil {
+		return fmt.Errorf("%s not found in destination", ui.Sanitize(rootKey))
+	}
+	specRaw, ok := servers[serverID]
+	if !ok {
+		// Server removed from dest: the user deleted it from the native
+		// config and chose write-back (per-item [w], confirmed bulk [W], or
+		// --auto-writeback) to persist that. Signal a tombstone;
+		// attemptWriteBack deletes the canonical mcp/<id>.toml through the
+		// approved os.Remove funnel (a pure deletion carries no secret), with
+		// the multi-agent fan-out guard.
+		return errDestDroppedServer
+	}
+	rawMap, _ := specRaw.(map[string]any)
+	if rawMap == nil {
+		return fmt.Errorf("%s mcp spec %s is not an object", ui.Sanitize(it.agentName), serverIDDisp)
+	}
+	// The spec is reconstructed from the destination through the rendering
+	// adapter's own inverse-of-Render, where apply wrote any ${secret:…} as
+	// resolved cleartext and which never carries source-only fields
+	// (agents/enabled). capture.Capture re-references the secrets and preserves
+	// those fields before writing — the same single boundary import uses, so the
+	// two paths can't drift apart again.
+	single := source.Canonical{MCPServers: []source.MCPServer{{ID: serverID, Server: ing.IngestMCPSpec(rawMap)}}}
+	if _, err := capture.Capture(s.home, &single, capture.Opts{Warn: s.cmd.ErrOrStderr()}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // writeBackFileItem handles file-level (replace strategy) items by copying

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -821,11 +821,12 @@ func pluginProvidedSourceIDs(c source.Canonical) map[string]string {
 // ("mcp/* (multiple)", "hooks/* (multiple)"), and Continue's whole-file MCP form
 // is "mcp/<id>.toml", so a prefix test covers both spellings.
 //
-// This is the ONE place the kind is derived, shared by write-back and the
-// pointer→source-file inversion. It is deliberately NOT derived from the
-// pointer's root key: root keys are per-agent data that both grow and COLLIDE
-// (see pluginOwnerForKeyItem's comment), so any root-keyed classification is
-// wrong for some agent.
+// This is the ONE place the kind is derived, shared by write-back, the
+// pointer→source-file inversion, `explain`'s pointer→component mapping, the
+// plugin-owner lookup and the registry guard test. It is deliberately NOT
+// derived from the pointer's root key: root keys are per-agent data that both
+// grow and COLLIDE (see pluginOwnerForKeyItem's comment), so any root-keyed
+// classification is wrong for some agent.
 func keyItemKind(sourceID string) string {
 	switch {
 	case strings.HasPrefix(sourceID, "mcp/"):
@@ -1404,7 +1405,19 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 			"native MCP translation — choose [o]verride to push canonical to the dest, or [i]gnore to suppress this item",
 			it.ptr, ui.Sanitize(it.agentName))
 	}
-	dest := readDestFile(it.op.MergeStrategy, it.op.Path)
+	// Read and decode by hand rather than through readDestFile, which swallows
+	// read and parse errors into an empty map for the drift walk's benefit: a
+	// destination the user broke between the walk and the [w] keystroke (a
+	// truncated edit, a file moved away) must be named as such, not reported as
+	// a missing root key.
+	data, err := readDestBytes(it.op.Path)
+	if err != nil {
+		return fmt.Errorf("read destination %s: %w", it.op.Path, err)
+	}
+	dest := map[string]any{}
+	if err := decodeDestBytes(it.op.MergeStrategy, data, &dest); err != nil {
+		return fmt.Errorf("destination %s does not parse (%s): %w", it.op.Path, it.op.MergeStrategy, err)
+	}
 	servers, _ := dest[rootKey].(map[string]any)
 	if servers == nil {
 		return fmt.Errorf("%s is absent from the destination or is not an object", ui.Sanitize(rootKey))

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -839,28 +839,28 @@ func keyItemKind(sourceID string) string {
 	}
 }
 
-// keyItemPointerParts splits a key-merge JSON pointer into its container root
-// key and the DECODED second segment (the server id / hook event). ok is false
-// when the pointer has no non-empty second segment, i.e. it names no single
-// entry.
+// keyItemPointerParts splits a key-merge JSON pointer into its DECODED
+// container root key and DECODED second segment (the server id / hook event).
+// ok is false when the pointer has no non-empty second segment, i.e. it names
+// no single entry.
 //
-// The second segment is JSON-pointer ENCODED on the way in — render.CollectPointers
-// builds every pointer with jsonkeys.EscapeToken — so it must be decoded before
-// it is used as a map key or a canonical filename (RFC 6901 §3: ~1 → "/", ~0 →
-// "~"). Using it raw was a live bug: an MCP server id containing "~" reached
-// write-back as "srv~0id", missed the destination map, and was reported as a
-// destination-side DELETION ("write-back: removed source mcp/srv~0id.toml") —
-// discarding the user's edit while telling them it had been persisted.
-//
-// The root key is returned VERBATIM: it is a single pointer segment produced by
-// the adapter's own render, and it is only ever used to index the decoded
-// destination object, never as a path.
+// Both segments are JSON-pointer ENCODED on the way in — render.CollectPointers
+// builds every pointer with jsonkeys.EscapeToken on each key — so both are
+// decoded (RFC 6901 §3: ~1 → "/", ~0 → "~") before use: the root key indexes
+// the decoded destination object, the id becomes a map key and a canonical
+// filename. Using the id raw was a live bug: an MCP server id containing "~"
+// reached write-back as "srv~0id", missed the destination map, and was reported
+// as a destination-side DELETION ("write-back: removed source mcp/srv~0id.toml")
+// — discarding the user's edit while telling them it had been persisted. No
+// rendered root key holds "~" or "/" today, so decoding it changes nothing
+// observable; it is decoded so the two segments cannot disagree the day one
+// does, which would be that same phantom tombstone one level up.
 func keyItemPointerParts(ptr string) (rootKey, id string, ok bool) {
 	parts := strings.SplitN(strings.TrimPrefix(ptr, "/"), "/", 3)
 	if len(parts) < 2 || parts[1] == "" {
 		return "", "", false
 	}
-	return parts[0], jsonkeys.UnescapeToken(parts[1]), true
+	return jsonkeys.UnescapeToken(parts[0]), jsonkeys.UnescapeToken(parts[1]), true
 }
 
 // pluginOwnerForKeyItem resolves the plugin owning the MCP/LSP server a
@@ -900,13 +900,8 @@ func keyItemPointerParts(ptr string) (rootKey, id string, ok bool) {
 // Pointer segments are JSON-pointer encoded, so keyItemPointerParts decodes
 // ~1/~0 first (RFC 6901 §3) — an id containing '/' would otherwise never match.
 func pluginOwnerForKeyItem(sourceID, ptr string, owners map[string]string) string {
-	var kind string
-	switch {
-	case strings.HasPrefix(sourceID, "mcp/"):
-		kind = "mcp"
-	case strings.HasPrefix(sourceID, "lsp/"):
-		kind = "lsp"
-	default:
+	kind := keyItemKind(sourceID)
+	if kind != "mcp" && kind != "lsp" {
 		return "" // hooks, or a shape with no per-entry provenance
 	}
 	_, id, ok := keyItemPointerParts(ptr)
@@ -1412,7 +1407,7 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	dest := readDestFile(it.op.MergeStrategy, it.op.Path)
 	servers, _ := dest[rootKey].(map[string]any)
 	if servers == nil {
-		return fmt.Errorf("%s not found in destination", ui.Sanitize(rootKey))
+		return fmt.Errorf("%s is absent from the destination or is not an object", ui.Sanitize(rootKey))
 	}
 	specRaw, ok := servers[serverID]
 	if !ok {
@@ -1428,6 +1423,13 @@ func (s *reconcileSession) writeBackKeyItem(it reconcileItem) error {
 	if rawMap == nil {
 		return fmt.Errorf("%s mcp spec %s is not an object", ui.Sanitize(it.agentName), serverIDDisp)
 	}
+	// The inverse COERCES: a non-string element inside a string-typed native
+	// field (a number in `args`, a bool in `env`) is dropped, on write-back
+	// exactly as on `import` — every dialect's translator has always read that
+	// way, and Claude's 1:1 shape used to refuse such an entry only because it
+	// went through a typed json.Unmarshal. Documented in the capability matrix;
+	// a refusal instead would need the interface to return an error (#267).
+	//
 	// The spec is reconstructed from the destination through the rendering
 	// adapter's own inverse-of-Render, where apply wrote any ${secret:…} as
 	// resolved cleartext and which never carries source-only fields

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -179,7 +179,7 @@ func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
 }
 
 // noInverseAdapter is an adapter that is REGISTERED but declares no
-// MCPSpecIngester: the shape the registry-wide guard makes unrepresentable for
+// MCPSpecIngester: the shape the registry-wide guard turns into a failing test for
 // the real adapters, driven here by hand so the refusal it exists to guard
 // (writeBackKeyItem's "declares no native MCP translation") has a test that
 // fails when the refusal is removed. The embedded Adapter is nil — only Name()
@@ -207,10 +207,10 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 	// cmd is set so a refusal that regressed into a fall-through reports as the
 	// assertion below, not as a nil-deref panic at capture.Capture's Warn.
 	s := &reconcileSession{reg: reg, home: t.TempDir(), cmd: &cobra.Command{}}
-	item := func(agent, strategy, dest, ptr string) reconcileItem {
+	item := func(agent, strategy, sourceID, dest, ptr string) reconcileItem {
 		return reconcileItem{
 			agentName: agent,
-			op:        adapter.FileOp{Path: dest, MergeStrategy: strategy, SourceID: "mcp/* (multiple)"},
+			op:        adapter.FileOp{Path: dest, MergeStrategy: strategy, SourceID: sourceID},
 			ptr:       ptr,
 		}
 	}
@@ -218,12 +218,38 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		name     string
 		agent    string
 		strategy string
+		sourceID string // "" means the ordinary "mcp/* (multiple)"
 		dest     string // the destination's bytes; "" with missing=true means no file at all
 		missing  bool
+		dir      bool // the destination path is a directory
 		ptr      string
 		want     []string // substrings the error must carry
 		reject   []string // substrings it must NOT carry
 	}{
+		{
+			// The kind gate: a key item whose SourceID is not an MCP section is
+			// refused before anything is read. TestReconcile_HookWriteBackIsRefused
+			// pins it end to end; this row pins it beside its siblings.
+			name: "component kind is not mcp", agent: "claude", strategy: "merge-json-keys",
+			sourceID: "hooks/* (multiple)", dest: `{"hooks": {"PreToolUse": []}}`, ptr: "/hooks/PreToolUse",
+			want: []string{"not implemented in v1", "MCP-server items"},
+		},
+		{
+			// Defensive in production (the render never emits a one-segment
+			// pointer for an object root), reachable here: the refusal must
+			// still refuse rather than index a nil map.
+			name: "pointer names no server", agent: "claude", strategy: "merge-json-keys",
+			dest: `{"mcpServers": {"github": {"command": "npx"}}}`, ptr: "/mcpServers",
+			want: []string{"names no MCP server"},
+		},
+		{
+			// The non-regular arm of the read refusal: no [o]verride offered,
+			// because the re-render's convergence read would hang on it (#241).
+			name: "destination is a directory", agent: "claude", strategy: "merge-json-keys",
+			dir: true, ptr: "/mcpServers/github",
+			want:   []string{"read destination", "not a regular file", "remove or replace", "[i]gnore"},
+			reject: []string{"[o]verride"},
+		},
 		{
 			name: "root key absent", agent: "claude", strategy: "merge-json-keys", dest: `{}`, ptr: "/mcpServers/github",
 			want: []string{"mcpServers", "absent"},
@@ -270,7 +296,7 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		{
 			// Reachable only by hand: the registry-wide guard makes a REAL
 			// adapter that renders MCP key items without the inverse
-			// unrepresentable. The refusal must still refuse — a nil here would
+			// a failing test. The refusal must still refuse — a nil here would
 			// call a nil interface, and a guess at a dialect would be worse.
 			name: "agent declares no inverse", agent: "noinverse", strategy: "merge-json-keys",
 			dest: `{"mcpServers": {"github": {"command": "npx"}}}`, ptr: "/mcpServers/github",
@@ -280,12 +306,21 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dest := filepath.Join(t.TempDir(), "dest")
-			if !tc.missing {
+			switch {
+			case tc.dir:
+				if err := os.Mkdir(dest, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			case !tc.missing:
 				if err := os.WriteFile(dest, []byte(tc.dest), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
-			err := s.writeBackKeyItem(item(tc.agent, tc.strategy, dest, tc.ptr))
+			sourceID := tc.sourceID
+			if sourceID == "" {
+				sourceID = "mcp/* (multiple)"
+			}
+			err := s.writeBackKeyItem(item(tc.agent, tc.strategy, sourceID, dest, tc.ptr))
 			if err == nil {
 				t.Fatal("writeBackKeyItem = nil, want a refusal: a nil here prints \"write-back:\" for an edit that was not persisted")
 			}
@@ -299,7 +334,7 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 					t.Errorf("err = %q names the wrong cause (%q)", err, r)
 				}
 			}
-			if tc.missing {
+			if tc.missing || tc.dir {
 				// os.ReadFile's error carries the path too; the refusal must not
 				// print it twice ("read destination X: open X: …").
 				if n := strings.Count(err.Error(), dest); n != 1 {
@@ -317,7 +352,7 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		if err := os.WriteFile(dest, []byte(`{"mcpServers": {"bad\u001b[31mid": 5}}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		err := s.writeBackKeyItem(item("claude", "merge-json-keys", dest, "/mcpServers/bad\x1b[31mid"))
+		err := s.writeBackKeyItem(item("claude", "merge-json-keys", "mcp/* (multiple)", dest, "/mcpServers/bad\x1b[31mid"))
 		if err == nil {
 			t.Fatal("want a refusal")
 		}
@@ -328,4 +363,22 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 			t.Fatalf("err = %q carries the raw ESC byte from the native id", err)
 		}
 	})
+}
+
+// TestWriteBackFileItem_ReadRefusalNamesThePathOnce pins the whole-file arm of
+// destReadRefusal the way the key-item table pins its own: os.ReadFile's error
+// already carries the path, so the message must not print it twice.
+func TestWriteBackFileItem_ReadRefusalNamesThePathOnce(t *testing.T) {
+	testenv.RequireContainer(t)
+	dest := filepath.Join(t.TempDir(), "gone.md")
+	err := writeBackFileItem(t.TempDir(), reconcileItem{op: adapter.FileOp{Path: dest, SourceID: "demo"}})
+	if err == nil {
+		t.Fatal("writeBackFileItem = nil for a missing destination, want the read refusal")
+	}
+	if !strings.Contains(err.Error(), "[o]verride") {
+		t.Fatalf("err = %q, want the absent-destination remedy", err)
+	}
+	if n := strings.Count(err.Error(), dest); n != 1 {
+		t.Fatalf("err = %q names the path %d times, want once", err, n)
+	}
 }

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestKeyItemKind pins the ONE derivation of a key-merge item's component kind.
+// It comes from the op's SourceID, never from the pointer's root key — root keys
+// are per-agent data that grow with every agent added and COLLIDE across agents
+// (Claude, Cursor, Gemini, Windsurf, Roo, Cline and eleven breadth-tier specs
+// all use "mcpServers"; OpenCode and Crush both use "mcp"), so no root-keyed
+// classification can be right for every agent.
+func TestKeyItemKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		sourceID string
+		want     string
+	}{
+		{"key-merge mcp section", "mcp/* (multiple)", "mcp"},
+		{"whole-file mcp (continue)", "mcp/github.toml", "mcp"},
+		{"key-merge hooks section", "hooks/* (multiple)", "hooks"},
+		{"whole-file hooks", "hooks/PreToolUse.toml", "hooks"},
+		{"lsp, unreachable today but symmetric", "lsp/* (multiple)", "lsp"},
+		{"no provenance", "", ""},
+		{"a non-key component", "skills/demo/SKILL.md", ""},
+		{"a bare prefix without the separator is NOT mcp", "mcpServers", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := keyItemKind(tc.sourceID); got != tc.want {
+				t.Errorf("keyItemKind(%q) = %q, want %q", tc.sourceID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeyItemPointerParts pins the pointer split, and specifically the RFC 6901
+// decode of the second segment. render.CollectPointers builds every pointer
+// with jsonkeys.EscapeToken, so the segment arrives encoded; using it raw was a
+// live bug — an MCP server id containing "~" reached write-back as "til~0de",
+// missed the destination map, and was reported as a destination-side DELETION.
+//
+// The root key is returned verbatim: it is one pointer segment produced by the
+// adapter's own render and is only ever used to index the decoded destination
+// object, never as a path. Crush's "mcp", Zed's "context_servers", Copilot's
+// "servers" and Amp's flat dotted "amp.mcpServers" all pass through unchanged.
+func TestKeyItemPointerParts(t *testing.T) {
+	tests := []struct {
+		name     string
+		ptr      string
+		wantRoot string
+		wantID   string
+		wantOK   bool
+	}{
+		{"claude", "/mcpServers/github", "mcpServers", "github", true},
+		{"opencode", "/mcp/github", "mcp", "github", true},
+		{"codex", "/mcp_servers/github", "mcp_servers", "github", true},
+		{"zed", "/context_servers/github", "context_servers", "github", true},
+		{"copilot", "/servers/github", "servers", "github", true},
+		{"amp flat dotted root", "/amp.mcpServers/github", "amp.mcpServers", "github", true},
+		{"deeper pointer keeps the id", "/mcpServers/github/env/TOKEN", "mcpServers", "github", true},
+		{"tilde is decoded", "/mcpServers/til~0de", "mcpServers", "til~de", true},
+		{"slash is decoded", "/mcpServers/a~1b", "mcpServers", "a/b", true},
+		{"tilde-one is decoded in the right order", "/mcpServers/x~01", "mcpServers", "x~1", true},
+		{"hook event segment", "/hooks/BeforeTool", "hooks", "BeforeTool", true},
+		{"root only", "/mcpServers", "", "", false},
+		{"empty id", "/mcpServers/", "", "", false},
+		{"empty pointer", "", "", "", false},
+		{"unrooted pointer is tolerated", "mcpServers/github", "mcpServers", "github", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, id, ok := keyItemPointerParts(tc.ptr)
+			if root != tc.wantRoot || id != tc.wantID || ok != tc.wantOK {
+				t.Errorf("keyItemPointerParts(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.ptr, root, id, ok, tc.wantRoot, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestPointerSourceFile_KindFromSourceID pins the pointer→canonical-source
+// inversion now that the kind is derived. Before this, a second root allowlist
+// ("mcpServers"/"mcp"/"mcp_servers", "lspServers"/"lsp") answered "" for every
+// breadth-tier root nobody had added: `explain <path>#/context_servers/<id>`
+// (Zed), `#/servers/<id>` (Copilot) and `#/amp.mcpServers/<id>` (Amp) reported
+// "assembled from several canonical sources" instead of naming mcp/<id>.toml,
+// and reconcile's multi-agent fan-out guard could not see those items at all.
+func TestPointerSourceFile_KindFromSourceID(t *testing.T) {
+	reg := registryFactory()
+	const home = "/src"
+	events := []string{"PreToolUse"}
+
+	tests := []struct {
+		name     string
+		agent    string
+		sourceID string
+		ptr      string
+		want     string
+	}{
+		{"claude mcp", "claude", "mcp/* (multiple)", "/mcpServers/github", filepath.Join(home, "mcp", "github.toml")},
+		{"opencode mcp", "opencode", "mcp/* (multiple)", "/mcp/github", filepath.Join(home, "mcp", "github.toml")},
+		{"codex mcp", "codex", "mcp/* (multiple)", "/mcp_servers/github", filepath.Join(home, "mcp", "github.toml")},
+		{"zed mcp (was unresolvable)", "zed", "mcp/* (multiple)", "/context_servers/github", filepath.Join(home, "mcp", "github.toml")},
+		{"copilot mcp (was unresolvable)", "copilot", "mcp/* (multiple)", "/servers/github", filepath.Join(home, "mcp", "github.toml")},
+		{"amp mcp (was unresolvable)", "amp", "mcp/* (multiple)", "/amp.mcpServers/github", filepath.Join(home, "mcp", "github.toml")},
+		{"crush mcp is crush, not opencode", "crush", "mcp/* (multiple)", "/mcp/github", filepath.Join(home, "mcp", "github.toml")},
+		{"tilde id is decoded into the filename", "claude", "mcp/* (multiple)", "/mcpServers/til~0de", filepath.Join(home, "mcp", "til~de.toml")},
+		{"lsp, unreachable today", "claude", "lsp/* (multiple)", "/lspServers/gopls", filepath.Join(home, "lsp", "gopls.toml")},
+		{"claude hook passes through", "claude", "hooks/* (multiple)", "/hooks/PreToolUse", filepath.Join(home, "hooks", "PreToolUse.toml")},
+		{"gemini hook is inverted", "gemini", "hooks/* (multiple)", "/hooks/BeforeTool", filepath.Join(home, "hooks", "PreToolUse.toml")},
+		{"a hook with no canonical equivalent", "gemini", "hooks/* (multiple)", "/hooks/BeforeModel", ""},
+		{"a root key alone names no entry", "claude", "mcp/* (multiple)", "/mcpServers", ""},
+		{"an op with no per-entry provenance", "claude", "", "/mcpServers/github", ""},
+		{"a non-key component SourceID", "claude", "skills/demo/SKILL.md", "/mcpServers/github", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pointerSourceFile(reg, home, tc.agent, tc.sourceID, tc.ptr, events)
+			if got != tc.want {
+				t.Errorf("pointerSourceFile(%s, %q, %q) = %q, want %q", tc.agent, tc.sourceID, tc.ptr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComponentFromPointer_KindFromSourceID pins `explain`'s (kind, name) for a
+// key-merge pointer, now that it shares keyItemKind / keyItemPointerParts with
+// reconcile. It was the fourth copy of the pointer-root allowlist: a breadth-tier
+// root nobody had listed answered ("", "") — so `explain <path>#<ptr>` printed no
+// component line for zed/copilot/amp items and matched none of their skips,
+// plugin origins or secret references — and a `~`-bearing id was named under its
+// escaped spelling.
+func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
+	reg := registryFactory()
+	events := []string{"PreToolUse"}
+
+	tests := []struct {
+		name     string
+		agent    string
+		sourceID string
+		ptr      string
+		wantKind string
+		wantName string
+	}{
+		{"claude mcp", "claude", "mcp/* (multiple)", "/mcpServers/github", "mcp", "github"},
+		{"opencode mcp", "opencode", "mcp/* (multiple)", "/mcp/github", "mcp", "github"},
+		{"codex mcp", "codex", "mcp/* (multiple)", "/mcp_servers/github", "mcp", "github"},
+		{"zed mcp (was unresolvable)", "zed", "mcp/* (multiple)", "/context_servers/github", "mcp", "github"},
+		{"copilot mcp (was unresolvable)", "copilot", "mcp/* (multiple)", "/servers/github", "mcp", "github"},
+		{"amp mcp (was unresolvable)", "amp", "mcp/* (multiple)", "/amp.mcpServers/github", "mcp", "github"},
+		{"crush mcp is crush, not opencode", "crush", "mcp/* (multiple)", "/mcp/github", "mcp", "github"},
+		{"tilde id is decoded into the name", "claude", "mcp/* (multiple)", "/mcpServers/til~0de", "mcp", "til~de"},
+		{"lsp, unreachable today", "claude", "lsp/* (multiple)", "/lspServers/gopls", "lsp", "gopls"},
+		{"claude hook passes through", "claude", "hooks/* (multiple)", "/hooks/PreToolUse", "hook", "PreToolUse"},
+		{"gemini hook is inverted", "gemini", "hooks/* (multiple)", "/hooks/BeforeTool", "hook", "PreToolUse"},
+		{"a hook with no canonical equivalent keeps the kind", "gemini", "hooks/* (multiple)", "/hooks/BeforeModel", "hook", ""},
+		{"a root key alone names no entry", "claude", "mcp/* (multiple)", "/mcpServers", "", ""},
+		{"an op with no per-entry provenance", "claude", "", "/mcpServers/github", "", ""},
+		{"a non-key component SourceID", "claude", "skills/demo/SKILL.md", "/mcpServers/github", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, name := componentFromPointer(reg, tc.agent, tc.sourceID, tc.ptr, events)
+			if kind != tc.wantKind || name != tc.wantName {
+				t.Errorf("componentFromPointer(%s, %q, %q) = (%q, %q), want (%q, %q)",
+					tc.agent, tc.sourceID, tc.ptr, kind, name, tc.wantKind, tc.wantName)
+			}
+		})
+	}
+}

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -179,8 +179,8 @@ func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
 }
 
 // noInverseAdapter is an adapter that is REGISTERED but declares no
-// MCPSpecIngester: the shape the registry-wide guard turns into a failing test for
-// the real adapters, driven here by hand so the refusal it exists to guard
+// MCPSpecIngester: the shape the registry-wide guard turns into a failing test
+// for the real adapters, driven here by hand so the refusal it exists to guard
 // (writeBackKeyItem's "declares no native MCP translation") has a test that
 // fails when the refusal is removed. The embedded Adapter is nil — only Name()
 // is called on the way to the refusal.
@@ -294,10 +294,10 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 			want: []string{"read destination", "[o]verride"},
 		},
 		{
-			// Reachable only by hand: the registry-wide guard makes a REAL
-			// adapter that renders MCP key items without the inverse
-			// a failing test. The refusal must still refuse — a nil here would
-			// call a nil interface, and a guess at a dialect would be worse.
+			// Reachable only by hand: for a REAL adapter that renders MCP key
+			// items without the inverse, the registry-wide guard is a failing
+			// test. The refusal must still refuse — a nil here would call a nil
+			// interface, and a guess at a dialect would be worse.
 			name: "agent declares no inverse", agent: "noinverse", strategy: "merge-json-keys",
 			dest: `{"mcpServers": {"github": {"command": "npx"}}}`, ptr: "/mcpServers/github",
 			want: []string{"noinverse", "declares no native MCP translation"},
@@ -381,4 +381,94 @@ func TestWriteBackFileItem_ReadRefusalNamesThePathOnce(t *testing.T) {
 	if n := strings.Count(err.Error(), dest); n != 1 {
 		t.Fatalf("err = %q names the path %d times, want once", err, n)
 	}
+}
+
+// TestWriteBackFileItem_Refusals pins the whole-file arm's own refusals the way
+// TestWriteBackKeyItem_Refusals pins the key item's: each row is one
+// `return fmt.Errorf(...)` in writeBackFileItem that must fail a test when it
+// becomes `return nil`. The two SourceID refusals had no such test. The
+// secret-bearing-kind refusal is new: Continue's per-server MCP file — the one
+// whole-file render of a kind walkSecretFields visits — used to be copied
+// VERBATIM into ~/.agentsync/mcp/<id>.toml: the agent's YAML into a canonical
+// TOML file, with the secrets the render had resolved in cleartext, outside
+// capture.Capture. A refusal that still wrote would be the same bug with a
+// message, so every row also asserts the canonical tree stayed empty.
+func TestWriteBackFileItem_Refusals(t *testing.T) {
+	testenv.RequireContainer(t)
+	tests := []struct {
+		name     string
+		agent    string
+		sourceID string
+		want     []string
+	}{
+		{
+			name: "no SourceID", agent: "claude", sourceID: "",
+			want: []string{"requires a single source-of-record", "[o]verride"},
+		},
+		{
+			name: "multiple source fragments", agent: "claude", sourceID: "skills/* (multiple)",
+			want: []string{"concatenation of multiple source fragments", "strand the others"},
+		},
+		{
+			name: "mcp whole-file render (continue)", agent: "continue", sourceID: filepath.Join("mcp", "gh.toml"),
+			want: []string{
+				"refused", "continue's whole-file render of the mcp component \"gh\"", "verbatim", "cleartext",
+				"`agentsync import continue:mcp:gh`", "[o]verride",
+			},
+		},
+		{
+			name: "lsp whole-file render", agent: "x", sourceID: "lsp/gopls.toml",
+			want: []string{"refused", "lsp component \"gopls\"", "`agentsync import x:lsp:gopls`"},
+		},
+		{
+			name: "hooks whole-file render", agent: "x", sourceID: "hooks/PreToolUse.toml",
+			want: []string{"refused", "hooks component \"PreToolUse\"", "`agentsync import x:hook:PreToolUse`"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			dest := filepath.Join(t.TempDir(), "dest.yaml")
+			if err := os.WriteFile(dest, []byte("mcpServers:\n- name: gh\n  command: npm\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := writeBackFileItem(home, reconcileItem{agentName: tc.agent, op: adapter.FileOp{Path: dest, SourceID: tc.sourceID}})
+			if err == nil {
+				t.Fatal("writeBackFileItem = nil, want a refusal")
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("err = %q\n  missing %q", err, w)
+				}
+			}
+			entries, rerr := os.ReadDir(home)
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			if len(entries) != 0 {
+				t.Errorf("a refusal still wrote into the canonical tree: %v", entries)
+			}
+		})
+	}
+	// Positive control: a text component — whose canonical form IS the rendered
+	// text — still writes back verbatim, so the kind gate is not over-broad.
+	t.Run("text component still writes back verbatim", func(t *testing.T) {
+		home := t.TempDir()
+		dest := filepath.Join(t.TempDir(), "hello.md")
+		const body = "# hello\n"
+		if err := os.WriteFile(dest, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		it := reconcileItem{agentName: "claude", op: adapter.FileOp{Path: dest, SourceID: filepath.Join("commands", "hello.md")}}
+		if err := writeBackFileItem(home, it); err != nil {
+			t.Fatalf("writeBackFileItem = %v for a command, want the verbatim write", err)
+		}
+		got, err := os.ReadFile(filepath.Join(home, "commands", "hello.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != body {
+			t.Fatalf("canonical commands/hello.md = %q, want %q", got, body)
+		}
+	})
 }

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spxrogers/agentsync/internal/adapter"
 	"github.com/spxrogers/agentsync/internal/testenv"
 )
@@ -186,7 +187,9 @@ func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
 // would have turned a plausible hand-edit into a silent "write-back:" lie.
 func TestWriteBackKeyItem_Refusals(t *testing.T) {
 	testenv.RequireContainer(t)
-	s := &reconcileSession{reg: registryFactory(), home: t.TempDir()}
+	// cmd is set so a refusal that regressed into a fall-through reports as the
+	// assertion below, not as a nil-deref panic at capture.Capture's Warn.
+	s := &reconcileSession{reg: registryFactory(), home: t.TempDir(), cmd: &cobra.Command{}}
 	item := func(dest, ptr string) reconcileItem {
 		return reconcileItem{
 			agentName: "claude",
@@ -241,6 +244,44 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		}
 		if strings.Contains(err.Error(), "\x1b") {
 			t.Fatalf("err = %q carries the raw ESC byte from the native id", err)
+		}
+	})
+}
+
+// TestWriteBackKeyItem_UnreadableDestination pins the third refusal: a
+// destination that cannot be read or parsed at the moment of the [w] keystroke
+// (reconcile is interactive, so the user can break the file between the drift
+// walk and the write-back) is named as such, rather than reported as a missing
+// root key by readDestFile's error-swallowing read.
+func TestWriteBackKeyItem_UnreadableDestination(t *testing.T) {
+	testenv.RequireContainer(t)
+	// cmd is set so a refusal that regressed into a fall-through reports as the
+	// assertion below, not as a nil-deref panic at capture.Capture's Warn.
+	s := &reconcileSession{reg: registryFactory(), home: t.TempDir(), cmd: &cobra.Command{}}
+	item := func(dest string) reconcileItem {
+		return reconcileItem{
+			agentName: "claude",
+			op:        adapter.FileOp{Path: dest, MergeStrategy: "merge-json-keys", SourceID: "mcp/* (multiple)"},
+			ptr:       "/mcpServers/github",
+		}
+	}
+	t.Run("missing file", func(t *testing.T) {
+		err := s.writeBackKeyItem(item(filepath.Join(t.TempDir(), "gone.json")))
+		if err == nil || !strings.Contains(err.Error(), "read destination") {
+			t.Fatalf("err = %v, want the read refusal", err)
+		}
+	})
+	t.Run("truncated file", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "claude.json")
+		if err := os.WriteFile(dest, []byte(`{ "mcpServers": `), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		err := s.writeBackKeyItem(item(dest))
+		if err == nil || !strings.Contains(err.Error(), "does not parse") {
+			t.Fatalf("err = %v, want the parse refusal", err)
+		}
+		if strings.Contains(err.Error(), "absent from the destination") {
+			t.Fatalf("err = %q names a missing root key for a file that does not parse", err)
 		}
 	})
 }

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -178,50 +178,132 @@ func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
 	}
 }
 
-// TestWriteBackKeyItem_Refusals pins the two refusals a hand-edited destination
-// can trigger before any translation happens — the root key missing or not an
-// object, and the entry not an object — and that the id surfaced in the second
-// is sanitized: the id comes from a native file, so a control byte in it must
-// not reach the terminal raw (issue #93/#171). Both refusals used to fail no
-// test: replacing either with `return nil` was green across the package, which
-// would have turned a plausible hand-edit into a silent "write-back:" lie.
+// noInverseAdapter is an adapter that is REGISTERED but declares no
+// MCPSpecIngester: the shape the registry-wide guard makes unrepresentable for
+// the real adapters, driven here by hand so the refusal it exists to guard
+// (writeBackKeyItem's "declares no native MCP translation") has a test that
+// fails when the refusal is removed. The embedded Adapter is nil — only Name()
+// is called on the way to the refusal.
+type noInverseAdapter struct {
+	adapter.Adapter
+	name string
+}
+
+func (a noInverseAdapter) Name() string { return a.name }
+
+// TestWriteBackKeyItem_Refusals pins every refusal a key-item write-back can
+// raise before any translation happens, and that the id surfaced in the
+// entry refusal is sanitized (the id comes from a native file, so a control
+// byte in it must not reach the terminal raw — issue #93/#171). These used to
+// fail no test: replacing any of them with `return nil` was green across the
+// package, which would have turned a plausible hand-edit into a silent
+// "write-back:" lie.
 func TestWriteBackKeyItem_Refusals(t *testing.T) {
 	testenv.RequireContainer(t)
+	reg := registryFactory()
+	if err := reg.Register(noInverseAdapter{name: "noinverse"}); err != nil {
+		t.Fatal(err)
+	}
 	// cmd is set so a refusal that regressed into a fall-through reports as the
 	// assertion below, not as a nil-deref panic at capture.Capture's Warn.
-	s := &reconcileSession{reg: registryFactory(), home: t.TempDir(), cmd: &cobra.Command{}}
-	item := func(dest, ptr string) reconcileItem {
+	s := &reconcileSession{reg: reg, home: t.TempDir(), cmd: &cobra.Command{}}
+	item := func(agent, strategy, dest, ptr string) reconcileItem {
 		return reconcileItem{
-			agentName: "claude",
-			op:        adapter.FileOp{Path: dest, MergeStrategy: "merge-json-keys", SourceID: "mcp/* (multiple)"},
+			agentName: agent,
+			op:        adapter.FileOp{Path: dest, MergeStrategy: strategy, SourceID: "mcp/* (multiple)"},
 			ptr:       ptr,
 		}
 	}
 	tests := []struct {
-		name string
-		dest string // the destination's JSON
-		ptr  string
-		want []string // substrings the error must carry
+		name     string
+		agent    string
+		strategy string
+		dest     string // the destination's bytes; "" with missing=true means no file at all
+		missing  bool
+		ptr      string
+		want     []string // substrings the error must carry
+		reject   []string // substrings it must NOT carry
 	}{
-		{"root key absent", `{}`, "/mcpServers/github", []string{"mcpServers", "absent"}},
-		{"root key is an array", `{"mcpServers": []}`, "/mcpServers/github", []string{"mcpServers", "not an object"}},
-		{"root key is a scalar", `{"mcpServers": 1}`, "/mcpServers/github", []string{"mcpServers", "not an object"}},
-		{"entry is a scalar", `{"mcpServers": {"github": 5}}`, "/mcpServers/github", []string{"claude", "github", "not an object"}},
-		{"entry is an array", `{"mcpServers": {"github": []}}`, "/mcpServers/github", []string{"github", "not an object"}},
+		{
+			name: "root key absent", agent: "claude", strategy: "merge-json-keys", dest: `{}`, ptr: "/mcpServers/github",
+			want: []string{"mcpServers", "absent"},
+		},
+		{
+			name: "root key is an array", agent: "claude", strategy: "merge-json-keys", dest: `{"mcpServers": []}`, ptr: "/mcpServers/github",
+			want: []string{"mcpServers", "not an object"},
+		},
+		{
+			name: "root key is a scalar", agent: "claude", strategy: "merge-json-keys", dest: `{"mcpServers": 1}`, ptr: "/mcpServers/github",
+			want: []string{"mcpServers", "not an object"},
+		},
+		{
+			name: "entry is a scalar", agent: "claude", strategy: "merge-json-keys", dest: `{"mcpServers": {"github": 5}}`, ptr: "/mcpServers/github",
+			want: []string{"claude", "github", "not an object"},
+		},
+		{
+			name: "entry is an array", agent: "claude", strategy: "merge-json-keys", dest: `{"mcpServers": {"github": []}}`, ptr: "/mcpServers/github",
+			want: []string{"github", "not an object"},
+		},
+		{
+			// The `>`-clobber shape. Whichever refusal names it, it must be refused:
+			// a zero-byte destination holds no server to write back.
+			name: "zero-byte file", agent: "claude", strategy: "merge-json-keys", dest: "", ptr: "/mcpServers/github",
+			want: []string{"mcpServers"},
+		},
+		{
+			// A destination the user broke between the drift walk and the [w]
+			// keystroke: readDestFile would swallow the parse error and report a
+			// missing root key; the by-hand read names the real cause.
+			name: "truncated JSON", agent: "claude", strategy: "merge-json-keys", dest: `{ "mcpServers": `, ptr: "/mcpServers/github",
+			want: []string{"does not parse", "merge-json-keys"}, reject: []string{"absent from the destination"},
+		},
+		{
+			// TOML decodes through a different arm than JSON/JSONC, and codex's
+			// config.toml is a live write-back destination.
+			name: "truncated TOML", agent: "codex", strategy: "merge-toml-keys", dest: "[mcp_servers.github\n", ptr: "/mcp_servers/github",
+			want: []string{"does not parse", "merge-toml-keys"}, reject: []string{"absent from the destination"},
+		},
+		{
+			name: "missing file", agent: "claude", strategy: "merge-json-keys", missing: true, ptr: "/mcpServers/github",
+			want: []string{"read destination", "[o]verride"},
+		},
+		{
+			// Reachable only by hand: the registry-wide guard makes a REAL
+			// adapter that renders MCP key items without the inverse
+			// unrepresentable. The refusal must still refuse — a nil here would
+			// call a nil interface, and a guess at a dialect would be worse.
+			name: "agent declares no inverse", agent: "noinverse", strategy: "merge-json-keys",
+			dest: `{"mcpServers": {"github": {"command": "npx"}}}`, ptr: "/mcpServers/github",
+			want: []string{"noinverse", "declares no native MCP translation"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dest := filepath.Join(t.TempDir(), "claude.json")
-			if err := os.WriteFile(dest, []byte(tc.dest), 0o644); err != nil {
-				t.Fatal(err)
+			dest := filepath.Join(t.TempDir(), "dest")
+			if !tc.missing {
+				if err := os.WriteFile(dest, []byte(tc.dest), 0o644); err != nil {
+					t.Fatal(err)
+				}
 			}
-			err := s.writeBackKeyItem(item(dest, tc.ptr))
+			err := s.writeBackKeyItem(item(tc.agent, tc.strategy, dest, tc.ptr))
 			if err == nil {
 				t.Fatal("writeBackKeyItem = nil, want a refusal: a nil here prints \"write-back:\" for an edit that was not persisted")
 			}
 			for _, w := range tc.want {
 				if !strings.Contains(err.Error(), w) {
 					t.Errorf("err = %q, want it to mention %q", err, w)
+				}
+			}
+			for _, r := range tc.reject {
+				if strings.Contains(err.Error(), r) {
+					t.Errorf("err = %q names the wrong cause (%q)", err, r)
+				}
+			}
+			if tc.missing {
+				// os.ReadFile's error carries the path too; the refusal must not
+				// print it twice ("read destination X: open X: …").
+				if n := strings.Count(err.Error(), dest); n != 1 {
+					t.Errorf("err = %q names the path %d times, want once", err, n)
 				}
 			}
 		})
@@ -235,7 +317,7 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		if err := os.WriteFile(dest, []byte(`{"mcpServers": {"bad\u001b[31mid": 5}}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		err := s.writeBackKeyItem(item(dest, "/mcpServers/bad\x1b[31mid"))
+		err := s.writeBackKeyItem(item("claude", "merge-json-keys", dest, "/mcpServers/bad\x1b[31mid"))
 		if err == nil {
 			t.Fatal("want a refusal")
 		}
@@ -244,44 +326,6 @@ func TestWriteBackKeyItem_Refusals(t *testing.T) {
 		}
 		if strings.Contains(err.Error(), "\x1b") {
 			t.Fatalf("err = %q carries the raw ESC byte from the native id", err)
-		}
-	})
-}
-
-// TestWriteBackKeyItem_UnreadableDestination pins the third refusal: a
-// destination that cannot be read or parsed at the moment of the [w] keystroke
-// (reconcile is interactive, so the user can break the file between the drift
-// walk and the write-back) is named as such, rather than reported as a missing
-// root key by readDestFile's error-swallowing read.
-func TestWriteBackKeyItem_UnreadableDestination(t *testing.T) {
-	testenv.RequireContainer(t)
-	// cmd is set so a refusal that regressed into a fall-through reports as the
-	// assertion below, not as a nil-deref panic at capture.Capture's Warn.
-	s := &reconcileSession{reg: registryFactory(), home: t.TempDir(), cmd: &cobra.Command{}}
-	item := func(dest string) reconcileItem {
-		return reconcileItem{
-			agentName: "claude",
-			op:        adapter.FileOp{Path: dest, MergeStrategy: "merge-json-keys", SourceID: "mcp/* (multiple)"},
-			ptr:       "/mcpServers/github",
-		}
-	}
-	t.Run("missing file", func(t *testing.T) {
-		err := s.writeBackKeyItem(item(filepath.Join(t.TempDir(), "gone.json")))
-		if err == nil || !strings.Contains(err.Error(), "read destination") {
-			t.Fatalf("err = %v, want the read refusal", err)
-		}
-	})
-	t.Run("truncated file", func(t *testing.T) {
-		dest := filepath.Join(t.TempDir(), "claude.json")
-		if err := os.WriteFile(dest, []byte(`{ "mcpServers": `), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		err := s.writeBackKeyItem(item(dest))
-		if err == nil || !strings.Contains(err.Error(), "does not parse") {
-			t.Fatalf("err = %v, want the parse refusal", err)
-		}
-		if strings.Contains(err.Error(), "absent from the destination") {
-			t.Fatalf("err = %q names a missing root key for a file that does not parse", err)
 		}
 	})
 }

--- a/internal/cli/reconcile_keyitem_internal_test.go
+++ b/internal/cli/reconcile_keyitem_internal_test.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/adapter"
+	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
 // TestKeyItemKind pins the ONE derivation of a key-merge item's component kind.
@@ -63,6 +68,7 @@ func TestKeyItemPointerParts(t *testing.T) {
 		{"tilde is decoded", "/mcpServers/til~0de", "mcpServers", "til~de", true},
 		{"slash is decoded", "/mcpServers/a~1b", "mcpServers", "a/b", true},
 		{"tilde-one is decoded in the right order", "/mcpServers/x~01", "mcpServers", "x~1", true},
+		{"root key is decoded too", "/a~1b/github", "a/b", "github", true},
 		{"hook event segment", "/hooks/BeforeTool", "hooks", "BeforeTool", true},
 		{"root only", "/mcpServers", "", "", false},
 		{"empty id", "/mcpServers/", "", "", false},
@@ -169,4 +175,72 @@ func TestComponentFromPointer_KindFromSourceID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWriteBackKeyItem_Refusals pins the two refusals a hand-edited destination
+// can trigger before any translation happens — the root key missing or not an
+// object, and the entry not an object — and that the id surfaced in the second
+// is sanitized: the id comes from a native file, so a control byte in it must
+// not reach the terminal raw (issue #93/#171). Both refusals used to fail no
+// test: replacing either with `return nil` was green across the package, which
+// would have turned a plausible hand-edit into a silent "write-back:" lie.
+func TestWriteBackKeyItem_Refusals(t *testing.T) {
+	testenv.RequireContainer(t)
+	s := &reconcileSession{reg: registryFactory(), home: t.TempDir()}
+	item := func(dest, ptr string) reconcileItem {
+		return reconcileItem{
+			agentName: "claude",
+			op:        adapter.FileOp{Path: dest, MergeStrategy: "merge-json-keys", SourceID: "mcp/* (multiple)"},
+			ptr:       ptr,
+		}
+	}
+	tests := []struct {
+		name string
+		dest string // the destination's JSON
+		ptr  string
+		want []string // substrings the error must carry
+	}{
+		{"root key absent", `{}`, "/mcpServers/github", []string{"mcpServers", "absent"}},
+		{"root key is an array", `{"mcpServers": []}`, "/mcpServers/github", []string{"mcpServers", "not an object"}},
+		{"root key is a scalar", `{"mcpServers": 1}`, "/mcpServers/github", []string{"mcpServers", "not an object"}},
+		{"entry is a scalar", `{"mcpServers": {"github": 5}}`, "/mcpServers/github", []string{"claude", "github", "not an object"}},
+		{"entry is an array", `{"mcpServers": {"github": []}}`, "/mcpServers/github", []string{"github", "not an object"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), "claude.json")
+			if err := os.WriteFile(dest, []byte(tc.dest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := s.writeBackKeyItem(item(dest, tc.ptr))
+			if err == nil {
+				t.Fatal("writeBackKeyItem = nil, want a refusal: a nil here prints \"write-back:\" for an edit that was not persisted")
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("err = %q, want it to mention %q", err, w)
+				}
+			}
+		})
+	}
+
+	t.Run("a control byte in the id is sanitized on the way out", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "claude.json")
+		// The id holds an ESC byte (JSON-escaped so the file parses, as a native
+		// file would spell it); the entry is a scalar so the refusal that
+		// interpolates the id is the one that fires.
+		if err := os.WriteFile(dest, []byte(`{"mcpServers": {"bad\u001b[31mid": 5}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		err := s.writeBackKeyItem(item(dest, "/mcpServers/bad\x1b[31mid"))
+		if err == nil {
+			t.Fatal("want a refusal")
+		}
+		if !strings.Contains(err.Error(), "not an object") {
+			t.Fatalf("err = %q, want the entry refusal (the one that names the id)", err)
+		}
+		if strings.Contains(err.Error(), "\x1b") {
+			t.Fatalf("err = %q carries the raw ESC byte from the native id", err)
+		}
+	})
 }

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -1,0 +1,314 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeCanonicalMCP seeds one canonical mcp/<id>.toml under home.
+func writeCanonicalMCP(t *testing.T, home, id, body string) string {
+	t.Helper()
+	p := filepath.Join(home, "mcp", id+".toml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestReconcile_Writeback_MCPDialects is the regression for reconcile's
+// key-level write-back selecting the native→canonical MCP translation by the
+// JSON POINTER'S ROOT KEY instead of by the rendering adapter.
+//
+// Root keys are per-agent data and they collide, so the old allowlist
+// ("mcpServers" → Claude's 1:1 JSON shape, "mcp" → OpenCode, "mcp_servers" →
+// Codex, anything else refused) was wrong in three distinct ways at once. Each
+// row below is one of them, driven end to end — apply, hand-edit the native MCP
+// entry, `reconcile --auto-writeback`, then assert the canonical file gained
+// EXACTLY the edit:
+//
+//	crush     root "mcp"              collides with OpenCode → its entry was
+//	                                  translated with OpenCode's dialect
+//	                                  (array `command`, `environment`), which
+//	                                  demoted `args`/`env` into [server.extra]
+//	gemini    root "mcpServers"       collides with Claude → `httpUrl` was not
+//	                                  inverted, so the URL left the model
+//	                                  entirely and landed in [server.extra]
+//	windsurf  root "mcpServers"       same, for `serverUrl`
+//	amp       root "amp.mcpServers"   matched nothing → refused outright
+//	                                  ("not implemented in v1"), exit 1
+//	zed       root "context_servers"  same
+//
+// The generic-tier rows (crush, amp, zed) are the ones no allowlist could ever
+// have covered: generic.Specs() grows with every agent added.
+func TestReconcile_Writeback_MCPDialects(t *testing.T) {
+	const remoteSrc = `[server]
+type = "http"
+url = "https://api.example.com/mcp"
+agents = ["%s"]
+enabled = true
+[server.headers]
+Authorization = "Bearer tok"
+`
+	const stdioSrc = `[server]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+agents = ["%s"]
+enabled = true
+[server.env]
+GITHUB_TOKEN = "tok"
+`
+	cases := []struct {
+		name   string
+		agent  string
+		native string // path relative to AGENTSYNC_TARGET_ROOT
+		src    string // canonical mcp/github.toml body (%s = agent name)
+		old    string // substring to replace in the native file
+		new    string
+		want   []string // substrings the canonical file must contain afterwards
+		reject []string // substrings it must NOT contain
+	}{
+		{
+			name: "crush root mcp is not opencode", agent: "crush",
+			native: ".config/crush/crush.json", src: stdioSrc,
+			old: `"npx"`, new: `"npm"`,
+			want: []string{"command = 'npm'", "args = ['-y', '@modelcontextprotocol/server-github']", "[server.env]", "GITHUB_TOKEN = 'tok'"},
+			// OpenCode's inverse reads `environment`, not `env`, and a string
+			// `command` as the whole argv — so args/env fell into Extra.
+			reject: []string{"[server.extra]"},
+		},
+		{
+			name: "gemini httpUrl is inverted", agent: "gemini",
+			native: ".gemini/settings.json", src: remoteSrc,
+			old: "api.example.com", new: "api.edited.com",
+			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			reject: []string{"[server.extra]", "httpUrl"},
+		},
+		{
+			name: "windsurf serverUrl is inverted", agent: "windsurf",
+			native: ".codeium/windsurf/mcp_config.json", src: remoteSrc,
+			old: "api.example.com", new: "api.edited.com",
+			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			reject: []string{"[server.extra]", "serverUrl"},
+		},
+		{
+			name: "amp flat namespaced root", agent: "amp",
+			native: ".config/amp/settings.json", src: remoteSrc,
+			old: "api.example.com", new: "api.edited.com",
+			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			reject: []string{"[server.extra]"},
+		},
+		{
+			name: "zed context_servers root", agent: "zed",
+			native: ".config/zed/settings.json", src: remoteSrc,
+			old: "api.example.com", new: "api.edited.com",
+			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			reject: []string{"[server.extra]"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+			if _, err := runCLI(t, env, "init"); err != nil {
+				t.Fatal(err)
+			}
+			if out, err := runCLI(t, env, "agent", "add", tc.agent); err != nil {
+				t.Fatalf("agent add %s: %v\n%s", tc.agent, err, out)
+			}
+			home := filepath.Join(tmp, ".agentsync")
+			srcFile := writeCanonicalMCP(t, home, "github", strings.ReplaceAll(tc.src, "%s", tc.agent))
+			if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+				t.Fatalf("apply: %v\n%s", err, out)
+			}
+
+			dest := filepath.Join(tmp, tc.native)
+			body, err := os.ReadFile(dest)
+			if err != nil {
+				t.Fatalf("read rendered dest %s: %v", tc.native, err)
+			}
+			if !strings.Contains(string(body), tc.old) {
+				t.Fatalf("rendered %s does not contain %q; the fixture no longer drives this dialect:\n%s",
+					tc.native, tc.old, body)
+			}
+			edited := strings.Replace(string(body), tc.old, tc.new, 1)
+			if err := os.WriteFile(dest, []byte(edited), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+			if err != nil {
+				t.Fatalf("reconcile --auto-writeback: %v\n%s", err, out)
+			}
+			if !strings.Contains(out, "write-back:") {
+				t.Fatalf("reconcile did not report a write-back:\n%s", out)
+			}
+			got, err := os.ReadFile(srcFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(string(got), w) {
+					t.Errorf("canonical mcp/github.toml is missing %q:\n%s", w, got)
+				}
+			}
+			for _, r := range tc.reject {
+				if strings.Contains(string(got), r) {
+					t.Errorf("canonical mcp/github.toml still carries %q — a modeled field was "+
+						"demoted to passthrough, i.e. the wrong dialect was applied:\n%s", r, got)
+				}
+			}
+			// Source-only fields the destination never carries must survive.
+			for _, keep := range []string{"agents", "enabled"} {
+				if !strings.Contains(string(got), keep) {
+					t.Errorf("write-back dropped the source-only %s field:\n%s", keep, got)
+				}
+			}
+		})
+	}
+}
+
+// TestReconcile_Writeback_TildeServerID is the regression for a pointer segment
+// being used RAW where RFC 6901 says it is escaped. An MCP server id containing
+// "~" renders as the pointer segment "~0" (jsonkeys.EscapeToken), so looking the
+// id up in the destination with the raw segment missed it — and a miss is the
+// tombstone signal. Reconcile therefore reported
+//
+//	write-back: removed source mcp/til~0de.toml (destination dropped …)
+//
+// for a server that had merely been EDITED: the user's edit was discarded, the
+// canonical file (spelled til~de.toml, so the unlink also missed) was left
+// stale, and the next apply overwrote the destination back.
+func TestReconcile_Writeback_TildeServerID(t *testing.T) {
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	srcFile := writeCanonicalMCP(t, home, "til~de", "[server]\ntype = \"stdio\"\ncommand = \"npx\"\nagents = [\"claude\"]\n")
+	if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".claude.json")
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+	if err != nil {
+		t.Fatalf("reconcile --auto-writeback: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "removed source") {
+		t.Fatalf("reconcile reported a destination-side DELETION for an edited server:\n%s", out)
+	}
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatalf("canonical mcp/til~de.toml: %v", err)
+	}
+	if !strings.Contains(string(got), "npm") {
+		t.Fatalf("write-back did not capture the edit for a ~-bearing server id:\n%s", got)
+	}
+}
+
+// TestReconcile_Writeback_SecretBearingDialect pins the SECRET half of the
+// dialect fix. Routing a crush entry through OpenCode's inverse moved the
+// server's `env` map into the `Extra` passthrough — which
+// secrets.ReReferenceCanonical does not visit — so capture.Capture's
+// fail-closed leak backstop (scanExtraResidual) correctly REFUSED the whole
+// write-back of any secret-bearing crush server, and the user could never
+// persist the edit at all.
+//
+// With the dialect taken from the rendering adapter the env map stays a modeled
+// field, re-reference restores ${secret:…}, and the write succeeds. The
+// assertion that matters either way: the resolved value never reaches
+// ~/.agentsync.
+func TestReconcile_Writeback_SecretBearingDialect(t *testing.T) {
+	const sentinel = "ghp_SENTINEL_VALUE_DO_NOT_PERSIST"
+	tmp := t.TempDir()
+	t.Setenv("GH_TOKEN", sentinel)
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	cfg := filepath.Join(home, "agentsync.toml")
+	existing, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// backend = "env" resolves ${secret:K} from the environment, so the backstop
+	// has a live secret value to detect without an age vault in the fixture.
+	if err := os.WriteFile(cfg, append(existing, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "agent", "add", "crush"); err != nil {
+		t.Fatalf("agent add crush: %v\n%s", err, out)
+	}
+	srcFile := writeCanonicalMCP(t, home, "github", `[server]
+type = "stdio"
+command = "npx"
+args = ["-y", "srv"]
+agents = ["crush"]
+[server.env]
+GITHUB_TOKEN = "${secret:GH_TOKEN}"
+`)
+	if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".config", "crush", "crush.json")
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), sentinel) {
+		t.Fatalf("apply did not resolve the secret into the crush destination:\n%s", body)
+	}
+	if err := os.WriteFile(dest, []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+	if err != nil {
+		t.Fatalf("reconcile --auto-writeback refused a secret-bearing crush write-back: %v\n%s", err, out)
+	}
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "${secret:GH_TOKEN}") {
+		t.Errorf("write-back did not restore the ${secret:…} reference:\n%s", got)
+	}
+	if !strings.Contains(string(got), "command = 'npm'") {
+		t.Errorf("write-back did not capture the dest edit:\n%s", got)
+	}
+	// The load-bearing assertion: no resolved cleartext anywhere under
+	// ~/.agentsync, whatever else happened.
+	if err := filepath.WalkDir(home, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		if strings.Contains(string(data), sentinel) {
+			rel, _ := filepath.Rel(home, p)
+			t.Errorf("resolved secret persisted into the canonical source at %s", rel)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
 // writeCanonicalMCP seeds one canonical mcp/<id>.toml under home.
@@ -115,12 +113,12 @@ GITHUB_TOKEN = "tok"
 		{
 			// CHARACTERIZATION, not an endorsement, of the documented coercion
 			// (docs/capability-matrix.md, #267): every dialect's inverse SKIPS a
-			// non-string element inside a
-			// string-typed native field — it is neither stringified nor passed
-			// through Extra. Claude's 1:1 shape used to refuse such an entry on
-			// write-back only because it went through a typed json.Unmarshal; it
-			// now reads exactly as `import` always has. A future refusal or
-			// stringification is a deliberate change that fails this row.
+			// non-string element inside a string-typed native field — it is
+			// neither stringified nor passed through Extra. Claude's 1:1 shape
+			// used to refuse such an entry on write-back only because it went
+			// through a typed json.Unmarshal; it now reads exactly as `import`
+			// always has. A future refusal or stringification is a deliberate
+			// change that fails this row.
 			name: "a number in args is skipped, not stringified or passed through", agent: "claude",
 			native: ".claude.json", src: stdioSrc,
 			old: `"-y"`, new: `"-y", 7`,
@@ -352,7 +350,6 @@ GITHUB_TOKEN = "${secret:GH_TOKEN}"
 // over a REMOTE server, which only the rendering adapter's own inverse reads
 // right.
 func TestReconcile_Writeback_DifferentDialectsAgree(t *testing.T) {
-	testenv.RequireContainer(t)
 	tmp := t.TempDir()
 	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
 	for _, a := range [][]string{{"init"}, {"agent", "add", "claude"}, {"agent", "add", "gemini"}} {
@@ -412,7 +409,6 @@ func TestReconcile_Writeback_DifferentDialectsAgree(t *testing.T) {
 // the whole package green while reconcile printed "write-back:" and exited 0
 // with the canonical file untouched.
 func TestReconcile_Writeback_RotatedSecretIsRefused(t *testing.T) {
-	testenv.RequireContainer(t)
 	const before = "ghp_OLD_VALUE_DO_NOT_PERSIST"
 	tmp := t.TempDir()
 	t.Setenv("GH_TOKEN", before)

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spxrogers/agentsync/internal/testenv"
 )
 
 // writeCanonicalMCP seeds one canonical mcp/<id>.toml under home.
@@ -86,28 +88,28 @@ GITHUB_TOKEN = "tok"
 			name: "gemini httpUrl is inverted", agent: "gemini",
 			native: ".gemini/settings.json", src: remoteSrc,
 			old: "api.example.com", new: "api.edited.com",
-			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			want:   []string{"type = 'http'\n", "url = 'https://api.edited.com/mcp'"},
 			reject: []string{"[server.extra]", "httpUrl"},
 		},
 		{
 			name: "windsurf serverUrl is inverted", agent: "windsurf",
 			native: ".codeium/windsurf/mcp_config.json", src: remoteSrc,
 			old: "api.example.com", new: "api.edited.com",
-			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			want:   []string{"type = 'http'\n", "url = 'https://api.edited.com/mcp'"},
 			reject: []string{"[server.extra]", "serverUrl"},
 		},
 		{
 			name: "amp flat namespaced root", agent: "amp",
 			native: ".config/amp/settings.json", src: remoteSrc,
 			old: "api.example.com", new: "api.edited.com",
-			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			want:   []string{"type = 'http'\n", "url = 'https://api.edited.com/mcp'"},
 			reject: []string{"[server.extra]"},
 		},
 		{
 			name: "zed context_servers root", agent: "zed",
 			native: ".config/zed/settings.json", src: remoteSrc,
 			old: "api.example.com", new: "api.edited.com",
-			want:   []string{"type = 'http'", "url = 'https://api.edited.com/mcp'"},
+			want:   []string{"type = 'http'\n", "url = 'https://api.edited.com/mcp'"},
 			reject: []string{"[server.extra]"},
 		},
 	}
@@ -310,5 +312,62 @@ GITHUB_TOKEN = "${secret:GH_TOKEN}"
 		return nil
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestReconcile_Writeback_DifferentDialectsAgree pins the fourth symptom of the
+// root-key allowlist: one canonical server fanned out to two agents with
+// DIFFERENT dialects, both edited identically, used to trip the multi-agent
+// fan-out guard — not because the edits differed, but because the
+// mistranslated side (Gemini read as Claude: `httpUrl` dropped, `type` empty)
+// produced a different canonical value from the correctly-translated one, so
+// reconcile printed a spurious `conflict:` and exited non-zero. The existing
+// identical-write-back test pairs claude with opencode over a STDIO server,
+// which both dialects already read correctly; this one pairs claude with gemini
+// over a REMOTE server, which only the rendering adapter's own inverse reads
+// right.
+func TestReconcile_Writeback_DifferentDialectsAgree(t *testing.T) {
+	testenv.RequireContainer(t)
+	tmp := t.TempDir()
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	for _, a := range [][]string{{"init"}, {"agent", "add", "claude"}, {"agent", "add", "gemini"}} {
+		if out, err := runCLI(t, env, a...); err != nil {
+			t.Fatalf("%v: %v\n%s", a, err, out)
+		}
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	srcFile := writeCanonicalMCP(t, home, "shared", "[server]\ntype = \"http\"\nurl = \"https://orig.example.com/mcp\"\nagents = [\"*\"]\n")
+	if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	for _, native := range []string{".claude.json", filepath.Join(".gemini", "settings.json")} {
+		dest := filepath.Join(tmp, native)
+		body, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("read rendered dest %s: %v", native, err)
+		}
+		if !strings.Contains(string(body), "orig.example.com") {
+			t.Fatalf("rendered %s does not carry the server url:\n%s", native, body)
+		}
+		edited := strings.Replace(string(body), "orig.example.com", "same.example.com", 1)
+		if err := os.WriteFile(dest, []byte(edited), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+	if err != nil {
+		t.Fatalf("identical edits behind two dialects must not conflict: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "conflict:") {
+		t.Fatalf("reconcile reported a conflict between two agents that hold the SAME edit:\n%s", out)
+	}
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range []string{"type = 'http'\n", "url = 'https://same.example.com/mcp'"} {
+		if !strings.Contains(string(got), w) {
+			t.Errorf("canonical mcp/shared.toml is missing %q:\n%s", w, got)
+		}
 	}
 }

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -485,3 +485,108 @@ GITHUB_TOKEN = "${secret:GH_TOKEN}"
 		t.Fatal(err)
 	}
 }
+
+// TestReconcile_Writeback_ContinueWholeFileIsRefused pins the one MCP write-back
+// that does NOT go through an adapter inverse. Continue renders each server as
+// a whole YAML file (MergeStrategy "replace", SourceID mcp/<id>.toml), so a
+// hand-edited server reaches writeBackFileItem — the verbatim copy meant for
+// text components. Before the kind gate, `--auto-writeback` overwrote
+// ~/.agentsync/mcp/<id>.toml with the YAML (every later load then failed to
+// parse it) and, because that arm bypasses capture.Capture, persisted the
+// `${secret:…}` value the render had resolved in cleartext. Three things must
+// hold: the run is refused and names the import selector that captures the
+// edit correctly, the canonical file is byte-unchanged, and the resolved value
+// is nowhere under ~/.agentsync.
+func TestReconcile_Writeback_ContinueWholeFileIsRefused(t *testing.T) {
+	const live = "ghp_LIVE_VALUE_DO_NOT_PERSIST"
+	tmp := t.TempDir()
+	t.Setenv("GH_TOKEN", live)
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	cfg := filepath.Join(home, "agentsync.toml")
+	existing, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfg, append(existing, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "agent", "add", "continue"); err != nil {
+		t.Fatalf("agent add continue: %v\n%s", err, out)
+	}
+	srcBody := `[server]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+agents = ["continue"]
+[server.env]
+GITHUB_TOKEN = "${secret:GH_TOKEN}"
+`
+	srcFile := writeCanonicalMCP(t, home, "github", srcBody)
+	if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".continue", "mcpServers", "github.yaml")
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), live) {
+		t.Fatalf("apply did not resolve the secret into the destination:\n%s", body)
+	}
+	if !strings.Contains(string(body), "command: npx") {
+		t.Fatalf("unexpected continue render (the hand-edit below targets `command: npx`):\n%s", body)
+	}
+	if err := os.WriteFile(dest, []byte(strings.Replace(string(body), "command: npx", "command: npm", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+	if err == nil {
+		t.Fatalf("reconcile --auto-writeback succeeded on a Continue MCP file; the whole-file arm copied YAML into the canonical TOML:\n%s", out)
+	}
+	for _, want := range []string{"refused", "verbatim", "`agentsync import continue:mcp:github`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reconcile output lacks %q:\n%s", want, out)
+		}
+	}
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != srcBody {
+		t.Errorf("a refused write-back changed the canonical file:\n%s", got)
+	}
+	if err := filepath.WalkDir(home, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		if strings.Contains(string(data), live) {
+			rel, _ := filepath.Rel(home, p)
+			t.Errorf("the resolved cleartext was persisted into the canonical source at %s", rel)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The remedy the refusal names must actually work: the edit lands in the
+	// canonical file through Continue's own translator with the secret
+	// re-referenced, and the cleartext still never touches ~/.agentsync.
+	if out, err := runCLI(t, env, "import", "continue:mcp:github", "--scope", "user"); err != nil {
+		t.Fatalf("import continue:mcp:github: %v\n%s", err, out)
+	}
+	got, err = os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "npm") || !strings.Contains(string(got), "${secret:GH_TOKEN}") || strings.Contains(string(got), live) {
+		t.Fatalf("import did not capture the edit with the secret re-referenced:\n%s", got)
+	}
+}

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -113,8 +113,9 @@ GITHUB_TOKEN = "tok"
 			reject: []string{"[server.extra]"},
 		},
 		{
-			// CHARACTERIZATION of the documented coercion (docs/capability-matrix.md,
-			// #267): every dialect's inverse SKIPS a non-string element inside a
+			// CHARACTERIZATION, not an endorsement, of the documented coercion
+			// (docs/capability-matrix.md, #267): every dialect's inverse SKIPS a
+			// non-string element inside a
 			// string-typed native field — it is neither stringified nor passed
 			// through Extra. Claude's 1:1 shape used to refuse such an entry on
 			// write-back only because it went through a typed json.Unmarshal; it
@@ -156,9 +157,12 @@ GITHUB_TOKEN = "tok"
 			if err != nil {
 				t.Fatalf("read rendered dest %s: %v", tc.native, err)
 			}
-			if !strings.Contains(string(body), tc.old) {
-				t.Fatalf("rendered %s does not contain %q; the fixture no longer drives this dialect:\n%s",
-					tc.native, tc.old, body)
+			if n := strings.Count(string(body), tc.old); n != 1 {
+				// Exactly once, so the single Replace below edits the intended slot:
+				// a row whose `want` asserts the ORIGINAL survives (the coercion
+				// rows) would otherwise pass with the edit landing elsewhere.
+				t.Fatalf("rendered %s contains %q %d times, want exactly once; the fixture no longer drives this dialect:\n%s",
+					tc.native, tc.old, n, body)
 			}
 			edited := strings.Replace(string(body), tc.old, tc.new, 1)
 			if err := os.WriteFile(dest, []byte(edited), 0o644); err != nil {
@@ -395,5 +399,93 @@ func TestReconcile_Writeback_DifferentDialectsAgree(t *testing.T) {
 		if !strings.Contains(string(got), w) {
 			t.Errorf("canonical mcp/shared.toml is missing %q:\n%s", w, got)
 		}
+	}
+}
+
+// TestReconcile_Writeback_RotatedSecretIsRefused pins the one refusal in the
+// write-back path with a security consequence: capture.Capture's fail-closed
+// leak backstop. Between apply and reconcile the secret is rotated, so the
+// resolved value in the destination no longer matches any live secret,
+// re-reference cannot restore the ${secret:…} reference, and the write MUST be
+// refused rather than persist the old cleartext value into ~/.agentsync. The
+// error return of that call was unpinned before this test: swallowing it left
+// the whole package green while reconcile printed "write-back:" and exited 0
+// with the canonical file untouched.
+func TestReconcile_Writeback_RotatedSecretIsRefused(t *testing.T) {
+	testenv.RequireContainer(t)
+	const before = "ghp_OLD_VALUE_DO_NOT_PERSIST"
+	tmp := t.TempDir()
+	t.Setenv("GH_TOKEN", before)
+	env := map[string]string{"AGENTSYNC_TARGET_ROOT": tmp}
+	if _, err := runCLI(t, env, "init"); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(tmp, ".agentsync")
+	cfg := filepath.Join(home, "agentsync.toml")
+	existing, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfg, append(existing, []byte("\n[secrets]\nbackend = \"env\"\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCLI(t, env, "agent", "add", "claude"); err != nil {
+		t.Fatalf("agent add claude: %v\n%s", err, out)
+	}
+	srcBody := `[server]
+type = "stdio"
+command = "npx"
+agents = ["claude"]
+[server.env]
+GITHUB_TOKEN = "${secret:GH_TOKEN}"
+`
+	srcFile := writeCanonicalMCP(t, home, "github", srcBody)
+	if out, err := runCLI(t, env, "apply", "--scope", "user"); err != nil {
+		t.Fatalf("apply: %v\n%s", err, out)
+	}
+	dest := filepath.Join(tmp, ".claude.json")
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), before) {
+		t.Fatalf("apply did not resolve the secret into the destination:\n%s", body)
+	}
+	if err := os.WriteFile(dest, []byte(strings.Replace(string(body), `"npx"`, `"npm"`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rotate: the destination still holds the OLD value, which no live secret
+	// matches, so re-reference cannot put the reference back.
+	t.Setenv("GH_TOKEN", "ghp_NEW_VALUE")
+	out, err := runCLI(t, env, "reconcile", "--scope", "user", "--auto-writeback")
+	if err == nil {
+		t.Fatalf("reconcile --auto-writeback succeeded against a rotated secret; the leak backstop's refusal was swallowed:\n%s", out)
+	}
+	if !strings.Contains(out, "refusing") && !strings.Contains(out, "failed to write back") {
+		t.Fatalf("reconcile failed for a reason other than the write-back refusal:\n%s", out)
+	}
+	got, err := os.ReadFile(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != srcBody {
+		t.Errorf("a refused write-back changed the canonical file:\n%s", got)
+	}
+	if err := filepath.WalkDir(home, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		if strings.Contains(string(data), before) {
+			rel, _ := filepath.Rel(home, p)
+			t.Errorf("the rotated-away cleartext was persisted into the canonical source at %s", rel)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/cli/reconcile_mcp_dialect_test.go
+++ b/internal/cli/reconcile_mcp_dialect_test.go
@@ -112,6 +112,27 @@ GITHUB_TOKEN = "tok"
 			want:   []string{"type = 'http'\n", "url = 'https://api.edited.com/mcp'"},
 			reject: []string{"[server.extra]"},
 		},
+		{
+			// CHARACTERIZATION of the documented coercion (docs/capability-matrix.md,
+			// #267): every dialect's inverse SKIPS a non-string element inside a
+			// string-typed native field — it is neither stringified nor passed
+			// through Extra. Claude's 1:1 shape used to refuse such an entry on
+			// write-back only because it went through a typed json.Unmarshal; it
+			// now reads exactly as `import` always has. A future refusal or
+			// stringification is a deliberate change that fails this row.
+			name: "a number in args is skipped, not stringified or passed through", agent: "claude",
+			native: ".claude.json", src: stdioSrc,
+			old: `"-y"`, new: `"-y", 7`,
+			want:   []string{"args = ['-y', '@modelcontextprotocol/server-github']"},
+			reject: []string{"'7'", "[server.extra]"},
+		},
+		{
+			name: "a bool in env is skipped, not stringified or passed through", agent: "claude",
+			native: ".claude.json", src: stdioSrc,
+			old: `"tok"`, new: `"tok", "NUM": true`,
+			want:   []string{"[server.env]", "GITHUB_TOKEN = 'tok'"},
+			reject: []string{"NUM", "[server.extra]"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -360,6 +381,11 @@ func TestReconcile_Writeback_DifferentDialectsAgree(t *testing.T) {
 	}
 	if strings.Contains(out, "conflict:") {
 		t.Fatalf("reconcile reported a conflict between two agents that hold the SAME edit:\n%s", out)
+	}
+	// Both key items must have been written back, or the "no conflict" above is
+	// satisfied by the claude-only outcome.
+	if n := strings.Count(out, "write-back:"); n != 2 {
+		t.Fatalf("want two write-back lines (one per agent), got %d:\n%s", n, out)
 	}
 	got, err := os.ReadFile(srcFile)
 	if err != nil {

--- a/internal/cli/reconcile_session_internal_test.go
+++ b/internal/cli/reconcile_session_internal_test.go
@@ -36,8 +36,10 @@ import (
 // (pruneStateFilesForPath on a nil st) and finish with a queued override
 // (Registry.Lookup on a nil reg) — so the orphan tests press only [k], [q] or
 // EOF, nothing here calls finish (TestReconcile_FinishRunsExactlyOnce covers it
-// end to end), and [w]rite-back, which needs a real ~/.agentsync, a plan and a
-// destination, stays in reconcile_test.go. A test that needs home sets it.
+// end to end), and [w]rite-back is driven end to end from reconcile_test.go and
+// the dialect table, with its refusals driven directly by
+// TestWriteBackKeyItem_Refusals on a session that sets reg and home. A test
+// that needs home sets it.
 //
 // The reader is NOT a fake: it is the same *bufio.Reader production wraps stdin
 // in, over a strings.Reader, so readChar sees production's exact EOF behaviour.

--- a/internal/cli/reporterror_internal_test.go
+++ b/internal/cli/reporterror_internal_test.go
@@ -174,10 +174,12 @@ func TestReportErrorCarriesTheErrorLabel(t *testing.T) {
 	}
 }
 
-// The quiet exit-code sentinel (`status --exit-code`, `diff --exit-code`) carries
-// its own code and an empty message: it must map to that code and print NOTHING,
-// so a CI gate gets a stable non-zero exit with no spurious diagnostic line. It
-// must be found through a `%w` wrapper too, since commands wrap on the way up.
+// The quiet exit-code sentinels (`status --exit-code`, `diff --exit-code`, and
+// `secret edit`'s interrupt) carry their own code: each must map to that code
+// and print NOTHING — whether its message is empty or not — so a CI gate gets a
+// stable non-zero exit with no spurious diagnostic line and an interrupted edit
+// looks like the Ctrl-C it was. A sentinel must be found through a `%w` wrapper
+// too, since commands wrap on the way up.
 func TestReportErrorQuietSentinel(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -186,6 +188,7 @@ func TestReportErrorQuietSentinel(t *testing.T) {
 	}{
 		{"direct", quietExitErr(3), 3},
 		{"wrapped", fmt.Errorf("status: %w", quietExitErr(2)), 2},
+		{"secret edit interrupt, non-empty message", errSecretEditInterrupted, exitCodeInterrupted},
 		{"nil", nil, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -145,10 +145,11 @@ func reportErrorTo(w io.Writer, mode ui.ColorMode, err error) int {
 	if err == nil {
 		return 0
 	}
-	// A quiet exit-code sentinel (status/diff --exit-code) carries its own
-	// process exit code and an empty message: map it to that code and print
-	// nothing, so a CI gate gets a stable non-zero exit with no spurious
-	// diagnostic line.
+	// A quiet exit-code sentinel (status/diff --exit-code, secret edit's
+	// interrupt) carries its own process exit code: map it to that code and
+	// print nothing — not even its message — so a CI gate gets a stable
+	// non-zero exit with no spurious diagnostic line, and an interrupted edit
+	// looks like the Ctrl-C it was.
 	var ec ExitCoder
 	if errors.As(err, &ec) {
 		return ec.ExitCode()

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -233,6 +233,13 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	// already-cancelled context.)
 	sigCtx, stopSignals := secretEditSignals(commandContext(cmd))
 	defer stopSignals()
+	if sigCtx.Err() != nil {
+		// Already interrupted: do not put the plaintext on disk at all. The
+		// checks below would abandon the edit anyway (and the deferred remove
+		// would take the file), so this is a narrower cleartext window, not a
+		// different outcome — which is also why no test can tell it apart.
+		return errSecretEditInterrupted
+	}
 
 	// Write to a tmp file in os.TempDir() (RAM-backed on macOS).
 	tmpFile, err := os.CreateTemp("", "agentsync-secrets-*.toml")
@@ -264,7 +271,10 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	// while SIGTERM is their "deadly signal" path, on which each restores the
 	// terminal and exits at once (measured under a pty). WaitDelay escalates
 	// to a kill for one that ignores even that, so the command can never wedge
-	// waiting for it.
+	// waiting for it. Where the signal cannot be sent at all (Windows has no
+	// SIGTERM delivery), exec reports the Cancel error through Wait, the
+	// interrupt check below wins over it, and the outcome degrades to the
+	// grace-period kill rather than to a hang.
 	editorCmd.Cancel = func() error { return editorCmd.Process.Signal(syscall.SIGTERM) }
 	editorCmd.WaitDelay = secretEditGrace
 	editorCmd.Stdin = os.Stdin

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
@@ -108,6 +110,65 @@ func loadSecretsConfig() (source.SecretsConfig, string, error) {
 	return cfg.Secrets, home, nil
 }
 
+// exitCodeInterrupted is the process exit code `secret edit` reports when a
+// SIGINT/SIGTERM ends the edit: 128 + SIGINT, the shell convention for "killed
+// by Ctrl-C". It is the code the old hard `os.Exit(130)` produced, preserved
+// exactly — what changed is HOW it is reached.
+const exitCodeInterrupted = 130
+
+// secretEditGrace is how long a signalled editor is given to exit on its own
+// before exec's WaitDelay kills it. An editor that handles the signal needs a
+// moment to restore the terminal it put into raw mode; an editor that ignores
+// even SIGTERM must not be able to wedge the command forever, which is what a
+// bare Wait would allow. The one tunable in this path.
+const secretEditGrace = 2 * time.Second
+
+// errSecretEditInterrupted is the quiet sentinel `secret edit` returns when a
+// SIGINT/SIGTERM arrives while a decrypted copy of the vault is on disk. It
+// carries exit code 130 via ExitCoder, so the root maps it to the process exit
+// code and prints nothing (reportErrorTo returns before any formatting) —
+// byte-identical output to the hard exit it replaces.
+//
+// Returning an error rather than calling os.Exit is the whole point: every
+// deferred cleanup runs, starting with the os.Remove of the cleartext temp file
+// and including the global lock's release, and the path becomes testable at all
+// (an os.Exit from a goroutine takes the test binary with it).
+var errSecretEditInterrupted error = secretEditInterruptedError{}
+
+type secretEditInterruptedError struct{}
+
+func (secretEditInterruptedError) Error() string { return "interrupted" }
+func (secretEditInterruptedError) ExitCode() int { return exitCodeInterrupted }
+
+// commandContext returns cmd's context, or context.Background() when it has
+// none. cobra's Command.Context() returns the field verbatim and only
+// Execute/ExecuteContext ever sets it, so a command invoked directly — a unit
+// test, or any future non-cobra caller — hands back nil, and context.WithCancel
+// panics on a nil parent. Every production path goes through Execute and has
+// one; this is the guard that keeps a direct call from panicking instead of
+// running.
+func commandContext(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+// secretEditSignals arms SIGINT/SIGTERM notification for the window in which a
+// decrypted copy of the vault exists on disk, returning a context cancelled on
+// the first such signal plus the stop function that disarms it. Injectable (the
+// gitBackupPrompter / subagentMigrationPrompter precedent) so a test can drive
+// the interrupt deterministically instead of signalling the test process.
+var secretEditSignals = notifySecretEditSignals
+
+// notifySecretEditSignals is the production arming: stdlib signal.NotifyContext,
+// the same primitive as `signal.Notify` + a goroutine but with the cancellation
+// plumbing already written. While it is armed the default disposition is
+// suppressed, so the signal cannot kill the process out from under the edit.
+func notifySecretEditSignals(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}
+
 // editorArgv builds the editor argv from $EDITOR and the file to edit. $EDITOR
 // may be empty, whitespace-only, or carry flags ("code --wait"); it is
 // word-split, with a "vi" fallback when it yields no words — so the launch
@@ -151,30 +212,28 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		// Always remove cleartext tmp; errors ignored.
 		_ = os.Remove(tmpPath) //nolint:forbidigo // cleartext temp file in os.TempDir(), not a native destination
 	}()
-	// The hard os.Exit(130) below stays for now: replacing it with an injectable
-	// cleanup hook is a BEHAVIOUR change (the process stops exiting from a
-	// goroutine) and is the only way to test it, so it is item 9b of #235 and
-	// lands in that issue's behaviour-change PR, not in this boundary move.
-	//
 	// A plain defer does NOT run when the process dies on an unhandled signal —
 	// and aborting the editor with Ctrl-C (SIGINT) is the normal way to bail on
-	// an edit, which would otherwise leave the decrypted secrets on disk. Remove
-	// the cleartext tmp on SIGINT/SIGTERM before exiting.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	editDone := make(chan struct{})
-	go func() {
-		select {
-		case <-sigCh:
-			_ = os.Remove(tmpPath) //nolint:forbidigo // cleartext temp file in os.TempDir(), not a native destination
-			os.Exit(130)           // 128 + SIGINT
-		case <-editDone:
-		}
-	}()
-	defer func() {
-		signal.Stop(sigCh)
-		close(editDone)
-	}()
+	// an edit, which would otherwise leave the decrypted secrets on disk. So arm
+	// notification for exactly the window in which a cleartext copy exists: from
+	// here (BEFORE the plaintext is written below) until this function returns.
+	//
+	// This replaces a goroutine that removed the temp file and then called
+	// os.Exit(130) directly. That spelling skipped every OTHER deferred cleanup
+	// (the global lock's release most of all), could fire mid-WriteVerified, and
+	// was untestable by construction — an os.Exit from a goroutine takes the
+	// test binary with it, so nothing could assert the temp file was gone.
+	//
+	// Now the signal cancels sigCtx. The editor runs under it, so exec signals
+	// the editor and Run returns; the interrupt checks below then return
+	// errSecretEditInterrupted and the command unwinds through the NORMAL error
+	// path — the deferred os.Remove above runs, the lock is released, and the
+	// process still exits 130 because the root maps the sentinel's ExitCoder.
+	// (A signal that lands before the editor is even started is handled by the
+	// same check: exec.CommandContext's Start fails immediately on an
+	// already-cancelled context.)
+	sigCtx, stopSignals := secretEditSignals(commandContext(cmd))
+	defer stopSignals()
 	if _, err := tmpFile.Write(plain); err != nil {
 		_ = tmpFile.Close()
 		return err
@@ -187,12 +246,28 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	// ("code --wait", "vim -u NONE", "emacsclient -c"); split on whitespace so
 	// they aren't treated as part of the executable path (which fails outright).
 	argv := editorArgv(os.Getenv("EDITOR"), tmpPath)
-	editorCmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec
+	editorCmd := exec.CommandContext(sigCtx, argv[0], argv[1:]...) //nolint:gosec
+	// Forward SIGTERM rather than exec's default SIGKILL, so an editor that put
+	// the terminal into raw mode gets the chance to restore it — and TERM rather
+	// than INT on purpose: the full-screen editors this is most likely running
+	// (vi, vim, nano) all treat SIGINT as an in-editor key and keep running,
+	// while SIGTERM is their "deadly signal" path, on which each restores the
+	// terminal and exits at once (measured under a pty). WaitDelay escalates
+	// to a kill for one that ignores even that, so the command can never wedge
+	// waiting for it.
+	editorCmd.Cancel = func() error { return editorCmd.Process.Signal(syscall.SIGTERM) }
+	editorCmd.WaitDelay = secretEditGrace
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr
-	if err := editorCmd.Run(); err != nil {
-		return fmt.Errorf("editor: %w", err)
+	runErr := editorCmd.Run()
+	if sigCtx.Err() != nil {
+		// Interrupted: abandon the edit. Nothing is re-encrypted, and the
+		// deferred os.Remove takes the cleartext temp file with it.
+		return errSecretEditInterrupted
+	}
+	if runErr != nil {
+		return fmt.Errorf("editor: %w", runErr)
 	}
 
 	// Read back edited bytes and validate with the SAME contract apply uses
@@ -206,6 +281,14 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	}
 	if err := secrets.ValidateVaultTOML(edited); err != nil {
 		return fmt.Errorf("edited secrets are invalid (not saved): %w", err)
+	}
+	// A signal that lands between the editor exiting and the vault being
+	// rewritten still means "abandon": the old goroutine would have os.Exit'd
+	// here — mid-WriteVerified if it was unlucky — so checking once more before
+	// the write is strictly safer than what it replaces, and it is the last
+	// point at which abandoning costs nothing.
+	if sigCtx.Err() != nil {
+		return errSecretEditInterrupted
 	}
 	if err := vault.WriteVerified(edited); err != nil {
 		return fmt.Errorf("re-encrypt: %w", err)

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -228,16 +228,20 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 	// path — the deferred os.Remove above runs, the editor has been signalled
 	// and reaped, and the process still exits 130 because the root maps the
 	// sentinel's ExitCoder.
-	// (A signal that lands before the editor is even started is handled by the
-	// same check: exec.CommandContext's Start fails immediately on an
-	// already-cancelled context.)
+	// (A signal that has already landed when the arming returns is caught by
+	// the check just below; one that lands between that check and the editor's
+	// start is caught by exec.CommandContext's Start, which fails on a
+	// cancelled context, and then by the same post-Run check as any other.)
 	sigCtx, stopSignals := secretEditSignals(commandContext(cmd))
 	defer stopSignals()
 	if sigCtx.Err() != nil {
 		// Already interrupted: do not put the plaintext on disk at all. The
 		// checks below would abandon the edit anyway (and the deferred remove
-		// would take the file), so this is a narrower cleartext window, not a
-		// different outcome — which is also why no test can tell it apart.
+		// would take the file), so on an ordinary run this only narrows the
+		// cleartext window. What it changes is the failure mode when the temp
+		// file cannot be created: without it, an interrupted edit on an
+		// unwritable TMPDIR exits 1 with "create tmp file", not 130 — the row
+		// that sets TMPDIR to a missing directory pins that.
 		return errSecretEditInterrupted
 	}
 

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -129,10 +129,12 @@ const secretEditGrace = 2 * time.Second
 // code and prints nothing (reportErrorTo returns before any formatting) —
 // byte-identical output to the hard exit it replaces.
 //
-// Returning an error rather than calling os.Exit is the whole point: every
-// deferred cleanup runs, starting with the os.Remove of the cleartext temp file
-// and including the global lock's release, and the path becomes testable at all
-// (an os.Exit from a goroutine takes the test binary with it).
+// Returning an error rather than calling os.Exit is the whole point: the
+// command unwinds through its deferred cleanups (the os.Remove of the cleartext
+// temp file first), nothing can fire between the encrypt and the verify, the
+// editor is signalled and reaped rather than orphaned on the terminal, and the
+// path becomes testable at all (an os.Exit from a goroutine takes the test
+// binary with it).
 var errSecretEditInterrupted error = secretEditInterruptedError{}
 
 type secretEditInterruptedError struct{}
@@ -202,6 +204,36 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// A plain defer does NOT run when the process dies on an unhandled signal —
+	// and aborting the editor with Ctrl-C (SIGINT) is the normal way to bail on
+	// an edit, which would otherwise leave the decrypted secrets on disk. So arm
+	// notification for the whole window in which a cleartext copy can exist:
+	// from here, BEFORE the temp file is even created, until this function
+	// returns. Arming first also orders the defers: LIFO runs the os.Remove
+	// below BEFORE stopSignals, so a second Ctrl-C arriving while the file is
+	// being removed is still caught rather than hitting the restored default
+	// disposition and killing the process with the cleartext still on disk.
+	//
+	// This replaces a goroutine that removed the temp file and then called
+	// os.Exit(130) directly. That spelling could fire mid-WriteVerified (between
+	// the encrypt and the verify), left a still-running editor orphaned on the
+	// terminal, and was untestable by construction — an os.Exit from a goroutine
+	// takes the test binary with it, so nothing could assert the temp file was
+	// gone. (The global lock is an flock the kernel releases on exit; it was
+	// never at stake.)
+	//
+	// Now the signal cancels sigCtx. The editor runs under it, so exec signals
+	// the editor and Run returns; the interrupt checks below then return
+	// errSecretEditInterrupted and the command unwinds through the NORMAL error
+	// path — the deferred os.Remove above runs, the editor has been signalled
+	// and reaped, and the process still exits 130 because the root maps the
+	// sentinel's ExitCoder.
+	// (A signal that lands before the editor is even started is handled by the
+	// same check: exec.CommandContext's Start fails immediately on an
+	// already-cancelled context.)
+	sigCtx, stopSignals := secretEditSignals(commandContext(cmd))
+	defer stopSignals()
+
 	// Write to a tmp file in os.TempDir() (RAM-backed on macOS).
 	tmpFile, err := os.CreateTemp("", "agentsync-secrets-*.toml")
 	if err != nil {
@@ -212,28 +244,6 @@ func secretsEdit(cmd *cobra.Command, _ []string) error {
 		// Always remove cleartext tmp; errors ignored.
 		_ = os.Remove(tmpPath) //nolint:forbidigo // cleartext temp file in os.TempDir(), not a native destination
 	}()
-	// A plain defer does NOT run when the process dies on an unhandled signal —
-	// and aborting the editor with Ctrl-C (SIGINT) is the normal way to bail on
-	// an edit, which would otherwise leave the decrypted secrets on disk. So arm
-	// notification for exactly the window in which a cleartext copy exists: from
-	// here (BEFORE the plaintext is written below) until this function returns.
-	//
-	// This replaces a goroutine that removed the temp file and then called
-	// os.Exit(130) directly. That spelling skipped every OTHER deferred cleanup
-	// (the global lock's release most of all), could fire mid-WriteVerified, and
-	// was untestable by construction — an os.Exit from a goroutine takes the
-	// test binary with it, so nothing could assert the temp file was gone.
-	//
-	// Now the signal cancels sigCtx. The editor runs under it, so exec signals
-	// the editor and Run returns; the interrupt checks below then return
-	// errSecretEditInterrupted and the command unwinds through the NORMAL error
-	// path — the deferred os.Remove above runs, the lock is released, and the
-	// process still exits 130 because the root maps the sentinel's ExitCoder.
-	// (A signal that lands before the editor is even started is handled by the
-	// same check: exec.CommandContext's Start fails immediately on an
-	// already-cancelled context.)
-	sigCtx, stopSignals := secretEditSignals(commandContext(cmd))
-	defer stopSignals()
 	if _, err := tmpFile.Write(plain); err != nil {
 		_ = tmpFile.Close()
 		return err

--- a/internal/cli/secrets_edit_interrupt_internal_test.go
+++ b/internal/cli/secrets_edit_interrupt_internal_test.go
@@ -1,0 +1,368 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/spf13/cobra"
+
+	"github.com/spxrogers/agentsync/internal/secrets"
+	"github.com/spxrogers/agentsync/internal/testenv"
+)
+
+// editFixture is the tree one interrupt row runs in. plainDir is where
+// secretsEdit's decrypted copy lands (TMPDIR is pointed at it), and it is
+// asserted EMPTY afterwards — so every helper file this test needs lives
+// outside it, under root.
+type editFixture struct {
+	root     string
+	agePath  string
+	plainDir string
+	workDir  string // editor scripts + markers; never inside plainDir
+}
+
+// newEditFixture builds a minimal age vault, points AGENTSYNC_HOME at it, and
+// redirects TMPDIR at an otherwise-empty directory. The TMPDIR redirection is
+// what makes "no cleartext left on disk" checkable at all: secretsEdit writes
+// its plaintext copy with os.CreateTemp(""), which honours $TMPDIR.
+func newEditFixture(t *testing.T, plaintext string) editFixture {
+	t.Helper()
+	testenv.RequireContainer(t)
+	f := editFixture{root: t.TempDir()}
+	f.plainDir = filepath.Join(f.root, "plain")
+	f.workDir = filepath.Join(f.root, "work")
+	home := filepath.Join(f.root, ".agentsync")
+	for _, d := range []string{f.plainDir, f.workDir, filepath.Join(home, "secrets")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	idPath := filepath.Join(f.root, "age.key")
+	if err := os.WriteFile(idPath, []byte(id.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f.agePath = filepath.Join(home, "secrets", "secrets.age")
+	if err := secrets.Encrypt([]byte(plaintext), id.Recipient().String(), f.agePath); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf("[secrets]\nbackend = \"age\"\nfile = \"secrets/secrets.age\"\nrecipient = %q\nidentity_file = %q\n",
+		id.Recipient().String(), idPath)
+	if err := os.WriteFile(filepath.Join(home, "agentsync.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTSYNC_HOME", home)
+	t.Setenv("TMPDIR", f.plainDir)
+	return f
+}
+
+// editor writes an executable shell script under workDir and points $EDITOR at
+// it. The script's last argument is the file to edit (editorArgv appends it).
+func (f editFixture) editor(t *testing.T, body string) {
+	t.Helper()
+	p := filepath.Join(f.workDir, "editor.sh")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EDITOR", p)
+}
+
+// marker is a path under workDir a script can touch and the seam can wait for.
+func (f editFixture) marker(name string) string { return filepath.Join(f.workDir, name) }
+
+// assertPlainDirEmpty fails if anything at all is left where the decrypted vault
+// copy was written, and separately if any of it contains needle. Emptiness is
+// the stronger assertion and the one the old os.Exit path could not be held to.
+func (f editFixture) assertPlainDirEmpty(t *testing.T, needle string) {
+	t.Helper()
+	var left []string
+	if err := filepath.WalkDir(f.plainDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		left = append(left, p)
+		if data, rerr := os.ReadFile(p); rerr == nil && strings.Contains(string(data), needle) {
+			t.Errorf("cleartext vault left on disk at %s", p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 0 {
+		t.Errorf("%d file(s) left under TMPDIR after `secret edit`: %v — the decrypted copy must be "+
+			"removed on every exit path, interrupted or not", len(left), left)
+	}
+}
+
+// seamCancelNow replaces secretEditSignals with one that hands back an
+// already-cancelled context — the shape of a signal that lands before the
+// editor is even started.
+func seamCancelNow(t *testing.T) {
+	t.Helper()
+	swapSeam(t, func(parent context.Context) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(parent)
+		cancel()
+		return ctx, cancel
+	})
+}
+
+// seamCancelOnMarker replaces secretEditSignals with one that cancels as soon
+// as the editor creates marker — i.e. a signal that lands WHILE the editor is
+// running, deterministically, with no real signal and no sleep-based race.
+func seamCancelOnMarker(t *testing.T, marker string) {
+	t.Helper()
+	swapSeam(t, func(parent context.Context) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(parent)
+		go func() {
+			for {
+				if _, err := os.Stat(marker); err == nil {
+					cancel()
+					return
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Millisecond):
+				}
+			}
+		}()
+		return ctx, cancel
+	})
+}
+
+// seamCancelWhenReadBlocks replaces secretEditSignals with one that cancels at
+// the ONE point no other seam can reach: after the editor has exited and
+// secretsEdit is inside os.ReadFile, before the vault is rewritten. The editor
+// replaces the temp file with a FIFO (writing its path to marker) and exits;
+// ReadFile then blocks opening the FIFO until a writer appears, and this seam
+// is that writer. A FIFO opened for writing blocks until a reader holds it, so
+// the open returning is proof that secretsEdit is already past its post-Run
+// check and inside ReadFile — the seam cancels THEN feeds it a valid vault.
+// Deterministic: no sleeps and no second production seam. (Should secretsEdit
+// never reach ReadFile — a failing row — the goroutine stays blocked in the
+// open until the test binary exits; it holds nothing the test asserts on.)
+func seamCancelWhenReadBlocks(t *testing.T, marker string) {
+	t.Helper()
+	swapSeam(t, func(parent context.Context) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(parent)
+		go func() {
+			var fifo string
+			for fifo == "" {
+				if b, err := os.ReadFile(marker); err == nil && len(b) > 0 {
+					fifo = string(b)
+					break
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Millisecond):
+				}
+			}
+			w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+			if err != nil {
+				return
+			}
+			cancel()
+			_, _ = w.WriteString("[edited]\nval = \"yes\"\n")
+			_ = w.Close()
+		}()
+		return ctx, cancel
+	})
+}
+
+// seamNeverCancels is the no-signal shape, so the happy path exercises the seam
+// too rather than bypassing it.
+func seamNeverCancels(t *testing.T) {
+	t.Helper()
+	swapSeam(t, context.WithCancel)
+}
+
+func swapSeam(t *testing.T, fn func(context.Context) (context.Context, context.CancelFunc)) {
+	t.Helper()
+	prev := secretEditSignals
+	t.Cleanup(func() { secretEditSignals = prev })
+	secretEditSignals = fn
+}
+
+func runSecretsEdit(t *testing.T) error {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetErr(&strings.Builder{})
+	return secretsEdit(cmd, nil)
+}
+
+// TestSecretsEdit_InterruptAbandonsTheEdit is the test that could not exist
+// before. `secret edit` used to handle SIGINT/SIGTERM in a goroutine that
+// removed the temp file and then called os.Exit(130) directly — and an os.Exit
+// from a goroutine takes the test binary with it, so nothing could assert that
+// the cleartext copy was gone, that the vault was left alone, or that the exit
+// code was the one it claimed. It also skipped every OTHER deferred cleanup,
+// the global lock's release included, and could fire mid-re-encrypt.
+//
+// Every row asserts the same four things: the sentinel error comes back, it
+// carries exit code 130 through ExitCoder so the root reproduces the old
+// process exit code, the vault on disk is byte-unchanged, and NOTHING is left
+// under TMPDIR.
+//
+// The "while the editor is running" row is the one that pins the no-hang
+// property: its editor writes a valid replacement vault and then sleeps for a
+// long time, so a `secret edit` that waited for the editor after the interrupt
+// would time the test out rather than fail it — and one that saved anyway would
+// fail the byte-unchanged assertion.
+func TestSecretsEdit_InterruptAbandonsTheEdit(t *testing.T) {
+	const secretValue = "SENTINEL_VAULT_VALUE_DO_NOT_LEAK"
+	const vault = "[svc]\ntoken = \"" + secretValue + "\"\n"
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, f editFixture)
+		minTaken time.Duration // lower bound on elapsed time, for the escalation row
+	}{
+		{
+			name: "before the editor starts",
+			setup: func(t *testing.T, f editFixture) {
+				// exec.CommandContext's Start fails immediately on an
+				// already-cancelled context, so the editor never opens — and
+				// the same post-Run check covers it.
+				f.editor(t, "exit 0")
+				seamCancelNow(t)
+			},
+		},
+		{
+			name: "while the editor is running",
+			setup: func(t *testing.T, f editFixture) {
+				// `exec` on the last line matters: without it the shell's
+				// child outlives the signalled shell and keeps the test
+				// binary's inherited stdout pipe open, which `go test` reports
+				// as "Test I/O incomplete 30s after exiting". A real editor is
+				// a single process too.
+				f.editor(t, `for a in "$@"; do f="$a"; done
+printf '[edited]\nval = "yes"\n' > "$f"
+touch `+f.marker("opened")+`
+exec sleep 600`)
+				seamCancelOnMarker(t, f.marker("opened"))
+			},
+		},
+		{
+			// An editor that IGNORES the forwarded signal must not be able to wedge
+			// the command. This is the row that pins exec's WaitDelay escalation:
+			// the script sets TERM (and INT) to ignored, so the forward does nothing
+			// and only the grace-period kill ends it. Without WaitDelay this row
+			// does not fail, it HANGS — which is exactly the regression it exists to
+			// catch.
+			//
+			// `exec sleep` keeps the editor a single process: an ignored
+			// disposition survives execve (POSIX), so the `sleep` still ignores the
+			// forward, and the kill leaves nothing behind holding the test binary's
+			// inherited stdout pipe (which `go test` reports as "Test I/O incomplete
+			// 30s after exiting"). The long duration is deliberate and load-bearing
+			// — shorten it and removing WaitDelay stops being detectable, because
+			// the editor would exit on its own before the assertion below could
+			// notice.
+			name: "an editor that ignores the interrupt is stopped after the grace period",
+			setup: func(t *testing.T, f editFixture) {
+				f.editor(t, `trap "" INT TERM
+for a in "$@"; do f="$a"; done
+touch `+f.marker("opened")+`
+exec sleep 600`)
+				seamCancelOnMarker(t, f.marker("opened"))
+			},
+			minTaken: secretEditGrace,
+		},
+		{
+			// The window between the editor exiting and the vault being rewritten:
+			// the check before WriteVerified is the only thing guarding it. No
+			// signal can be placed there by hand, so the editor turns the temp file
+			// into a FIFO and exits, and the seam cancels only once secretsEdit is
+			// blocked reading it (see seamCancelWhenReadBlocks). Remove that check
+			// and this row fails: the vault is rewritten.
+			name: "after the editor exits but before the re-encrypt",
+			setup: func(t *testing.T, f editFixture) {
+				f.editor(t, `for a in "$@"; do f="$a"; done
+rm -f "$f"
+mkfifo "$f"
+printf '%s' "$f" > `+f.marker("fifo.tmp")+` && mv `+f.marker("fifo.tmp")+` `+f.marker("fifo")+`
+exit 0`)
+				seamCancelWhenReadBlocks(t, f.marker("fifo"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEditFixture(t, vault)
+			before, err := os.ReadFile(f.agePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.setup(t, f)
+
+			started := time.Now()
+			gotErr := runSecretsEdit(t)
+			taken := time.Since(started)
+			if tc.minTaken > 0 && taken < tc.minTaken {
+				t.Errorf("returned after %s, want at least %s: an editor that ignores the interrupt "+
+					"should have been killed by the grace-period escalation, not exited on its own",
+					taken, tc.minTaken)
+			}
+
+			if !errors.Is(gotErr, errSecretEditInterrupted) {
+				t.Fatalf("secretsEdit = %v, want the interrupt sentinel", gotErr)
+			}
+			var ec ExitCoder
+			if !errors.As(gotErr, &ec) {
+				t.Fatal("the interrupt sentinel does not implement ExitCoder, so the root cannot map it to 130")
+			}
+			if ec.ExitCode() != exitCodeInterrupted {
+				t.Errorf("ExitCode() = %d, want %d (128 + SIGINT, the code the old os.Exit produced)",
+					ec.ExitCode(), exitCodeInterrupted)
+			}
+			after, err := os.ReadFile(f.agePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Error("an interrupted `secret edit` rewrote the vault; nothing may be saved once the user has bailed")
+			}
+			f.assertPlainDirEmpty(t, secretValue)
+		})
+	}
+}
+
+// TestSecretsEdit_UninterruptedStillSaves is the other half of the pair: the
+// seam must not change the happy path. Without it, the rows above would pass
+// just as well against a `secret edit` that refused every edit.
+func TestSecretsEdit_UninterruptedStillSaves(t *testing.T) {
+	const secretValue = "SENTINEL_VAULT_VALUE_DO_NOT_LEAK"
+	f := newEditFixture(t, "[svc]\ntoken = \""+secretValue+"\"\n")
+	before, err := os.ReadFile(f.agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.editor(t, `for a in "$@"; do f="$a"; done; printf '[edited]\nval = "yes"\n' > "$f"`)
+	seamNeverCancels(t)
+
+	if err := runSecretsEdit(t); err != nil {
+		t.Fatalf("secretsEdit with no interrupt: %v", err)
+	}
+	after, err := os.ReadFile(f.agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) == string(before) {
+		t.Error("an uninterrupted `secret edit` did not rewrite the vault")
+	}
+	f.assertPlainDirEmpty(t, secretValue)
+}

--- a/internal/cli/secrets_edit_interrupt_internal_test.go
+++ b/internal/cli/secrets_edit_interrupt_internal_test.go
@@ -271,6 +271,18 @@ func TestSecretsEdit_InterruptAbandonsTheEdit(t *testing.T) {
 			},
 		},
 		{
+			// The one observable the pre-CreateTemp check adds: an interrupt that
+			// has already landed must exit 130 EVEN IF the temp file could not
+			// have been created. Without the check this row returns "create tmp
+			// file: …" — exit 1, no ExitCoder — instead of the sentinel.
+			name: "before the editor starts, with an unwritable temp dir",
+			setup: func(t *testing.T, f editFixture) {
+				f.editor(t, "exit 0")
+				t.Setenv("TMPDIR", filepath.Join(f.root, "no-such-dir"))
+				seamCancelNow(t)
+			},
+		},
+		{
 			name: "while the editor is running",
 			setup: func(t *testing.T, f editFixture) {
 				// `exec` on the last line matters: without it the shell's

--- a/internal/cli/secrets_edit_interrupt_internal_test.go
+++ b/internal/cli/secrets_edit_interrupt_internal_test.go
@@ -181,11 +181,14 @@ func seamCancelWhenReadBlocks(t *testing.T, marker string) {
 	})
 }
 
-// seamNeverCancels is the no-signal shape, so the happy path exercises the seam
-// too rather than bypassing it.
-func seamNeverCancels(t *testing.T) {
+// dirIsEmpty reports whether dir holds no entries at all.
+func dirIsEmpty(t *testing.T, dir string) bool {
 	t.Helper()
-	swapSeam(t, context.WithCancel)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries) == 0
 }
 
 func swapSeam(t *testing.T, fn func(context.Context) (context.Context, context.CancelFunc)) {
@@ -403,10 +406,29 @@ func TestSecretsEdit_UninterruptedStillSaves(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.editor(t, `for a in "$@"; do f="$a"; done; printf '[edited]\nval = "yes"\n' > "$f"`)
-	seamNeverCancels(t)
+	// The seam's stop is the deferred stopSignals. The signal is armed BEFORE the
+	// temp file is created precisely so that defer LIFO removes the cleartext
+	// while the signal is still caught — so at the moment stop runs, the plain
+	// dir must already be empty. Arm after the file instead and this records
+	// false.
+	var plainEmptyAtStop *bool
+	swapSeam(t, func(parent context.Context) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(parent)
+		return ctx, func() {
+			empty := dirIsEmpty(t, f.plainDir)
+			plainEmptyAtStop = &empty
+			cancel()
+		}
+	})
 
 	if err := runSecretsEdit(t); err != nil {
 		t.Fatalf("secretsEdit with no interrupt: %v", err)
+	}
+	if plainEmptyAtStop == nil {
+		t.Fatal("the seam's stop never ran: stopSignals is not deferred")
+	} else if !*plainEmptyAtStop {
+		t.Error("stopSignals ran while the cleartext temp file still existed: the signal must stay " +
+			"armed until the file is removed, i.e. be armed BEFORE the file is created")
 	}
 	after, err := os.ReadFile(f.agePath)
 	if err != nil {

--- a/internal/cli/secrets_edit_interrupt_internal_test.go
+++ b/internal/cli/secrets_edit_interrupt_internal_test.go
@@ -203,6 +203,32 @@ func runSecretsEdit(t *testing.T) error {
 	return secretsEdit(cmd, nil)
 }
 
+// secretEditReturnBound is how long a row waits for secretsEdit to come back
+// before declaring it wedged. Generous against a loaded runner (ten grace
+// periods), tiny against the alternative: without exec's WaitDelay, an editor
+// that ignores the forwarded signal keeps secretsEdit in Wait for as long as
+// the editor lives, and the only signal used to be the package's own timeout.
+const secretEditReturnBound = 10 * secretEditGrace
+
+// runSecretsEditWithin runs secretsEdit and FAILS, rather than hangs, when it
+// does not return within bound. secretsEdit touches nothing of t, so running it
+// on another goroutine is safe; on the failure path the fake editor's `sleep`
+// is left to `go test` to report, which is the ugly-but-finite outcome this
+// exists to guarantee.
+func runSecretsEditWithin(t *testing.T, bound time.Duration) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- runSecretsEdit(t) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(bound):
+		t.Fatalf("secretsEdit did not return within %s: an interrupted edit must end on the "+
+			"forwarded signal or on the grace-period kill, never by waiting for the editor", bound)
+		return nil
+	}
+}
+
 // TestSecretsEdit_InterruptAbandonsTheEdit is the test that could not exist
 // before. `secret edit` used to handle SIGINT/SIGTERM in a goroutine that
 // removed the temp file and then called os.Exit(130) directly — and an os.Exit
@@ -229,6 +255,7 @@ func TestSecretsEdit_InterruptAbandonsTheEdit(t *testing.T) {
 		name     string
 		setup    func(t *testing.T, f editFixture)
 		minTaken time.Duration // lower bound on elapsed time, for the escalation row
+		maxTaken time.Duration // upper bound, for the row that must NOT need the escalation
 	}{
 		{
 			name: "before the editor starts",
@@ -259,9 +286,10 @@ exec sleep 600`)
 			// An editor that IGNORES the forwarded signal must not be able to wedge
 			// the command. This is the row that pins exec's WaitDelay escalation:
 			// the script sets TERM (and INT) to ignored, so the forward does nothing
-			// and only the grace-period kill ends it. Without WaitDelay this row
-			// does not fail, it HANGS — which is exactly the regression it exists to
-			// catch.
+			// and only the grace-period kill ends it. Without WaitDelay secretsEdit
+			// waits for the editor for as long as it lives; runSecretsEditWithin
+			// turns that into a failure at secretEditReturnBound instead of a
+			// package-level hang.
 			//
 			// `exec sleep` keeps the editor a single process: an ignored
 			// disposition survives execve (POSIX), so the `sleep` still ignores the
@@ -280,6 +308,25 @@ exec sleep 600`)
 				seamCancelOnMarker(t, f.marker("opened"))
 			},
 			minTaken: secretEditGrace,
+		},
+		{
+			// The forwarded signal is SIGTERM, not SIGINT, on purpose: the
+			// full-screen editors this is most likely running (vi, vim, nano) treat
+			// SIGINT as an in-editor key and keep going, while SIGTERM is their
+			// "deadly signal" path. This editor models exactly that — INT ignored,
+			// TERM honoured — and must be gone well before the grace period, i.e.
+			// on the forward itself, not on the escalation. Forward SIGINT instead
+			// and it sits out the whole grace until the kill, so the upper bound
+			// fires.
+			name: "an editor that ignores SIGINT but honours SIGTERM exits on the forward",
+			setup: func(t *testing.T, f editFixture) {
+				f.editor(t, `trap "" INT
+for a in "$@"; do f="$a"; done
+touch `+f.marker("opened")+`
+exec sleep 600`)
+				seamCancelOnMarker(t, f.marker("opened"))
+			},
+			maxTaken: secretEditGrace,
 		},
 		{
 			// The window between the editor exiting and the vault being rewritten:
@@ -310,12 +357,16 @@ exit 0`)
 			tc.setup(t, f)
 
 			started := time.Now()
-			gotErr := runSecretsEdit(t)
+			gotErr := runSecretsEditWithin(t, secretEditReturnBound)
 			taken := time.Since(started)
 			if tc.minTaken > 0 && taken < tc.minTaken {
 				t.Errorf("returned after %s, want at least %s: an editor that ignores the interrupt "+
 					"should have been killed by the grace-period escalation, not exited on its own",
 					taken, tc.minTaken)
+			}
+			if tc.maxTaken > 0 && taken >= tc.maxTaken {
+				t.Errorf("returned after %s, want under %s: an editor that honours SIGTERM should have "+
+					"exited on the forward, not waited out the grace period for the kill", taken, tc.maxTaken)
 			}
 
 			if !errors.Is(gotErr, errSecretEditInterrupted) {

--- a/internal/cli/secrets_edit_signal_test.go
+++ b/internal/cli/secrets_edit_signal_test.go
@@ -1,0 +1,101 @@
+package cli_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spxrogers/agentsync/internal/cli"
+	secrets_pkg "github.com/spxrogers/agentsync/internal/secrets"
+)
+
+// TestSecretsEdit_RealSIGINTExitsThroughTheNormalPath drives the PRODUCTION
+// signal wiring — signal.NotifyContext, no seam swapped — by having the fake
+// editor send a real SIGINT to its parent, which is this test process.
+//
+// It is deliberately separate from the seam-driven table in
+// secrets_edit_interrupt_internal_test.go: that table pins the BEHAVIOUR at each
+// point of the window, this pins that the production arming is actually hooked
+// up. Sending the signal is safe and race-free because secretsEdit arms
+// notification BEFORE it launches the editor, so the default "terminate"
+// disposition is already suppressed by the time the editor can fire; and the
+// signal is targeted at $PPID, so nothing else in the process tree sees it.
+//
+// Before this change the handler was a goroutine that called os.Exit(130): this
+// test could not have been written at all — the os.Exit would have taken the
+// test binary down mid-run, reported as a hard exit with no failure attributed
+// to any test.
+func TestSecretsEdit_RealSIGINTExitsThroughTheNormalPath(t *testing.T) {
+	const secretValue = "SENTINEL_REAL_SIGNAL_VALUE"
+	env, agePath, _, id := setupSecretsEnv(t)
+	if err := secrets_pkg.Encrypt([]byte("[svc]\ntoken = \""+secretValue+"\"\n"), id.Recipient().String(), agePath); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both dirs are created BEFORE $TMPDIR is redirected, so t.TempDir() does
+	// not place them inside the directory asserted empty below.
+	work := t.TempDir()
+	plain := t.TempDir()
+	edScript := filepath.Join(work, "editor.sh")
+	// `kill -INT $PPID` targets the agentsync process (this test binary; runCLI
+	// runs the command tree in process). `exec` on the last line keeps the
+	// script a single process, so signalling it leaves nothing behind holding
+	// the test binary's inherited stdout pipe.
+	body := "#!/bin/sh\nkill -INT $PPID\nexec sleep 600\n"
+	if err := os.WriteFile(edScript, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EDITOR", edScript)
+	t.Setenv("TMPDIR", plain)
+
+	out, err := runCLI(t, env, "secret", "edit")
+	if err == nil {
+		t.Fatalf("`secret edit` interrupted by SIGINT returned no error; it must not report success\n%s", out)
+	}
+	var ec cli.ExitCoder
+	if !errors.As(err, &ec) {
+		t.Fatalf("`secret edit` returned %v, which carries no ExitCoder — the process would exit 1, "+
+			"not 130 as it did before", err)
+	}
+	if ec.ExitCode() != 130 {
+		t.Errorf("ExitCode() = %d, want 130 (128 + SIGINT)", ec.ExitCode())
+	}
+	// An ExitCoder is mapped by the root and its message is never printed, so
+	// the interrupt stays as quiet as the old hard exit was.
+	if out != "" {
+		t.Errorf("an interrupted `secret edit` printed %q; the old os.Exit(130) printed nothing", out)
+	}
+
+	after, err := os.ReadFile(agePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Error("an interrupted `secret edit` rewrote the vault")
+	}
+
+	// The point of the whole exercise: no decrypted copy survives.
+	var left []string
+	if err := filepath.WalkDir(plain, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() {
+			return werr
+		}
+		left = append(left, p)
+		if data, rerr := os.ReadFile(p); rerr == nil && strings.Contains(string(data), secretValue) {
+			t.Errorf("cleartext vault left on disk at %s after SIGINT", p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 0 {
+		t.Errorf("%d file(s) left under TMPDIR after a real SIGINT: %v", len(left), left)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -47,9 +47,12 @@ type statusModel struct {
 // detected" apart from "the command itself failed".
 const exitCodeDrift = 2
 
-// ExitCoder is implemented by the quiet sentinel error `status`/`diff` return
-// under --exit-code. main() maps it to a process exit code and prints nothing
-// (the sentinel's Error() is empty), so a CI gate gets a stable non-zero exit
+// ExitCoder is implemented by the quiet sentinel errors that carry their OWN
+// process exit code: `status`/`diff` under --exit-code (exitCodeDrift), and
+// `secret edit`'s interrupt sentinel (exitCodeInterrupted). main() maps it to
+// that code and prints NOTHING — reportErrorTo returns on the ExitCoder branch
+// before any formatting, so the sentinel's message never reaches the user
+// whether it is empty or not. A CI gate therefore gets a stable non-zero exit
 // without a spurious "agentsync: ..." line. The root command already sets
 // SilenceErrors, so cobra prints nothing for it either.
 type ExitCoder interface{ ExitCode() int }

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -99,7 +99,9 @@ agentsync secret get github.token            # read one back (to verify)
 `secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
-decrypted copy, saves nothing, and exits `130` without printing anything. An
+decrypted copy, saves nothing (unless the interrupt lands during the final
+re-encrypt, which is allowed to finish so the vault is never half-written), and
+exits `130` without printing anything. An
 editor that ignores the interrupt is given a couple of seconds to exit on its own
 and is then stopped, so the command can never hang waiting for it. The vault is
 rewritten only when the editor exits normally *and* the edited file passes the

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -99,14 +99,14 @@ agentsync secret get github.token            # read one back (to verify)
 `secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
-decrypted copy, saves nothing, and exits `130` without printing anything. An
+decrypted copy, saves nothing, and exits `130` without printing anything. The one
+exception to that is an interrupt that lands during the final re-encrypt itself:
+that write is allowed to finish so the vault is never half-written, and the
+command then reports the save and exits `0` as if it had not been interrupted. An
 editor that ignores the interrupt is given a couple of seconds to exit on its own
 and is then stopped, so the command can never hang waiting for it. The vault is
 rewritten only when the editor exits normally *and* the edited file passes the
-same validation `apply` uses. The one exception is an interrupt that lands during
-the final re-encrypt itself: that write is allowed to finish so the vault is never
-half-written, and the command then reports the save and exits `0` as if it had
-not been interrupted.
+same validation `apply` uses.
 
 <Aside type="danger" title="Back up your age key">
 	Decryption needs the **identity** file (private key), which is per-machine.

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -99,13 +99,14 @@ agentsync secret get github.token            # read one back (to verify)
 `secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
 window in which your secrets exist in cleartext on disk. **Interrupting it
 (Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
-decrypted copy, saves nothing (unless the interrupt lands during the final
-re-encrypt, which is allowed to finish so the vault is never half-written), and
-exits `130` without printing anything. An
+decrypted copy, saves nothing, and exits `130` without printing anything. An
 editor that ignores the interrupt is given a couple of seconds to exit on its own
 and is then stopped, so the command can never hang waiting for it. The vault is
 rewritten only when the editor exits normally *and* the edited file passes the
-same validation `apply` uses.
+same validation `apply` uses. The one exception is an interrupt that lands during
+the final re-encrypt itself: that write is allowed to finish so the vault is never
+half-written, and the command then reports the save and exits `0` as if it had
+not been interrupted.
 
 <Aside type="danger" title="Back up your age key">
 	Decryption needs the **identity** file (private key), which is per-machine.

--- a/website/src/content/docs/guides/secrets.mdx
+++ b/website/src/content/docs/guides/secrets.mdx
@@ -96,6 +96,15 @@ agentsync secret edit                        # open the whole vault in $EDITOR
 agentsync secret get github.token            # read one back (to verify)
 ```
 
+`secret edit` decrypts the vault to a temp file for `$EDITOR`, so there is a
+window in which your secrets exist in cleartext on disk. **Interrupting it
+(Ctrl-C, or `kill`) is safe**: agentsync signals the editor, removes the
+decrypted copy, saves nothing, and exits `130` without printing anything. An
+editor that ignores the interrupt is given a couple of seconds to exit on its own
+and is then stopped, so the command can never hang waiting for it. The vault is
+rewritten only when the editor exits normally *and* the edited file passes the
+same validation `apply` uses.
+
 <Aside type="danger" title="Back up your age key">
 	Decryption needs the **identity** file (private key), which is per-machine.
 	**agentsync does not back it up for you.** Lose it and you lose access to every


### PR DESCRIPTION
## Summary

Third and last PR for #235 (the last sub-issue of the #226 series; PR 1 was #264, PR 2 was #266). This one carries the batch's two **behaviour changes** — items 3 and 9b — plus the item-9c decision note. Three commits, each independently green, plus six review-loop commits (the loop ran its full five-round budget, then a targeted regression pass on the fifth round's fix); both changes are user-visible bug fixes and the CHANGELOG says so under `Fixed`/`Changed`, not `Internal`.

**C1 — the native MCP spec inverse comes from the rendering adapter** (`7124494`, `feat(adapter)`). A new **optional** extension beside `PluginIngester`:

```go
type MCPSpecIngester interface {
    IngestMCPSpec(raw map[string]any) source.MCPServerSpec
}
```

Read-only by construction (an inverse of `Render`, never a second render path; its result reaches `~/.agentsync/` only through `capture.Capture`). Implemented by every adapter that renders MCP as a key-merge op — claude (its translator is extracted from `Ingest` into an exported `IngestMCPSpec`, so the dialect has exactly one definition), opencode, codex, cursor, gemini, windsurf, roo, cline (each a one-line delegation to the package translator `Ingest` already used), and the generic breadth tier per its `Spec`'s `MCPTarget`. **Continue deliberately does not implement it**: it renders one whole file per server (`replace`) and its own `IngestMCPSpec` operand is a YAML list element, not a root-keyed value — documented in the interface doc, `components.md` and `architecture.md`. (Since round 5 its MCP write-back reaches the whole-file arm but is refused there: that arm copies verbatim and cannot re-reference secrets, so it refuses the kind and names `agentsync import continue:mcp:<id>` as the remedy.) Why an optional interface and not a method on `Adapter` (which would force all 31 adapters, `noop` and Continue included, to implement a contract they cannot honor) or a registry-side `name → func` table (which is exactly the hand-maintained allowlist this PR deletes): the doc comment carries the argument. The registry-wide guard `TestMCPSpecIngester_CoversEveryKeyMergeMCPRenderer` renders a real two-server fixture (one stdio, one remote) through every registered adapter at both scopes and fails if any adapter emits an MCP key-merge `FileOp` without implementing the interface — **and** asserts each adapter's own render → `IngestMCPSpec` round trip keeps every modeled field modeled, never demoted into `Extra`. That second half is what makes "route write-back through the rendering adapter" a guarantee rather than a hope. Docs: `architecture.md` §3 (a new `MCPSpecIngester (read-only)` section, and the optional-extension lead-in now lists all six), `components.md` key lists for the nine packages and the Continue exemption.

**C2 — MCP write-back asks the rendering adapter, not the pointer root** (`cfd99d8`, `fix(reconcile)`, item 3). `writeBackKeyItem` used to pick its native→canonical translation from a hard-coded list of three pointer roots (`mcpServers` → Claude's 1:1 JSON shape, `mcp` → OpenCode, `mcp_servers` → Codex). Root keys are per-agent data, not a fixed set, and they **collide**, so the list was wrong **four measured ways** (all reproduced with base and head binaries; see Test plan):

- **Crush was silently translated as OpenCode** (both key MCP under `mcp`): a stdio server's `args` and `env` were demoted into `[server.extra]`, corrupting the server for every other agent it fans out to; with a `${secret:…}` in `env` the write-back was **refused outright** by the leak backstop (`Extra` is outside re-reference's reach), so the edit could never be persisted at all.
- **Cursor, Gemini, Windsurf, Roo and Cline were silently translated as Claude** (all key under `mcpServers`): Gemini's `httpUrl` and Windsurf's `serverUrl` left the model entirely (`type = ''`, URL in `[server.extra]`), Roo's `streamable-http` was not canonicalized, and a server fanned out to Gemini plus a correct agent produced a spurious `conflict:` and a non-zero exit. Cursor's dialect happens to match Claude's, so it was unaffected in fact.
- **Zed (`context_servers`), Copilot (`servers`) and Amp (`amp.mcpServers`) were refused** with the three-root message, and `explain <path>#<ptr>` answered "assembled from several canonical sources" for them and printed no `component:` line — so none of the item's skips, plugin origin or secret references could be matched either (the spec reviewer found this **fourth** copy of the allowlist in `explain_model.go`; it is gone too).
- **A `~`-bearing server id was reported as a destination-side deletion.** Pointer segments are RFC 6901 encoded; `til~de` arrived as `til~0de`, missed the destination map, and a miss is the tombstone signal — `reconcile --auto-writeback` printed `write-back: removed source mcp/til~0de.toml (destination dropped …)`, discarded the edit, and left the next `apply` to overwrite the destination.

Now both derivations happen once: the **kind** from the op's `SourceID` (`keyItemKind`, the way `pluginOwnerForKeyItem` already did it), the **dialect** from the rendering adapter via `MCPSpecIngester`, and the pointer's entry segment decoded once (`keyItemPointerParts`) before it becomes a map key, a canonical filename or a component name. `pointerSourceFile`, `componentFromPointer` and `pluginOwnerForKeyItem` all share the two helpers; `writeBackItem`/`writeBackKeyItem` become session methods because the registry is what maps an agent name to its adapter; `internal/cli` stops importing `adapter/claude`, `adapter/codex` and `adapter/opencode`. The one refusal string that named the three roots verbatim is replaced by three refusals naming the component kind, the pointer shape, and (unreachable while the guard holds) a missing adapter inverse — no test or feature file pinned the old text. Docs: `architecture.md` §5 (key-level write-back derives both kind and dialect; the decoding note), `capability-matrix.md` prose (three claims that were false via `reconcile` — breadth-tier transport normalization, Windsurf/Cline remote MCP, the `[server.extra]` converse — now hold and cite their tests; **no matrix cell moves**, the page has no write-back column), CHANGELOG `Fixed` ×2.

**C3 — `secret edit` exits through the normal path on SIGINT/SIGTERM** (`55c14d0`, `fix(cli)`, item 9b). The signal goroutine that removed the temp file and called `os.Exit(130)` could fire mid-`WriteVerified`, left a still-running editor orphaned on the terminal, and was untestable by construction. Now `signal.NotifyContext` arms SIGINT/SIGTERM for exactly the window in which a cleartext copy exists; the editor runs under `exec.CommandContext` with `Cancel` forwarding **SIGTERM** (measured under a pty: vi, vim and nano all ignore SIGINT as an in-editor key and all restore the terminal and exit on SIGTERM — the spec reviewer's amendment; the planner had SIGINT) and `WaitDelay = 2s` escalating to a kill for an editor that ignores even that, so the command can never wedge; an interrupt returns `errSecretEditInterrupted`, a quiet sentinel implementing `ExitCoder` so the root maps it to **130** and prints nothing — byte-identical output to the hard exit it replaces — and every deferred cleanup runs. An interrupt that lands after the editor exits but before the re-encrypt also abandons (now pinned: the fake editor swaps the temp file for a FIFO so the seam can cancel while the read blocks). The signal arming is a package-var seam (`secretEditSignals`, the prompter precedent) so tests drive it deterministically; one test still sends a real SIGINT to the test process to prove the arming. `commandContext` guards cobra's nil context for direct callers. Docs: `user-guide.md` and the website secrets guide gain the "interrupting is safe" paragraph; CHANGELOG `Changed`. **Not changed, recorded on #267:** `secret edit` still persists an emptied buffer as an emptied vault.

**Item 9c — decision note, no code.** `loadSecretsConfig`'s second config-load path is intentionally left alone. #228 examined it and declined it in writing (`internal/cli/sourceinit_guard_internal_test.go`'s documented KNOWN EXCEPTION), its one measured gap (a FIFO `agentsync.toml` hangs `secret list`) is #238's, and that note says closing it "belongs to the loader rather than to a secrets-validation change". Retiring it here would re-litigate that decision in the wrong package.

**The secret surface, in one paragraph.** C2 widens *which* key items reach write-back; it does not add a path. Every reconstructed spec still goes through `capture.Capture` (re-reference + the fail-closed leak backstop); no `source.Write*` call is added from a write-back path; no `secrets.Resolved` is constructed or unwrapped; `walkSecretFields` and `internal/capture` are untouched; `.golangci.yml` is not in the diff; the `//nolint` count goes 44 → 43 (the deleted goroutine's `os.Remove`). Measured end to end: a crush server whose `env` carries `${secret:GH_TOKEN}` is applied, hand-edited natively, and reconciled with write-back — the canonical file comes back with the reference restored and the sentinel value is absent from the whole `~/.agentsync` tree (on `main` that write-back was refused outright).

**Review provenance.** The execution spec and patch series were produced by a planner and challenged by an independent reviewer who replicated them in clones: the planner's tree reproduced exactly; every gate, all fifteen break-verify rows and all five oracles re-ran with identical results. The reviewer found three ISSUEs, folded into the series applied here (tree `cfafee45…`, replay-verified by `git am` onto a virgin `63bf0c7`): the fourth allowlist in `explain_model.go`; SIGTERM instead of SIGINT for the editor; and a test for the pre-`WriteVerified` interrupt check the planner had reported as failing no mutation (it now fails one). One pre-existing bug it surfaced is filed as #268: `reconcile --scope project` write-back mints the canonical file under the **user** tree. Left as they were, all pre-existing: cursor's inverse yields `type = ""` for remote servers; SIGHUP is not in the notify list; editor-owned residue (vim swap files) is outside agentsync's reach; `claude.Ingest`'s map-order nondeterminism is #263.

**Review loop, round 1** (on `55c14d0`, closed by `c05eee4`; four independent read-only lenses): no BLOCKER. Two lenses converged on a fifth copy of the kind derivation — `pluginOwnerForKeyItem` kept its own prefix switch (and the guard test a sixth), which made "the ONE place the kind is derived" false; both now call `keyItemKind`. Also fixed: the root key is decoded like the id (`CollectPointers` escapes every segment); the "global lock's release" that three comments, the CHANGELOG and one commit body credited to the new unwind path was never at stake (an flock the kernel releases on exit) and the prose now names the real gains; the signal is armed before the temp file exists so a second Ctrl-C during the cleartext removal is still caught; the capability-matrix paragraph said four breadth-tier root keys where there are five and had swallowed the qwen sentence's antecedent; the root-key refusal names both of its causes; the root's sentinel comment. Test rigor and adversarial measured four gaps, each now pinned and break-verified: an editor that ignores SIGINT but honours SIGTERM must exit on the forward (the SIGTERM amendment had no test that failed with SIGINT); the two hand-edit refusals each fail nothing when replaced by `return nil` (a six-row table, including one proving a control byte in a native id is sanitized on the way out); the CHANGELOG's fourth symptom — one server fanned out to claude and gemini, edited identically, tripping the fan-out guard — had no test; the root's quiet-sentinel test never saw the interrupt sentinel. The escalation row now fails at ten grace periods instead of hanging the package when `WaitDelay` is removed; the guard refuses a dialect that renders fewer fixture servers than given; the transport pins carry their newline. One adversarial finding is acknowledged rather than fixed: every dialect's inverse drops a non-string element inside a string-typed native field (a number in `args`), on write-back exactly as on `import`; Claude's 1:1 path used to refuse such an entry only because it went through a typed `json.Unmarshal`. A refusal needs the interface to return an error — a contract change for all nine implementors and `import` alike — so it is documented at the call site and in the capability matrix and recorded on #267 with the root-key-absent asymmetry. Declined: folding the pre-existing OpenCode/Codex write-back tests into the dialect table.

**Review loop, round 2** (on `c05eee4`, closed by `872e075`): correctness and adversarial found nothing above NIT and re-measured every round-1 pin (the API lens confirmed the hand-built session has precedent in this package and that the fan-out test pins the symptom, not the guard). Test rigor found the two ISSUEs: the root-key refusal had a third, unnamed cause — `readDestFile` swallows read and parse errors, so a destination the user truncated between the drift walk and the `[w]` keystroke was reported as a missing root key; the write-back now reads and decodes by hand and names each failure, with a row for a missing file and one for a truncated file. And the capability matrix's new coercion claim had no test; two characterization rows now pin that a number in `args` and a bool in `env` are skipped, neither stringified nor passed through `Extra`, so the refusal #267 records is a deliberate change that fails a row. The API lens's ISSUE was procedural: the code cited #267 for entries not yet posted; they are posted. NITs taken: the happy-path interrupt test's seam records whether the cleartext directory is already empty when the deferred stop runs, pinning both the arm-before-`CreateTemp` ordering and the defer itself; the fan-out test counts two write-back lines; a signal that has already landed when the arming returns no longer puts the plaintext on disk at all; `keyItemKind`'s doc names all five callers; "nothing is saved once the user has interrupted" was unconditional where a signal inside the re-encrypt is absorbed so the vault is never half-written, and the CHANGELOG, user guide and website now say so; the editor's `Cancel` comment says what happens where SIGTERM cannot be sent; the hand-built sessions carry a `cobra.Command` so a regressed refusal reports as an assertion, not a panic. Recorded for #267: a JSON `null` nested in an array under an unmodeled native key fails write-back with an unactionable TOML error, and a top-level `null` is dropped leaving an empty `[server.extra]` (pre-existing on every capture path).

**Review loop, round 3** (on `872e075`, closed by `e6fdede`): two prose ISSUEs converged from correctness and API design — round 2 had qualified "saves nothing" by the re-encrypt window but left "exits 130 and prints nothing" unconditional beside it, and in that window the save completes with exit 0; the CHANGELOG, user guide and website now carry the exception as its own sentence. The comment above the signal arming named a mechanism (`Start` failing on a cancelled context) that the early check had made unreachable; rewritten. Test rigor found two: the last unpinned refusal — an adapter that renders MCP key items but declares no inverse — is now driven by a stub adapter registered by hand, the only way to reach a state the registry guard forbids for real adapters; and the early check before `CreateTemp`, which round 2 called untestable, is pinnable after all: with an unwritable `TMPDIR` an interrupt that has already landed must still exit 130, and without the check it exits 1. The adversarial sweep (every C2/C3 branch mutated, CAUGHT/UNPINNED tabulated) found the one refusal with a security consequence unpinned: `capture.Capture`'s error return, the fail-closed leak backstop, could be swallowed with the package green; a test now rotates the secret between apply and reconcile and requires the write to be refused, the canonical file byte-unchanged, and the old cleartext absent from the whole tree (pre-existing at the base, but this PR's theme). NITs taken: the refusal tests are one table (missing, zero-byte, truncated JSON and truncated TOML rows added), the read refusal names its next step the way the whole-file path does (no `[o]verride` for a non-regular file, where it would hang per #241) and no longer prints the path twice (nor does the whole-file arm), the dialect table refuses a non-unique replace target, the pointer-shape refusal says it is defensive, and the coercion rows carry the house-style "not an endorsement" label. Declined: an OpenCode coercion row (the claim is measured true across all ten dialects). Recorded for #267: OpenCode's fused `command` means a skipped non-string element promotes the next string to the executable.

**Review loop, round 4** (on `e6fdede`, closed by `c4c766e`): adversarial CLEAN, with every round-3 pin re-measured (the rotated-secret test fails the moment the leak backstop is disabled, so it pins the backstop and nothing earlier; the hand-registered stub cannot leak, `registryFactory` being fresh per call). Test rigor and correctness converged on the refusal table's claim to pin "every refusal" being three rows short — the kind gate, the pointer that names no server, and the non-regular arm of the read refusal, where offering `[o]verride` would hang on a FIFO (#241); all three have rows and each fails under mutation. The API lens's ISSUE was placement: the re-encrypt exception in the user guide and on the website followed the validation sentence and read as an exception to validation; it now follows the interrupt sentence and says what it excepts. NITs taken: the two destination-read refusals are one helper, `destReadRefusal`, which ended their wording divergence and carries the #241 rationale once; the whole-file arm's path-once fix has its own test; `pathlessStatErr` is `pathlessErr`; the CHANGELOG names the by-hand destination read; "unrepresentable" (two test comments, one architecture sentence) became "a failing test", which is what a guard test makes of a state; an orphaned comment line and two redundant container gates. Declined: a production seam around `WriteVerified` to test the absorbed re-encrypt's exit code (a doc-only claim, as the lens allowed). Posted on #267: OpenCode's fused `command` turns a skipped element into a position shift, and `null` values under unmodeled native keys.

**Review loop, round 5** (on `c4c766e`, closed by `921d1e3`; the budget's last): correctness and adversarial converged on a pre-existing bug the four earlier rounds had read past, and both reproduced it at the base: Continue renders each MCP server as a whole YAML file, so its hand-edited server went down the whole-file write-back arm — the verbatim copy meant for text components — which overwrote `~/.agentsync/mcp/<id>.toml` with YAML (every later command then died on `toml: expected character =`), exited 0, and persisted the `${secret:…}` value the render had resolved in cleartext, outside `capture.Capture`. Both lenses tagged the behaviour defer-to-#267 and the capability-matrix sentence claiming every dialect round-trips through `reconcile` as the one must-fix; the main session overruled that split: it is the bug class the secret invariants exist to prevent, this PR's theme is MCP write-back routing, and the docs this PR added called the whole-file path Continue's intended route. The arm now refuses a SourceID under `mcp/`, `lsp/` or `hooks/` by kind and names `agentsync import <agent>:<component>:<name>` as the remedy (measured: the import captures the edit with the reference restored and no cleartext under the tree); a refusal table pins that row and the two SourceID refusals test rigor measured as unpinned, with a positive control that a command still writes back verbatim; an end-to-end test drives the whole sequence, import included. Docs: the interface doc, `architecture.md` §3/§5, `components.md`, the capability matrix, `SECURITY.md`, CHANGELOG. NITs taken: the symlink arms say "read destination" like the helper (round 4's "divergence ended" was half-true); two comments quoted the pre-round-4 message shape; a garbled sentence; the interface doc says the signature returns no error and what that costs. Deferred to #267: a dangling symlink at a key-merge destination is advised `[o]verride`, which then fails in `iox.resolveSymlinkDest`; and a real inverse for Continue's whole-file MCP render so its write-back works instead of refusing. API design and test rigor both closed with `CLEAN — ship it`; adversarial's remaining pins (Stat follows links, so a symlink to a FIFO lands in the non-regular arm; hostile ids refused at `ValidateComponentID`; the C3 defers) all held. **Targeted regression pass on the round-5 fix** (two read-only lenses scoped to `c4c766e..921d1e3`, at the author's request): no regression — the kind gate reaches only Continue's per-server MCP file (every other whole-file SourceID is memory, commands, subagents or skills; the `(multiple)` forms are caught earlier; orphans never enter the arm), Windows separators normalise before the gate, the refusal is counted like its peers, nothing pinned the old `read dest` prefix, and both new tests prove their claims under a repeated `-race` run and a fresh mutation probe. Its one wording NIT is `8b85c06`: the interface doc and `architecture.md` said Continue's write-back "does not go through the whole-file path", which reads as if the gate were dead code; it reaches that arm and is refused there.

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor (no behavior change)
- [x] Docs
- [x] Tests / CI / tooling

## Test plan

**Gates on the head** (run by the planner, re-run by the reviewer on both the planner's and the amended tree, and run again here on the applied tree): `go build`, `go vet`, `gofmt -l` empty, gofumpt + `go mod tidy` rewrote nothing, `AGENTSYNC_TEST_IN_CONTAINER=1 go test ./...` (29 packages ok, zero `-json` failures), the host `test-fast` recipe (the justfile's exact command without the container variable — every new test lives in `internal/cli`, which it does not run), `-race ./internal/cli/...` ok (the reviewer ran it three times: no flake in the new signal tests), `-tags=e2e` ok, `-tags=bdd` ok, `GOOS=windows go build ./...` and `GOOS=windows go vet ./internal/cli/` ok, `GOTOOLCHAIN=go1.26.2 golangci-lint@v2.12.2 run ./...` with a fresh cache → 0 issues. Each of the three commits is independently green on the same set.

**New tests (five files, ~1,140 lines):** `mcpspecingester_guard_test.go` (the registry-wide guard: every adapter that renders an MCP key-merge op implements the interface, and its own render→ingest round trip keeps modeled fields modeled); `reconcile_keyitem_internal_test.go` (`keyItemKind`, `keyItemPointerParts`, `pointerSourceFile` kind-from-SourceID over amp/copilot/zed roots, hook inversion and `~` ids); `reconcile_mcp_dialect_test.go` (end-to-end apply → hand-edit → `--auto-writeback` per dialect: crush stdio is not OpenCode, gemini `httpUrl` and windsurf `serverUrl` inverted, amp's flat namespaced root, zed's `context_servers`, a `~` server id, a secret-bearing crush server re-referenced, and the `explain` component line for a breadth root); `secrets_edit_interrupt_internal_test.go` (interrupt before the editor, during the editor, after the editor exits but before re-encrypt, and an editor that ignores SIGTERM and is stopped after the grace period — each asserting the temp dir is empty, no secret bytes remain on disk, the vault is byte-unchanged, and the error's `ExitCode()` is 130; plus the uninterrupted path still saves); `secrets_edit_signal_test.go` (a real SIGINT to the test process exits through the normal path and prints nothing). Round 5 added `TestWriteBackFileItem_Refusals` (the whole-file arm's three refusals, incl. the new secret-bearing-kind gate, plus a positive control) and `TestReconcile_Writeback_ContinueWholeFileIsRefused` (apply a secret-bearing Continue server → hand-edit → `--auto-writeback` refused by name, canonical byte-unchanged, no cleartext under `~/.agentsync` → the named `import` captures the edit with the reference restored).

**Break-verifies** (all executed by the planner, all re-executed by the reviewer with identical fail sets, from `go test -json` over the whole module): against **base** with only the dialect test added, all eight subtests fail with their own diagnostics (crush `missing "[server.env]"`; gemini/windsurf `missing "type = 'http'"` + `still carries "httpUrl"`/`"serverUrl"`; amp/zed `1 item(s) failed to write back`; the `~` id `reconcile reported a destination-side DELETION for an edited server`; the secret-bearing crush row `refused a secret-bearing crush write-back`). On head: generic's method ignoring its Spec dialect → the guard for antigravity/copilot/copilot-cli/crush/factory/qwen + the crush row; windsurf's method deleted → the guard's windsurf row + the windsurf dialect row; the adapter looked up as a fixed `"claude"` → `TestReconcile_SharedMCPIdenticalWriteBackOK`, `TestReconcile_Writeback_OpenCodeMCP` and the amp/gemini/windsurf/zed rows; the raw (undecoded) segment → `TestKeyItemPointerParts` ×3, the pre-existing `TestPluginOwnerForKeyItem/escaped_slash_in_id`, the tilde `pointerSourceFile` row and `TestReconcile_Writeback_TildeServerID`; `keyItemKind` without `hooks` → its two hook rows, two `pointerSourceFile` hook rows and the pre-existing `TestExplainPath_RenamedHookEventResolves`; the three-root allowlist re-added to `pointerSourceFile` → the amp/copilot/zed rows; the `!= "mcp"` guard dropped → the pre-existing `TestReconcile_HookWriteBackIsRefused`; claude's translator dropping `Extra` → three pre-existing claude ingest tests (what makes the extraction provably neutral); the allowlist re-added to `componentFromPointer` → the zed/copilot/amp `explain` rows. Item 9b: the post-`Run` interrupt check dropped, or `ExitCode()` removed, or the deferred `os.Remove` removed → the interrupt tests (and, for the last, the uninterrupted-saves test); the pre-`WriteVerified` check dropped → the new FIFO row (it failed nothing before the reviewer's amendment, and the spec said so); `WaitDelay` removed → the escalation row fails at ten grace periods (before round 1 it hung the package, which was the honest signal but an ugly one); `Cancel` removed → the escalation row's elapsed bound fires; the arming replaced by a bare `context.WithCancel` → the real-signal test kills the `internal/cli` binary with `signal: interrupt`.

**Oracles** (base and head binaries, isolated homes; transcripts in the planner's and reviewer's logs): **O1** crush stdio / crush stdio with `${secret:…}` / amp, zed, windsurf, gemini remote / claude, cursor — base shows each of the four bugs above, head writes back the modeled fields with secrets re-referenced, claude and cursor byte-identical. **O2** `explain <path>#<ptr>` for amp and zed: base "assembled from several canonical sources", head `source: mcp/github.toml` (and, after the amendment, a `component:` line). **O3** the `~` id: base "removed source … destination dropped" with the canonical unchanged, head `write-back: …#/mcpServers/til~0de` with the edit persisted. **O4 output identity** for every non-generic path: a 30-step lifecycle over claude + opencode + codex (init, agent add ×3, check, apply, status, `status --json`, diff, explain, five hand-edited key-merge destinations, eight `explain <path>#<ptr>` forms, `reconcile --auto-writeback`, every canonical `mcp/*.toml`, re-apply, import dry-runs, the whole file tree and every file's bytes): **three base runs and three head runs, one md5** — the three dialects that were already right do not move. **O5** the same with cursor, gemini and continue added: exactly two deltas — the intended gemini fix (base printed a spurious `conflict:` and exited non-zero) and the pre-existing #263 map-order flip. The reviewer additionally ran a registry-wide render → inject-unmodelled-key → ingest check over 144 entries: every modeled field survived, none was demoted to `Extra` (only the documented `sse → http` flips). Item 9b has no transcript oracle because the behaviour is silent by design; its oracle is the test suite above.

- [ ] `just test-release` is green (the release bar) — `just` is not installable in this session; every layer the recipe orchestrates was run directly as listed above, and CI's hermetic `test-release` job runs on the PR.
- [x] `just lint` is clean — run directly with the pinned toolchain and a fresh cache; `go.mod`/`go.sum` untouched.

## Checklist

- [x] Conventional commit messages with a scope (e.g. `fix(secrets): …`).
- [x] Tests added/updated for the behavior changed.
- [x] If this touches `internal/secrets`, `internal/capture`, or any
      `source.Write*` path, I've re-read the secret-handling invariants in
      `CLAUDE.md` / `SECURITY.md` and not weakened them. — See "The secret surface, in one paragraph" above: the widened write-back set still ends in `capture.Capture`; nothing new writes to the canonical source; `internal/secrets` and `internal/capture` are not in the diff; `SECURITY.md` gains one clause (round 5) saying the whole-file text write-back refuses the secret-bearing kinds — an invariant restored, not one weakened.
- [x] Docs updated if behavior, CLI surface, or capability coverage changed. — `docs/architecture.md` §3 and §5, `docs/components.md`, `docs/capability-matrix.md` (prose only; no cell moves), `docs/user-guide.md`, `website/src/content/docs/guides/secrets.mdx`, `SECURITY.md`, `CHANGELOG.md`; no CLI surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4VNyoCuGXx7pYxNfLVbFG